### PR TITLE
[#17] packages/shared 스캐폴드 + zod 스키마

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,8 @@
 # 📌 현재 상태 (마지막 업데이트: 2026-04-17)
 
 - 진행 중 Phase: 1 (기존 코드 진단 & 모노레포 정비)
-- 완료 이슈: 없음
-- 진행 중 이슈: #15 (프로젝트 진단 & 베이스라인 문서화)
+- 완료 이슈: #15, #17 (2개)
+- 진행 중 이슈: 없음 (다음 후보: 루트 typecheck 집계 + 웹/모바일 vitest/jest 셋업)
 - blocked 이슈: 없음
 - 루프 작업 브랜치: `develop_loop` (origin 푸시 완료)
 
@@ -10,6 +10,22 @@
 
 ## 루프 로그
 
-(아직 머지된 이슈가 없습니다. 첫 이슈 완료 시 아래에 append 됩니다.)
+## 2026-04-17 · Issue #15 · 프로젝트 진단 및 베이스라인 문서화
+- 브랜치: `feature/issue-15-project-diagnosis`
+- PR: #16 (merged)
+- 변경 파일: 5개 (문서만)
+- 요약: `TASK.md` 커밋, `docs/STRUCTURE_BASELINE.md` · `docs/ARCHITECTURE_DECISION.md` · `docs/DIAGNOSIS.md` 신규, `PROGRESS.md` 초기화.
+- 다음: #17 모노레포 구조 유지 확정 + `packages/shared` 스캐폴드
+- 리스크: 없음 (문서 PR)
+
+---
+
+## 2026-04-17 · Issue #17 · 모노레포 구조 유지 + packages/shared 스캐폴드
+- 브랜치: `feature/issue-17-shared-scaffold`
+- PR: (작성 예정)
+- 변경 파일: 8개 (신규 `packages/shared/**` + `package-lock.json` 갱신)
+- 요약: `@voice-alarm/shared` 워크스페이스 추가, `UserPlan`·`UserSchema`·`VoiceProfile` zod 스키마와 vitest 6건 추가.
+- 다음: 루트 통합 typecheck 스크립트 + 웹/모바일 테스트 러너 추가 이슈 생성
+- 리스크: 기존 백엔드/웹/모바일은 아직 `@voice-alarm/shared` 를 import 하지 않음 — 후속 이슈에서 점진 적용.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -2821,6 +2821,10 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@voice-alarm/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5439,6 +5443,15 @@
         "error-stack-parser-es": "^1.0.5"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/backend": {
       "version": "1.0.0",
       "dependencies": {
@@ -5450,6 +5463,17 @@
         "typescript": "^5.9.3",
         "vitest": "^4.1.4",
         "wrangler": "^4.81.0"
+      }
+    },
+    "packages/shared": {
+      "name": "@voice-alarm/shared",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
       }
     },
     "packages/web": {

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,40 @@
+# @voice-alarm/shared
+
+모노레포 공용 타입·zod 스키마 패키지.
+
+- 루트 `package.json` 의 workspaces(`packages/*`) 에 자동 포함된다.
+- 백엔드/웹/모바일에서 import 하여 API 계약 타입과 런타임 validator 를 공유한다.
+
+## 구조
+
+```
+packages/shared/
+├── src/
+│   ├── index.ts            barrel export
+│   └── schemas/
+│       ├── user.ts         UserPlan, UserSchema
+│       └── voice.ts        VoiceProfileStatus, VoiceProfileSchema
+├── test/
+│   └── schemas.test.ts     zod 스키마 단위 테스트
+├── package.json
+├── tsconfig.json
+└── vitest.config.ts
+```
+
+## 스크립트
+
+```bash
+cd packages/shared
+npm run typecheck   # tsc --noEmit
+npm run test        # vitest
+```
+
+## 사용 예
+
+```ts
+import { UserSchema } from "@voice-alarm/shared";
+
+const user = UserSchema.parse(await fetchMe());
+```
+
+> 현재는 스캐폴드만 있다. 실제 import 는 별도 이슈에서 백엔드·웹·모바일로 점진 확장한다.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@voice-alarm/shared",
+  "version": "0.1.0",
+  "description": "Shared TypeScript types and zod schemas for voice_alarm monorepo",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
+  },
+  "private": true
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas/user.js";
+export * from "./schemas/voice.js";

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const UserPlanSchema = z.enum(["free", "plus", "family"]);
+export type UserPlan = z.infer<typeof UserPlanSchema>;
+
+export const UserSchema = z.object({
+  id: z.string().min(1),
+  email: z.string().email(),
+  name: z.string().min(1).max(64),
+  plan: UserPlanSchema,
+  createdAt: z.string().datetime(),
+});
+export type User = z.infer<typeof UserSchema>;

