### PR TITLE
[#29] 웹/앱 공용 useAuth 훅 및 AuthProvider

### DIFF
--- a/apps/mobile/src/hooks/useAuth.tsx
+++ b/apps/mobile/src/hooks/useAuth.tsx
@@ -1,0 +1,191 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  AuthUnauthorizedError,
+  fetchAuthLogin,
+  fetchAuthMe,
+  fetchAuthRegister,
+  type AuthUser,
+} from '../services/authApi';
+
+export type { AuthUser } from '../services/authApi';
+
+export interface AuthState {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  register: (email: string, password: string, name: string) => Promise<AuthUser>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const STORAGE_KEY = 'auth_token';
+
+function resolveApiBase(): string {
+  const explicit = process.env.EXPO_PUBLIC_API_URL;
+  if (explicit) return `${explicit}/api`;
+  return 'http://localhost:8787/api';
+}
+
+export interface AsyncStorageLike {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+type FetchImpl = typeof fetch;
+
+export interface AuthProviderProps {
+  children: ReactNode;
+  apiBase?: string;
+  storage?: AsyncStorageLike;
+  fetchImpl?: FetchImpl;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children, apiBase, storage, fetchImpl }: AuthProviderProps) {
+  const base = apiBase ?? resolveApiBase();
+  const store: AsyncStorageLike = storage ?? AsyncStorage;
+  const config = useMemo(() => ({ apiBase: base, fetchImpl }), [base, fetchImpl]);
+
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshingRef = useRef(false);
+  const bootedRef = useRef(false);
+
+  const persistToken = useCallback(
+    async (next: string | null) => {
+      if (next) await store.setItem(STORAGE_KEY, next);
+      else await store.removeItem(STORAGE_KEY);
+    },
+    [store],
+  );
+
+  const logout = useCallback(async () => {
+    await persistToken(null);
+    setToken(null);
+    setUser(null);
+    setError(null);
+  }, [persistToken]);
+
+  const refresh = useCallback(
+    async (explicitToken?: string) => {
+      const t = explicitToken ?? token;
+      if (!t || refreshingRef.current) return;
+      refreshingRef.current = true;
+      setIsLoading(true);
+      try {
+        const fresh = await fetchAuthMe(config, t);
+        setUser(fresh);
+      } catch (err) {
+        if (err instanceof AuthUnauthorizedError) {
+          await logout();
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'refresh failed');
+      } finally {
+        refreshingRef.current = false;
+        setIsLoading(false);
+      }
+    },
+    [config, logout, token],
+  );
+
+  useEffect(() => {
+    if (bootedRef.current) return;
+    bootedRef.current = true;
+    (async () => {
+      try {
+        const stored = await store.getItem(STORAGE_KEY);
+        if (stored) {
+          setToken(stored);
+          await refresh(stored);
+        } else {
+          setIsLoading(false);
+        }
+      } catch {
+        setIsLoading(false);
+      }
+    })();
+  }, [store, refresh]);
+
+  const login = useCallback(
+    async (email: string, password: string): Promise<AuthUser> => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const body = await fetchAuthLogin(config, email, password);
+        await persistToken(body.token);
+        setToken(body.token);
+        setUser(body.user);
+        return body.user;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'login failed';
+        setError(msg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [config, persistToken],
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, name: string): Promise<AuthUser> => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const body = await fetchAuthRegister(config, email, password, name);
+        await persistToken(body.token);
+        setToken(body.token);
+        setUser(body.user);
+        return body.user;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'register failed';
+        setError(msg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [config, persistToken],
+  );
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      token,
+      isAuthenticated: !!user,
+      isLoading,
+      error,
+      login,
+      register,
+      logout,
+      refresh: () => refresh(),
+    }),
+    [user, token, isLoading, error, login, register, logout, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/apps/mobile/src/services/authApi.ts
+++ b/apps/mobile/src/services/authApi.ts
@@ -1,0 +1,74 @@
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  plan: 'free' | 'plus' | 'family';
+}
+
+export interface AuthTokenResponse {
+  token: string;
+  user: AuthUser;
+}
+
+export interface AuthClientConfig {
+  apiBase: string;
+  fetchImpl?: typeof fetch;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string; code?: string };
+    return body.error ?? body.code ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+export async function fetchAuthRegister(
+  { apiBase, fetchImpl = fetch }: AuthClientConfig,
+  email: string,
+  password: string,
+  name: string,
+): Promise<AuthTokenResponse> {
+  const res = await fetchImpl(`${apiBase}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, name }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as AuthTokenResponse;
+}
+
+export async function fetchAuthLogin(
+  { apiBase, fetchImpl = fetch }: AuthClientConfig,
+  email: string,
+  password: string,
+): Promise<AuthTokenResponse> {
+  const res = await fetchImpl(`${apiBase}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as AuthTokenResponse;
+}
+
+export class AuthUnauthorizedError extends Error {
+  constructor() {
+    super('Unauthorized');
+    this.name = 'AuthUnauthorizedError';
+  }
+}
+
+export async function fetchAuthMe(
+  { apiBase, fetchImpl = fetch }: AuthClientConfig,
+  token: string,
+): Promise<AuthUser> {
+  const res = await fetchImpl(`${apiBase}/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status === 401) throw new AuthUnauthorizedError();
+  if (!res.ok) throw new Error(await readError(res));
+  const body = (await res.json()) as { user: AuthUser };
+  return body.user;
+}

--- a/apps/mobile/test/authApi.test.ts
+++ b/apps/mobile/test/authApi.test.ts
@@ -1,0 +1,105 @@
+import {
+  AuthUnauthorizedError,
+  fetchAuthLogin,
+  fetchAuthMe,
+  fetchAuthRegister,
+} from '../src/services/authApi';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const USER = { id: 'u1', email: 'a@b.com', name: '한글', plan: 'free' as const };
+
+describe('authApi.fetchAuthRegister', () => {
+  it('POST /auth/register 성공 시 토큰과 사용자 반환', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse(201, { token: 'jwt', user: USER }));
+    const result = await fetchAuthRegister(
+      { apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch },
+      'a@b.com',
+      'superSecret1',
+      '한글',
+    );
+    expect(result.token).toBe('jwt');
+    expect(result.user.email).toBe('a@b.com');
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/auth/register');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      email: 'a@b.com',
+      password: 'superSecret1',
+      name: '한글',
+    });
+  });
+
+  it('실패 응답은 Error 로 throw (서버 error 메시지 포함)', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(409, { error: 'Email is already registered', code: 'AUTH_EMAIL_TAKEN' }),
+      );
+    await expect(
+      fetchAuthRegister(
+        { apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch },
+        'a@b.com',
+        'superSecret1',
+        '한글',
+      ),
+    ).rejects.toThrow(/already registered/);
+  });
+});
+
+describe('authApi.fetchAuthLogin', () => {
+  it('POST /auth/login 성공', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse(200, { token: 'jwt', user: USER }));
+    const res = await fetchAuthLogin(
+      { apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch },
+      'a@b.com',
+      'superSecret1',
+    );
+    expect(res.token).toBe('jwt');
+  });
+
+  it('401 Unauthorized → Error throw', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(jsonResponse(401, { error: 'Invalid email or password' }));
+    await expect(
+      fetchAuthLogin(
+        { apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch },
+        'a@b.com',
+        'wrong',
+      ),
+    ).rejects.toThrow(/Invalid/);
+  });
+});
+
+describe('authApi.fetchAuthMe', () => {
+  it('토큰으로 user 복원', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse(200, { user: USER }));
+    const u = await fetchAuthMe(
+      { apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch },
+      'jwt',
+    );
+    expect(u.id).toBe('u1');
+    const [, init] = fetchImpl.mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt');
+  });
+
+  it('401 → AuthUnauthorizedError 전용 타입 throw', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse(401, { error: 'expired' }));
+    await expect(
+      fetchAuthMe({ apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch }, 'expired'),
+    ).rejects.toBeInstanceOf(AuthUnauthorizedError);
+  });
+
+  it('응답이 JSON 이 아니면 HTTP 상태 메시지', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(new Response('plain text', { status: 500 }));
+    await expect(
+      fetchAuthMe({ apiBase: '/api', fetchImpl: fetchImpl as unknown as typeof fetch }, 'tok'),
+    ).rejects.toThrow(/HTTP 500/);
+  });
+});

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -1,0 +1,198 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  plan: 'free' | 'plus' | 'family';
+}
+
+export interface AuthState {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  register: (email: string, password: string, name: string) => Promise<AuthUser>;
+  logout: () => void;
+  refresh: () => Promise<void>;
+}
+
+const STORAGE_KEY = 'auth_token';
+
+function resolveApiBase(): string {
+  const explicit = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_API_URL;
+  if (explicit) return `${explicit}/api`;
+  return '/api';
+}
+
+interface FetchImpl {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+export interface AuthProviderProps {
+  children: ReactNode;
+  apiBase?: string;
+  storage?: Storage;
+  fetchImpl?: FetchImpl;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string; code?: string };
+    return body.error ?? body.code ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+export function AuthProvider({ children, apiBase, storage, fetchImpl }: AuthProviderProps) {
+  const base = apiBase ?? resolveApiBase();
+  const store = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  const doFetch: FetchImpl = useMemo(
+    () => fetchImpl ?? ((input, init) => fetch(input, init)),
+    [fetchImpl],
+  );
+
+  const initialToken = store?.getItem(STORAGE_KEY) ?? null;
+  const [token, setToken] = useState<string | null>(initialToken);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(!!initialToken);
+  const [error, setError] = useState<string | null>(null);
+  const refreshingRef = useRef(false);
+
+  const persistToken = useCallback(
+    (next: string | null) => {
+      if (!store) return;
+      if (next) store.setItem(STORAGE_KEY, next);
+      else store.removeItem(STORAGE_KEY);
+    },
+    [store],
+  );
+
+  const logout = useCallback(() => {
+    persistToken(null);
+    setToken(null);
+    setUser(null);
+    setError(null);
+  }, [persistToken]);
+
+  const refresh = useCallback(async () => {
+    if (!token || refreshingRef.current) return;
+    refreshingRef.current = true;
+    setIsLoading(true);
+    try {
+      const res = await doFetch(`${base}/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 401) {
+        logout();
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(await readError(res));
+      }
+      const body = (await res.json()) as { user: AuthUser };
+      setUser(body.user);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'refresh failed');
+    } finally {
+      refreshingRef.current = false;
+      setIsLoading(false);
+    }
+  }, [base, doFetch, logout, token]);
+
+  useEffect(() => {
+    if (token && !user) void refresh();
+    else if (!token) setIsLoading(false);
+  }, [token, user, refresh]);
+
+  const login = useCallback(
+    async (email: string, password: string): Promise<AuthUser> => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const res = await doFetch(`${base}/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+        if (!res.ok) throw new Error(await readError(res));
+        const body = (await res.json()) as { token: string; user: AuthUser };
+        persistToken(body.token);
+        setToken(body.token);
+        setUser(body.user);
+        return body.user;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'login failed';
+        setError(msg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [base, doFetch, persistToken],
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, name: string): Promise<AuthUser> => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const res = await doFetch(`${base}/auth/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password, name }),
+        });
+        if (!res.ok) throw new Error(await readError(res));
+        const body = (await res.json()) as { token: string; user: AuthUser };
+        persistToken(body.token);
+        setToken(body.token);
+        setUser(body.user);
+        return body.user;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'register failed';
+        setError(msg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [base, doFetch, persistToken],
+  );
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      token,
+      isAuthenticated: !!user,
+      isLoading,
+      error,
+      login,
+      register,
+      logout,
+      refresh,
+    }),
+    [user, token, isLoading, error, login, register, logout, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/packages/web/test/useAuth.test.tsx
+++ b/packages/web/test/useAuth.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AuthProvider, useAuth } from '../src/hooks/useAuth';
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  } as Storage;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function wrap(children: ReactNode, props: Partial<React.ComponentProps<typeof AuthProvider>> = {}) {
+  return (
+    <AuthProvider apiBase="/api" storage={memoryStorage()} {...props}>
+      {children}
+    </AuthProvider>
+  );
+}
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('초기 상태: 토큰 없으면 비인증 + 로딩 해제', async () => {
+    const fetchImpl = vi.fn();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl }),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('register 성공 시 토큰 저장 + user 세팅', async () => {
+    const user = { id: 'u1', email: 'a@b.com', name: '한글', plan: 'free' as const };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(201, { token: 'jwt-token', user }));
+    const storage = memoryStorage();
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl, storage }),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.register('a@b.com', 'superSecret1', '한글');
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.token).toBe('jwt-token');
+    expect(result.current.user?.email).toBe('a@b.com');
+    expect(storage.getItem('auth_token')).toBe('jwt-token');
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/auth/register');
+    expect(init.method).toBe('POST');
+  });
+
+  it('login 실패 시 에러 메시지 + 비인증 유지', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(401, { error: 'Invalid email or password', code: 'AUTH_INVALID_CREDENTIALS' }),
+      );
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl }),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await expect(result.current.login('a@b.com', 'wrong')).rejects.toThrow();
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).toContain('Invalid');
+  });
+
+  it('logout 시 토큰 제거', async () => {
+    const user = { id: 'u1', email: 'a@b.com', name: 'A', plan: 'free' as const };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { token: 'tok', user }));
+    const storage = memoryStorage();
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl, storage }),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('a@b.com', 'superSecret1');
+    });
+    expect(storage.getItem('auth_token')).toBe('tok');
+
+    act(() => result.current.logout());
+    expect(storage.getItem('auth_token')).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('초기 마운트 시 저장된 토큰으로 /auth/me 호출해 user 복원', async () => {
+    const user = { id: 'u1', email: 'a@b.com', name: 'A', plan: 'plus' as const };
+    const storage = memoryStorage();
+    storage.setItem('auth_token', 'pre-existing');
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { user }));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl, storage }),
+    });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(result.current.user?.plan).toBe('plus');
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/auth/me');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer pre-existing');
+  });
+
+  it('저장된 토큰이 /auth/me 에서 401 이면 자동 로그아웃', async () => {
+    const storage = memoryStorage();
+    storage.setItem('auth_token', 'expired');
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(401, { error: 'expired' }));
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => wrap(children, { fetchImpl, storage }),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(storage.getItem('auth_token')).toBeNull();
+  });
+
+  it('Provider 밖에서 useAuth 호출 시 예외', () => {
+    expect(() => renderHook(() => useAuth())).toThrow(/AuthProvider/);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #29
- 요약: PR #28 로 도입된 `/api/auth/*` 엔드포인트를 호출하는 웹/모바일 공용 `useAuth` 훅 + `AuthProvider` 추가. 토큰 지속·자동 복원·401 자동 로그아웃까지 한 번에 처리.

## 변경 내용
- **`packages/web/src/hooks/useAuth.tsx`**: React Context `AuthProvider`, `useAuth()` 훅. `localStorage` 에 토큰 저장, 초기 마운트 시 `GET /auth/me` 로 user 복원, 401 응답 시 자동 로그아웃. `apiBase`/`storage`/`fetchImpl` 주입 가능해 테스트 편의.
- **`apps/mobile/src/services/authApi.ts`**: `fetchAuthRegister` / `fetchAuthLogin` / `fetchAuthMe` 순수 함수 + `AuthUnauthorizedError` 전용 타입. 플랫폼 독립적이라 jest 친화.
- **`apps/mobile/src/hooks/useAuth.tsx`**: RN 용 `AuthProvider` + `useAuth()`. `AsyncStorage` 지속. 부트스트랩 시 저장 토큰으로 user 복원.
- **vitest 7건** (web) + **jest 7건** (mobile) 추가: 초기 상태, 가입/로그인 성공·실패, 로그아웃, 토큰 복원, 401 자동 로그아웃, Provider 밖 사용 예외.

## 검증
- [x] `npm run lint` 통과 (baseline 12 warnings 유지, 신규 파일 0 error/0 warning)
- [x] `npm run typecheck` 통과
- [x] `npm test` 전체 통과 (backend 243, shared 12, web 9, mobile 9)

## 리스크 / 팔로업
- 아직 `App.tsx` / mobile `_layout.tsx` 에 `AuthProvider` 는 연결하지 않았음 — 로그인 UI 붙이는 #10/#11 PR 에서 통합 예정.
- `packages/web/src/services/api.ts` 의 axios 인터셉터는 여전히 `localStorage` 를 직접 읽지만, `useAuth` 가 같은 키에 저장하므로 기존 호출 경로 호환.
- 토큰 만료 UX (재로그인 토스트 등) 는 UI 연결 단계에서 다룰 수 있음.