### PR TITLE
feat(voice): 음성 프로필 이름 변경 기능 (#45)

### DIFF
--- a/apps/mobile/app/voice/[id].tsx
+++ b/apps/mobile/app/voice/[id].tsx
@@ -1,16 +1,28 @@
-import { View, Text, StyleSheet, FlatList, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { useState } from 'react';
+import {
+  Alert,
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  FlatList,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Colors, Spacing, BorderRadius, FontSize } from '../../src/constants/theme';
-import { getVoiceProfiles, getMessages, getAlarms } from '../../src/services/api';
+import { getVoiceProfiles, getMessages, getAlarms, updateVoiceProfile } from '../../src/services/api';
 import { useAppStore } from '../../src/stores/useAppStore';
+import { sanitizeVoiceName } from '../../src/lib/voiceName';
 import type { Message, Alarm, VoiceProfile } from '../../src/types';
 
 export default function VoiceDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const isAuthenticated = useAppStore((s) => s.isAuthenticated);
   const { t } = useTranslation();
 
@@ -19,6 +31,40 @@ export default function VoiceDetailScreen() {
     queryFn: getVoiceProfiles,
     enabled: isAuthenticated,
   });
+
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [draftName, setDraftName] = useState('');
+
+  const renameMutation = useMutation({
+    mutationFn: (name: string) => updateVoiceProfile(id!, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['voiceProfiles'] });
+      setIsEditingName(false);
+      setDraftName('');
+    },
+    onError: (err) => {
+      Alert.alert('이름 변경 실패', err instanceof Error ? err.message : '네트워크 오류');
+    },
+  });
+
+  const beginEdit = (currentName: string) => {
+    setDraftName(currentName);
+    setIsEditingName(true);
+  };
+
+  const commitEdit = (currentName: string) => {
+    const sanitized = sanitizeVoiceName(draftName);
+    if (!sanitized.ok) {
+      Alert.alert('입력 오류', sanitized.error ?? '이름이 올바르지 않습니다.');
+      return;
+    }
+    if (sanitized.value === currentName) {
+      setIsEditingName(false);
+      setDraftName('');
+      return;
+    }
+    renameMutation.mutate(sanitized.value);
+  };
 
   const { data: messages, isLoading: loadingMessages } = useQuery({
     queryKey: ['messages'],
@@ -45,7 +91,50 @@ export default function VoiceDetailScreen() {
           <View style={styles.avatarLarge}>
             <Text style={styles.avatarText}>{profile.name.charAt(0)}</Text>
           </View>
-          <Text style={styles.profileName}>{profile.name}</Text>
+          {isEditingName ? (
+            <View style={styles.renameRow}>
+              <TextInput
+                autoFocus
+                value={draftName}
+                onChangeText={setDraftName}
+                onSubmitEditing={() => commitEdit(profile.name)}
+                maxLength={60}
+                style={styles.renameInput}
+                accessibilityLabel="음성 이름 입력"
+              />
+              <TouchableOpacity
+                accessibilityLabel="이름 변경 저장"
+                onPress={() => commitEdit(profile.name)}
+                disabled={renameMutation.isPending}
+                style={styles.renameSaveBtn}
+              >
+                <Text style={styles.renameSaveText}>
+                  {renameMutation.isPending ? '저장…' : '저장'}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                accessibilityLabel="이름 변경 취소"
+                onPress={() => {
+                  setIsEditingName(false);
+                  setDraftName('');
+                }}
+                style={styles.renameCancelBtn}
+              >
+                <Text style={styles.renameCancelText}>취소</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <>
+              <Text style={styles.profileName}>{profile.name}</Text>
+              <TouchableOpacity
+                accessibilityLabel="음성 이름 변경"
+                onPress={() => beginEdit(profile.name)}
+                style={styles.renameBtn}
+              >
+                <Text style={styles.renameText}>이름 변경</Text>
+              </TouchableOpacity>
+            </>
+          )}
           <Text style={styles.profileDate}>
             {new Date(profile.created_at).toLocaleDateString('ko-KR')}
           </Text>
@@ -164,6 +253,52 @@ const styles = StyleSheet.create({
     fontSize: FontSize.sm,
     color: Colors.light.textTertiary,
     marginTop: Spacing.xs,
+  },
+  renameBtn: {
+    marginTop: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+  },
+  renameText: {
+    fontSize: FontSize.sm,
+    color: Colors.light.primary,
+    fontWeight: '600',
+  },
+  renameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    marginTop: Spacing.xs,
+  },
+  renameInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderRadius: BorderRadius.sm,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 6,
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+  },
+  renameSaveBtn: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 6,
+    backgroundColor: Colors.light.primary,
+    borderRadius: BorderRadius.sm,
+  },
+  renameSaveText: {
+    color: '#fff',
+    fontSize: FontSize.sm,
+    fontWeight: '700',
+  },
+  renameCancelBtn: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 6,
+  },
+  renameCancelText: {
+    color: Colors.light.textSecondary,
+    fontSize: FontSize.sm,
   },
   statsRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/lib/voiceName.ts
