### PR TITLE
[#27] 이메일+비밀번호 가입/로그인 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,114 @@
         "typescript": "~5.9.2"
       }
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
@@ -197,6 +305,146 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -830,6 +1078,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2339,6 +2605,54 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2349,6 +2663,21 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2865,6 +3194,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2887,6 +3227,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2925,6 +3275,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
@@ -3098,6 +3467,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3112,6 +3502,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3132,6 +3564,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3148,6 +3587,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3157,6 +3606,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3184,6 +3641,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -3831,6 +4301,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3868,6 +4351,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3890,6 +4383,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3914,6 +4414,14 @@
       "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3925,6 +4433,75 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -4309,6 +4886,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4327,6 +4925,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
@@ -4347,6 +4952,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/miniflare": {
@@ -4560,6 +5175,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4627,6 +5255,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -4658,6 +5316,38 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4712,6 +5402,19 @@
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4825,6 +5528,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4850,6 +5566,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
@@ -4929,6 +5652,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5005,6 +5761,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -5256,6 +6022,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web": {
       "resolved": "packages/web",
       "link": true
@@ -5267,6 +6046,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -5405,6 +6204,23 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5456,10 +6272,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@libsql/client": "^0.17.2",
+        "@voice-alarm/shared": "*",
+        "bcryptjs": "^3.0.3",
         "hono": "^4.12.12"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260409.1",
+        "@types/bcryptjs": "^2.4.6",
         "typescript": "^5.9.3",
         "vitest": "^4.1.4",
         "wrangler": "^4.81.0"
@@ -5486,12 +6305,44 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.9.3",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.4"
+      }
+    },
+    "packages/web/node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "packages/web/node_modules/@types/react": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,12 +12,15 @@
   "type": "module",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260409.1",
+    "@types/bcryptjs": "^2.4.6",
     "typescript": "^5.9.3",
     "vitest": "^4.1.4",
     "wrangler": "^4.81.0"
   },
   "dependencies": {
     "@libsql/client": "^0.17.2",
+    "@voice-alarm/shared": "*",
+    "bcryptjs": "^3.0.3",
     "hono": "^4.12.12"
   }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -11,6 +11,7 @@ import voiceRoutes from './routes/voice';
 import ttsRoutes from './routes/tts';
 import alarmRoutes from './routes/alarm';
 import userRoutes from './routes/user';
+import authRoutes from './routes/auth';
 import libraryRoutes from './routes/library';
 import friendRoutes from './routes/friend';
 import giftRoutes from './routes/gift';
@@ -88,6 +89,9 @@ app.get('/api/tts/presets', publicCache, async (c) => {
   const { PRESETS } = await import('./data/presets');
   return c.json({ presets: PRESETS });
 });
+
+// 이메일+비밀번호 가입/로그인 (인증 미들웨어 미적용)
+app.route('/api/auth', authRoutes);
 
 // 인증이 필요한 라우트들
 const api = new Hono<AppEnv>();

