### PR TITLE
[#21] 기본 테스트 러너 설정 — 웹 vitest + 모바일 jest + 루트 통합

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,7 +7,12 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "testMatch": ["**/__tests__/**/*.test.{ts,tsx}", "**/test/**/*.test.{ts,tsx}"]
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
@@ -41,8 +46,11 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.1.0",
     "babel-preset-expo": "^54.0.10",
+    "jest": "^29.7.0",
+    "jest-expo": "^55.0.16",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/apps/mobile/test/setup.test.ts
+++ b/apps/mobile/test/setup.test.ts
@@ -1,0 +1,9 @@
+describe('mobile test runner', () => {
+  it('jest 환경이 정상 동작한다', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('기본 문자열 연산이 동작한다', () => {
+    expect('Voice' + 'Alarm').toBe('VoiceAlarm');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"apps/**/*.{ts,tsx}\" \"packages/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"apps/**/*.{ts,tsx}\" \"packages/**/*.{ts,tsx,css}\"",
-    "typecheck": "npm run typecheck --workspaces --if-present && cd apps/mobile && npx tsc --noEmit"
+    "typecheck": "npm run typecheck --workspaces --if-present && cd apps/mobile && npx tsc --noEmit",
+    "test": "npm test --workspaces --if-present && cd apps/mobile && npm test"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,17 +6,22 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "type": "module",
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.2",

--- a/packages/web/test/setup.test.ts
+++ b/packages/web/test/setup.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('web test runner', () => {
+  it('vitest 환경이 정상 동작한다', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('DOM 환경이 설정되어 있다', () => {
+    const el = document.createElement('div');
+    el.textContent = 'hello';
+    expect(el.textContent).toBe('hello');
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## 개요
- 이슈: #21
- 요약: 전 워크스페이스에 테스트 러너 설정 완료, 루트에서 일괄 실행 가능

## 변경 내용
- `packages/web`: vitest + jsdom + @testing-library/react 설치, vitest.config.ts 추가, 기본 테스트 2건
- `apps/mobile`: jest-expo 설치, jest 프리셋 설정, 기본 테스트 2건
- 루트 `package.json`: `test` 스크립트 추가 (workspaces --if-present + mobile)

## 검증
- [x] `npm test` 루트에서 전체 실행 — 222건 통과 (backend 212 + shared 6 + web 2 + mobile 2)
- [x] `npm run lint` 통과 (경고만, 에러 0)
- [x] `npm run typecheck` 통과

## 리스크 / 팔로업
- web/mobile 테스트는 스캐폴드 수준 — 실제 컴포넌트 테스트는 Phase 3 이후 추가