### PR TITLE
[#35] packages/voice 어댑터 인터페이스 및 MockVoiceProvider 스캐폴드

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,6 +3154,10 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@voice-alarm/voice": {
+      "resolved": "packages/voice",
+      "link": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6286,6 +6290,17 @@
     },
     "packages/shared": {
       "name": "@voice-alarm/shared",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
+      }
+    },
+    "packages/voice": {
+      "name": "@voice-alarm/voice",
       "version": "0.1.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@voice-alarm/voice",
+  "version": "0.1.0",
+  "description": "Voice provider adapter layer (VoiceProvider interface + MockVoiceProvider) for voice_alarm monorepo",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
+  },
+  "private": true
+}

--- a/packages/voice/src/MockVoiceProvider.ts
+++ b/packages/voice/src/MockVoiceProvider.ts
@@ -1,0 +1,63 @@
+import {
+  EnrollInput,
+  EnrollInputSchema,
+  EnrollResult,
+  SeparateInput,
+  SeparateInputSchema,
+  SeparateResult,
+  SynthesizeInput,
+  SynthesizeInputSchema,
+  SynthesizeResult,
+  VoiceProvider,
+} from './types.js';
+
+// TODO: real perso.ai integration
+// TODO: real elevenlabs integration
+export class MockVoiceProvider implements VoiceProvider {
+  readonly name = 'mock';
+
+  async enroll(input: EnrollInput): Promise<EnrollResult> {
+    const parsed = EnrollInputSchema.parse(input);
+    const voiceId = `mock_vp_${parsed.userId}_${hash(parsed.displayName)}`;
+    return {
+      voiceId,
+      status: 'ready',
+      provider: this.name,
+    };
+  }
+
+  async synthesize(input: SynthesizeInput): Promise<SynthesizeResult> {
+    const parsed = SynthesizeInputSchema.parse(input);
+    const charCount = Array.from(parsed.text).length;
+    const durationMs = Math.max(500, charCount * 80);
+    return {
+      audioUri: `mock://tts/${parsed.voiceId}/${parsed.languageCode}/${hash(parsed.text)}.wav`,
+      durationMs,
+      provider: this.name,
+    };
+  }
+
+  async separate(input: SeparateInput): Promise<SeparateResult> {
+    const parsed = SeparateInputSchema.parse(input);
+    const seed = hash(parsed.audioUri);
+    const count = (seed % parsed.maxSpeakers) + 1;
+    const speakers = Array.from({ length: count }, (_, i) => ({
+      speakerId: `mock_spk_${i + 1}`,
+      startMs: i * 3000,
+      endMs: (i + 1) * 3000,
+      confidence: 0.9 - i * 0.05,
+    }));
+    return {
+      speakers,
+      provider: this.name,
+    };
+  }
+}
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export { MockVoiceProvider } from './MockVoiceProvider.js';

--- a/packages/voice/src/types.ts
+++ b/packages/voice/src/types.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+export const EnrollInputSchema = z.object({
+  userId: z.string().min(1),
+  displayName: z.string().min(1).max(32),
+  samples: z
+    .array(
+      z.object({
+        uri: z.string().min(1),
+        durationMs: z.number().int().positive(),
+      }),
+    )
+    .min(1)
+    .max(10),
+});
+export type EnrollInput = z.infer<typeof EnrollInputSchema>;
+
+export const EnrollResultSchema = z.object({
+  voiceId: z.string().min(1),
+  status: z.enum(['processing', 'ready', 'failed']),
+  provider: z.string().min(1),
+});
+export type EnrollResult = z.infer<typeof EnrollResultSchema>;
+
+export const SynthesizeInputSchema = z.object({
+  voiceId: z.string().min(1),
+  text: z.string().min(1).max(2000),
+  languageCode: z.string().min(2).max(10).default('ko-KR'),
+});
+export type SynthesizeInput = z.infer<typeof SynthesizeInputSchema>;
+
+export const SynthesizeResultSchema = z.object({
+  audioUri: z.string().min(1),
+  durationMs: z.number().int().positive(),
+  provider: z.string().min(1),
+});
+export type SynthesizeResult = z.infer<typeof SynthesizeResultSchema>;
+
+export const SeparateInputSchema = z.object({
+  audioUri: z.string().min(1),
+  maxSpeakers: z.number().int().min(1).max(6).default(3),
+});
+export type SeparateInput = z.infer<typeof SeparateInputSchema>;
+
+export const SeparatedSpeakerSchema = z.object({
+  speakerId: z.string().min(1),
+  startMs: z.number().int().nonnegative(),
+  endMs: z.number().int().positive(),
+  confidence: z.number().min(0).max(1),
+});
+export type SeparatedSpeaker = z.infer<typeof SeparatedSpeakerSchema>;
+
+export const SeparateResultSchema = z.object({
+  speakers: z.array(SeparatedSpeakerSchema).min(1),
+  provider: z.string().min(1),
+});
+export type SeparateResult = z.infer<typeof SeparateResultSchema>;
+
+export interface VoiceProvider {
+  readonly name: string;
+  enroll(input: EnrollInput): Promise<EnrollResult>;
+  synthesize(input: SynthesizeInput): Promise<SynthesizeResult>;
+  separate(input: SeparateInput): Promise<SeparateResult>;
+}