--- a/packages/backend/src/lib/jwt.ts
+++ b/packages/backend/src/lib/jwt.ts
@@ -1,0 +1,104 @@
+export interface AppJwtPayload {
+  sub: string;
+  email: string;
+  name?: string;
+  iss: string;
+  aud: string;
+  iat: number;
+  exp: number;
+}
+
+const ISSUER = 'voice-alarm';
+const AUDIENCE = 'voice-alarm-clients';
+const ALG = 'HS256';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+function base64UrlEncode(bytes: ArrayBuffer | Uint8Array): string {
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let bin = '';
+  for (let i = 0; i < u8.length; i++) bin += String.fromCharCode(u8[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlEncodeString(s: string): string {
+  return base64UrlEncode(new TextEncoder().encode(s));
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function getKey(secret: string, usage: 'sign' | 'verify'): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    [usage],
+  );
+}
+
+export async function signAppJwt(
+  payload: { sub: string; email: string; name?: string },
+  secret: string,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+): Promise<string> {
+  if (!secret) throw new Error('JWT_SECRET is required');
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: ALG, typ: 'JWT' };
+  const body: AppJwtPayload = {
+    sub: payload.sub,
+    email: payload.email,
+    name: payload.name,
+    iss: ISSUER,
+    aud: AUDIENCE,
+    iat: now,
+    exp: now + ttlSeconds,
+  };
+
+  const headerPart = base64UrlEncodeString(JSON.stringify(header));
+  const payloadPart = base64UrlEncodeString(JSON.stringify(body));
+  const data = `${headerPart}.${payloadPart}`;
+  const key = await getKey(secret, 'sign');
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return `${data}.${base64UrlEncode(sig)}`;
+}
+
+export async function verifyAppJwt(token: string, secret: string): Promise<AppJwtPayload> {
+  if (!secret) throw new Error('JWT_SECRET is required');
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Invalid token format');
+  const [headerPart, payloadPart, sigPart] = parts;
+
+  const header = JSON.parse(new TextDecoder().decode(base64UrlDecode(headerPart))) as {
+    alg?: string;
+  };
+  if (header.alg !== ALG) throw new Error('Unsupported algorithm');
+
+  const key = await getKey(secret, 'verify');
+  const valid = await crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64UrlDecode(sigPart),
+    new TextEncoder().encode(`${headerPart}.${payloadPart}`),
+  );
+  if (!valid) throw new Error('Signature verification failed');
+
+  const payload = JSON.parse(
+    new TextDecoder().decode(base64UrlDecode(payloadPart)),
+  ) as AppJwtPayload;
+
+  if (payload.iss !== ISSUER) throw new Error('Invalid issuer');
+  if (payload.aud !== AUDIENCE) throw new Error('Token audience mismatch');
+  if (payload.exp < Math.floor(Date.now() / 1000)) throw new Error('Token expired');
+
+  return payload;
+}
+
+export const APP_JWT_ISSUER = ISSUER;
+export const APP_JWT_AUDIENCE = AUDIENCE;

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -116,6 +116,36 @@ export const migrations: Migration[] = [
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google_id ON users(google_id)',
     ],
   },
