### PR TITLE
[#39] 업로드 오디오 화자 분리 mock — MockVoiceProvider 연동

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -164,6 +164,22 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_voice_uploads_created ON voice_uploads(created_at)',
     ],
   },
+  {
+    id: 4,
+    name: 'voice-speakers',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS voice_speakers (
+        id TEXT PRIMARY KEY,
+        upload_id TEXT NOT NULL REFERENCES voice_uploads(id),
+        label TEXT NOT NULL,
+        start_ms INTEGER NOT NULL,
+        end_ms INTEGER NOT NULL,
+        confidence REAL NOT NULL,
+        created_at TEXT DEFAULT (datetime('now'))
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_voice_speakers_upload ON voice_speakers(upload_id)',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/voice.ts
+++ b/packages/backend/src/routes/voice.ts
@@ -2,12 +2,13 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { ElevenLabsClient } from '../lib/elevenlabs';
 import { getDB } from '../lib/db';
-import { getSharedInMemoryVoiceStorage } from '@voice-alarm/voice';
+import { getSharedInMemoryVoiceStorage, MockVoiceProvider } from '@voice-alarm/voice';
 
 const voice = new Hono<AppEnv>();
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MiB
+const MAX_SPEAKERS = 3;
 
 /** 원본 오디오 업로드 — 화자 분리/클론 전 단계 저장소. */
 // TODO: real object storage integration (R2 / S3) — currently in-memory only.
@@ -98,6 +99,92 @@ voice.post('/upload', async (c) => {
     },
     201,
   );
+});
+
+/**
+ * 업로드된 오디오의 화자 분리 (mock).
+ * NEEDS_VERIFICATION: real diarization algorithm — 실제 알고리즘은 perso.ai/ElevenLabs 영역.
+ */
+voice.post('/uploads/:uploadId/separate', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const uploadId = c.req.param('uploadId');
+
+  if (!UUID_RE.test(uploadId)) {
+    return c.json({ error: 'Invalid upload ID format' }, 400);
+  }
+
+  const uploadRes = await db.execute({
+    sql: 'SELECT id, user_id, object_key FROM voice_uploads WHERE id = ?',
+    args: [uploadId],
+  });
+  if (uploadRes.rows.length === 0) {
+    return c.json({ error: 'Voice upload not found' }, 404);
+  }
+  const upload = uploadRes.rows[0] as { id: string; user_id: string; object_key: string };
+  if (upload.user_id !== userId) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const provider = new MockVoiceProvider();
+  const result = await provider.separate({
+    audioUri: upload.object_key,
+    maxSpeakers: MAX_SPEAKERS,
+  });
+
+  await db.execute({
+    sql: 'DELETE FROM voice_speakers WHERE upload_id = ?',
+    args: [uploadId],
+  });
+
+  const speakers = result.speakers.map((s, idx) => ({
+    id: crypto.randomUUID(),
+    uploadId,
+    label: `화자 ${idx + 1}`,
+    startMs: s.startMs,
+    endMs: s.endMs,
+    confidence: s.confidence,
+  }));
+
+  for (const sp of speakers) {
+    await db.execute({
+      sql: `INSERT INTO voice_speakers (id, upload_id, label, start_ms, end_ms, confidence)
+            VALUES (?, ?, ?, ?, ?, ?)`,
+      args: [sp.id, sp.uploadId, sp.label, sp.startMs, sp.endMs, sp.confidence],
+    });
+  }
+
+  return c.json({ speakers, provider: result.provider }, 201);
+});
+
+/** 업로드된 오디오의 분리된 화자 목록 조회 */
+voice.get('/uploads/:uploadId/speakers', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const uploadId = c.req.param('uploadId');
+
+  if (!UUID_RE.test(uploadId)) {
+    return c.json({ error: 'Invalid upload ID format' }, 400);
+  }
+
+  const uploadRes = await db.execute({
+    sql: 'SELECT id, user_id FROM voice_uploads WHERE id = ?',
+    args: [uploadId],
+  });
+  if (uploadRes.rows.length === 0) {
+    return c.json({ error: 'Voice upload not found' }, 404);
+  }
+  if ((uploadRes.rows[0] as { user_id: string }).user_id !== userId) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const speakersRes = await db.execute({
+    sql: `SELECT id, upload_id, label, start_ms, end_ms, confidence, created_at
+          FROM voice_speakers WHERE upload_id = ? ORDER BY start_ms ASC`,
+    args: [uploadId],
+  });
+
+  return c.json({ speakers: speakersRes.rows });
 });
 
 /** 음성 프로필 목록 조회 */

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -20,6 +20,11 @@ export function createMockDB() {
     results.push({ rows, rowsAffected });
   }
 
