### PR TITLE
[#33] 모바일 로그인·가입 화면 (이메일+비밀번호)

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import { getAlarms, getMessages, getStats } from '../../src/services/api';
 import type { Stats, WeekTrend } from '../../src/services/api';
 import { playAudio, getLocalAudioPath, isAudioCached } from '../../src/services/audio';
 import LoginButtons from '../../src/components/LoginButtons';
+import EmailPasswordForm from '../../src/components/EmailPasswordForm';
 import { useAppStore } from '../../src/stores/useAppStore';
 import { useNetworkStatus } from '../../src/hooks/useNetworkStatus';
 import {
@@ -193,9 +194,16 @@ export default function HomeScreen() {
               {stats.trends && <TrendBadge trend={stats.trends.friends} />}
             </View>
             {stats.gifts.receivedPending > 0 && (
-              <TouchableOpacity style={styles.statItem} onPress={() => router.push('/gift/received')}>
-                <Text style={[styles.statCount, { color: Colors.light.accent }]}>{stats.gifts.receivedPending}</Text>
-                <Text style={[styles.statLabel, { color: Colors.light.accent }]}>{t('home.pendingGifts', '대기 선물')}</Text>
+              <TouchableOpacity
+                style={styles.statItem}
+                onPress={() => router.push('/gift/received')}
+              >
+                <Text style={[styles.statCount, { color: Colors.light.accent }]}>
+                  {stats.gifts.receivedPending}
+                </Text>
+                <Text style={[styles.statLabel, { color: Colors.light.accent }]}>
+                  {t('home.pendingGifts', '대기 선물')}
+                </Text>
               </TouchableOpacity>
             )}
           </View>
@@ -307,6 +315,12 @@ export default function HomeScreen() {
             <Text style={styles.loginEmoji}>🔐</Text>
             <Text style={styles.loginTitle}>{t('home.loginTitle')}</Text>
             <Text style={styles.loginDesc}>{t('home.loginDesc')}</Text>
+            <EmailPasswordForm />
+            <View style={styles.loginDivider}>
+              <View style={styles.loginDividerLine} />
+              <Text style={styles.loginDividerText}>또는</Text>
+              <View style={styles.loginDividerLine} />
+            </View>
             <LoginButtons />
           </View>
         )}
@@ -492,6 +506,22 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: Spacing.lg,
+  },
+  loginDivider: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginVertical: Spacing.md,
+    width: '100%',
+  },
+  loginDividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: Colors.light.border,
+  },
+  loginDividerText: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
   },
   statsErrorCard: {
     backgroundColor: Colors.light.surface,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import {
   SNOOZE_ACTION,
 } from '../src/services/notifications';
 import { OfflineBanner } from '../src/components/OfflineBanner';
+import { AuthProvider } from '../src/hooks/useAuth';
 import '../src/i18n';
 
 const queryClient = new QueryClient({
@@ -84,62 +85,80 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
-        <StatusBar style="dark" />
-        <OfflineBanner />
-        <Stack
-          screenOptions={{
-            headerShown: false,
-            contentStyle: { backgroundColor: '#FFF5F3' },
-            animation: 'slide_from_right',
-          }}
-        >
-          <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="onboarding" options={{ animation: 'fade' }} />
-          <Stack.Screen
-            name="voice/[id]"
-            options={{ headerShown: true, title: t('screen.voiceDetail') }}
-          />
-          <Stack.Screen
-            name="voice/record"
-            options={{ headerShown: true, title: t('screen.voiceRecord'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="voice/upload"
-            options={{ headerShown: true, title: t('screen.fileUpload'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="voice/diarize"
-            options={{ headerShown: true, title: t('screen.diarize'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="alarm/create"
-            options={{ headerShown: true, title: t('screen.alarmSetting'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="alarm/edit"
-            options={{ headerShown: true, title: t('alarmEdit.title'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="message/[id]"
-            options={{ headerShown: true, title: t('messageDetail.title'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="message/create"
-            options={{ headerShown: true, title: t('screen.writeMessage'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="gift/received"
-            options={{ headerShown: true, title: t('screen.receivedGifts'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="dub/translate"
-            options={{ headerShown: true, title: t('dub.title'), presentation: 'modal' }}
-          />
-          <Stack.Screen
-            name="player"
-            options={{ presentation: 'transparentModal', animation: 'fade' }}
-          />
-        </Stack>
+        <AuthProvider>
+          <StatusBar style="dark" />
+          <OfflineBanner />
+          <Stack
+            screenOptions={{
+              headerShown: false,
+              contentStyle: { backgroundColor: '#FFF5F3' },
+              animation: 'slide_from_right',
+            }}
+          >
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="onboarding" options={{ animation: 'fade' }} />
+            <Stack.Screen
+              name="voice/[id]"
+              options={{ headerShown: true, title: t('screen.voiceDetail') }}
+            />
+            <Stack.Screen
+              name="voice/record"
+              options={{ headerShown: true, title: t('screen.voiceRecord'), presentation: 'modal' }}
+            />
+            <Stack.Screen
+              name="voice/upload"
+              options={{ headerShown: true, title: t('screen.fileUpload'), presentation: 'modal' }}
+            />
+            <Stack.Screen
+              name="voice/diarize"
+              options={{ headerShown: true, title: t('screen.diarize'), presentation: 'modal' }}
+            />
+            <Stack.Screen
+              name="alarm/create"
+              options={{
+                headerShown: true,
+                title: t('screen.alarmSetting'),
+                presentation: 'modal',
+              }}
+            />
+            <Stack.Screen
+              name="alarm/edit"
+              options={{ headerShown: true, title: t('alarmEdit.title'), presentation: 'modal' }}
+            />
+            <Stack.Screen
+              name="message/[id]"
+              options={{
+                headerShown: true,
+                title: t('messageDetail.title'),
+                presentation: 'modal',
+              }}
+            />
+            <Stack.Screen
+              name="message/create"
+              options={{
+                headerShown: true,
+                title: t('screen.writeMessage'),
+                presentation: 'modal',
+              }}
+            />
+            <Stack.Screen
+              name="gift/received"
+              options={{
+                headerShown: true,
+                title: t('screen.receivedGifts'),
+                presentation: 'modal',
+              }}
+            />
+            <Stack.Screen
+              name="dub/translate"
+              options={{ headerShown: true, title: t('dub.title'), presentation: 'modal' }}
+            />
+            <Stack.Screen
+              name="player"
+              options={{ presentation: 'transparentModal', animation: 'fade' }}
+            />
+          </Stack>
+        </AuthProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
   );

--- a/apps/mobile/src/components/EmailPasswordForm.tsx
+++ b/apps/mobile/src/components/EmailPasswordForm.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useAuth } from '../hooks/useAuth';
+import { useAppStore } from '../stores/useAppStore';
+import { BorderRadius, Colors, FontSize, Spacing } from '../constants/theme';
+import { validateEmailPasswordForm, type AuthMode } from '../lib/authFormValidation';
+
+export type Mode = AuthMode;
+
+export interface EmailPasswordFormProps {
+  defaultMode?: Mode;
+  onSuccess?: () => void;
+}
+
+export default function EmailPasswordForm({
+  defaultMode = 'login',
+  onSuccess,
+}: EmailPasswordFormProps) {
+  const { login, register, isLoading, token, user: authUser } = useAuth();
+  const setAppAuth = useAppStore((s) => s.setAuth);
+
+  const [mode, setMode] = useState<Mode>(defaultMode);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const isRegister = mode === 'register';
+
+  useEffect(() => {
+    if (token && authUser) {
+      setAppAuth(token, authUser.id);
+    }
+  }, [token, authUser, setAppAuth]);
+
+  async function handleSubmit() {
+    setSubmitError(null);
+    const err = validateEmailPasswordForm({ mode, email, password, name });
+    if (err) {
+      setSubmitError(err);
+      return;
+    }
+    try {
+      if (isRegister) await register(email, password, name);
+      else await login(email, password);
+      onSuccess?.();
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : '요청 처리 중 오류가 발생했습니다.');
+    }
+  }
+
+  return (
+    <View style={styles.container} accessibilityLabel="이메일 로그인">
+      <View style={styles.tabRow}>
+        <TouchableOpacity
+          accessibilityRole="tab"
+          accessibilityState={{ selected: mode === 'login' }}
+          onPress={() => setMode('login')}
+          style={[styles.tab, mode === 'login' && styles.tabActive]}
+        >
+          <Text style={[styles.tabText, mode === 'login' && styles.tabTextActive]}>로그인</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="tab"
+          accessibilityState={{ selected: mode === 'register' }}
+          onPress={() => setMode('register')}
+          style={[styles.tab, mode === 'register' && styles.tabActive]}
+        >
+          <Text style={[styles.tabText, mode === 'register' && styles.tabTextActive]}>
+            가입하기
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {isRegister && (
+        <View style={styles.field}>
+          <Text style={styles.label}>이름</Text>
+          <TextInput
+            value={name}
+            onChangeText={setName}
+            placeholder="홍길동"
+            placeholderTextColor={Colors.light.textTertiary}
+            autoComplete="name"
+            style={styles.input}
+            accessibilityLabel="이름"
+          />
+        </View>
+      )}
+
+      <View style={styles.field}>
+        <Text style={styles.label}>이메일</Text>
+        <TextInput
+          value={email}
+          onChangeText={setEmail}
+          placeholder="you@example.com"
+          placeholderTextColor={Colors.light.textTertiary}
+          autoComplete="email"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          style={styles.input}
+          accessibilityLabel="이메일"
+        />
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>비밀번호</Text>
+        <TextInput
+          value={password}
+          onChangeText={setPassword}
+          placeholder={isRegister ? '8자 이상' : '비밀번호'}
+          placeholderTextColor={Colors.light.textTertiary}
+          autoComplete={isRegister ? 'new-password' : 'current-password'}
+          secureTextEntry
+          style={styles.input}
+          accessibilityLabel="비밀번호"
+        />
+      </View>
+
+      {submitError && (
+        <Text style={styles.errorText} accessibilityRole="alert">
+          {submitError}
+        </Text>
+      )}
+
+      <TouchableOpacity
+        onPress={handleSubmit}
+        disabled={isLoading}
+        style={[styles.submitButton, isLoading && styles.submitButtonDisabled]}
+        accessibilityRole="button"
+        accessibilityLabel={isRegister ? '가입하기' : '로그인'}
+      >
+        {isLoading ? (
+          <ActivityIndicator color="#FFFFFF" />
+        ) : (
+          <Text style={styles.submitText}>{isRegister ? '가입하기' : '로그인'}</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    gap: Spacing.sm,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    gap: Spacing.xs,
+    marginBottom: Spacing.xs,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+  },
+  tabActive: {
+    backgroundColor: Colors.light.surfaceVariant,
+  },
+  tabText: {
+    fontSize: FontSize.sm,
+    color: Colors.light.textSecondary,
+  },
+  tabTextActive: {
+    color: Colors.light.primary,
+    fontWeight: '600',
+  },
+  field: {
+    gap: 4,
+  },
+  label: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textSecondary,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    color: Colors.light.text,
+    backgroundColor: Colors.light.surface,
+    fontSize: FontSize.md,
+  },
+  errorText: {
+    color: Colors.light.error,
+    fontSize: FontSize.sm,
+  },
+  submitButton: {
+    marginTop: Spacing.xs,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.light.primary,
+    alignItems: 'center',
+  },
+  submitButtonDisabled: {
+    opacity: 0.6,
+  },
+  submitText: {
+    color: '#FFFFFF',
+    fontSize: FontSize.md,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/lib/authFormValidation.ts
+++ b/apps/mobile/src/lib/authFormValidation.ts
@@ -1,0 +1,16 @@
+export type AuthMode = 'login' | 'register';
+
+export interface EmailPasswordFormValues {
+  mode: AuthMode;
+  email: string;
+  password: string;
+  name: string;
+}
+
+export function validateEmailPasswordForm(values: EmailPasswordFormValues): string | null {
+  const { mode, email, password, name } = values;
+  if (!email.trim() || !password) return '모든 필드를 입력해주세요.';
+  if (mode === 'register' && !name.trim()) return '모든 필드를 입력해주세요.';
+  if (mode === 'register' && password.length < 8) return '비밀번호는 최소 8자 이상이어야 합니다.';
+  return null;
+}

--- a/apps/mobile/test/emailPasswordForm.test.ts
+++ b/apps/mobile/test/emailPasswordForm.test.ts
@@ -1,0 +1,80 @@
+import { validateEmailPasswordForm } from '../src/lib/authFormValidation';
+
+describe('validateEmailPasswordForm', () => {
+  it('로그인: 이메일/비밀번호 모두 있으면 null', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'login',
+        email: 'a@b.com',
+        password: 'anything',
+        name: '',
+      }),
+    ).toBeNull();
+  });
+
+  it('로그인: 이메일 공백이면 "모든 필드" 에러', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'login',
+        email: '   ',
+        password: 'pw',
+        name: '',
+      }),
+    ).toContain('모든 필드');
+  });
+
+  it('로그인: 비밀번호 누락이면 에러', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'login',
+        email: 'a@b.com',
+        password: '',
+        name: '',
+      }),
+    ).toContain('모든 필드');
+  });
+
+  it('가입: 이름 누락이면 에러', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'register',
+        email: 'a@b.com',
+        password: 'superSecret1',
+        name: '',
+      }),
+    ).toContain('모든 필드');
+  });
+
+  it('가입: 비밀번호가 8자 미만이면 "8자" 에러', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'register',
+        email: 'a@b.com',
+        password: 'short',
+        name: '홍길동',
+      }),
+    ).toContain('8자');
+  });
+
+  it('가입: 이메일·비번(8자 이상)·이름 모두 있으면 null', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'register',
+        email: 'a@b.com',
+        password: 'eightchars1',
+        name: '홍길동',
+      }),
+    ).toBeNull();
+  });
+
+  it('로그인 모드에서는 비밀번호 길이 제한을 걸지 않는다', () => {
+    expect(
+      validateEmailPasswordForm({
+        mode: 'login',
+        email: 'a@b.com',
+        password: 'pw',
+        name: '',
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #33
- 요약: 모바일 앱에 이메일+비밀번호 로그인/가입 UI 추가. 웹(#10/#32)과 동일한 `useAuth` 훅 경로 사용.

## 변경 내용
- **EmailPasswordForm** (`apps/mobile/src/components/`): RN 컴포넌트. 로그인/가입 탭, 8자 검증, 로딩 스피너, 에러 표시.
- **validateEmailPasswordForm** (`apps/mobile/src/lib/authFormValidation.ts`): 순수 함수로 분리 — jest 가 AsyncStorage 를 로드하지 않고 단독 테스트.
- **_layout.tsx**: `QueryClientProvider` 안쪽에 `AuthProvider` 래핑.
- **홈 탭 (`(tabs)/index.tsx`)**: 비로그인 영역(`loginPrompt`)에 `<EmailPasswordForm />` + "또는" 구분선 + 기존 `<LoginButtons />` (Google/Apple) 공존.
- **동기화**: `useAuth` 토큰·유저 변화를 `useAppStore.setAuth` 로 미러링하여 기존 UI 가 로그인 상태를 그대로 읽을 수 있게 함.

## 검증
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — backend / shared / web / mobile 모두 통과
- [x] `npm test` — backend 242 / shared 12 / web 14 / mobile 16 = **284 건 통과**
- [x] jest 7건: 로그인/가입 검증 조합 모두 커버

## 리스크 / 팔로업
- `LoginButtons` (Google/Apple) 는 여전히 `useAppStore.setAuth` 를 직접 호출. 향후 `useAuth.loginWithToken` 으로 통합 필요 (별도 이슈).
- perso.ai / ElevenLabs / 결제 PG 실호출 없음.
- 다음 이슈: Phase 2 마무리 검토 후 Phase 3 #12 로 진행.

Closes #33