### PR TITLE
feat(backend): 알람 CRUD 응답 정규화 — repeat_days/is_active/mode 일관화 (#51)

### DIFF
--- a/packages/backend/src/routes/alarm.ts
+++ b/packages/backend/src/routes/alarm.ts
@@ -6,6 +6,41 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const ALARM_MODES = ['sound-only', 'tts'] as const;
 type AlarmMode = (typeof ALARM_MODES)[number];
 
+type AlarmRow = Record<string, unknown> & {
+  repeat_days?: unknown;
+  is_active?: unknown;
+  mode?: unknown;
+  voice_profile_id?: unknown;
+  speaker_id?: unknown;
+};
+
+function normalizeAlarmRow(row: AlarmRow) {
+  const rawRepeat = row.repeat_days;
+  let repeatDays: number[] = [];
+  if (typeof rawRepeat === 'string' && rawRepeat.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(rawRepeat);
+      if (Array.isArray(parsed)) repeatDays = parsed.filter((n): n is number => Number.isInteger(n));
+    } catch {
+      repeatDays = [];
+    }
+  } else if (Array.isArray(rawRepeat)) {
+    repeatDays = rawRepeat.filter((n): n is number => Number.isInteger(n));
+  }
+
+  const mode: AlarmMode =
+    row.mode === 'sound-only' || row.mode === 'tts' ? row.mode : 'tts';
+
+  return {
+    ...row,
+    repeat_days: repeatDays,
+    is_active: row.is_active === 1 || row.is_active === true,
+    mode,
+    voice_profile_id: (row.voice_profile_id ?? null) as string | null,
+    speaker_id: (row.speaker_id ?? null) as string | null,
+  };
+}
+
 const alarm = new Hono<AppEnv>();
 
 /** 알람 목록 조회 */
@@ -52,7 +87,8 @@ alarm.get('/', async (c) => {
   ]);
 
   const total = Number(countRes.rows[0].total);
-  return c.json({ alarms: result.rows, total, limit, offset });
+  const alarms = (result.rows as AlarmRow[]).map(normalizeAlarmRow);
+  return c.json({ alarms, total, limit, offset });
 });
 
 /** 단일 알람 조회 */
@@ -80,7 +116,7 @@ alarm.get('/:id', async (c) => {
     return c.json({ error: 'Alarm not found' }, 404);
   }
 
-  return c.json({ alarm: result.rows[0] });
+  return c.json({ alarm: normalizeAlarmRow(result.rows[0] as AlarmRow) });
 });
 
 /** 알람 생성 */
@@ -205,7 +241,18 @@ alarm.post('/', async (c) => {
     ],
   });
 
-  return c.json({ alarm: { id: alarmId, ...body, mode } }, 201);
+  return c.json(
+    {
+      alarm: {
+        id: alarmId,
+        ...body,
+        mode,
+        voice_profile_id: body.voice_profile_id ?? null,
+        speaker_id: body.speaker_id ?? null,
+      },
+    },
+    201,
+  );
 });
 
 /** 알람 수정 */
@@ -347,14 +394,9 @@ alarm.patch('/:id', async (c) => {
     args: [id],
   });
 
-  const row = updated.rows[0];
   return c.json({
     success: true,
-    alarm: {
-      ...row,
-      repeat_days: row.repeat_days ? JSON.parse(row.repeat_days as string) : [],
-      is_active: row.is_active === 1,
-    },
+    alarm: normalizeAlarmRow(updated.rows[0] as AlarmRow),
   });
 });
 

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -52,6 +52,101 @@ describe('GET /alarm — 알람 목록', () => {
     expect(body.alarms).toHaveLength(1);
     expect(body.alarms[0].time).toBe('07:00');
   });
