### PR TITLE
[#23] CI 워크플로우 보강 — lint/typecheck/test + develop_loop 트리거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,34 @@ name: CI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, develop_loop, main]
   pull_request:
-    branches: [develop, main]
+    branches: [develop, develop_loop, main]
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Lint
+        run: npm run lint
+
   typecheck:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: [packages/backend, packages/web, apps/mobile]
+        package: [packages/backend, packages/shared, packages/web, apps/mobile]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,3 +50,37 @@ jobs:
       - name: Typecheck
         working-directory: ${{ matrix.package }}
         run: npx tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package: packages/backend
+            command: npm test
+          - package: packages/shared
+            command: npm test
+          - package: packages/web
+            command: npm test
+          - package: apps/mobile
+            command: npm test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci || npm install
+
+      - name: Install package dependencies
+        if: matrix.package == 'apps/mobile'
+        working-directory: apps/mobile
+        run: npm install
+
+      - name: Test
+        working-directory: ${{ matrix.package }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
## 개요
- 이슈: #23
- 요약: CI 워크플로우에 lint, test job 추가 및 develop_loop 브랜치 트리거 설정

## 변경 내용
- `develop_loop` 브랜치 push/PR 트리거 추가
- lint job 신규 (루트 ESLint 실행)
- test job 신규 (backend/shared/web/mobile 매트릭스)
- typecheck 매트릭스에 `packages/shared` 추가

## 검증
- [x] YAML 문법 검증
- [x] 시크릿 불필요 확인 (모든 job이 로컬 테스트만 실행)
- [x] 로컬에서 lint/typecheck/test 전부 통과 확인 완료

## 리스크 / 팔로업
- CI 캐시 최적화 (node_modules 캐시 등) — 후속 이슈
- mobile의 경우 apps/mobile에 별도 npm install 필요 (workspaces 외부)