### PR TITLE
[#43] 화자 선택 UI 모바일 — SpeakerPicker 화면 + reducer

### DIFF
--- a/apps/mobile/app/(tabs)/voices.tsx
+++ b/apps/mobile/app/(tabs)/voices.tsx
@@ -182,6 +182,14 @@ export default function VoicesScreen() {
             </Text>
           </View>
         </TouchableOpacity>
+
+        <TouchableOpacity style={styles.addCard} onPress={() => router.push('/voice/picker')}>
+          <Text style={styles.addEmoji}>🧩</Text>
+          <View>
+            <Text style={styles.addTitle}>화자 감지 (mock)</Text>
+            <Text style={styles.addDesc}>업로드 후 감지된 화자를 직접 선택·편집합니다.</Text>
+          </View>
+        </TouchableOpacity>
       </View>
 
       <View style={styles.listSection}>

--- a/apps/mobile/app/voice/picker.tsx
+++ b/apps/mobile/app/voice/picker.tsx
@@ -1,0 +1,283 @@
+import { useCallback, useReducer } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import * as DocumentPicker from 'expo-document-picker';
+import { BorderRadius, Colors, FontSize, Spacing } from '../../src/constants/theme';
+import {
+  listSpeakers,
+  renameSpeaker,
+  separateUpload,
+  uploadVoiceAudio,
+  type SpeakerSegment,
+} from '../../src/services/api';
+import {
+  INITIAL_STATE,
+  sanitizeLabel,
+  speakerPickerReducer,
+} from '../../src/lib/speakerPickerState';
+
+export default function SpeakerPickerScreen() {
+  const router = useRouter();
+  const [state, dispatch] = useReducer(speakerPickerReducer, INITIAL_STATE);
+
+  const pickFile = useCallback(async () => {
+    const result = await DocumentPicker.getDocumentAsync({
+      type: ['audio/*'],
+      copyToCacheDirectory: true,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      const asset = result.assets[0];
+      dispatch({
+        type: 'PICK_FILE',
+        file: { uri: asset.uri, name: asset.name, type: asset.mimeType || 'audio/wav' },
+      });
+    }
+  }, []);
+
+  const runFlow = useCallback(async () => {
+    if (!state.file) return;
+    dispatch({ type: 'UPLOAD_START' });
+    try {
+      const upload = await uploadVoiceAudio(state.file);
+      dispatch({ type: 'UPLOAD_SUCCESS', upload });
+
+      const existing = await listSpeakers(upload.id).catch(() => [] as SpeakerSegment[]);
+      if (existing.length > 0) {
+        dispatch({ type: 'READY', speakers: existing });
+        return;
+      }
+
+      dispatch({ type: 'SEPARATE_START' });
+      const detected = await separateUpload(upload.id);
+      dispatch({ type: 'READY', speakers: detected });
+    } catch (err) {
+      dispatch({ type: 'FAIL', message: err instanceof Error ? err.message : '업로드 실패' });
+    }
+  }, [state.file]);
+
+  const commitEdit = useCallback(
+    async (speaker: SpeakerSegment) => {
+      if (!state.upload) return;
+      const sanitized = sanitizeLabel(state.draftLabel);
+      if (!sanitized.ok) {
+        dispatch({ type: 'FAIL', message: sanitized.error ?? '라벨 오류' });
+        return;
+      }
+      if (sanitized.value === speaker.label) {
+        dispatch({ type: 'EDIT_CANCEL' });
+        return;
+      }
+      try {
+        await renameSpeaker(state.upload.id, speaker.id, sanitized.value);
+        dispatch({ type: 'EDIT_COMMIT', speakerId: speaker.id, label: sanitized.value });
+      } catch (err) {
+        dispatch({
+          type: 'FAIL',
+          message: err instanceof Error ? err.message : '라벨 수정 실패',
+        });
+      }
+    },
+    [state.upload, state.draftLabel],
+  );
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Text style={styles.title}>화자 감지 (mock)</Text>
+        <Text style={styles.desc}>
+          오디오를 업로드하면 모의 분리 알고리즘이 화자를 나눕니다. 감지된 화자 중에서 선택하고
+          라벨을 편집할 수 있어요.
+        </Text>
+      </View>
+
+      {state.phase === 'idle' && (
+        <>
+          <TouchableOpacity style={styles.pickButton} onPress={pickFile}>
+            <Text style={styles.pickEmoji}>📁</Text>
+            <Text style={styles.pickText}>
+              {state.file ? state.file.name : '오디오 파일 선택'}
+            </Text>
+          </TouchableOpacity>
+
+          {state.file && (
+            <TouchableOpacity style={styles.primaryButton} onPress={runFlow}>
+              <Text style={styles.primaryText}>업로드 후 화자 감지</Text>
+            </TouchableOpacity>
+          )}
+        </>
+      )}
+
+      {(state.phase === 'uploading' || state.phase === 'separating') && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator color={Colors.light.primary} />
+          <Text style={styles.statusText}>
+            {state.phase === 'uploading' ? '업로드 중…' : '화자 분리 중…'}
+          </Text>
+        </View>
+      )}
+
+      {state.phase === 'error' && (
+        <View style={styles.errorCard}>
+          <Text style={styles.errorText}>{state.error ?? '알 수 없는 오류'}</Text>
+          <TouchableOpacity
+            style={styles.secondaryButton}
+            onPress={() => dispatch({ type: 'RESET' })}
+          >
+            <Text style={styles.secondaryText}>다시 시도</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {state.phase === 'ready' && (
+        <>
+          {state.speakers.length === 0 ? (
+            <Text style={styles.emptyText}>감지된 화자가 없습니다.</Text>
+          ) : (
+            state.speakers.map((sp) => {
+              const isSelected = state.selectedSpeakerId === sp.id;
+              const isEditing = state.editingSpeakerId === sp.id;
+              const durationSec = Math.max(0, (sp.end_ms - sp.start_ms) / 1000);
+              return (
+                <TouchableOpacity
+                  key={sp.id}
+                  style={[styles.speakerCard, isSelected && styles.speakerCardSelected]}
+                  onPress={() => dispatch({ type: 'SELECT', speakerId: sp.id })}
+                >
+                  <View style={styles.speakerRow}>
+                    {isEditing ? (
+                      <TextInput
+                        autoFocus
+                        value={state.draftLabel}
+                        onChangeText={(txt) => dispatch({ type: 'EDIT_CHANGE', label: txt })}
+                        onBlur={() => void commitEdit(sp)}
+                        onSubmitEditing={() => void commitEdit(sp)}
+                        style={styles.labelInput}
+                      />
+                    ) : (
+                      <Text style={styles.labelText}>{sp.label}</Text>
+                    )}
+                    <TouchableOpacity
+                      onPress={() =>
+                        dispatch({ type: 'EDIT_BEGIN', speakerId: sp.id, label: sp.label })
+                      }
+                    >
+                      <Text style={styles.renameText}>이름 변경</Text>
+                    </TouchableOpacity>
+                  </View>
+                  <Text style={styles.metaText}>
+                    {durationSec.toFixed(1)}초 · 신뢰도 {(sp.confidence * 100).toFixed(0)}%
+                  </Text>
+                </TouchableOpacity>
+              );
+            })
+          )}
+
+          <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()}>
+            <Text style={styles.secondaryText}>닫기</Text>
+          </TouchableOpacity>
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.light.background },
+  content: { padding: Spacing.lg, paddingBottom: 120 },
+  header: { marginBottom: Spacing.lg },
+  title: {
+    fontSize: FontSize.xxl,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: Spacing.sm,
+  },
+  desc: { fontSize: FontSize.md, color: Colors.light.textSecondary, lineHeight: 22 },
+  pickButton: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.xl,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: Colors.light.primary,
+    borderStyle: 'dashed',
+    marginBottom: Spacing.lg,
+  },
+  pickEmoji: { fontSize: 48, marginBottom: Spacing.sm },
+  pickText: { fontSize: FontSize.md, color: Colors.light.primary, fontWeight: '600' },
+  primaryButton: {
+    backgroundColor: Colors.light.primary,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.md,
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  primaryText: { color: '#FFF', fontSize: FontSize.lg, fontWeight: '700' },
+  secondaryButton: {
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.md,
+    alignItems: 'center',
+    marginTop: Spacing.md,
+  },
+  secondaryText: { color: Colors.light.textSecondary, fontSize: FontSize.md },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing.xl,
+  },
+  statusText: { marginLeft: Spacing.sm, color: Colors.light.textSecondary },
+  errorCard: {
+    backgroundColor: Colors.light.surface,
+    borderColor: '#F87171',
+    borderWidth: 1,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    marginBottom: Spacing.md,
+  },
+  errorText: { color: '#B91C1C', fontSize: FontSize.md },
+  emptyText: {
+    textAlign: 'center',
+    color: Colors.light.textSecondary,
+    padding: Spacing.xl,
+  },
+  speakerCard: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    marginBottom: Spacing.md,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  speakerCardSelected: { borderColor: Colors.light.primary },
+  speakerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  labelText: { fontSize: FontSize.lg, fontWeight: '600', color: Colors.light.text },
+  labelInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderRadius: BorderRadius.sm,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 4,
+    marginRight: Spacing.sm,
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+  },
+  renameText: { color: Colors.light.primary, fontSize: FontSize.sm, fontWeight: '600' },
+  metaText: {
+    marginTop: Spacing.sm,
+    fontSize: FontSize.sm,
+    color: Colors.light.textTertiary,
+  },
+});

--- a/apps/mobile/src/lib/speakerPickerState.ts
+++ b/apps/mobile/src/lib/speakerPickerState.ts
@@ -1,0 +1,99 @@
+import type { SpeakerSegment, VoiceUploadMeta } from '../services/api';
+
+export type SpeakerPickerPhase =
+  | 'idle'
+  | 'uploading'
+  | 'separating'
+  | 'ready'
+  | 'error';
+
+export interface SpeakerPickerState {
+  phase: SpeakerPickerPhase;
+  file: { uri: string; name: string; type: string } | null;
+  upload: VoiceUploadMeta | null;
+  speakers: SpeakerSegment[];
+  selectedSpeakerId: string | null;
+  editingSpeakerId: string | null;
+  draftLabel: string;
+  error: string | null;
+}
+
+export const INITIAL_STATE: SpeakerPickerState = {
+  phase: 'idle',
+  file: null,
+  upload: null,
+  speakers: [],
+  selectedSpeakerId: null,
+  editingSpeakerId: null,
+  draftLabel: '',
+  error: null,
+};
+
+export type SpeakerPickerAction =
+  | { type: 'PICK_FILE'; file: { uri: string; name: string; type: string } | null }
+  | { type: 'UPLOAD_START' }
+  | { type: 'UPLOAD_SUCCESS'; upload: VoiceUploadMeta }
+  | { type: 'SEPARATE_START' }
+  | { type: 'READY'; speakers: SpeakerSegment[] }
+  | { type: 'FAIL'; message: string }
+  | { type: 'SELECT'; speakerId: string }
+  | { type: 'EDIT_BEGIN'; speakerId: string; label: string }
+  | { type: 'EDIT_CHANGE'; label: string }
+  | { type: 'EDIT_CANCEL' }
+  | { type: 'EDIT_COMMIT'; speakerId: string; label: string }
+  | { type: 'RESET' };
+
+export function speakerPickerReducer(
+  state: SpeakerPickerState,
+  action: SpeakerPickerAction,
+): SpeakerPickerState {
+  switch (action.type) {
+    case 'PICK_FILE':
+      return { ...state, file: action.file, error: null };
+    case 'UPLOAD_START':
+      return { ...state, phase: 'uploading', error: null };
+    case 'UPLOAD_SUCCESS':
+      return { ...state, upload: action.upload };
+    case 'SEPARATE_START':
+      return { ...state, phase: 'separating' };
+    case 'READY':
+      return { ...state, phase: 'ready', speakers: action.speakers, error: null };
+    case 'FAIL':
+      return { ...state, phase: 'error', error: action.message };
+    case 'SELECT':
+      return { ...state, selectedSpeakerId: action.speakerId };
+    case 'EDIT_BEGIN':
+      return { ...state, editingSpeakerId: action.speakerId, draftLabel: action.label };
+    case 'EDIT_CHANGE':
+      return { ...state, draftLabel: action.label };
+    case 'EDIT_CANCEL':
+      return { ...state, editingSpeakerId: null, draftLabel: '' };
+    case 'EDIT_COMMIT': {
+      const next = state.speakers.map((s) =>
+        s.id === action.speakerId ? { ...s, label: action.label } : s,
+      );
+      return { ...state, speakers: next, editingSpeakerId: null, draftLabel: '' };
+    }
+    case 'RESET':
+      return INITIAL_STATE;
+    default:
+      return state;
+  }
+}
+
+export interface SanitizedLabel {
+  ok: boolean;
+  value: string;
+  error?: string;
+}
+
+export function sanitizeLabel(raw: string): SanitizedLabel {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, value: '', error: '라벨을 입력하세요.' };
+  }
+  if (trimmed.length > 50) {
+    return { ok: false, value: trimmed, error: '라벨은 50자 이하여야 합니다.' };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -147,6 +147,80 @@ export async function deleteVoiceProfile(id: string) {
   await del(`/voice/${id}`);
 }
 
+// ===== Voice upload + speaker picker (mock path) =====
+
+export interface VoiceUploadMeta {
+  id: string;
+  objectKey: string;
+  mimeType: string;
+  sizeBytes: number;
+  durationMs: number | null;
+  originalName: string | null;
+  createdAt: string;
+}
+
+export interface SpeakerSegment {
+  id: string;
+  upload_id: string;
+  label: string;
+  start_ms: number;
+  end_ms: number;
+  confidence: number;
+  created_at?: string;
+}
+
+function normalizeSpeakerSegment(raw: Record<string, unknown>): SpeakerSegment {
+  return {
+    id: String(raw.id ?? raw['speaker_id'] ?? ''),
+    upload_id: String(raw.upload_id ?? raw.uploadId ?? ''),
+    label: String(raw.label ?? ''),
+    start_ms: Number(raw.start_ms ?? raw.startMs ?? 0),
+    end_ms: Number(raw.end_ms ?? raw.endMs ?? 0),
+    confidence: Number(raw.confidence ?? 0),
+    created_at: raw.created_at as string | undefined,
+  };
+}
+
+export async function uploadVoiceAudio(
+  audioFile: { uri: string; name: string; type: string },
+  durationMs?: number,
+): Promise<VoiceUploadMeta> {
+  const formData = new FormData();
+  formData.append('audio', audioFile as unknown as Blob);
+  if (durationMs !== undefined) formData.append('durationMs', String(durationMs));
+  if (audioFile.name) formData.append('originalName', audioFile.name);
+  const data = await post<{ upload: VoiceUploadMeta }>('/voice/upload', formData, {
+    isFormData: true,
+  });
+  return data.upload;
+}
+
+export async function separateUpload(uploadId: string): Promise<SpeakerSegment[]> {
+  const data = await post<{ speakers: Array<Record<string, unknown>> }>(
+    `/voice/uploads/${uploadId}/separate`,
+  );
+  return data.speakers.map(normalizeSpeakerSegment);
+}
+
+export async function listSpeakers(uploadId: string): Promise<SpeakerSegment[]> {
+  const data = await get<{ speakers: Array<Record<string, unknown>> }>(
+    `/voice/uploads/${uploadId}/speakers`,
+  );
+  return data.speakers.map(normalizeSpeakerSegment);
+}
+
+export async function renameSpeaker(
+  uploadId: string,
+  speakerId: string,
+  label: string,
+): Promise<{ id: string; label: string }> {
+  const data = await patch<{ speaker: { id: string; label: string } }>(
+    `/voice/uploads/${uploadId}/speakers/${speakerId}`,
+    { label },
+  );
+  return data.speaker;
+}
+
 // ===== TTS API =====
 
 export async function generateTTS(params: {

--- a/apps/mobile/test/speakerPickerState.test.ts
+++ b/apps/mobile/test/speakerPickerState.test.ts
@@ -1,0 +1,145 @@
+import {
+  INITIAL_STATE,
+  sanitizeLabel,
+  speakerPickerReducer,
+  type SpeakerPickerState,
+} from '../src/lib/speakerPickerState';
+
+const uploadMeta = {
+  id: 'u1',
+  objectKey: 'mem://u/x',
+  mimeType: 'audio/mpeg',
+  sizeBytes: 4,
+  durationMs: 3000,
+  originalName: 'a.mp3',
+  createdAt: '2026-04-21T00:00:00Z',
+};
+
+function speaker(id: string, label: string) {
+  return {
+    id,
+    upload_id: 'u1',
+    label,
+    start_ms: 0,
+    end_ms: 3000,
+    confidence: 0.9,
+  };
+}
+
+describe('speakerPickerReducer', () => {
+  it('초기 상태는 idle/빈 배열/에러 없음', () => {
+    expect(INITIAL_STATE.phase).toBe('idle');
+    expect(INITIAL_STATE.speakers).toHaveLength(0);
+    expect(INITIAL_STATE.error).toBeNull();
+  });
+
+  it('PICK_FILE 은 파일을 설정하고 이전 에러를 비운다', () => {
+    const start: SpeakerPickerState = { ...INITIAL_STATE, phase: 'error', error: '이전 실패' };
+    const next = speakerPickerReducer(start, {
+      type: 'PICK_FILE',
+      file: { uri: 'file://a', name: 'a.mp3', type: 'audio/mpeg' },
+    });
+    expect(next.file?.name).toBe('a.mp3');
+    expect(next.error).toBeNull();
+  });
+
+  it('UPLOAD_START → UPLOAD_SUCCESS → SEPARATE_START → READY 정상 플로우', () => {
+    let s: SpeakerPickerState = INITIAL_STATE;
+    s = speakerPickerReducer(s, { type: 'UPLOAD_START' });
+    expect(s.phase).toBe('uploading');
+    s = speakerPickerReducer(s, { type: 'UPLOAD_SUCCESS', upload: uploadMeta });
+    expect(s.upload?.id).toBe('u1');
+    s = speakerPickerReducer(s, { type: 'SEPARATE_START' });
+    expect(s.phase).toBe('separating');
+    s = speakerPickerReducer(s, {
+      type: 'READY',
+      speakers: [speaker('s1', '화자 1'), speaker('s2', '화자 2')],
+    });
+    expect(s.phase).toBe('ready');
+    expect(s.speakers).toHaveLength(2);
+  });
+
+  it('FAIL 은 에러 상태로 전이하고 메시지를 저장한다', () => {
+    const next = speakerPickerReducer(INITIAL_STATE, { type: 'FAIL', message: '네트워크 오류' });
+    expect(next.phase).toBe('error');
+    expect(next.error).toBe('네트워크 오류');
+  });
+
+  it('SELECT 는 selectedSpeakerId 를 바꾼다', () => {
+    const start: SpeakerPickerState = {
+      ...INITIAL_STATE,
+      speakers: [speaker('s1', '화자 1')],
+      phase: 'ready',
+    };
+    const next = speakerPickerReducer(start, { type: 'SELECT', speakerId: 's1' });
+    expect(next.selectedSpeakerId).toBe('s1');
+  });
+
+  it('EDIT_BEGIN/CHANGE/CANCEL 은 editing 상태만 바꾸고 speakers 배열은 유지', () => {
+    const start: SpeakerPickerState = {
+      ...INITIAL_STATE,
+      speakers: [speaker('s1', '화자 1')],
+      phase: 'ready',
+    };
+    let s = speakerPickerReducer(start, { type: 'EDIT_BEGIN', speakerId: 's1', label: '화자 1' });
+    expect(s.editingSpeakerId).toBe('s1');
+    expect(s.draftLabel).toBe('화자 1');
+    s = speakerPickerReducer(s, { type: 'EDIT_CHANGE', label: '엄마' });
+    expect(s.draftLabel).toBe('엄마');
+    expect(s.speakers[0].label).toBe('화자 1');
+    s = speakerPickerReducer(s, { type: 'EDIT_CANCEL' });
+    expect(s.editingSpeakerId).toBeNull();
+    expect(s.draftLabel).toBe('');
+  });
+
+  it('EDIT_COMMIT 은 대상 화자 라벨만 교체한다', () => {
+    const start: SpeakerPickerState = {
+      ...INITIAL_STATE,
+      speakers: [speaker('s1', '화자 1'), speaker('s2', '화자 2')],
+      editingSpeakerId: 's1',
+      draftLabel: '엄마',
+      phase: 'ready',
+    };
+    const next = speakerPickerReducer(start, {
+      type: 'EDIT_COMMIT',
+      speakerId: 's1',
+      label: '엄마',
+    });
+    expect(next.speakers[0].label).toBe('엄마');
+    expect(next.speakers[1].label).toBe('화자 2');
+    expect(next.editingSpeakerId).toBeNull();
+  });
+
+  it('RESET 은 초기 상태로 되돌린다', () => {
+    const dirty: SpeakerPickerState = {
+      ...INITIAL_STATE,
+      phase: 'ready',
+      speakers: [speaker('s1', '화자 1')],
+      selectedSpeakerId: 's1',
+    };
+    expect(speakerPickerReducer(dirty, { type: 'RESET' })).toEqual(INITIAL_STATE);
+  });
+});
+
+describe('sanitizeLabel', () => {
+  it('앞뒤 공백을 제거한다', () => {
+    expect(sanitizeLabel('  엄마  ')).toEqual({ ok: true, value: '엄마' });
+  });
+
+  it('빈 문자열은 거절한다', () => {
+    const r = sanitizeLabel('   ');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('입력');
+  });
+
+  it('51자 이상이면 거절한다', () => {
+    const r = sanitizeLabel('가'.repeat(51));
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('50자');
+  });
+
+  it('50자 정확히는 허용', () => {
+    const r = sanitizeLabel('가'.repeat(50));
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## 개요
Phase 3 #16 `화자 선택 UI (모바일)` 이슈(#43) 처리. 모바일에서도 업로드 → 분리 → 화자 선택 → 라벨 편집을 할 수 있는 새 화면을 제공한다. 기존 `diarize.tsx`(ElevenLabs 경로)는 건드리지 않고, mock 경로 전용 화면을 `app/voice/picker.tsx` 로 신규 추가.

perso.ai / ElevenLabs 실호출 없음 — 모두 `MockVoiceProvider` 경로.

## 변경 내용
- `apps/mobile/src/services/api.ts` — `uploadVoiceAudio`, `separateUpload`, `listSpeakers`, `renameSpeaker` + `SpeakerSegment` / `VoiceUploadMeta` 타입. snake/camel 응답을 `normalizeSpeakerSegment` 로 흡수.
- `apps/mobile/src/lib/speakerPickerState.ts` — 화면 상태 전이를 순수 reducer 로 분리. `idle → uploading → separating → ready` / `error` 전이 + SELECT / EDIT_BEGIN / EDIT_CHANGE / EDIT_COMMIT / EDIT_CANCEL / RESET. `sanitizeLabel()` 로 입력 검증.
- `apps/mobile/app/voice/picker.tsx` — `useReducer` 기반 신규 화면. `expo-document-picker` 로 파일 선택 → 업로드 → 기존 결과 있으면 `listSpeakers` 재사용, 없으면 `separateUpload` 실행 → radio 선택 + inline 라벨 편집.
- `apps/mobile/app/(tabs)/voices.tsx` — 헤더 카드 리스트에 "화자 감지 (mock)" 카드 링크 추가.
- `apps/mobile/test/speakerPickerState.test.ts` — reducer 8건 + sanitizeLabel 4건 = 12건 jest 테스트.

## 검증
- `npm test` (모노레포 전체): backend 265 · voice 12 · shared 11 · web 21 · **mobile 28** — **337건 통과** (신규 mobile +12).
- `npm run typecheck` — 전 워크스페이스 통과.
- `npm run lint` — 오류 0건 (기존 경고 11건 유지).

## 리스크 / 팔로업
- 선택된 화자 → `voice_profiles` 클론 전환은 별도 후속 이슈.
- 오디오 세그먼트 재생 UI 는 URL 체계 정리 후 연결.
- 기존 `/voice/diarize` 경로의 ElevenLabs→mock 전환은 별도 정리 이슈.

Refs: #43