### PR TITLE
[#19] 린트·포맷·타입체크 파이프라인 통합

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"apps/**/*.{ts,tsx}\" \"packages/**/*.{ts,tsx,css}\"",
-    "format:check": "prettier --check \"apps/**/*.{ts,tsx}\" \"packages/**/*.{ts,tsx,css}\""
+    "format:check": "prettier --check \"apps/**/*.{ts,tsx}\" \"packages/**/*.{ts,tsx,css}\"",
+    "typecheck": "npm run typecheck --workspaces --if-present && cd apps/mobile && npx tsc --noEmit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
## 개요
- 이슈: #19
- 요약: 루트에서 lint, format:check, typecheck를 일괄 실행할 수 있도록 스크립트 통합

## 변경 내용
- 루트 `package.json`에 `typecheck` 스크립트 추가 (`npm run typecheck --workspaces --if-present && cd apps/mobile && npx tsc --noEmit`)
- `packages/web/package.json`에 `typecheck` 스크립트 추가
- `apps/mobile/package.json`에 `typecheck` 스크립트 추가

## 검증
- [x] `npm run lint` 루트에서 전 워크스페이스 실행 — 경고 12건(기존), 에러 0건
- [x] `npm run typecheck` 루트에서 backend, shared, web, mobile 전부 통과
- [x] `npm run format:check` 루트에서 실행 — 포맷 미적용 파일 103건(기존)

## 리스크 / 팔로업
- format 미적용 파일 103건 — 별도 이슈에서 `npm run format` 일괄 적용 가능
- ESLint 경고 12건 — 코드 품질 이슈이므로 별도 이슈에서 점진 수정