### PR TITLE
[#31] 웹 로그인·가입 화면 (이메일+비밀번호)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import LoginPage from './components/LoginPage';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useDarkMode } from './hooks/useDarkMode';
+import { useAuth } from './hooks/useAuth';
 
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const VoicesPage = lazy(() => import('./pages/VoicesPage'));
@@ -25,27 +26,28 @@ const NAV_ITEMS: { key: Page; label: string; emoji: string }[] = [
 
 export default function App() {
   const [page, setPage] = useState<Page>('dashboard');
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const darkMode = useDarkMode();
+  const { isAuthenticated, isLoading, logout } = useAuth();
 
-  useEffect(() => {
-    const token = localStorage.getItem('auth_token');
-    setIsLoggedIn(!!token);
-  }, []);
+  if (isLoading) {
+    return (
+      <div
+        className="min-h-screen flex items-center justify-center bg-[var(--color-bg)]"
+        role="status"
+        aria-label="인증 확인 중"
+      >
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
 
-  const handleLogin = (idToken: string) => {
-    localStorage.setItem('auth_token', idToken);
-    setIsLoggedIn(true);
-  };
+  if (!isAuthenticated) {
+    return <LoginPage />;
+  }
 
   const handleLogout = () => {
-    localStorage.removeItem('auth_token');
-    setIsLoggedIn(false);
+    logout();
   };
-
-  if (!isLoggedIn) {
-    return <LoginPage onLogin={handleLogin} />;
-  }
 
   const renderPage = () => {
     switch (page) {

--- a/packages/web/src/components/EmailPasswordForm.tsx
+++ b/packages/web/src/components/EmailPasswordForm.tsx
@@ -1,0 +1,134 @@
+import { useState, type FormEvent } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+type Mode = 'login' | 'register';
+
+export interface EmailPasswordFormProps {
+  defaultMode?: Mode;
+  onSuccess?: () => void;
+}
+
+export default function EmailPasswordForm({
+  defaultMode = 'login',
+  onSuccess,
+}: EmailPasswordFormProps) {
+  const { login, register, isLoading } = useAuth();
+
+  const [mode, setMode] = useState<Mode>(defaultMode);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const isRegister = mode === 'register';
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitError(null);
+
+    if (!email || !password || (isRegister && !name)) {
+      setSubmitError('모든 필드를 입력해주세요.');
+      return;
+    }
+    if (isRegister && password.length < 8) {
+      setSubmitError('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+
+    try {
+      if (isRegister) await register(email, password, name);
+      else await login(email, password);
+      onSuccess?.();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : '요청 처리 중 오류가 발생했습니다.');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-full" aria-label="이메일 로그인">
+      <div className="flex gap-2 text-sm" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'login'}
+          onClick={() => setMode('login')}
+          className={`flex-1 py-2 rounded-lg transition-colors ${
+            mode === 'login'
+              ? 'bg-[var(--color-primary)]/10 text-[var(--color-primary)] font-semibold'
+              : 'text-[var(--color-text-secondary)]'
+          }`}
+        >
+          로그인
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'register'}
+          onClick={() => setMode('register')}
+          className={`flex-1 py-2 rounded-lg transition-colors ${
+            mode === 'register'
+              ? 'bg-[var(--color-primary)]/10 text-[var(--color-primary)] font-semibold'
+              : 'text-[var(--color-text-secondary)]'
+          }`}
+        >
+          가입하기
+        </button>
+      </div>
+
+      {isRegister && (
+        <label className="flex flex-col gap-1 text-left">
+          <span className="text-xs text-[var(--color-text-secondary)]">이름</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="홍길동"
+            className="px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
+            autoComplete="name"
+            required
+          />
+        </label>
+      )}
+
+      <label className="flex flex-col gap-1 text-left">
+        <span className="text-xs text-[var(--color-text-secondary)]">이메일</span>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
+          autoComplete="email"
+          required
+        />
+      </label>
+
+      <label className="flex flex-col gap-1 text-left">
+        <span className="text-xs text-[var(--color-text-secondary)]">비밀번호</span>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder={isRegister ? '8자 이상' : '비밀번호'}
+          className="px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)]"
+          autoComplete={isRegister ? 'new-password' : 'current-password'}
+          required
+        />
+      </label>
+
+      {submitError && (
+        <p role="alert" className="text-sm text-red-500">
+          {submitError}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="mt-1 py-2.5 rounded-lg bg-[var(--color-primary)] text-white font-semibold disabled:opacity-60"
+      >
+        {isLoading ? '처리 중…' : isRegister ? '가입하기' : '로그인'}
+      </button>
+    </form>
+  );
+}

--- a/packages/web/src/components/LoginPage.tsx
+++ b/packages/web/src/components/LoginPage.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import EmailPasswordForm from './EmailPasswordForm';
+import { useAuth } from '../hooks/useAuth';
 
 declare const google:
   | {
@@ -16,14 +18,14 @@ declare const google:
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
 
-interface LoginPageProps {
-  onLogin: (idToken: string) => void;
-}
-
-export default function LoginPage({ onLogin }: LoginPageProps) {
+export default function LoginPage() {
   const googleButtonRef = useRef<HTMLDivElement>(null);
+  const { loginWithToken } = useAuth();
+  const [googleError, setGoogleError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!GOOGLE_CLIENT_ID) return;
+
     const script = document.createElement('script');
     script.src = 'https://accounts.google.com/gsi/client';
     script.async = true;
@@ -32,7 +34,9 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
       google?.accounts.id.initialize({
         client_id: GOOGLE_CLIENT_ID,
         callback: (response: { credential: string }) => {
-          onLogin(response.credential);
+          loginWithToken(response.credential).catch((err: unknown) => {
+            setGoogleError(err instanceof Error ? err.message : 'Google 로그인 실패');
+          });
         },
       });
       if (googleButtonRef.current) {
@@ -49,40 +53,52 @@ export default function LoginPage({ onLogin }: LoginPageProps) {
     document.body.appendChild(script);
 
     return () => {
-      document.body.removeChild(script);
+      if (script.parentNode) document.body.removeChild(script);
     };
-  }, []);
+  }, [loginWithToken]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg)]">
-      <div className="bg-[var(--color-surface)] rounded-3xl p-12 shadow-lg max-w-md w-full text-center transition-colors">
-        <p className="text-6xl mb-6">🎙️</p>
+    <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg)] p-4">
+      <div className="bg-[var(--color-surface)] rounded-3xl p-8 md:p-10 shadow-lg max-w-md w-full text-center transition-colors">
+        <p className="text-6xl mb-4">🎙️</p>
         <h1 className="text-3xl font-bold text-[var(--color-text)] mb-2">VoiceAlarm</h1>
-        <p className="text-[var(--color-text-secondary)] mb-8">
+        <p className="text-[var(--color-text-secondary)] mb-6">
           소중한 사람의 목소리로
           <br />
           매일 따뜻한 메시지를 받아보세요
         </p>
 
-        <div className="flex flex-col items-center gap-4">
-          <div ref={googleButtonRef} />
+        <EmailPasswordForm />
 
-          {!GOOGLE_CLIENT_ID && (
+        <div className="flex items-center gap-3 my-6" aria-hidden="true">
+          <div className="flex-1 h-px bg-[var(--color-border)]" />
+          <span className="text-xs text-[var(--color-text-tertiary)]">또는</span>
+          <div className="flex-1 h-px bg-[var(--color-border)]" />
+        </div>
+
+        <div className="flex flex-col items-center gap-3">
+          {GOOGLE_CLIENT_ID ? (
+            <div ref={googleButtonRef} />
+          ) : (
             <div
               role="alert"
-              className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4 text-sm text-yellow-700 dark:text-yellow-400"
+              className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4 text-xs text-yellow-700 dark:text-yellow-400 text-left"
             >
-              <p className="font-semibold mb-1">Google Client ID 필요</p>
+              <p className="font-semibold mb-1">Google 로그인 비활성</p>
               <p>
-                <code>packages/web/src/components/LoginPage.tsx</code>에서
-                <br />
-                <code>GOOGLE_CLIENT_ID</code>를 설정해주세요.
+                <code>VITE_GOOGLE_CLIENT_ID</code>가 설정되지 않았습니다. 이메일 로그인은 정상
+                동작합니다.
               </p>
             </div>
           )}
+          {googleError && (
+            <p role="alert" className="text-sm text-red-500">
+              {googleError}
+            </p>
+          )}
         </div>
 
-        <p className="text-xs text-[var(--color-text-tertiary)] mt-8">
+        <p className="text-xs text-[var(--color-text-tertiary)] mt-6">
           로그인 시 이용약관 및 개인정보처리방침에 동의합니다.
         </p>
       </div>

--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -24,6 +24,7 @@ export interface AuthState {
   error: string | null;
   login: (email: string, password: string) => Promise<AuthUser>;
   register: (email: string, password: string, name: string) => Promise<AuthUser>;
+  loginWithToken: (token: string) => Promise<AuthUser | null>;
   logout: () => void;
   refresh: () => Promise<void>;
 }
@@ -146,6 +147,37 @@ export function AuthProvider({ children, apiBase, storage, fetchImpl }: AuthProv
     [base, doFetch, persistToken],
   );
 
+  const loginWithToken = useCallback(
+    async (nextToken: string): Promise<AuthUser | null> => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        persistToken(nextToken);
+        setToken(nextToken);
+        const res = await doFetch(`${base}/auth/me`, {
+          headers: { Authorization: `Bearer ${nextToken}` },
+        });
+        if (res.status === 401) {
+          persistToken(null);
+          setToken(null);
+          setUser(null);
+          throw new Error(await readError(res));
+        }
+        if (!res.ok) throw new Error(await readError(res));
+        const body = (await res.json()) as { user: AuthUser };
+        setUser(body.user);
+        return body.user;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'login failed';
+        setError(msg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [base, doFetch, persistToken],
+  );
+
   const register = useCallback(
     async (email: string, password: string, name: string): Promise<AuthUser> => {
       setError(null);
@@ -182,10 +214,11 @@ export function AuthProvider({ children, apiBase, storage, fetchImpl }: AuthProv
       error,
       login,
       register,
+      loginWithToken,
       logout,
       refresh,
     }),
-    [user, token, isLoading, error, login, register, logout, refresh],
+    [user, token, isLoading, error, login, register, loginWithToken, logout, refresh],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+import { AuthProvider } from './hooks/useAuth';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -11,7 +12,9 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/packages/web/test/EmailPasswordForm.test.tsx
+++ b/packages/web/test/EmailPasswordForm.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import EmailPasswordForm from '../src/components/EmailPasswordForm';
+import { AuthProvider } from '../src/hooks/useAuth';
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  } as Storage;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function wrap(children: ReactNode, fetchImpl: typeof fetch) {
+  return (
+    <AuthProvider apiBase="/api" storage={memoryStorage()} fetchImpl={fetchImpl}>
+      {children}
+    </AuthProvider>
+  );
+}
+
+function type(el: HTMLElement, value: string) {
+  fireEvent.change(el, { target: { value } });
+}
+
+describe('EmailPasswordForm', () => {
+  it('기본은 로그인 탭이며 이름 필드가 보이지 않는다', () => {
+    const fetchImpl = vi.fn();
+    render(wrap(<EmailPasswordForm />, fetchImpl as unknown as typeof fetch));
+    expect(screen.getByRole('tab', { name: '로그인' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.queryByPlaceholderText('홍길동')).toBeNull();
+  });
+
+  it('가입 탭으로 전환하면 이름 필드가 나타난다', () => {
+    const fetchImpl = vi.fn();
+    render(wrap(<EmailPasswordForm />, fetchImpl as unknown as typeof fetch));
+    fireEvent.click(screen.getByRole('tab', { name: '가입하기' }));
+    expect(screen.getByRole('tab', { name: '가입하기' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByPlaceholderText('홍길동')).not.toBeNull();
+  });
+
+  it('가입 시 비밀번호가 8자 미만이면 에러 메시지 표시', async () => {
+    const fetchImpl = vi.fn();
+    render(wrap(<EmailPasswordForm />, fetchImpl as unknown as typeof fetch));
+    fireEvent.click(screen.getByRole('tab', { name: '가입하기' }));
+
+    type(screen.getByPlaceholderText('홍길동'), '홍길동');
+    type(screen.getByPlaceholderText('you@example.com'), 'a@b.com');
+    type(screen.getByPlaceholderText('8자 이상'), 'short');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '가입하기' }));
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('8자');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('로그인 성공 시 onSuccess 콜백이 호출된다', async () => {
+    const apiUser = { id: 'u1', email: 'a@b.com', name: 'A', plan: 'free' as const };
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { token: 'jwt-x', user: apiUser }));
+    const onSuccess = vi.fn();
+
+    render(wrap(<EmailPasswordForm onSuccess={onSuccess} />, fetchImpl as unknown as typeof fetch));
+
+    type(screen.getByPlaceholderText('you@example.com'), 'a@b.com');
+    type(screen.getByPlaceholderText('비밀번호'), 'superSecret1');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '로그인' }));
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/auth/login');
+    expect(init.method).toBe('POST');
+  });
+
+  it('서버 401 응답 시 에러 메시지 표시 + onSuccess 미호출', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(401, { error: 'Invalid email or password', code: 'AUTH_INVALID_CREDENTIALS' }),
+      );
+    const onSuccess = vi.fn();
+
+    render(wrap(<EmailPasswordForm onSuccess={onSuccess} />, fetchImpl as unknown as typeof fetch));
+
+    type(screen.getByPlaceholderText('you@example.com'), 'a@b.com');
+    type(screen.getByPlaceholderText('비밀번호'), 'wrongPass1');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '로그인' }));
+    });
+
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeNull());
+    expect(screen.getByRole('alert').textContent).toMatch(/Invalid/);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 요약

Phase 2 #10 — 웹 대시보드에 이메일+비밀번호 로그인/가입 UI 추가.

- **EmailPasswordForm** (신규): 로그인/가입 탭 토글, 필드 검증, 제출 중 버튼 비활성화, 에러 메시지 표시.
- **LoginPage**: 기존 Google 버튼만 있던 카드에 이메일 폼을 기본 경로로 배치. Google 로그인은 `loginWithToken` 으로 일원화.
- **useAuth**: `loginWithToken(idToken)` 메서드 추가 — 외부 토큰(Google idToken 등) 저장 후 `/auth/me` 로 user 복원.
- **App.tsx**: `useState<isLoggedIn>` + `localStorage` 직접 접근 제거 → `useAuth().isAuthenticated` 로 통합. 초기 로딩 스피너 추가.
- **main.tsx**: `AuthProvider` 로 앱 루트 래핑.

## 검증

- [x] `npm test` — backend 242 / shared 12 / web 14 / mobile 9 = **277 건 통과**
- [x] `npm run lint` — 0 errors (기존 경고만)
- [x] `npm run typecheck` — backend / shared / web / mobile 모두 통과
- [x] 새 테스트 5건: 탭 전환, 이름 필드 표시, 비밀번호 8자 검증, 로그인 성공 콜백, 401 에러 메시지

## 참고

- perso.ai / ElevenLabs / 결제 PG 실호출 없음 (이번 이슈 범위 외)
- 다음 이슈: #11 모바일 로그인·가입 화면

Closes #31