+++ b/apps/mobile/src/lib/voiceName.ts
@@ -1,0 +1,16 @@
+export interface SanitizedVoiceName {
+  ok: boolean;
+  value: string;
+  error?: string;
+}
+
+export function sanitizeVoiceName(raw: string): SanitizedVoiceName {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, value: '', error: '이름을 입력하세요.' };
+  }
+  if (trimmed.length > 50) {
+    return { ok: false, value: trimmed, error: '이름은 50자 이하여야 합니다.' };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -147,6 +147,11 @@ export async function deleteVoiceProfile(id: string) {
   await del(`/voice/${id}`);
 }
 
+export async function updateVoiceProfile(id: string, name: string) {
+  const data = await patch<{ profile: { id: string; name: string } }>(`/voice/${id}`, { name });
+  return data.profile;
+}
+
 // ===== Voice upload + speaker picker (mock path) =====
 
 export interface VoiceUploadMeta {

--- a/apps/mobile/test/voiceName.test.ts
+++ b/apps/mobile/test/voiceName.test.ts
@@ -1,0 +1,28 @@
+import { sanitizeVoiceName } from '../src/lib/voiceName';
+
+describe('sanitizeVoiceName', () => {
+  it('앞뒤 공백을 제거한다', () => {
+    expect(sanitizeVoiceName('  엄마  ')).toEqual({ ok: true, value: '엄마' });
+  });
+
+  it('빈 문자열은 거절한다', () => {
+    const r = sanitizeVoiceName('   ');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('입력');
+  });
+
+  it('51자 이상이면 거절한다', () => {
+    const r = sanitizeVoiceName('가'.repeat(51));
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('50자');
+  });
+
+  it('50자 정확히는 허용', () => {
+    const r = sanitizeVoiceName('가'.repeat(50));
+    expect(r.ok).toBe(true);
+  });
+
+  it('일반 한글 이름 허용', () => {
+    expect(sanitizeVoiceName('아빠 목소리').ok).toBe(true);
+  });
+});

--- a/packages/backend/src/routes/voice.ts
+++ b/packages/backend/src/routes/voice.ts
@@ -289,6 +289,44 @@ voice.get('/:id', async (c) => {
   return c.json({ profile: result.rows[0] });
 });
 
+/** 음성 프로필 이름 변경 */
+voice.patch('/:id', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const id = c.req.param('id');
+
+  if (!UUID_RE.test(id)) {
+    return c.json({ error: 'Invalid voice profile ID format' }, 400);
+  }
+
+  let body: { name?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'JSON body required' }, 400);
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (name.length === 0 || name.length > 50) {
+    return c.json({ error: 'name must be 1-50 characters' }, 400);
+  }
+
+  const existing = await db.execute({
+    sql: 'SELECT id FROM voice_profiles WHERE id = ? AND user_id = ?',
+    args: [id, userId],
+  });
+  if (existing.rows.length === 0) {
+    return c.json({ error: 'Voice profile not found' }, 404);
+  }
+
+  await db.execute({
+    sql: "UPDATE voice_profiles SET name = ?, updated_at = datetime('now') WHERE id = ?",
+    args: [name, id],
+  });
+
+  return c.json({ profile: { id, name } });
+});
+
 /** 음성 클론 생성 (오디오 업로드) */
 voice.post('/clone', async (c) => {
   const userId = c.get('userId');

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -110,6 +110,68 @@ describe('GET /voice/:id — 음성 프로필 상세', () => {
   });
 });
 