+
+  it('목록 응답이 정규화된다 — repeat_days 배열, is_active boolean, mode 기본값', async () => {
+    mockDB.pushResult([{ total: 1 }]);
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        time: '07:00',
+        is_active: 1,
+        repeat_days: '[1,3,5]',
+        mode: null,
+        voice_profile_id: null,
+        speaker_id: null,
+        message_text: 'hi',
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/alarm'));
+    const body = await res.json();
+    expect(body.alarms[0].repeat_days).toEqual([1, 3, 5]);
+    expect(body.alarms[0].is_active).toBe(true);
+    expect(body.alarms[0].mode).toBe('tts');
+    expect(body.alarms[0].voice_profile_id).toBeNull();
+    expect(body.alarms[0].speaker_id).toBeNull();
+  });
+
+  it('목록: mode=sound-only + voice_profile_id/speaker_id 를 그대로 노출', async () => {
+    const vp = '40000000-0000-4000-8000-000000000001';
+    const sp = '50000000-0000-4000-8000-000000000001';
+    mockDB.pushResult([{ total: 1 }]);
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        time: '08:00',
+        is_active: 0,
+        repeat_days: '[]',
+        mode: 'sound-only',
+        voice_profile_id: vp,
+        speaker_id: sp,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/alarm'));
+    const body = await res.json();
+    expect(body.alarms[0].mode).toBe('sound-only');
+    expect(body.alarms[0].is_active).toBe(false);
+    expect(body.alarms[0].voice_profile_id).toBe(vp);
+    expect(body.alarms[0].speaker_id).toBe(sp);
+  });
+
+  it('목록: repeat_days 가 잘못된 JSON 이어도 빈 배열로 fallback', async () => {
+    mockDB.pushResult([{ total: 1 }]);
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        time: '07:00',
+        is_active: 1,
+        repeat_days: 'not-json',
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/alarm'));
+    const body = await res.json();
+    expect(body.alarms[0].repeat_days).toEqual([]);
+  });
+});
+
+describe('GET /alarm/:id — 단일 조회 정규화', () => {
+  it('단일 조회 응답이 정규화된다', async () => {
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        time: '09:00',
+        is_active: 1,
+        repeat_days: '[0,6]',
+        mode: 'tts',
+        voice_profile_id: null,
+        speaker_id: null,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', `/alarm/${ID.alarm}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.alarm.repeat_days).toEqual([0, 6]);
+    expect(body.alarm.is_active).toBe(true);
+    expect(body.alarm.mode).toBe('tts');
+    expect(body.alarm.voice_profile_id).toBeNull();
+  });
+
+  it('존재하지 않으면 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', `/alarm/${ID.alarm404}`));
+    expect(res.status).toBe(404);
+  });
 });
 
 describe('POST /alarm — 알람 생성', () => {
@@ -225,6 +320,20 @@ describe('POST /alarm — 알람 생성', () => {
     expect(body.alarm.mode).toBe('tts');
     const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
     expect(insert!.args).toContain('tts');
+  });
+
+  it('POST 응답에 voice_profile_id/speaker_id 가 null 로 명시된다', async () => {
+    mockDB.pushResult([{ plan: 'plus' }]);
+    mockDB.pushResult([{ id: ID.message }]);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/alarm', { message_id: ID.message, time: '07:00' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm).toHaveProperty('voice_profile_id', null);
+    expect(body.alarm).toHaveProperty('speaker_id', null);
   });
 });
 


### PR DESCRIPTION
## 요약

#19 에서 추가한 `mode`·`voice_profile_id`·`speaker_id` 가 GET 응답에 raw row 로만 실려 오고, `repeat_days` 가 JSON 문자열, `is_active` 가 0/1 정수로 노출되던 비일관성을 해결합니다.

## 변경 내역

- `normalizeAlarmRow` 헬퍼 추가 — repeat_days JSON→배열, is_active→boolean, mode null→`tts`, voice_profile_id/speaker_id `undefined`→`null`
- GET /alarm · GET /alarm/:id 두 엔드포인트가 통일된 형태로 직렬화
- PATCH /alarm/:id 반환도 동일 헬퍼로 교체 (기존 인라인 파싱 제거)
- POST /alarm 응답 객체에 voice_profile_id/speaker_id 를 null 로 명시 (이전엔 body 스프레드에 의존)
- vitest 6건 추가
  - 목록 정규화 (repeat_days 배열, is_active boolean, mode 기본값)
  - 목록: sound-only + UUID 2종 그대로 노출
  - 목록: 잘못된 JSON → 빈 배열 fallback
  - 단일 조회 정규화 + 미존재 404
  - POST 응답에 voice_profile_id/speaker_id null 명시

## 테스트

- `npm test --workspaces` — 338건 통과 (backend 283→289, 나머지 동일)
- `npm run typecheck` — 0 error
- `npm run lint` — 0 error (기존 warning 만 존재)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)