### PR TITLE
[#37] 원본 오디오 업로드 API + VoiceStorage 추상화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6277,6 +6277,7 @@
       "dependencies": {
         "@libsql/client": "^0.17.2",
         "@voice-alarm/shared": "*",
+        "@voice-alarm/voice": "*",
         "bcryptjs": "^3.0.3",
         "hono": "^4.12.12"
       },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@libsql/client": "^0.17.2",
     "@voice-alarm/shared": "*",
+    "@voice-alarm/voice": "*",
     "bcryptjs": "^3.0.3",
     "hono": "^4.12.12"
   }

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -146,6 +146,24 @@ export const migrations: Migration[] = [
       'CREATE UNIQUE INDEX idx_users_google_id ON users(google_id) WHERE google_id IS NOT NULL',
     ],
   },
+  {
+    id: 3,
+    name: 'voice-uploads',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS voice_uploads (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES users(id),
+        object_key TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL,
+        duration_ms INTEGER,
+        original_name TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_voice_uploads_user ON voice_uploads(user_id)',
+      'CREATE INDEX IF NOT EXISTS idx_voice_uploads_created ON voice_uploads(created_at)',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {
@@ -154,7 +172,7 @@ export async function runMigrations(db: Client): Promise<string[]> {
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL,
       applied_at TEXT DEFAULT (datetime('now'))
-    )`
+    )`,
   );
 
   const applied = await db.execute('SELECT id FROM _migrations ORDER BY id');

--- a/packages/backend/src/routes/voice.ts
+++ b/packages/backend/src/routes/voice.ts
@@ -2,10 +2,103 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { ElevenLabsClient } from '../lib/elevenlabs';
 import { getDB } from '../lib/db';
+import { getSharedInMemoryVoiceStorage } from '@voice-alarm/voice';
 
 const voice = new Hono<AppEnv>();
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+/** 원본 오디오 업로드 — 화자 분리/클론 전 단계 저장소. */
+// TODO: real object storage integration (R2 / S3) — currently in-memory only.
+voice.post('/upload', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: 'multipart/form-data body required' }, 400);
+  }
+
+  const audioFile = formData.get('audio') as unknown as File | null;
+  if (!audioFile || typeof audioFile === 'string') {
+    return c.json({ error: 'audio file is required' }, 400);
+  }
+
+  const mimeType = audioFile.type || 'application/octet-stream';
+  if (!mimeType.startsWith('audio/')) {
+    return c.json({ error: 'audio/* MIME type required' }, 415);
+  }
+
+  const buffer = await audioFile.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    return c.json({ error: 'audio file is empty' }, 400);
+  }
+  if (buffer.byteLength > MAX_UPLOAD_BYTES) {
+    return c.json(
+      { error: `audio file exceeds ${MAX_UPLOAD_BYTES} bytes (got ${buffer.byteLength})` },
+      413,
+    );
+  }
+
+  const durationRaw = formData.get('durationMs');
+  let durationMs: number | undefined;
+  if (typeof durationRaw === 'string' && durationRaw.length > 0) {
+    const n = Number.parseInt(durationRaw, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      return c.json({ error: 'durationMs must be a positive integer' }, 400);
+    }
+    durationMs = n;
+  }
+
+  const originalNameRaw = formData.get('originalName');
+  const originalName =
+    typeof originalNameRaw === 'string' && originalNameRaw.length > 0
+      ? originalNameRaw.slice(0, 200)
+      : audioFile.name || undefined;
+
+  const storage = getSharedInMemoryVoiceStorage();
+  const meta = await storage.store({
+    userId,
+    bytes: new Uint8Array(buffer),
+    mimeType,
+    durationMs,
+    originalName,
+  });
+
+  const uploadId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO voice_uploads
+          (id, user_id, object_key, mime_type, size_bytes, duration_ms, original_name)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      uploadId,
+      userId,
+      meta.objectKey,
+      meta.mimeType,
+      meta.sizeBytes,
+      meta.durationMs ?? null,
+      meta.originalName ?? null,
+    ],
+  });
+
+  return c.json(
+    {
+      upload: {
+        id: uploadId,
+        objectKey: meta.objectKey,
+        mimeType: meta.mimeType,
+        sizeBytes: meta.sizeBytes,
+        durationMs: meta.durationMs ?? null,
+        originalName: meta.originalName ?? null,
+        createdAt: meta.createdAt,
+      },
+    },
+    201,
+  );
+});
 
 /** 음성 프로필 목록 조회 */
 voice.get('/', async (c) => {
@@ -246,11 +339,14 @@ voice.delete('/:id', async (c) => {
   const msgCount = Number((msgCheck.rows[0] as Record<string, unknown>)?.cnt ?? 0);
 
   if (msgCount > 0 && c.req.query('force') !== 'true') {
-    return c.json({
-      warning: true,
-      message_count: msgCount,
-      message: `This voice profile has ${msgCount} message(s). Add ?force=true to delete anyway.`,
-    }, 409);
+    return c.json(
+      {
+        warning: true,
+        message_count: msgCount,
+        message: `This voice profile has ${msgCount} message(s). Add ?force=true to delete anyway.`,
+      },
+      409,
+    );
   }
 
   // ElevenLabs에서도 삭제

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -23,9 +23,7 @@ describe('migrations', () => {
     const initial = migrations.find((m) => m.id === 1);
     expect(initial).toBeDefined();
 
-    const createStatements = initial!.statements.filter((s) =>
-      s.trim().startsWith('CREATE TABLE')
-    );
+    const createStatements = initial!.statements.filter((s) => s.trim().startsWith('CREATE TABLE'));
     expect(createStatements.length).toBe(8);
   });
 
@@ -33,8 +31,8 @@ describe('migrations', () => {
     const initial = migrations.find((m) => m.id === 1);
     expect(initial).toBeDefined();
 
-    const indexStatements = initial!.statements.filter((s) =>
-      s.trim().startsWith('CREATE INDEX') || s.trim().startsWith('CREATE UNIQUE INDEX')
+    const indexStatements = initial!.statements.filter(
+      (s) => s.trim().startsWith('CREATE INDEX') || s.trim().startsWith('CREATE UNIQUE INDEX'),
     );
     expect(indexStatements.length).toBe(19);
   });
@@ -52,5 +50,15 @@ describe('migrations', () => {
     expect(all).toContain('users_new');
     expect(all).toContain('password_hash');
     expect(all).toContain('idx_users_email_unique');
+  });
+
+  it('마이그레이션 #3 에서 voice_uploads 테이블과 인덱스를 추가한다', () => {
+    const m = migrations.find((x) => x.id === 3);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS voice_uploads');
+    expect(all).toContain('object_key');
+    expect(all).toContain('size_bytes');
+    expect(all).toContain('idx_voice_uploads_user');
   });
 });

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import type { AppEnv } from '../src/types';
 import { createMockDB, fakeAuthMiddleware, jsonReq, ID } from './helpers';
+import { resetSharedInMemoryVoiceStorage } from '@voice-alarm/voice';
 
 const V1 = '40000000-0000-4000-8000-000000000001';
 const V404 = '40000000-0000-4000-8000-0000000000ff';
@@ -23,7 +24,29 @@ function buildApp(userId = 'user-1') {
 
 beforeEach(() => {
   mockDB.calls.length = 0;
+  resetSharedInMemoryVoiceStorage();
 });
+
+function uploadRequest(
+  path: string,
+  opts: {
+    audio?: { bytes: Uint8Array; type: string; name?: string } | null;
+    fields?: Record<string, string>;
+    noAudio?: boolean;
+  } = {},
+): Request {
+  const form = new FormData();
+  if (opts.audio) {
+    const blob = new Blob([opts.audio.bytes], { type: opts.audio.type });
+    form.append('audio', blob, opts.audio.name ?? 'sample.mp3');
+  }
+  if (opts.fields) {
+    for (const [k, v] of Object.entries(opts.fields)) {
+      form.append(k, v);
+    }
+  }
+  return new Request(`http://localhost${path}`, { method: 'POST', body: form });
+}
 
 describe('GET /voice — 음성 프로필 목록', () => {
   it('빈 목록 반환', async () => {
@@ -117,6 +140,79 @@ describe('GET /voice/:id/stats — 음성 프로필 통계', () => {
   });
 });
 
+describe('POST /voice/upload — 원본 오디오 업로드', () => {
+  it('정상 업로드는 201 과 upload 메타를 돌려준다', async () => {
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(
+      uploadRequest('/voice/upload', {
+        audio: { bytes: new Uint8Array([1, 2, 3, 4]), type: 'audio/mpeg', name: 'hi.mp3' },
+        fields: { durationMs: '3200' },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.upload.sizeBytes).toBe(4);
+    expect(body.upload.mimeType).toBe('audio/mpeg');
+    expect(body.upload.durationMs).toBe(3200);
+    expect(body.upload.objectKey.startsWith('mem://user-1/')).toBe(true);
+    expect(typeof body.upload.id).toBe('string');
+
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO voice_uploads'));
+    expect(insert).toBeDefined();
+    expect(insert!.args).toContain('user-1');
+    expect(insert!.args).toContain('audio/mpeg');
+  });
+
+  it('audio 파일이 없으면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(uploadRequest('/voice/upload', { audio: null }));
+    expect(res.status).toBe(400);
+  });
+
+  it('MIME 이 audio/* 가 아니면 415', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      uploadRequest('/voice/upload', {
+        audio: { bytes: new Uint8Array([1, 2]), type: 'image/png', name: 'x.png' },
+      }),
+    );
+    expect(res.status).toBe(415);
+  });
+
+  it('빈 파일이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      uploadRequest('/voice/upload', {
+        audio: { bytes: new Uint8Array([]), type: 'audio/wav' },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('10 MiB 초과면 413', async () => {
+    const tooBig = new Uint8Array(10 * 1024 * 1024 + 1);
+    const app = buildApp();
+    const res = await app.request(
+      uploadRequest('/voice/upload', {
+        audio: { bytes: tooBig, type: 'audio/mpeg' },
+      }),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it('durationMs 가 숫자가 아니면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      uploadRequest('/voice/upload', {
+        audio: { bytes: new Uint8Array([1]), type: 'audio/mpeg' },
+        fields: { durationMs: 'abc' },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
 describe('DELETE /voice/:id — 음성 프로필 삭제', () => {
   it('잘못된 UUID 형식이면 400', async () => {
     const app = buildApp();
@@ -132,7 +228,9 @@ describe('DELETE /voice/:id — 음성 프로필 삭제', () => {
   });
 
   it('연관 메시지 있으면 409 경고', async () => {
-    mockDB.pushResult([{ id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null }]);
+    mockDB.pushResult([
+      { id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null },
+    ]);
     mockDB.pushResult([{ cnt: 3 }]);
     const app = buildApp();
     const res = await app.request(jsonReq('DELETE', `/voice/${V1}`));
@@ -143,7 +241,9 @@ describe('DELETE /voice/:id — 음성 프로필 삭제', () => {
   });
 
   it('force=true로 연관 메시지 있어도 삭제', async () => {
-    mockDB.pushResult([{ id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null }]);
+    mockDB.pushResult([
+      { id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null },
+    ]);
     mockDB.pushResult([{ cnt: 3 }]);
     mockDB.pushResult([], 1);
     const app = buildApp();
@@ -154,7 +254,9 @@ describe('DELETE /voice/:id — 음성 프로필 삭제', () => {
   });
 
   it('연관 메시지 없으면 바로 삭제', async () => {
-    mockDB.pushResult([{ id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null }]);
+    mockDB.pushResult([
+      { id: V1, name: 'Voice A', perso_voice_id: null, elevenlabs_voice_id: null },
+    ]);
     mockDB.pushResult([{ cnt: 0 }]);
     mockDB.pushResult([], 1);
     const app = buildApp();

--- a/packages/voice/src/VoiceStorage.ts
+++ b/packages/voice/src/VoiceStorage.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+export const StoreInputSchema = z.object({
+  userId: z.string().min(1),
+  bytes: z.instanceof(Uint8Array),
+  mimeType: z.string().min(1).max(100),
+  durationMs: z.number().int().positive().optional(),
+  originalName: z.string().max(200).optional(),
+});
+export type StoreInput = z.infer<typeof StoreInputSchema>;
+
+export const StoredObjectSchema = z.object({
+  objectKey: z.string().min(1),
+  userId: z.string().min(1),
+  mimeType: z.string().min(1),
+  sizeBytes: z.number().int().nonnegative(),
+  durationMs: z.number().int().positive().optional(),
+  originalName: z.string().optional(),
+  createdAt: z.string().min(1),
+});
+export type StoredObject = z.infer<typeof StoredObjectSchema>;
+
+export interface VoiceStorage {
+  readonly name: string;
+  store(input: StoreInput): Promise<StoredObject>;
+  get(objectKey: string): Promise<{ meta: StoredObject; bytes: Uint8Array } | null>;
+  delete(objectKey: string): Promise<boolean>;
+}
+
+// TODO: real object storage integration (R2 / S3 / local filesystem)
+export class InMemoryVoiceStorage implements VoiceStorage {
+  readonly name = 'memory';
+  private items = new Map<string, { meta: StoredObject; bytes: Uint8Array }>();
+  private counter = 0;
+
+  async store(input: StoreInput): Promise<StoredObject> {
+    const parsed = StoreInputSchema.parse(input);
+    this.counter += 1;
+    const objectKey = `mem://${parsed.userId}/${Date.now()}_${this.counter}`;
+    const meta: StoredObject = {
+      objectKey,
+      userId: parsed.userId,
+      mimeType: parsed.mimeType,
+      sizeBytes: parsed.bytes.byteLength,
+      durationMs: parsed.durationMs,
+      originalName: parsed.originalName,
+      createdAt: new Date().toISOString(),
+    };
+    this.items.set(objectKey, { meta, bytes: parsed.bytes });
+    return meta;
+  }
+
+  async get(objectKey: string): Promise<{ meta: StoredObject; bytes: Uint8Array } | null> {
+    return this.items.get(objectKey) ?? null;
+  }
+
+  async delete(objectKey: string): Promise<boolean> {
+    return this.items.delete(objectKey);
+  }
+
+  reset(): void {
+    this.items.clear();
+    this.counter = 0;
+  }
+
+  size(): number {
+    return this.items.size;
+  }
+}
+
+let sharedStorage: InMemoryVoiceStorage | null = null;
+export function getSharedInMemoryVoiceStorage(): InMemoryVoiceStorage {
+  if (!sharedStorage) sharedStorage = new InMemoryVoiceStorage();
+  return sharedStorage;
+}
+export function resetSharedInMemoryVoiceStorage(): void {
+  sharedStorage?.reset();
+}

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export { MockVoiceProvider } from './MockVoiceProvider.js';
+export * from './VoiceStorage.js';

--- a/packages/voice/test/VoiceStorage.test.ts
+++ b/packages/voice/test/VoiceStorage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryVoiceStorage, StoredObjectSchema } from '../src/index.js';
+
+describe('InMemoryVoiceStorage.store', () => {
+  it('새 객체를 저장하면 고유 objectKey 와 메타를 돌려준다', async () => {
+    const storage = new InMemoryVoiceStorage();
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const meta = await storage.store({
+      userId: 'u_1',
+      bytes,
+      mimeType: 'audio/mpeg',
+      durationMs: 2500,
+      originalName: 'hello.mp3',
+    });
+    expect(() => StoredObjectSchema.parse(meta)).not.toThrow();
+    expect(meta.sizeBytes).toBe(5);
+    expect(meta.objectKey.startsWith('mem://u_1/')).toBe(true);
+    expect(storage.size()).toBe(1);
+  });
+
+  it('연속 호출 시 objectKey 는 서로 다르다', async () => {
+    const storage = new InMemoryVoiceStorage();
+    const a = await storage.store({
+      userId: 'u_1',
+      bytes: new Uint8Array([1]),
+      mimeType: 'audio/wav',
+    });
+    const b = await storage.store({
+      userId: 'u_1',
+      bytes: new Uint8Array([2]),
+      mimeType: 'audio/wav',
+    });
+    expect(a.objectKey).not.toBe(b.objectKey);
+  });
+
+  it('get/delete 로 저장 내용 조회·삭제가 동작한다', async () => {
+    const storage = new InMemoryVoiceStorage();
+    const meta = await storage.store({
+      userId: 'u_1',
+      bytes: new Uint8Array([9, 9]),
+      mimeType: 'audio/mpeg',
+    });
+    const got = await storage.get(meta.objectKey);
+    expect(got).not.toBeNull();
+    expect(got?.bytes.byteLength).toBe(2);
+
+    const ok = await storage.delete(meta.objectKey);
+    expect(ok).toBe(true);
+    expect(await storage.get(meta.objectKey)).toBeNull();
+  });
+
+  it('userId 가 비어있으면 검증 실패', async () => {
+    const storage = new InMemoryVoiceStorage();
+    await expect(
+      storage.store({
+        userId: '',
+        bytes: new Uint8Array([1]),
+        mimeType: 'audio/mpeg',
+      }),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #37
- 요약: 음성 등록 플로우의 첫 단계인 "원본 오디오 업로드 후 저장" 을 담당하는 `POST /voice/upload` 엔드포인트와 `packages/voice` 의 `VoiceStorage` 추상화를 추가. 외부 저장소/TTS 실호출 없이 in-memory 로 동작하여 다음 이슈 (화자 분리, 음성 클론) 의 기반이 된다.

## 변경 내용
- `packages/voice/src/VoiceStorage.ts` 신규 — `VoiceStorage` 인터페이스, `InMemoryVoiceStorage` 구현, module-level 싱글톤 헬퍼.
- `packages/voice/test/VoiceStorage.test.ts` 신규 — store/get/delete 동작 및 검증 실패 케이스 4건.
- `packages/backend/package.json` — `@voice-alarm/voice` 워크스페이스 의존성 추가.
- `packages/backend/src/lib/migrations.ts` — 마이그레이션 #3 `voice-uploads` 테이블 + 인덱스 2종 추가.
- `packages/backend/src/routes/voice.ts` — `POST /voice/upload` 라우트 신규. 10 MiB 제한, `audio/*` MIME 강제, 빈 파일 거부, durationMs/originalName 선택 필드 지원.
- `packages/backend/test/voice.test.ts` — `/voice/upload` 6 건 (정상, 파일 없음, MIME 오류, 빈 파일, 크기 초과, durationMs 형식).
- `packages/backend/test/migrations.test.ts` — 마이그레이션 #3 검증 1 건.

## 검증
- [x] `npm run lint` 통과 (0 errors, 기존 경고 11건 유지)
- [x] `npm run typecheck` 통과 (backend / shared / voice / web / mobile 전부)
- [x] `npm test` 통과 — 302건 이상 (backend 249 / voice 11 / shared 12 / web 14 / mobile 16)

## 리스크 / 팔로업
- `InMemoryVoiceStorage` 는 Cloudflare Workers 리퀘스트 간 공유되지 않음 — 실환경에서는 R2/S3 어댑터가 필요 (`// TODO: real object storage integration` 표시).
- 기존 `/voice/clone` 은 여전히 `ElevenLabsClient` 를 직접 호출 — 별도 팔로업 이슈에서 `VoiceProvider` 어댑터로 교체.
- 다음 이슈 #14 에서 업로드된 `object_key` 를 받아 화자 분리 mock 을 연결한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)