+  function reset() {
+    calls.length = 0;
+    results.length = 0;
+  }
+
   const client = {
     execute: async (query: { sql: string; args: (string | number | null)[] }) => {
       calls.push({ sql: query.sql, args: query.args });
@@ -28,7 +33,7 @@ export function createMockDB() {
     batch: async () => {},
   };
 
-  return { client, calls, pushResult };
+  return { client, calls, pushResult, reset };
 }
 
 export function fakeAuthMiddleware(userId = 'user-1', email = 'user@test.com') {

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -61,4 +61,14 @@ describe('migrations', () => {
     expect(all).toContain('size_bytes');
     expect(all).toContain('idx_voice_uploads_user');
   });
+
+  it('마이그레이션 #4 에서 voice_speakers 테이블과 인덱스를 추가한다', () => {
+    const m = migrations.find((x) => x.id === 4);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS voice_speakers');
+    expect(all).toContain('upload_id');
+    expect(all).toContain('confidence');
+    expect(all).toContain('idx_voice_speakers_upload');
+  });
 });

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -23,7 +23,7 @@ function buildApp(userId = 'user-1') {
 }
 
 beforeEach(() => {
-  mockDB.calls.length = 0;
+  mockDB.reset();
   resetSharedInMemoryVoiceStorage();
 });
 
@@ -210,6 +210,115 @@ describe('POST /voice/upload — 원본 오디오 업로드', () => {
       }),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /voice/uploads/:uploadId/separate — 화자 분리 mock', () => {
+  const UPLOAD_ID = '50000000-0000-4000-8000-000000000001';
+
+  it('잘못된 UUID 형식이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/voice/uploads/bad-id/separate'));
+    expect(res.status).toBe(400);
+  });
+
+  it('업로드가 없으면 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', `/voice/uploads/${UPLOAD_ID}/separate`));
+    expect(res.status).toBe(404);
+  });
+
+  it('타인 소유 업로드면 403', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'other-user', object_key: 'mem://other/x' }]);
+    const app = buildApp('user-1');
+    const res = await app.request(jsonReq('POST', `/voice/uploads/${UPLOAD_ID}/separate`));
+    expect(res.status).toBe(403);
+  });
+
+  it('정상 호출은 화자 1~3명과 201 을 반환하고 INSERT 를 수행한다', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'user-1', object_key: 'mem://user-1/abc' }]);
+    mockDB.pushResult([], 0); // DELETE
+    for (let i = 0; i < 3; i++) mockDB.pushResult([], 1); // INSERTs
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', `/voice/uploads/${UPLOAD_ID}/separate`));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(Array.isArray(body.speakers)).toBe(true);
+    expect(body.speakers.length).toBeGreaterThanOrEqual(1);
+    expect(body.speakers.length).toBeLessThanOrEqual(3);
+    expect(body.provider).toBe('mock');
+    expect(body.speakers[0].label).toMatch(/^화자 \d+$/);
+    expect(body.speakers[0].uploadId).toBe(UPLOAD_ID);
+
+    const del = mockDB.calls.find((c) => c.sql.includes('DELETE FROM voice_speakers'));
+    expect(del).toBeDefined();
+    const ins = mockDB.calls.filter((c) => c.sql.includes('INSERT INTO voice_speakers'));
+    expect(ins.length).toBe(body.speakers.length);
+  });
+
+  it('같은 업로드에 대해 재호출해도 멱등적으로 동일한 화자 수', async () => {
+    const prime = () => {
+      mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'user-1', object_key: 'mem://user-1/abc' }]);
+      mockDB.pushResult([], 0);
+      for (let i = 0; i < 3; i++) mockDB.pushResult([], 1);
+    };
+    const app = buildApp();
+    prime();
+    const r1 = await app.request(jsonReq('POST', `/voice/uploads/${UPLOAD_ID}/separate`));
+    const b1 = await r1.json();
+
+    mockDB.reset();
+    prime();
+    const r2 = await app.request(jsonReq('POST', `/voice/uploads/${UPLOAD_ID}/separate`));
+    const b2 = await r2.json();
+    expect(b1.speakers.length).toBe(b2.speakers.length);
+  });
+});
+
+describe('GET /voice/uploads/:uploadId/speakers — 저장된 화자 조회', () => {
+  const UPLOAD_ID = '50000000-0000-4000-8000-000000000002';
+
+  it('잘못된 UUID 형식이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/voice/uploads/bad/speakers'));
+    expect(res.status).toBe(400);
+  });
+
+  it('업로드가 없으면 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', `/voice/uploads/${UPLOAD_ID}/speakers`));
+    expect(res.status).toBe(404);
+  });
+
+  it('저장된 화자를 start_ms 순으로 돌려준다', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'user-1' }]);
+    mockDB.pushResult([
+      {
+        id: 's1',
+        upload_id: UPLOAD_ID,
+        label: '화자 1',
+        start_ms: 0,
+        end_ms: 3000,
+        confidence: 0.9,
+      },
+      {
+        id: 's2',
+        upload_id: UPLOAD_ID,
+        label: '화자 2',
+        start_ms: 3000,
+        end_ms: 6000,
+        confidence: 0.85,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', `/voice/uploads/${UPLOAD_ID}/speakers`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.speakers).toHaveLength(2);
+    expect(body.speakers[0].label).toBe('화자 1');
   });
 });
 


