### PR TITLE
chore(mobile): Android 네이티브 빌드 스크립트 전환

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,8 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- `package.json`의 android/ios 스크립트를 `expo run:android/ios`로 변경
- Android Studio 에뮬레이터에서 네이티브 빌드 후 핫 리로딩 개발 지원

Closes #3

## Test plan
- [ ] `npm run android`로 에뮬레이터에서 앱 빌드 및 실행 확인
- [ ] 코드 수정 시 Fast Refresh 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)