### PR TITLE
[#41] 화자 선택 UI 웹 — SpeakerPicker + 라벨 편집 API

### DIFF
--- a/packages/backend/src/routes/voice.ts
+++ b/packages/backend/src/routes/voice.ts
@@ -121,7 +121,7 @@ voice.post('/uploads/:uploadId/separate', async (c) => {
   if (uploadRes.rows.length === 0) {
     return c.json({ error: 'Voice upload not found' }, 404);
   }
-  const upload = uploadRes.rows[0] as { id: string; user_id: string; object_key: string };
+  const upload = uploadRes.rows[0] as unknown as { id: string; user_id: string; object_key: string };
   if (upload.user_id !== userId) {
     return c.json({ error: 'Forbidden' }, 403);
   }
@@ -174,7 +174,7 @@ voice.get('/uploads/:uploadId/speakers', async (c) => {
   if (uploadRes.rows.length === 0) {
     return c.json({ error: 'Voice upload not found' }, 404);
   }
-  if ((uploadRes.rows[0] as { user_id: string }).user_id !== userId) {
+  if ((uploadRes.rows[0] as unknown as { user_id: string }).user_id !== userId) {
     return c.json({ error: 'Forbidden' }, 403);
   }
 
@@ -185,6 +185,55 @@ voice.get('/uploads/:uploadId/speakers', async (c) => {
   });
 
   return c.json({ speakers: speakersRes.rows });
+});
+
+/** 분리된 화자 라벨 수정 */
+voice.patch('/uploads/:uploadId/speakers/:speakerId', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const uploadId = c.req.param('uploadId');
+  const speakerId = c.req.param('speakerId');
+
+  if (!UUID_RE.test(uploadId) || !UUID_RE.test(speakerId)) {
+    return c.json({ error: 'Invalid ID format' }, 400);
+  }
+
+  let body: { label?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'JSON body required' }, 400);
+  }
+  const label = typeof body.label === 'string' ? body.label.trim() : '';
+  if (label.length === 0 || label.length > 50) {
+    return c.json({ error: 'label must be 1-50 characters' }, 400);
+  }
+
+  const uploadRes = await db.execute({
+    sql: 'SELECT id, user_id FROM voice_uploads WHERE id = ?',
+    args: [uploadId],
+  });
+  if (uploadRes.rows.length === 0) {
+    return c.json({ error: 'Voice upload not found' }, 404);
+  }
+  if ((uploadRes.rows[0] as unknown as { user_id: string }).user_id !== userId) {
+    return c.json({ error: 'Forbidden' }, 403);
+  }
+
+  const speakerRes = await db.execute({
+    sql: 'SELECT id FROM voice_speakers WHERE id = ? AND upload_id = ?',
+    args: [speakerId, uploadId],
+  });
+  if (speakerRes.rows.length === 0) {
+    return c.json({ error: 'Speaker not found' }, 404);
+  }
+
+  await db.execute({
+    sql: 'UPDATE voice_speakers SET label = ? WHERE id = ?',
+    args: [label, speakerId],
+  });
+
+  return c.json({ speaker: { id: speakerId, uploadId, label } });
 });
 
 /** 음성 프로필 목록 조회 */

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -322,6 +322,81 @@ describe('GET /voice/uploads/:uploadId/speakers — 저장된 화자 조회', ()
   });
 });
 