+describe('PATCH /voice/:id — 음성 프로필 이름 변경', () => {
+  it('잘못된 UUID 형식이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/voice/bad-id', { name: '새 이름' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('JSON 이 아니면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request(`http://localhost/voice/${V1}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not-json',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('이름이 공백이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', `/voice/${V1}`, { name: '   ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('이름이 51자 이상이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('PATCH', `/voice/${V1}`, { name: '가'.repeat(51) }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('존재하지 않거나 소유자가 아니면 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('PATCH', `/voice/${V404}`, { name: '새 이름' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('정상 변경은 200 과 새 이름을 반환하고 updated_at 이 갱신된다', async () => {
+    mockDB.pushResult([{ id: V1 }]);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('PATCH', `/voice/${V1}`, { name: '  엄마 목소리  ' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile.id).toBe(V1);
+    expect(body.profile.name).toBe('엄마 목소리');
+
+    const update = mockDB.calls.find((c) => c.sql.includes('UPDATE voice_profiles'));
+    expect(update).toBeDefined();
+    expect(update!.sql).toContain('updated_at');
+    expect(update!.args).toContain('엄마 목소리');
+    expect(update!.args).toContain(V1);
+  });
+});
+
 describe('GET /voice/:id/stats — 음성 프로필 통계', () => {
   it('잘못된 UUID 형식이면 400', async () => {
     const app = buildApp();

--- a/packages/web/src/lib/voiceName.ts
+++ b/packages/web/src/lib/voiceName.ts
@@ -1,0 +1,16 @@
+export interface SanitizedVoiceName {
+  ok: boolean;
+  value: string;
+  error?: string;
+}
+
+export function sanitizeVoiceName(raw: string): SanitizedVoiceName {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, value: '', error: '이름을 입력하세요.' };
+  }
+  if (trimmed.length > 50) {
+    return { ok: false, value: trimmed, error: '이름은 50자 이하여야 합니다.' };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/packages/web/src/pages/VoicesPage.tsx
+++ b/packages/web/src/pages/VoicesPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getVoiceProfiles, createVoiceClone, deleteVoiceProfile, generateTTS, getMessagesByVoice, getAlarms } from '../services/api';
+import { getVoiceProfiles, createVoiceClone, deleteVoiceProfile, updateVoiceProfile, generateTTS, getMessagesByVoice, getAlarms } from '../services/api';
 import type { VoiceProfile, Message, Alarm } from '../types';
 import { getApiErrorMessage } from '../types';
 import { VoiceCardSkeleton } from '../components/Skeleton';
 import SpeakerPicker from '../components/SpeakerPicker';
+import { sanitizeVoiceName } from '../lib/voiceName';
 
 export default function VoicesPage() {
   const queryClient = useQueryClient();
@@ -33,6 +34,28 @@ export default function VoicesPage() {
       setUploadFile(null);
     },
   });
+
+  const renameMutation = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => updateVoiceProfile(id, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['voiceProfiles'] });
+    },
+    onError: (err) => {
+      alert(`이름 변경 실패: ${getApiErrorMessage(err, '네트워크 오류')}`);
+    },
+  });
+
+  const handleRename = (profile: VoiceProfile) => {
+    const raw = window.prompt('새 이름을 입력하세요 (1~50자)', profile.name);
+    if (raw === null) return;
+    const sanitized = sanitizeVoiceName(raw);
+    if (!sanitized.ok) {
+      alert(sanitized.error ?? '이름이 올바르지 않습니다.');
+      return;
+    }
+    if (sanitized.value === profile.name) return;
+    renameMutation.mutate({ id: profile.id, name: sanitized.value });
+  };
 
   const deleteMutation = useMutation({
     mutationFn: deleteVoiceProfile,
@@ -278,6 +301,16 @@ export default function VoicesPage() {
                   onClick={(e) => { e.stopPropagation(); handleTest(profile.id); }}
                 >
                   {testingId === profile.id ? '생성 중...' : '테스트'}
+                </button>
+                <button
+                  aria-label={`${profile.name} 이름 변경`}
+                  className="text-sm text-[var(--color-text-secondary)] font-medium hover:underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRename(profile);
+                  }}
+                >
+                  이름 변경
                 </button>
                 <button
                   aria-label={`${profile.name} 프로필 삭제`}

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -56,6 +56,11 @@ export async function deleteVoiceProfile(id: string) {
   await api.delete(`/voice/${id}`);
 }
 
+export async function updateVoiceProfile(id: string, name: string) {
+  const { data } = await api.patch(`/voice/${id}`, { name });
+  return data.profile as { id: string; name: string };
+}
+
 export async function generateTTS(params: {
   voice_profile_id: string;
   text: string;

--- a/packages/web/test/voiceName.test.ts
+++ b/packages/web/test/voiceName.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeVoiceName } from '../src/lib/voiceName';
+
+describe('sanitizeVoiceName (web)', () => {
+  it('앞뒤 공백을 제거한다', () => {
+    expect(sanitizeVoiceName('  엄마  ')).toEqual({ ok: true, value: '엄마' });
+  });
+
+  it('빈 문자열은 거절한다', () => {
+    const r = sanitizeVoiceName('   ');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('입력');
+  });
+
+  it('51자 이상이면 거절한다', () => {
+    const r = sanitizeVoiceName('가'.repeat(51));
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('50자');
+  });
+
+  it('50자 정확히는 허용', () => {
+    const r = sanitizeVoiceName('가'.repeat(50));
+    expect(r.ok).toBe(true);
+  });
+
+  it('일반 한글 이름 허용', () => {
+    expect(sanitizeVoiceName('아빠 목소리').ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## 요약
TASK.md Phase 3 #17 "음성 라이브러리 — 이름 변경" 구현. 이슈 #45 해결.

## 변경 사항
- **백엔드** `PATCH /voice/:id` 추가
  - UUID 검증, JSON body 파싱, `name` 트림 후 1~50자 검증
  - 소유권 확인(사용자별 조회) → 없으면 404
  - `UPDATE voice_profiles SET name = ?, updated_at = datetime('now')`
- **웹** `services/api.ts::updateVoiceProfile` + `VoicesPage` 카드에 "이름 변경" 버튼(window.prompt 기반) + `lib/voiceName.ts` 순수 함수
- **모바일** `services/api.ts::updateVoiceProfile` + `app/voice/[id].tsx` 인라인 `TextInput` 편집 UI(iOS/Android 공통) + `src/lib/voiceName.ts` 순수 함수

## 테스트
- 백엔드 vitest 6건 (400 bad UUID / 400 bad JSON / 400 empty / 400 over-50 / 404 / 200 + UPDATE 검증)
- 웹 vitest 5건 (`sanitizeVoiceName` 규칙)
- 모바일 jest 5건 (`sanitizeVoiceName` 규칙)
- 전체: typecheck/lint/test 모두 통과

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test --workspaces`
- [x] `cd apps/mobile && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)