### PR DESCRIPTION
## 개요
Phase 3 #14 `화자 분리 mock` 이슈(#39) 처리. 업로드된 원본 오디오에 대해 `MockVoiceProvider.separate`를 호출해 화자 세그먼트를 DB에 적재하고, 결과를 조회하는 엔드포인트 2종을 추가한다.

perso.ai / ElevenLabs 실제 화자 분리 API는 호출하지 않으며, 모든 로직은 mock 경로로 처리된다.

## 변경 내용
- `packages/backend/src/lib/migrations.ts` — 마이그레이션 #4 `voice-speakers` 추가 (`voice_speakers` 테이블 + `idx_voice_speakers_upload` 인덱스).
- `packages/backend/src/routes/voice.ts`
  - `POST /voice/uploads/:uploadId/separate` — 업로드 소유권 확인 후 `MockVoiceProvider.separate` 실행, 기존 화자 레코드 삭제 후 새 세그먼트 INSERT. 응답: `{ speakers, provider: 'mock' }`.
  - `GET /voice/uploads/:uploadId/speakers` — 저장된 화자 세그먼트 조회 (시작 시간 오름차순).
  - 주석에 `// NEEDS_VERIFICATION: real diarization` 마커로 실제 구현 전환 포인트 표시.
- `packages/backend/test/helpers.ts` — `createMockDB().reset()`이 `calls` + `results` 큐 모두 초기화하도록 확장 (테스트 격리 이슈 해결).
- `packages/backend/test/voice.test.ts` — separate/speakers 엔드포인트 8종 케이스 추가 (400/404/403/201/idempotency, 400/404/list).
- `packages/backend/test/migrations.test.ts` — 마이그레이션 #4 검증 테스트.

## 검증
- `pnpm -C packages/backend test` — 258개 테스트 통과 (신규 9개 포함).
- `pnpm -C packages/backend lint` — 오류 0건 (기존 경고 11건 유지).
- `pnpm typecheck` — 모노레포 전체 통과.

## 리스크 / 후속
- 기존 `/voice/clone`, `/voice/diarize` 라우트는 이번 PR에서 건드리지 않음 — 여전히 ElevenLabs 호출 경로 존재. 별도 이슈에서 mock 전환 예정.
- 화자 라벨(`화자 1/2/3`)은 고정 문자열 — 사용자 지정 라벨 편집 UI는 Phase 3 #15에서 처리.

Refs: #39