+describe('PATCH /voice/uploads/:uploadId/speakers/:speakerId — 화자 라벨 수정', () => {
+  const UPLOAD_ID = '50000000-0000-4000-8000-000000000003';
+  const SPEAKER_ID = '60000000-0000-4000-8000-000000000001';
+
+  function patchReq(uploadId: string, speakerId: string, body: unknown): Request {
+    return new Request(`http://localhost/voice/uploads/${uploadId}/speakers/${speakerId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('잘못된 UUID 형식이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(patchReq('bad', SPEAKER_ID, { label: '엄마' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('JSON body 가 아니면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request(`http://localhost/voice/uploads/${UPLOAD_ID}/speakers/${SPEAKER_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not-json',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('빈 label 이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(patchReq(UPLOAD_ID, SPEAKER_ID, { label: '   ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('업로드가 없으면 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(patchReq(UPLOAD_ID, SPEAKER_ID, { label: '엄마' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('타인 소유 업로드면 403', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'other-user' }]);
+    const app = buildApp('user-1');
+    const res = await app.request(patchReq(UPLOAD_ID, SPEAKER_ID, { label: '엄마' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('화자가 없으면 404', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'user-1' }]);
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(patchReq(UPLOAD_ID, SPEAKER_ID, { label: '엄마' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('정상 호출은 200 과 업데이트된 라벨을 반환한다', async () => {
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: 'user-1' }]);
+    mockDB.pushResult([{ id: SPEAKER_ID }]);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(patchReq(UPLOAD_ID, SPEAKER_ID, { label: '  엄마  ' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.speaker.id).toBe(SPEAKER_ID);
+    expect(body.speaker.label).toBe('엄마');
+
+    const upd = mockDB.calls.find((c) => c.sql.startsWith('UPDATE voice_speakers'));
+    expect(upd).toBeDefined();
+    expect(upd!.args).toContain('엄마');
+  });
+});
+
 describe('DELETE /voice/:id — 음성 프로필 삭제', () => {
   it('잘못된 UUID 형식이면 400', async () => {
     const app = buildApp();

--- a/packages/web/src/components/SpeakerPicker.tsx
+++ b/packages/web/src/components/SpeakerPicker.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  listSpeakers as listSpeakersDefault,
+  renameSpeaker as renameSpeakerDefault,
+  separateUpload as separateUploadDefault,
+  uploadVoiceAudio as uploadVoiceAudioDefault,
+  type Speaker,
+  type VoiceUploadMeta,
+} from '../services/api';
+
+export interface SpeakerPickerApi {
+  uploadVoiceAudio: (file: File, durationMs?: number) => Promise<VoiceUploadMeta>;
+  separateUpload: (uploadId: string) => Promise<Speaker[]>;
+  listSpeakers: (uploadId: string) => Promise<Speaker[]>;
+  renameSpeaker: (uploadId: string, speakerId: string, label: string) => Promise<{ id: string; label: string }>;
+}
+
+export interface SpeakerPickerProps {
+  onClose: () => void;
+  onConfirm?: (speaker: Speaker, upload: VoiceUploadMeta) => void;
+  api?: Partial<SpeakerPickerApi>;
+}
+
+const DEFAULT_API: SpeakerPickerApi = {
+  uploadVoiceAudio: uploadVoiceAudioDefault,
+  separateUpload: separateUploadDefault,
+  listSpeakers: listSpeakersDefault,
+  renameSpeaker: renameSpeakerDefault,
+};
+
+type Phase = 'idle' | 'uploading' | 'separating' | 'ready' | 'error';
+
+export default function SpeakerPicker({ onClose, onConfirm, api }: SpeakerPickerProps) {
+  const apiFns: SpeakerPickerApi = useMemo(() => ({ ...DEFAULT_API, ...api }), [api]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [upload, setUpload] = useState<VoiceUploadMeta | null>(null);
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftLabel, setDraftLabel] = useState('');
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const hydrate = useCallback(
+    async (uploadId: string) => {
+      try {
+        const existing = await apiFns.listSpeakers(uploadId);
+        if (existing.length > 0) {
+          setSpeakers(existing);
+          setPhase('ready');
+          return true;
+        }
+      } catch {
+        // 조회 실패 → 새 분리 시도로 fallback
+      }
+      return false;
+    },
+    [apiFns],
+  );
+
+  async function handleUpload() {
+    if (!file) return;
+    setError(null);
+    setPhase('uploading');
+    try {
+      const meta = await apiFns.uploadVoiceAudio(file);
+      setUpload(meta);
+      const reused = await hydrate(meta.id);
+      if (!reused) {
+        setPhase('separating');
+        const detected = await apiFns.separateUpload(meta.id);
+        setSpeakers(detected);
+        setPhase('ready');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '업로드 실패');
+      setPhase('error');
+    }
+  }
+
+  async function commitLabel(speaker: Speaker) {
+    if (!upload) return;
+    const next = draftLabel.trim();
+    if (next.length === 0 || next === speaker.label) {
+      setEditingId(null);
+      return;
+    }
+    try {
+      await apiFns.renameSpeaker(upload.id, speaker.id, next);
+      setSpeakers((prev) => prev.map((s) => (s.id === speaker.id ? { ...s, label: next } : s)));
+      setEditingId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '라벨 수정 실패');
+    }
+  }
+
+  useEffect(() => {
+    // 모달 내부에 자동 포커스
+    fileInputRef.current?.focus();
+  }, []);
+
+  const selected = speakers.find((s) => s.id === selectedId) ?? null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-label="화자 감지 및 선택"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[var(--color-bg)] rounded-2xl w-full max-w-lg max-h-[85vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-5 border-b border-[var(--color-border)]">
+          <h3 className="text-lg font-bold text-[var(--color-text)]">화자 감지</h3>
+          <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+            오디오를 업로드하면 모의 알고리즘이 화자를 나눕니다.
+          </p>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {phase === 'idle' && (
+            <div className="space-y-3">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="audio/*"
+                aria-label="오디오 파일 선택"
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                className="block w-full text-sm"
+              />
+              {file && (
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                  선택된 파일: <strong>{file.name}</strong>
+                </p>
+              )}
+              <button
+                onClick={handleUpload}
+                disabled={!file}
+                className="w-full py-2.5 rounded-xl bg-[var(--color-primary)] text-white font-semibold hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                업로드 후 화자 감지
+              </button>
+            </div>
+          )}
+
+          {(phase === 'uploading' || phase === 'separating') && (
+            <div className="text-center py-10 text-[var(--color-text-secondary)]" role="status">
+              {phase === 'uploading' ? '업로드 중…' : '화자 분리 중…'}
+            </div>
+          )}
+
+          {phase === 'error' && (
+            <div
+              role="alert"
+              className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-3 text-sm text-red-700 dark:text-red-400"
+            >
+              {error ?? '알 수 없는 오류'}
+            </div>
+          )}
+
+          {phase === 'ready' && (
+            <>
+              {speakers.length === 0 ? (
+                <p className="text-center py-8 text-[var(--color-text-secondary)]">
+                  감지된 화자가 없습니다.
+                </p>
+              ) : (
+                <ul className="space-y-2" role="radiogroup" aria-label="감지된 화자 목록">
+                  {speakers.map((sp) => {
+                    const isSelected = selectedId === sp.id;
+                    const isEditing = editingId === sp.id;
+                    const durationSec = Math.max(0, (sp.end_ms - sp.start_ms) / 1000);
+                    return (
+                      <li
+                        key={sp.id}
+                        className={`border rounded-xl p-3 cursor-pointer transition-colors ${
+                          isSelected
+                            ? 'border-[var(--color-primary)] bg-[var(--color-primary-light)]/20'
+                            : 'border-[var(--color-border)] hover:border-[var(--color-primary-light)]'
+                        }`}
+                        role="radio"
+                        aria-checked={isSelected}
+                        onClick={() => setSelectedId(sp.id)}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          {isEditing ? (
+                            <input
+                              autoFocus
+                              aria-label={`${sp.label} 라벨 편집`}
+                              value={draftLabel}
+                              onChange={(e) => setDraftLabel(e.target.value)}
+                              onBlur={() => void commitLabel(sp)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') void commitLabel(sp);
+                                if (e.key === 'Escape') setEditingId(null);
+                              }}
+                              onClick={(e) => e.stopPropagation()}
+                              className="flex-1 border border-[var(--color-border)] bg-[var(--color-surface)] rounded-lg px-2 py-1 text-sm"
+                            />
+                          ) : (
+                            <p className="font-semibold text-[var(--color-text)]">{sp.label}</p>
+                          )}
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDraftLabel(sp.label);
+                              setEditingId(sp.id);
+                            }}
+                            aria-label={`${sp.label} 이름 변경`}
+                            className="text-xs text-[var(--color-primary)] hover:underline"
+                          >
+                            이름 변경
+                          </button>
+                        </div>
+                        <p className="text-xs text-[var(--color-text-tertiary)] mt-1">
+                          {durationSec.toFixed(1)}초 · 신뢰도{' '}
+                          {(sp.confidence * 100).toFixed(0)}%
+                        </p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="p-4 border-t border-[var(--color-border)] flex gap-2">
+          {phase === 'ready' && onConfirm && upload && (
+            <button
+              onClick={() => selected && onConfirm(selected, upload)}
+              disabled={!selected}
+              className="flex-1 py-2.5 rounded-xl bg-[var(--color-primary)] text-white font-semibold hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              선택한 화자로 진행
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className={`${
+              phase === 'ready' && onConfirm ? 'flex-1' : 'w-full'
+            } py-2.5 rounded-xl text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-alt)] transition-colors font-medium`}
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/VoicesPage.tsx
+++ b/packages/web/src/pages/VoicesPage.tsx
@@ -4,6 +4,7 @@ import { getVoiceProfiles, createVoiceClone, deleteVoiceProfile, generateTTS, ge
 import type { VoiceProfile, Message, Alarm } from '../types';
 import { getApiErrorMessage } from '../types';
 import { VoiceCardSkeleton } from '../components/Skeleton';
+import SpeakerPicker from '../components/SpeakerPicker';
 
 export default function VoicesPage() {
   const queryClient = useQueryClient();
@@ -16,6 +17,7 @@ export default function VoicesPage() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [detailProfile, setDetailProfile] = useState<VoiceProfile | null>(null);
+  const [showSpeakerPicker, setShowSpeakerPicker] = useState(false);
 
   const { data: profiles, isLoading } = useQuery({
     queryKey: ['voiceProfiles'],
@@ -107,14 +109,26 @@ export default function VoicesPage() {
           <h2 className="text-3xl font-bold text-[var(--color-text)]">음성 프로필</h2>
           <p className="text-[var(--color-text-secondary)] mt-1">소중한 사람의 목소리를 관리하세요</p>
         </div>
-        <button
-          onClick={() => setShowUpload(!showUpload)}
-          aria-expanded={showUpload}
-          className="bg-[var(--color-primary)] text-white px-6 py-3 rounded-xl font-semibold hover:opacity-90 transition-colors"
-        >
-          + 음성 등록
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowSpeakerPicker(true)}
+            className="bg-[var(--color-surface)] border border-[var(--color-primary)] text-[var(--color-primary)] px-5 py-3 rounded-xl font-semibold hover:bg-[var(--color-primary-light)]/20 transition-colors"
+          >
+            화자 감지
+          </button>
+          <button
+            onClick={() => setShowUpload(!showUpload)}
+            aria-expanded={showUpload}
+            className="bg-[var(--color-primary)] text-white px-6 py-3 rounded-xl font-semibold hover:opacity-90 transition-colors"
+          >
+            + 음성 등록
+          </button>
+        </div>
       </div>
+
+      {showSpeakerPicker && (
+        <SpeakerPicker onClose={() => setShowSpeakerPicker(false)} />
+      )}
 
       {showUpload && (
         <div className="bg-[var(--color-surface)] rounded-2xl p-6 mb-6 border border-[var(--color-border)] shadow-sm transition-colors">

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -283,4 +283,68 @@ export async function getDubJobs() {
   return data.jobs as DubJob[];
 }
 
+// ===== Voice upload & speaker picker =====
+
+export interface VoiceUploadMeta {
+  id: string;
+  objectKey: string;
+  mimeType: string;
+  sizeBytes: number;
+  durationMs: number | null;
+  originalName: string | null;
+  createdAt: string;
+}
+
+export interface Speaker {
+  id: string;
+  upload_id: string;
+  label: string;
+  start_ms: number;
+  end_ms: number;
+  confidence: number;
+  created_at?: string;
+}
+
+export async function uploadVoiceAudio(file: File, durationMs?: number): Promise<VoiceUploadMeta> {
+  const form = new FormData();
+  form.append('audio', file);
+  if (durationMs !== undefined) form.append('durationMs', String(durationMs));
+  if (file.name) form.append('originalName', file.name);
+  const { data } = await api.post('/voice/upload', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return data.upload as VoiceUploadMeta;
+}
+
+export async function separateUpload(uploadId: string): Promise<Speaker[]> {
+  const { data } = await api.post(`/voice/uploads/${uploadId}/separate`);
+  return (data.speakers as Array<Record<string, unknown>>).map(normalizeSpeaker);
+}
+
+export async function listSpeakers(uploadId: string): Promise<Speaker[]> {
+  const { data } = await api.get(`/voice/uploads/${uploadId}/speakers`);
+  return (data.speakers as Array<Record<string, unknown>>).map(normalizeSpeaker);
+}
+
+export async function renameSpeaker(
+  uploadId: string,
+  speakerId: string,
+  label: string,
+): Promise<{ id: string; label: string }> {
+  const { data } = await api.patch(`/voice/uploads/${uploadId}/speakers/${speakerId}`, { label });
+  return data.speaker as { id: string; label: string };
+}
+
+function normalizeSpeaker(raw: Record<string, unknown>): Speaker {
+  return {
+    id: String(raw.id ?? raw['speaker_id'] ?? ''),
+    upload_id: String(raw.upload_id ?? raw.uploadId ?? ''),
+    label: String(raw.label ?? ''),
+    start_ms: Number(raw.start_ms ?? raw.startMs ?? 0),
+    end_ms: Number(raw.end_ms ?? raw.endMs ?? 0),
+    confidence: Number(raw.confidence ?? 0),
+    created_at: raw.created_at as string | undefined,
+  };
+}
+
 export default api;

--- a/packages/web/test/SpeakerPicker.test.tsx
+++ b/packages/web/test/SpeakerPicker.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import SpeakerPicker, { type SpeakerPickerApi } from '../src/components/SpeakerPicker';
+import type { Speaker, VoiceUploadMeta } from '../src/services/api';
+
+function makeFile(name = 'sample.mp3') {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type: 'audio/mpeg' });
+}
+
+function meta(overrides: Partial<VoiceUploadMeta> = {}): VoiceUploadMeta {
+  return {
+    id: '50000000-0000-4000-8000-000000000001',
+    objectKey: 'mem://u/x',
+    mimeType: 'audio/mpeg',
+    sizeBytes: 4,
+    durationMs: 4200,
+    originalName: 'sample.mp3',
+    createdAt: '2026-04-21T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function speaker(id: string, label: string, startMs = 0, endMs = 3000): Speaker {
+  return { id, upload_id: meta().id, label, start_ms: startMs, end_ms: endMs, confidence: 0.9 };
+}
+
+function fakeApi(overrides: Partial<SpeakerPickerApi> = {}): SpeakerPickerApi {
+  return {
+    uploadVoiceAudio: vi.fn().mockResolvedValue(meta()),
+    separateUpload: vi.fn().mockResolvedValue([
+      speaker('s1', '화자 1', 0, 3000),
+      speaker('s2', '화자 2', 3000, 6000),
+    ]),
+    listSpeakers: vi.fn().mockResolvedValue([]),
+    renameSpeaker: vi.fn().mockResolvedValue({ id: 's1', label: '엄마' }),
+    ...overrides,
+  };
+}
+
+function selectFile(file: File) {
+  const input = screen.getByLabelText('오디오 파일 선택') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+describe('SpeakerPicker', () => {
+  it('최초에는 파일 선택 입력만 노출된다', () => {
+    render(<SpeakerPicker onClose={vi.fn()} api={fakeApi()} />);
+    expect(screen.getByLabelText('오디오 파일 선택')).not.toBeNull();
+    expect(screen.queryByRole('radiogroup', { name: '감지된 화자 목록' })).toBeNull();
+  });
+
+  it('업로드 후 분리 결과를 리스트로 표시한다', async () => {
+    const api = fakeApi();
+    render(<SpeakerPicker onClose={vi.fn()} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('radiogroup', { name: '감지된 화자 목록' })).not.toBeNull(),
+    );
+    expect(screen.getByText('화자 1')).not.toBeNull();
+    expect(screen.getByText('화자 2')).not.toBeNull();
+    expect(api.uploadVoiceAudio).toHaveBeenCalledTimes(1);
+    expect(api.separateUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('업로드 실패 시 에러 메시지를 표시하고 분리 API 를 호출하지 않는다', async () => {
+    const api = fakeApi({
+      uploadVoiceAudio: vi.fn().mockRejectedValue(new Error('네트워크 오류')),
+    });
+    render(<SpeakerPicker onClose={vi.fn()} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('네트워크 오류');
+    expect(api.separateUpload).not.toHaveBeenCalled();
+  });
+
+  it('기존 분리 결과가 있으면 재분리하지 않고 즉시 노출한다', async () => {
+    const api = fakeApi({
+      listSpeakers: vi.fn().mockResolvedValue([speaker('s9', '이전 화자', 100, 2000)]),
+    });
+    render(<SpeakerPicker onClose={vi.fn()} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+
+    await waitFor(() => expect(screen.getByText('이전 화자')).not.toBeNull());
+    expect(api.separateUpload).not.toHaveBeenCalled();
+  });
+
+  it('라벨 편집 후 엔터로 renameSpeaker 를 호출한다', async () => {
+    const api = fakeApi();
+    render(<SpeakerPicker onClose={vi.fn()} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+    await screen.findByText('화자 1');
+
+    const [renameBtn] = screen.getAllByRole('button', { name: /이름 변경/ });
+    fireEvent.click(renameBtn);
+    const editInput = await screen.findByLabelText('화자 1 라벨 편집');
+    fireEvent.change(editInput, { target: { value: '엄마' } });
+    await act(async () => {
+      fireEvent.keyDown(editInput, { key: 'Enter' });
+    });
+
+    await waitFor(() => expect(api.renameSpeaker).toHaveBeenCalledTimes(1));
+    const [uploadIdArg, speakerIdArg, labelArg] = (api.renameSpeaker as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    expect(uploadIdArg).toBe(meta().id);
+    expect(speakerIdArg).toBe('s1');
+    expect(labelArg).toBe('엄마');
+  });
+
+  it('선택 전에는 onConfirm 버튼이 비활성화된다', async () => {
+    const onConfirm = vi.fn();
+    const api = fakeApi();
+    render(<SpeakerPicker onClose={vi.fn()} onConfirm={onConfirm} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+    await screen.findByText('화자 1');
+
+    const confirm = screen.getByRole('button', { name: /선택한 화자로 진행/ });
+    expect(confirm.getAttribute('disabled')).not.toBeNull();
+
+    fireEvent.click(screen.getByText('화자 2'));
+    await waitFor(() => expect(confirm.getAttribute('disabled')).toBeNull());
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].id).toBe('s2');
+  });
+
+  it('빈 결과는 "감지된 화자가 없습니다." 안내를 보여준다', async () => {
+    const api = fakeApi({
+      separateUpload: vi.fn().mockResolvedValue([]),
+    });
+    render(<SpeakerPicker onClose={vi.fn()} api={api} />);
+
+    selectFile(makeFile());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /업로드 후 화자 감지/ }));
+    });
+
+    await waitFor(() => expect(screen.getByText(/감지된 화자가 없습니다/)).not.toBeNull());
+  });
+});


### PR DESCRIPTION
## 개요
Phase 3 #15 `화자 선택 UI (웹)` 이슈(#41) 처리. 업로드된 오디오에서 감지된 화자를 웹에서 시각화·선택·이름 편집할 수 있도록 `SpeakerPicker` 모달과 라벨 편집 API 를 추가한다.

perso.ai / ElevenLabs 실호출 없음 — 화자 감지는 `MockVoiceProvider` 경로 유지.

## 변경 내용
- `packages/backend/src/routes/voice.ts`
  - `PATCH /voice/uploads/:uploadId/speakers/:speakerId` — 라벨을 1~50자로 수정. 업로드 소유권 + 화자-업로드 매칭 검증 후 `UPDATE voice_speakers SET label = ?`.
  - 기존 `Row` → 객체 캐스트 3곳을 `unknown` 경유로 변경해 `tsc --noEmit` strict 통과.
- `packages/web/src/services/api.ts` — `uploadVoiceAudio`, `separateUpload`, `listSpeakers`, `renameSpeaker` + `Speaker` / `VoiceUploadMeta` 타입. snake_case ↔ camelCase 응답을 `normalizeSpeaker`로 흡수.
- `packages/web/src/components/SpeakerPicker.tsx` — 모달 컴포넌트. 파일 선택 → 업로드 → (기존 결과 있으면 재사용, 없으면 분리) → 화자 리스트 표시 → radio 선택 + inline 라벨 편집. API 함수 주입(`api` prop) 가능 설계로 테스트 용이.
- `packages/web/src/pages/VoicesPage.tsx` — 헤더에 "화자 감지" 버튼 추가 → `SpeakerPicker` 모달 열기.

## 검증
- `npm test` (모노레포 전체): backend 265 · voice 12 · shared 11 · web 21 · mobile 16 — **325건 통과** (신규: backend 7 + web 7).
- `npm run typecheck` — 전 워크스페이스 통과.
- `npm run lint` — 오류 0건 (기존 경고 11건 유지).

## 리스크 / 팔로업
- 선택된 화자를 실제 `voice_profiles` 로 전환하는 클론 연결은 별도 이슈(Phase 3 후속)로 분리.
- 모바일 화자 선택 UI 는 #16 에서 처리 예정.
- `SpeakerPicker` 는 세그먼트 오디오 재생을 아직 제공하지 않음(InlineAudioPlayer 연결은 mock 업로드 URL 체계가 필요해 후속).

Refs: #41