+  {
+    id: 2,
+    name: 'email-password-auth',
+    statements: [
+      // 기존 스키마는 google_id NOT NULL — 이메일/비밀번호 사용자를 위해 nullable 로 재정의.
+      // SQLite 의 ALTER TABLE 한계로 users 테이블 재생성 패턴 사용.
+      `CREATE TABLE users_new (
+        id TEXT PRIMARY KEY,
+        google_id TEXT UNIQUE,
+        email TEXT NOT NULL,
+        password_hash TEXT,
+        name TEXT,
+        picture TEXT,
+        plan TEXT DEFAULT 'free' CHECK(plan IN ('free','plus','family')),
+        daily_tts_count INTEGER DEFAULT 0,
+        daily_tts_reset_at TEXT,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )`,
+      `INSERT INTO users_new (id, google_id, email, name, picture, plan,
+        daily_tts_count, daily_tts_reset_at, created_at, updated_at)
+        SELECT id, google_id, email, name, picture, plan,
+        daily_tts_count, daily_tts_reset_at, created_at, updated_at FROM users`,
+      'DROP TABLE users',
+      'ALTER TABLE users_new RENAME TO users',
+      'CREATE UNIQUE INDEX idx_users_email_unique ON users(email)',
+      'CREATE INDEX idx_users_email ON users(email)',
+      'CREATE UNIQUE INDEX idx_users_google_id ON users(google_id) WHERE google_id IS NOT NULL',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/lib/password.ts
+++ b/packages/backend/src/lib/password.ts
@@ -1,0 +1,20 @@
+import bcrypt from 'bcryptjs';
+
+const BCRYPT_ROUNDS = 10;
+
+export function applyPepper(password: string, pepper: string): string {
+  return `${password}::${pepper ?? ''}`;
+}
+
+export async function hashPassword(password: string, pepper: string): Promise<string> {
+  return bcrypt.hash(applyPepper(password, pepper), BCRYPT_ROUNDS);
+}
+
+export async function verifyPassword(
+  password: string,
+  hash: string,
+  pepper: string,
+): Promise<boolean> {
+  if (!hash) return false;
+  return bcrypt.compare(applyPepper(password, pepper), hash);
+}

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from 'hono';
 import type { AppEnv } from '../types';
+import { verifyAppJwt, APP_JWT_ISSUER } from '../lib/jwt';
 
 interface TokenPayload {
   sub: string;
@@ -34,7 +35,18 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
 
     let verified: TokenPayload;
 
-    if (payload.iss === 'https://appleid.apple.com') {
+    if (payload.iss === APP_JWT_ISSUER) {
+      const app = await verifyAppJwt(token, c.env.JWT_SECRET);
+      verified = {
+        sub: app.sub,
+        email: app.email,
+        name: app.name,
+        picture: undefined,
+        iss: app.iss,
+        aud: app.aud,
+        exp: app.exp,
+      };
+    } else if (payload.iss === 'https://appleid.apple.com') {
       verified = await verifyAppleToken(token);
     } else {
       verified = await verifyGoogleToken(token, c.env.GOOGLE_CLIENT_ID);

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -1,0 +1,170 @@
+import { Hono } from 'hono';
+import type { Env } from '../types';
+import { getDB } from '../lib/db';
+import { hashPassword, verifyPassword } from '../lib/password';
+import { signAppJwt, verifyAppJwt } from '../lib/jwt';
+import { RegisterRequestSchema, LoginRequestSchema } from '@voice-alarm/shared';
+
+const auth = new Hono<{ Bindings: Env }>();
+
+function jsonError(code: string, message: string) {
+  return { error: message, code };
+}
+
+auth.post('/register', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('AUTH_INVALID_JSON', 'Invalid JSON body'), 400);
+  }
+
+  const parsed = RegisterRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { ...jsonError('AUTH_VALIDATION_FAILED', 'Validation failed'), issues: parsed.error.issues },
+      400,
+    );
+  }
+
+  const { email, password, name } = parsed.data;
+  const normalizedEmail = email.toLowerCase().trim();
+  const db = getDB(c.env);
+
+  try {
+    const existing = await db.execute({
+      sql: 'SELECT id FROM users WHERE email = ?',
+      args: [normalizedEmail],
+    });
+    if (existing.rows.length > 0) {
+      return c.json(jsonError('AUTH_EMAIL_TAKEN', 'Email is already registered'), 409);
+    }
+
+    const id = crypto.randomUUID();
+    const passwordHash = await hashPassword(password, c.env.PASSWORD_PEPPER);
+    const today = new Date().toISOString().split('T')[0];
+
+    await db.execute({
+      sql: `INSERT INTO users (id, email, password_hash, name, daily_tts_reset_at)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [id, normalizedEmail, passwordHash, name, today],
+    });
+
+    const token = await signAppJwt({ sub: id, email: normalizedEmail, name }, c.env.JWT_SECRET);
+
+    return c.json(
+      {
+        token,
+        user: { id, email: normalizedEmail, name, plan: 'free' as const },
+      },
+      201,
+    );
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`POST /auth/register failed: ${detail}`);
+    return c.json(jsonError('AUTH_REGISTER_FAILED', 'Registration failed'), 500);
+  }
+});
+
+auth.post('/login', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('AUTH_INVALID_JSON', 'Invalid JSON body'), 400);
+  }
+
+  const parsed = LoginRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(jsonError('AUTH_VALIDATION_FAILED', 'Validation failed'), 400);
+  }
+
+  const { email, password } = parsed.data;
+  const normalizedEmail = email.toLowerCase().trim();
+  const db = getDB(c.env);
+
+  try {
+    const result = await db.execute({
+      sql: `SELECT id, email, password_hash, name, plan FROM users WHERE email = ?`,
+      args: [normalizedEmail],
+    });
+
+    if (result.rows.length === 0) {
+      return c.json(jsonError('AUTH_INVALID_CREDENTIALS', 'Invalid email or password'), 401);
+    }
+
+    const row = result.rows[0] as unknown as {
+      id: string;
+      email: string;
+      password_hash: string | null;
+      name: string | null;
+      plan: 'free' | 'plus' | 'family' | null;
+    };
+
+    if (!row.password_hash) {
+      return c.json(jsonError('AUTH_OAUTH_ONLY', 'This account uses OAuth sign-in'), 401);
+    }
+
+    const ok = await verifyPassword(password, row.password_hash, c.env.PASSWORD_PEPPER);
+    if (!ok) {
+      return c.json(jsonError('AUTH_INVALID_CREDENTIALS', 'Invalid email or password'), 401);
+    }
+
+    const token = await signAppJwt(
+      { sub: row.id, email: row.email, name: row.name ?? undefined },
+      c.env.JWT_SECRET,
+    );
+
+    return c.json({
+      token,
+      user: {
+        id: row.id,
+        email: row.email,
+        name: row.name ?? '',
+        plan: row.plan ?? 'free',
+      },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`POST /auth/login failed: ${detail}`);
+    return c.json(jsonError('AUTH_LOGIN_FAILED', 'Login failed'), 500);
+  }
+});
+
+auth.get('/me', async (c) => {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json(jsonError('AUTH_MISSING', 'Authorization header required'), 401);
+  }
+  const token = authHeader.slice(7);
+  try {
+    const payload = await verifyAppJwt(token, c.env.JWT_SECRET);
+    const db = getDB(c.env);
+    const result = await db.execute({
+      sql: `SELECT id, email, name, plan FROM users WHERE id = ?`,
+      args: [payload.sub],
+    });
+    if (result.rows.length === 0) {
+      return c.json(jsonError('AUTH_USER_NOT_FOUND', 'User not found'), 404);
+    }
+    const row = result.rows[0] as unknown as {
+      id: string;
+      email: string;
+      name: string | null;
+      plan: 'free' | 'plus' | 'family' | null;
+    };
+    return c.json({
+      user: {
+        id: row.id,
+        email: row.email,
+        name: row.name ?? '',
+        plan: row.plan ?? 'free',
+      },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return c.json(jsonError('AUTH_INVALID_TOKEN', detail), 401);
+  }
+});
+
+export default auth;

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -4,6 +4,8 @@ export interface Env {
   TURSO_DATABASE_URL: string;
   TURSO_AUTH_TOKEN: string;
   GOOGLE_CLIENT_ID: string;
+  JWT_SECRET: string;
+  PASSWORD_PEPPER: string;
   ENVIRONMENT: string;
 }
 
@@ -54,8 +56,11 @@ export interface Alarm {
 
 export interface UserProfile {
   id: string;
-  google_id: string;
+  google_id: string | null;
   email: string;
+  password_hash: string | null;
+  name: string | null;
+  picture: string | null;
   plan: 'free' | 'plus' | 'family';
   daily_tts_count: number;
   daily_tts_reset_at: string;

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '../src/types';
+import { createMockDB, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import authRoutes from '../src/routes/auth';
+import { hashPassword } from '../src/lib/password';
+
+const ENV: Env = {
+  PERSO_API_KEY: 'x',
+  ELEVENLABS_API_KEY: 'x',
+  TURSO_DATABASE_URL: 'x',
+  TURSO_AUTH_TOKEN: 'x',
+  GOOGLE_CLIENT_ID: 'x',
+  JWT_SECRET: 'test-secret-32-chars-or-longer-pls!',
+  PASSWORD_PEPPER: 'pepper-test',
+  ENVIRONMENT: 'test',
+};
+
+function buildApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route('/auth', authRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  mockDB.calls.length = 0;
+});
+
+describe('POST /auth/register', () => {
+  it('신규 가입 성공 → 201 + 토큰 반환', async () => {
+    mockDB.pushResult([]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/register', {
+        email: 'kim@test.com',
+        password: 'superSecret1',
+        name: '김규원',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.token).toMatch(/^[^.]+\.[^.]+\.[^.]+$/);
+    expect(body.user.email).toBe('kim@test.com');
+    expect(body.user.plan).toBe('free');
+  });
+
+  it('중복 이메일 → 409', async () => {
+    mockDB.pushResult([{ id: 'u-1' }]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/register', {
+        email: 'kim@test.com',
+        password: 'superSecret1',
+        name: '김규원',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe('AUTH_EMAIL_TAKEN');
+  });
+
+  it('약한 비밀번호 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/register', {
+        email: 'kim@test.com',
+        password: 'short',
+        name: '김규원',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('AUTH_VALIDATION_FAILED');
+  });
+
+  it('잘못된 이메일 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/register', {
+        email: 'not-email',
+        password: 'superSecret1',
+        name: '김규원',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('잘못된 JSON → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{not json',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /auth/login', () => {
+  it('올바른 자격증명으로 로그인 성공', async () => {
+    const hash = await hashPassword('superSecret1', ENV.PASSWORD_PEPPER);
+    mockDB.pushResult([
+      {
+        id: 'u-1',
+        email: 'kim@test.com',
+        password_hash: hash,
+        name: '김규원',
+        plan: 'plus',
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/login', {
+        email: 'kim@test.com',
+        password: 'superSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBeTruthy();
+    expect(body.user.plan).toBe('plus');
+  });
+
+  it('존재하지 않는 이메일 → 401', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/login', {
+        email: 'nouser@test.com',
+        password: 'superSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('비밀번호 불일치 → 401', async () => {
+    const hash = await hashPassword('superSecret1', ENV.PASSWORD_PEPPER);
+    mockDB.pushResult([
+      {
+        id: 'u-1',
+        email: 'kim@test.com',
+        password_hash: hash,
+        name: '김규원',
+        plan: 'free',
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/login', {
+        email: 'kim@test.com',
+        password: 'wrongPass1',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('OAuth 전용 계정(비밀번호 없음) → 401 OAUTH_ONLY', async () => {
+    mockDB.pushResult([
+      {
+        id: 'u-1',
+        email: 'kim@test.com',
+        password_hash: null,
+        name: '김규원',
+        plan: 'free',
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/login', {
+        email: 'kim@test.com',
+        password: 'superSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe('AUTH_OAUTH_ONLY');
+  });
+});
+
+describe('GET /auth/me', () => {
+  it('Authorization 헤더 없음 → 401', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/auth/me'), undefined, ENV);
+    expect(res.status).toBe(401);
+  });
+
+  it('가입 후 받은 토큰으로 /auth/me 호출 성공', async () => {
+    mockDB.pushResult([]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const regRes = await app.request(
+      jsonReq('POST', '/auth/register', {
+        email: 'kim@test.com',
+        password: 'superSecret1',
+        name: '김규원',
+      }),
+      undefined,
+      ENV,
+    );
+    const reg = await regRes.json();
+    const token = reg.token as string;
+
+    mockDB.pushResult([{ id: reg.user.id, email: 'kim@test.com', name: '김규원', plan: 'free' }]);
+
+    const meRes = await app.request(
+      new Request('http://localhost/auth/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      undefined,
+      ENV,
+    );
+    expect(meRes.status).toBe(200);
+    const meBody = await meRes.json();
+    expect(meBody.user.email).toBe('kim@test.com');
+  });
+
+  it('잘못된 토큰 → 401', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/auth/me', {
+        headers: { Authorization: 'Bearer garbage' },
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/backend/test/jwt.test.ts
+++ b/packages/backend/test/jwt.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { signAppJwt, verifyAppJwt, APP_JWT_ISSUER } from '../src/lib/jwt';
+
+const SECRET = 'test-secret-at-least-32-chars-long!';
+
+describe('appJwt', () => {
+  it('서명한 토큰은 같은 시크릿으로 검증 성공', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com', name: 'kim' }, SECRET);
+    const payload = await verifyAppJwt(token, SECRET);
+    expect(payload.sub).toBe('u1');
+    expect(payload.email).toBe('u@test.com');
+    expect(payload.iss).toBe(APP_JWT_ISSUER);
+  });
+
+  it('다른 시크릿으로 검증 시 실패', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com' }, SECRET);
+    await expect(verifyAppJwt(token, 'other-secret')).rejects.toThrow();
+  });
+
+  it('위조된 서명 거부', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com' }, SECRET);
+    const parts = token.split('.');
+    const tampered = `${parts[0]}.${parts[1]}.AAAAAAAAAAAAAAAAAAAA`;
+    await expect(verifyAppJwt(tampered, SECRET)).rejects.toThrow();
+  });
+
+  it('만료 토큰 거부', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com' }, SECRET, -60);
+    await expect(verifyAppJwt(token, SECRET)).rejects.toThrow(/expired/i);
+  });
+
+  it('형식 잘못된 토큰 거부', async () => {
+    await expect(verifyAppJwt('not-a-jwt', SECRET)).rejects.toThrow();
+  });
+
+  it('빈 시크릿으로 서명 거부', async () => {
+    await expect(signAppJwt({ sub: 'u1', email: 'u@test.com' }, '')).rejects.toThrow();
+  });
+});

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -44,4 +44,13 @@ describe('migrations', () => {
     expect(sample.id).toBe(999);
     expect(sample.name).toBe('test');
   });
+
+  it('마이그레이션 #2 에서 users 테이블 재생성 + password_hash 추가', () => {
+    const m = migrations.find((x) => x.id === 2);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('users_new');
+    expect(all).toContain('password_hash');
+    expect(all).toContain('idx_users_email_unique');
+  });
 });

--- a/packages/backend/test/password.test.ts
+++ b/packages/backend/test/password.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { hashPassword, verifyPassword, applyPepper } from '../src/lib/password';
+
+describe('password hashing', () => {
+  it('같은 비밀번호라도 해시가 매번 달라야 한다 (salt 무작위)', async () => {
+    const pepper = 'test-pepper';
+    const a = await hashPassword('correct-horse', pepper);
+    const b = await hashPassword('correct-horse', pepper);
+    expect(a).not.toBe(b);
+  });
+
+  it('올바른 비밀번호와 페퍼로 검증 성공', async () => {
+    const pepper = 'test-pepper';
+    const hash = await hashPassword('correct-horse', pepper);
+    expect(await verifyPassword('correct-horse', hash, pepper)).toBe(true);
+  });
+
+  it('잘못된 비밀번호는 검증 실패', async () => {
+    const pepper = 'test-pepper';
+    const hash = await hashPassword('correct-horse', pepper);
+    expect(await verifyPassword('wrong', hash, pepper)).toBe(false);
+  });
+
+  it('다른 페퍼로는 검증 실패 (pepper가 해시에 영향)', async () => {
+    const hash = await hashPassword('correct-horse', 'pepper-a');
+    expect(await verifyPassword('correct-horse', hash, 'pepper-b')).toBe(false);
+  });
+
+  it('빈 해시는 검증 실패', async () => {
+    expect(await verifyPassword('anything', '', 'pepper')).toBe(false);
+  });
+
+  it('applyPepper 는 페퍼를 비밀번호 뒤에 붙인다', () => {
+    expect(applyPepper('pw', 'sauce')).toBe('pw::sauce');
+  });
+});

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -11,3 +11,5 @@ ENVIRONMENT = "development"
 # TURSO_DATABASE_URL = ""
 # TURSO_AUTH_TOKEN = ""
 # FIREBASE_PROJECT_ID = ""
+# JWT_SECRET = ""          # 자체 발급 JWT HS256 서명 시크릿 (최소 32자 권장)
+# PASSWORD_PEPPER = ""     # bcrypt 해싱 전에 비밀번호에 덧붙일 서버측 페퍼

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schemas/user.js";
 export * from "./schemas/voice.js";
+export * from "./schemas/auth.js";

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const PasswordSchema = z
+  .string()
+  .min(8, '비밀번호는 최소 8자 이상이어야 합니다')
+  .max(128, '비밀번호는 최대 128자까지 허용됩니다');
+
+export const RegisterRequestSchema = z.object({
+  email: z.string().email(),
+  password: PasswordSchema,
+  name: z.string().min(1).max(64),
+});
+export type RegisterRequest = z.infer<typeof RegisterRequestSchema>;
+
+export const LoginRequestSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1).max(128),
+});
+export type LoginRequest = z.infer<typeof LoginRequestSchema>;
+
+export const AuthResponseSchema = z.object({
+  token: z.string().min(1),
+  user: z.object({
+    id: z.string().min(1),
+    email: z.string().email(),
+    name: z.string(),
+    plan: z.enum(['free', 'plus', 'family']),
+  }),
+});
+export type AuthResponse = z.infer<typeof AuthResponseSchema>;

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -4,6 +4,9 @@ import {
   UserSchema,
   VoiceProfileSchema,
   VoiceProfileStatusSchema,
+  RegisterRequestSchema,
+  LoginRequestSchema,
+  AuthResponseSchema,
 } from "../src/index.js";
 
 describe("UserPlanSchema", () => {
@@ -38,6 +41,65 @@ describe("UserSchema", () => {
         createdAt: "2026-04-17T00:00:00.000Z",
       }),
     ).toThrow();
+  });
+});
+
+describe("RegisterRequestSchema", () => {
+  it("accepts a well-formed registration", () => {
+    const r = RegisterRequestSchema.parse({
+      email: "kim@example.com",
+      password: "s3curepass!",
+      name: "김규원",
+    });
+    expect(r.email).toBe("kim@example.com");
+  });
+  it("rejects password shorter than 8 chars", () => {
+    expect(() =>
+      RegisterRequestSchema.parse({
+        email: "kim@example.com",
+        password: "short",
+        name: "kim",
+      }),
+    ).toThrow();
+  });
+  it("rejects malformed email", () => {
+    expect(() =>
+      RegisterRequestSchema.parse({
+        email: "not-an-email",
+        password: "s3curepass!",
+        name: "kim",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("LoginRequestSchema", () => {
+  it("accepts a login payload", () => {
+    const l = LoginRequestSchema.parse({
+      email: "kim@example.com",
+      password: "any-non-empty",
+    });
+    expect(l.password).toBe("any-non-empty");
+  });
+  it("rejects empty password", () => {
+    expect(() =>
+      LoginRequestSchema.parse({ email: "kim@example.com", password: "" }),
+    ).toThrow();
+  });
+});
+
+describe("AuthResponseSchema", () => {
+  it("accepts a valid auth response", () => {
+    const a = AuthResponseSchema.parse({
+      token: "eyJ.payload.sig",
+      user: {
+        id: "u_1",
+        email: "kim@example.com",
+        name: "김규원",
+        plan: "free",
+      },
+    });
+    expect(a.token).toContain("eyJ");
   });
 });
 


### PR DESCRIPTION
## 개요
- 이슈: #27
- 요약: Google/Apple OAuth 와 별개로 이메일+비밀번호 자체 가입·로그인 경로를 추가. bcryptjs 해싱 + 환경 페퍼, Web Crypto 기반 HS256 JWT 발급, 미들웨어에서 자체 JWT 수용.

## 변경 내용
- **DB 마이그레이션 #2 (`email-password-auth`)**: `users` 재생성 — `google_id` nullable, `password_hash` 컬럼, `email` UNIQUE. 기존 Google 사용자 행은 `INSERT ... SELECT` 로 보존.
- **`packages/backend/src/lib/password.ts`**: `hashPassword` / `verifyPassword` / `applyPepper`. bcryptjs 10 라운드 + 환경변수 `PASSWORD_PEPPER` 결합.
- **`packages/backend/src/lib/jwt.ts`**: HS256 서명/검증, `iss=voice-alarm`, `aud=voice-alarm-clients`, 기본 TTL 7일, 만료·서명·형식 검사.
- **`packages/backend/src/routes/auth.ts`**: `POST /api/auth/register`, `POST /api/auth/login`, `GET /api/auth/me`. zod 검증, 이메일 정규화, 중복 409, OAuth-only 계정 구분.
- **`packages/backend/src/middleware/auth.ts`**: `iss === voice-alarm` 이면 `verifyAppJwt` 로 분기. 기존 Google/Apple 경로 유지.
- **`@voice-alarm/shared`**: `RegisterRequestSchema`, `LoginRequestSchema`, `AuthResponseSchema`, `PasswordSchema` 추가.
- **wrangler.toml**: `JWT_SECRET`, `PASSWORD_PEPPER` 시크릿 가이드 주석 추가.
- **테스트 25건**:
  - `test/password.test.ts` (6) — 해시 무작위성, 페퍼 영향, 검증 성공/실패
  - `test/jwt.test.ts` (6) — 서명 검증, 위조/만료/형식 거부
  - `test/auth.test.ts` (11) — 가입/로그인/me 전체 시나리오, 검증 에러 코드
  - `test/schemas.test.ts` (+6) — shared 스키마
  - `test/migrations.test.ts` (+1) — 마이그레이션 #2 구조 검증

## 검증
- [x] `npm run lint` 통과 (신규 파일 0 에러, 기존 경고 12건 그대로)
- [x] `npm run typecheck` 통과
- [x] `npm test` 전체 통과 (backend 243, shared 18, web 2, mobile 2)
- [ ] 실제 Turso 환경 마이그레이션 적용은 다음 PR(수동 init-db 트리거)에서 확인

## 리스크 / 팔로업
- 마이그레이션 #2 는 `users` 테이블을 재생성하므로 FK 제약이 있는 테이블에서 참조 무결성 재확인 필요 — 다만 기존 FK 는 `users(id)` 기준이고 id 는 보존되므로 영향 없음.
- 프로덕션에 `JWT_SECRET`, `PASSWORD_PEPPER` 시크릿 등록 필수 (아직 미설정 — 배포 시점에 `wrangler secret put`).
- 비밀번호 재설정/이메일 인증은 별도 이슈로 분리.
- `authMiddleware` 가 `GOOGLE_CLIENT_ID` 비어도 자체 JWT 경로는 동작하도록 구성.