--- a/packages/shared/src/schemas/voice.ts
+++ b/packages/shared/src/schemas/voice.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const VoiceProfileStatusSchema = z.enum(["processing", "ready", "failed"]);
+export type VoiceProfileStatus = z.infer<typeof VoiceProfileStatusSchema>;
+
+export const VoiceProfileSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  name: z.string().min(1).max(32),
+  status: VoiceProfileStatusSchema,
+  sampleCount: z.number().int().nonnegative(),
+});
+export type VoiceProfile = z.infer<typeof VoiceProfileSchema>;

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  UserPlanSchema,
+  UserSchema,
+  VoiceProfileSchema,
+  VoiceProfileStatusSchema,
+} from "../src/index.js";
+
+describe("UserPlanSchema", () => {
+  it("accepts known plans", () => {
+    expect(UserPlanSchema.parse("free")).toBe("free");
+    expect(UserPlanSchema.parse("plus")).toBe("plus");
+    expect(UserPlanSchema.parse("family")).toBe("family");
+  });
+  it("rejects unknown plans", () => {
+    expect(() => UserPlanSchema.parse("enterprise")).toThrow();
+  });
+});
+
+describe("UserSchema", () => {
+  it("parses a well-formed user", () => {
+    const u = UserSchema.parse({
+      id: "u_1",
+      email: "kim@example.com",
+      name: "김규원",
+      plan: "plus",
+      createdAt: "2026-04-17T00:00:00.000Z",
+    });
+    expect(u.plan).toBe("plus");
+  });
+  it("rejects malformed email", () => {
+    expect(() =>
+      UserSchema.parse({
+        id: "u_1",
+        email: "not-an-email",
+        name: "kim",
+        plan: "free",
+        createdAt: "2026-04-17T00:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("VoiceProfileSchema", () => {
+  it("parses a valid profile", () => {
+    const p = VoiceProfileSchema.parse({
+      id: "vp_1",
+      userId: "u_1",
+      name: "엄마 목소리",
+      status: "ready",
+      sampleCount: 3,
+    });
+    expect(VoiceProfileStatusSchema.parse(p.status)).toBe("ready");
+  });
+  it("rejects negative sample count", () => {
+    expect(() =>
+      VoiceProfileSchema.parse({
+        id: "vp_1",
+        userId: "u_1",
+        name: "엄마 목소리",
+        status: "ready",
+        sampleCount: -1,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## 개요
- 이슈: #17
- 요약: 모노레포 공용 타입 패키지 \`@voice-alarm/shared\` 를 신규 추가하고 zod 기반 \`UserPlan\`·\`User\`·\`VoiceProfile\` 스키마와 단위 테스트를 등록한다.

## 변경 내용
- \`packages/shared/\` 신규
  - \`package.json\`, \`tsconfig.json\`, \`vitest.config.ts\`, \`README.md\`
  - \`src/index.ts\` barrel export
  - \`src/schemas/user.ts\` — \`UserPlan\`, \`UserSchema\`
  - \`src/schemas/voice.ts\` — \`VoiceProfileStatus\`, \`VoiceProfileSchema\`
  - \`test/schemas.test.ts\` — vitest 6건 (정상/거절 케이스)
- 루트 \`package-lock.json\` 갱신 (zod, vitest 를 shared 의존성으로 끌어옴)
- \`PROGRESS.md\` 에 #15, #17 완료 로그 append

## 검증
- [x] \`npm install\` 정상 완료 (root 에서 shared 자동 링크)
- [x] \`cd packages/shared && npm run test\` → 6/6 통과
- [x] \`cd packages/shared && npm run typecheck\` → 오류 없음
- [x] 기존 백엔드/웹/모바일은 아직 shared 를 import 하지 않음 → 영향 없음

## 리스크 / 팔로업
- 리스크: 없음 (스캐폴드. 기존 코드 영향 없음)
- 다음: 루트에서 일괄 \`typecheck\` 하는 스크립트 + web/mobile 테스트 러너 셋업 이슈