--- a/packages/voice/test/MockVoiceProvider.test.ts
+++ b/packages/voice/test/MockVoiceProvider.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EnrollResultSchema,
+  MockVoiceProvider,
+  SeparateResultSchema,
+  SynthesizeResultSchema,
+} from '../src/index.js';
+
+describe('MockVoiceProvider.enroll', () => {
+  it('유효 입력을 받으면 ready 상태의 voiceId 를 반환한다', async () => {
+    const provider = new MockVoiceProvider();
+    const result = await provider.enroll({
+      userId: 'u_1',
+      displayName: '엄마 목소리',
+      samples: [{ uri: 'file://a.wav', durationMs: 5000 }],
+    });
+    expect(() => EnrollResultSchema.parse(result)).not.toThrow();
+    expect(result.status).toBe('ready');
+    expect(result.provider).toBe('mock');
+    expect(result.voiceId).toContain('u_1');
+  });
+
+  it('같은 userId/displayName 은 결정론적으로 같은 voiceId 를 반환한다', async () => {
+    const provider = new MockVoiceProvider();
+    const a = await provider.enroll({
+      userId: 'u_2',
+      displayName: '아빠',
+      samples: [{ uri: 'file://x.wav', durationMs: 1000 }],
+    });
+    const b = await provider.enroll({
+      userId: 'u_2',
+      displayName: '아빠',
+      samples: [{ uri: 'file://y.wav', durationMs: 2000 }],
+    });
+    expect(a.voiceId).toBe(b.voiceId);
+  });
+
+  it('samples 배열이 비어있으면 검증 실패한다', async () => {
+    const provider = new MockVoiceProvider();
+    await expect(
+      provider.enroll({
+        userId: 'u_1',
+        displayName: '엄마',
+        samples: [],
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('MockVoiceProvider.synthesize', () => {
+  it('텍스트 길이에 비례한 durationMs 를 돌려준다', async () => {
+    const provider = new MockVoiceProvider();
+    const result = await provider.synthesize({
+      voiceId: 'mock_vp_u_1_x',
+      text: '안녕하세요, 좋은 아침입니다!',
+      languageCode: 'ko-KR',
+    });
+    expect(() => SynthesizeResultSchema.parse(result)).not.toThrow();
+    expect(result.durationMs).toBeGreaterThanOrEqual(500);
+    expect(result.audioUri.startsWith('mock://tts/')).toBe(true);
+  });
+
+  it('빈 텍스트는 검증 실패한다', async () => {
+    const provider = new MockVoiceProvider();
+    await expect(
+      provider.synthesize({
+        voiceId: 'mock_vp_u_1_x',
+        text: '',
+        languageCode: 'ko-KR',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('MockVoiceProvider.separate', () => {
+  it('최소 1명, maxSpeakers 이하의 화자를 반환한다', async () => {
+    const provider = new MockVoiceProvider();
+    const result = await provider.separate({
+      audioUri: 'file://call_001.wav',
+      maxSpeakers: 3,
+    });
+    expect(() => SeparateResultSchema.parse(result)).not.toThrow();
+    expect(result.speakers.length).toBeGreaterThanOrEqual(1);
+    expect(result.speakers.length).toBeLessThanOrEqual(3);
+  });
+
+  it('같은 audioUri 에 대해 결정론적으로 같은 화자 수를 돌려준다', async () => {
+    const provider = new MockVoiceProvider();
+    const a = await provider.separate({ audioUri: 'file://same.wav', maxSpeakers: 3 });
+    const b = await provider.separate({ audioUri: 'file://same.wav', maxSpeakers: 3 });
+    expect(a.speakers.length).toBe(b.speakers.length);
+  });
+});

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/voice/vitest.config.ts
+++ b/packages/voice/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## 개요
- 이슈: #35
- 요약: Phase 3 음성 기능의 근간이 되는 `packages/voice` 워크스페이스 신규. 실제 perso.ai / ElevenLabs 연동 전까지 쓸 결정론적 `MockVoiceProvider` 와 zod 기반 입력/결과 스키마, `VoiceProvider` 인터페이스 추가.

## 변경 내용
- `packages/voice/package.json` · `tsconfig.json` · `vitest.config.ts` — `packages/shared` 와 동일한 컨벤션으로 스캐폴드.
- `src/types.ts` — `EnrollInputSchema`, `SynthesizeInputSchema`, `SeparateInputSchema` (+ 각 Result 스키마) 와 `VoiceProvider` 인터페이스.
- `src/MockVoiceProvider.ts` — 3개 메서드 모두 결정론적 mock 응답. 외부 HTTP 호출 없음. `// TODO: real perso.ai integration`, `// TODO: real elevenlabs integration` 주석 포함.
- `test/MockVoiceProvider.test.ts` — 7건 (enroll 3 / synthesize 2 / separate 2).

## 검증
- [x] `npm run lint` 통과 (0 errors, 기존 경고 11건 유지)
- [x] `npm run typecheck` 통과 (backend / shared / voice / web / mobile 전부)
- [x] `npm test` 통과 — 291건 (backend 242 / shared 12 / voice 7 / web 14 / mobile 16)

## 리스크 / 팔로업
- 백엔드 라우트에 아직 연결 안 됨 — 다음 이슈 #13 (음성 업로드 API) 에서 주입.
- `MockVoiceProvider.separate` 는 `audioUri` 해시로 화자 수를 결정 — 실제 화자 감지 아님. `// TODO: real perso.ai integration` 로 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)