### PR TITLE
feat(backend): 알람 모델 확장 — mode/voice_profile_id/speaker_id (#49)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -180,6 +180,20 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_voice_speakers_upload ON voice_speakers(upload_id)',
     ],
   },
+  {
+    id: 5,
+    name: 'alarm-mode-voice-speaker',
+    statements: [
+      // mode: 'sound-only' 는 원본 오디오 재생, 'tts' 는 합성 메시지 재생 (기본)
+      `ALTER TABLE alarms ADD COLUMN mode TEXT NOT NULL DEFAULT 'tts'
+        CHECK(mode IN ('sound-only','tts'))`,
+      // 메시지 경유 없이 알람이 특정 음성 프로필·화자 세그먼트에 직접 바인딩될 수 있음
+      'ALTER TABLE alarms ADD COLUMN voice_profile_id TEXT',
+      'ALTER TABLE alarms ADD COLUMN speaker_id TEXT',
+      'CREATE INDEX IF NOT EXISTS idx_alarms_voice_profile ON alarms(voice_profile_id)',
+      'CREATE INDEX IF NOT EXISTS idx_alarms_speaker ON alarms(speaker_id)',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/alarm.ts
+++ b/packages/backend/src/routes/alarm.ts
@@ -3,6 +3,8 @@ import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ALARM_MODES = ['sound-only', 'tts'] as const;
+type AlarmMode = (typeof ALARM_MODES)[number];
 
 const alarm = new Hono<AppEnv>();
 
@@ -92,6 +94,9 @@ alarm.post('/', async (c) => {
     repeat_days?: number[];
     snooze_minutes?: number;
     target_user_id?: string;
+    mode?: string;
+    voice_profile_id?: string;
+    speaker_id?: string;
   }>();
 
   if (!body.message_id || !body.time) {
@@ -104,6 +109,18 @@ alarm.post('/', async (c) => {
 
   if (body.target_user_id && typeof body.target_user_id !== 'string') {
     return c.json({ error: 'Invalid target_user_id' }, 400);
+  }
+
+  if (body.mode !== undefined && !ALARM_MODES.includes(body.mode as AlarmMode)) {
+    return c.json({ error: `mode must be one of: ${ALARM_MODES.join(', ')}` }, 400);
+  }
+
+  if (body.voice_profile_id !== undefined && !UUID_RE.test(body.voice_profile_id)) {
+    return c.json({ error: 'Invalid voice_profile_id format' }, 400);
+  }
+
+  if (body.speaker_id !== undefined && !UUID_RE.test(body.speaker_id)) {
+    return c.json({ error: 'Invalid speaker_id format' }, 400);
   }
 
   if (!/^\d{2}:\d{2}$/.test(body.time)) {
@@ -168,9 +185,12 @@ alarm.post('/', async (c) => {
   }
 
   const alarmId = crypto.randomUUID();
+  const mode: AlarmMode = (body.mode as AlarmMode | undefined) ?? 'tts';
   await db.execute({
-    sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, repeat_days, snooze_minutes)
-          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO alarms
+            (id, user_id, target_user_id, message_id, time, repeat_days, snooze_minutes,
+             mode, voice_profile_id, speaker_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       alarmId,
       userId,
@@ -179,10 +199,13 @@ alarm.post('/', async (c) => {
       body.time,
       JSON.stringify(body.repeat_days ?? []),
       body.snooze_minutes ?? 5,
+      mode,
+      body.voice_profile_id ?? null,
+      body.speaker_id ?? null,
     ],
   });
 
-  return c.json({ alarm: { id: alarmId, ...body } }, 201);
+  return c.json({ alarm: { id: alarmId, ...body, mode } }, 201);
 });
 
 /** 알람 수정 */
@@ -201,10 +224,33 @@ alarm.patch('/:id', async (c) => {
     is_active?: boolean;
     snooze_minutes?: number;
     message_id?: string;
+    mode?: string;
+    voice_profile_id?: string | null;
+    speaker_id?: string | null;
   }>();
 
   if (body.message_id !== undefined && !UUID_RE.test(body.message_id)) {
     return c.json({ error: 'Invalid message_id format' }, 400);
+  }
+
+  if (body.mode !== undefined && !ALARM_MODES.includes(body.mode as AlarmMode)) {
+    return c.json({ error: `mode must be one of: ${ALARM_MODES.join(', ')}` }, 400);
+  }
+
+  if (
+    body.voice_profile_id !== undefined &&
+    body.voice_profile_id !== null &&
+    !UUID_RE.test(body.voice_profile_id)
+  ) {
+    return c.json({ error: 'Invalid voice_profile_id format' }, 400);
+  }
+
+  if (
+    body.speaker_id !== undefined &&
+    body.speaker_id !== null &&
+    !UUID_RE.test(body.speaker_id)
+  ) {
+    return c.json({ error: 'Invalid speaker_id format' }, 400);
   }
 
   // 알람 소유 확인
@@ -246,7 +292,7 @@ alarm.patch('/:id', async (c) => {
   }
 
   const updates: string[] = [];
-  const args: (string | number)[] = [];
+  const args: (string | number | null)[] = [];
 
   if (body.time !== undefined) {
     updates.push('time = ?');
@@ -268,6 +314,18 @@ alarm.patch('/:id', async (c) => {
     updates.push('message_id = ?');
     args.push(body.message_id);
   }
+  if (body.mode !== undefined) {
+    updates.push('mode = ?');
+    args.push(body.mode);
+  }
+  if (body.voice_profile_id !== undefined) {
+    updates.push('voice_profile_id = ?');
+    args.push(body.voice_profile_id);
+  }
+  if (body.speaker_id !== undefined) {
+    updates.push('speaker_id = ?');
+    args.push(body.speaker_id);
+  }
 
   if (updates.length === 0) {
     return c.json({ error: 'No fields to update' }, 400);
@@ -283,7 +341,8 @@ alarm.patch('/:id', async (c) => {
 
   const updated = await db.execute({
     sql: `SELECT id, user_id, target_user_id, message_id, time, repeat_days,
-                 is_active, snooze_minutes, created_at, updated_at
+                 is_active, snooze_minutes, mode, voice_profile_id, speaker_id,
+                 created_at, updated_at
           FROM alarms WHERE id = ?`,
     args: [id],
   });

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -149,6 +149,83 @@ describe('POST /alarm — 알람 생성', () => {
     );
     expect(res.status).toBe(201);
   });
+
+  it('mode 가 허용 목록 밖이면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', { message_id: ID.message, time: '07:00', mode: 'video' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('voice_profile_id UUID 형식이 아니면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', {
+        message_id: ID.message,
+        time: '07:00',
+        voice_profile_id: 'not-a-uuid',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('speaker_id UUID 형식이 아니면 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', {
+        message_id: ID.message,
+        time: '07:00',
+        speaker_id: 'bad',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('mode + voice_profile_id + speaker_id 포함해 정상 생성', async () => {
+    const voiceProfileId = '40000000-0000-4000-8000-000000000001';
+    const speakerId = '50000000-0000-4000-8000-000000000001';
+    mockDB.pushResult([{ plan: 'plus' }]);
+    mockDB.pushResult([{ id: ID.message }]);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', {
+        message_id: ID.message,
+        time: '07:00',
+        mode: 'sound-only',
+        voice_profile_id: voiceProfileId,
+        speaker_id: speakerId,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm.mode).toBe('sound-only');
+
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain('mode');
+    expect(insert!.sql).toContain('voice_profile_id');
+    expect(insert!.sql).toContain('speaker_id');
+    expect(insert!.args).toContain('sound-only');
+    expect(insert!.args).toContain(voiceProfileId);
+    expect(insert!.args).toContain(speakerId);
+  });
+
+  it('mode 미지정 시 기본값은 tts', async () => {
+    mockDB.pushResult([{ plan: 'plus' }]);
+    mockDB.pushResult([{ id: ID.message }]);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', { message_id: ID.message, time: '07:00' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm.mode).toBe('tts');
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(insert!.args).toContain('tts');
+  });
 });
 
 describe('PATCH /alarm/:id — 알람 수정', () => {
@@ -184,6 +261,47 @@ describe('PATCH /alarm/:id — 알람 수정', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
+  });
+
+  it('mode/voice_profile_id/speaker_id 변경 반영', async () => {
+    const voiceProfileId = '40000000-0000-4000-8000-0000000000aa';
+    const speakerId = '50000000-0000-4000-8000-0000000000bb';
+    mockDB.pushResult([{ id: ID.alarm }]); // existing
+    mockDB.pushResult([], 1); // update
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        time: '07:00',
+        is_active: 1,
+        snooze_minutes: 5,
+        repeat_days: '[]',
+        mode: 'sound-only',
+        voice_profile_id: voiceProfileId,
+        speaker_id: speakerId,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('PATCH', `/alarm/${ID.alarm}`, {
+        mode: 'sound-only',
+        voice_profile_id: voiceProfileId,
+        speaker_id: speakerId,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.alarm.mode).toBe('sound-only');
+    expect(body.alarm.voice_profile_id).toBe(voiceProfileId);
+    expect(body.alarm.speaker_id).toBe(speakerId);
+
+    const update = mockDB.calls.find((c) => c.sql.startsWith('UPDATE alarms SET'));
+    expect(update).toBeDefined();
+    expect(update!.sql).toContain('mode = ?');
+    expect(update!.sql).toContain('voice_profile_id = ?');
+    expect(update!.sql).toContain('speaker_id = ?');
+    expect(update!.args).toContain('sound-only');
+    expect(update!.args).toContain(voiceProfileId);
+    expect(update!.args).toContain(speakerId);
   });
 });
 

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -71,4 +71,16 @@ describe('migrations', () => {
     expect(all).toContain('confidence');
     expect(all).toContain('idx_voice_speakers_upload');
   });
+
+  it('마이그레이션 #5 에서 alarms 에 mode/voice_profile_id/speaker_id 컬럼을 추가한다', () => {
+    const m = migrations.find((x) => x.id === 5);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('ALTER TABLE alarms ADD COLUMN mode');
+    expect(all).toContain("CHECK(mode IN ('sound-only','tts'))");
+    expect(all).toContain('ALTER TABLE alarms ADD COLUMN voice_profile_id');
+    expect(all).toContain('ALTER TABLE alarms ADD COLUMN speaker_id');
+    expect(all).toContain('idx_alarms_voice_profile');
+    expect(all).toContain('idx_alarms_speaker');
+  });
 });


### PR DESCRIPTION
## 요약

알람이 단일 메시지 경유가 아닌, **모드별 재생 경로**와 **직접 음성 바인딩**을 갖도록 스키마와 API를 확장했습니다.

- `alarms.mode` — `sound-only` | `tts` (기본 `tts`)
- `alarms.voice_profile_id`, `alarms.speaker_id` — 화자 세그먼트를 직접 지정할 수 있는 선택 필드
- 인덱스 2개 추가 (voice_profile_id, speaker_id)

## 변경 내역

- `migrations.ts`: 마이그레이션 #5 `alarm-mode-voice-speaker` 추가 (ALTER TABLE ADD COLUMN × 3 + 인덱스 × 2)
- `routes/alarm.ts`:
  - POST/PATCH 모두에 mode 허용값 검증(`sound-only`|`tts`), `voice_profile_id`/`speaker_id` UUID 형식 검증
  - POST INSERT 에 mode/voice_profile_id/speaker_id 포함, 기본 mode = `tts`
  - PATCH UPDATE 에 신규 필드 추가, 후속 SELECT 에도 노출
- `test/alarm.test.ts`: 6건 추가
  - mode 허용값 밖 400 / voice_profile_id·speaker_id UUID 검증 400
  - mode+voice_profile_id+speaker_id 정상 생성 (INSERT SQL·args 교차 확인)
  - mode 미지정 시 기본값 tts
  - PATCH mode/voice_profile_id/speaker_id 변경 반영 (UPDATE SQL 교차 확인)
- `test/migrations.test.ts`: #5 커버리지 추가

## 테스트

- `npm run typecheck` — 0 error
- `npm run lint` — 0 error (기존 warning 만 존재)
- `npm test --workspaces` — 332건 전부 통과 (backend 283, shared 12, voice 11, web 26)
- perso.ai / ElevenLabs / 결제 PG 실호출 없음

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)