### PR TITLE
fix(mobile): 온보딩 중복 표시 버그 수정

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -39,23 +39,16 @@ function TrendBadge({ trend }: { trend: WeekTrend }) {
 export default function HomeScreen() {
   const router = useRouter();
   const { t } = useTranslation();
-  const { isAuthenticated, hasCompletedOnboarding, stateLoaded, setPlaying, currentPlayingId } = useAppStore();
+  const { isAuthenticated, setPlaying, currentPlayingId } = useAppStore();
   const isConnected = useNetworkStatus();
   const [currentSound, setCurrentSound] = useState<Audio.Sound | null>(null);
   const [cachedAlarmsList, setCachedAlarmsList] = useState<Alarm[] | null>(null);
   const [cachedMessagesList, setCachedMessagesList] = useState<Message[] | null>(null);
 
-  const [mounted, setMounted] = useState(false);
   useEffect(() => {
-    setMounted(true);
     getCachedAlarms().then(setCachedAlarmsList);
     getCachedMessages().then(setCachedMessagesList);
   }, []);
-  useEffect(() => {
-    if (mounted && stateLoaded && !hasCompletedOnboarding) {
-      router.replace('/onboarding');
-    }
-  }, [mounted, stateLoaded, hasCompletedOnboarding]);
 
   const {
     data: alarms,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -28,9 +28,18 @@ const queryClient = new QueryClient({
 
 export default function RootLayout() {
   const loadPersistedState = useAppStore((s) => s.loadPersistedState);
+  const { hasCompletedOnboarding, stateLoaded } = useAppStore();
   const { t } = useTranslation();
   const router = useRouter();
   const responseListener = useRef<Notifications.EventSubscription | null>(null);
+  const hasNavigatedToOnboarding = useRef(false);
+
+  useEffect(() => {
+    if (stateLoaded && !hasCompletedOnboarding && !hasNavigatedToOnboarding.current) {
+      hasNavigatedToOnboarding.current = true;
+      router.replace('/onboarding');
+    }
+  }, [stateLoaded, hasCompletedOnboarding]);
 
   useEffect(() => {
     loadPersistedState();


### PR DESCRIPTION
## Summary
- 온보딩 리다이렉션 로직을 `_layout.tsx`로 통합, `useRef` 플래그로 1회만 실행
- `(tabs)/index.tsx`의 중복 온보딩 체크 제거

Closes #2

## Test plan
- [ ] 앱 첫 실행 시 온보딩 3페이지 1회만 표시 확인
- [ ] 온보딩 완료 후 홈 화면 정상 진입 확인
- [ ] 앱 재시작 시 온보딩 다시 안 뜨는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)