### PR TITLE
feat(backend): 알람 스케줄러 + Cloudflare Cron Trigger 스텁 (#53)

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -7,6 +7,7 @@ import { rateLimitMiddleware } from './middleware/rateLimit';
 import { bodyLimitMiddleware } from './middleware/bodyLimit';
 import { publicCache, privateCache, noStore } from './middleware/cache';
 import { getDB, initDB } from './lib/db';
+import { selectFiringAlarms, type ScheduledAlarm } from './lib/scheduler';
 import voiceRoutes from './routes/voice';
 import ttsRoutes from './routes/tts';
 import alarmRoutes from './routes/alarm';
@@ -128,4 +129,53 @@ app.onError((err, c) => {
   return c.json({ error: 'Internal server error', requestId }, 500);
 });
 
-export default app;
+// Cloudflare Workers Cron Trigger 진입점 — wrangler.toml 에 `[triggers] crons = ["* * * * *"]` 등록 시 1분 주기로 호출됨
+async function scheduled(event: ScheduledEvent, env: Env): Promise<void> {
+  const db = getDB(env);
+  const now = new Date(event.scheduledTime);
+
+  const result = await db.execute(
+    `SELECT id, user_id, target_user_id, time, repeat_days, is_active,
+            mode, voice_profile_id, speaker_id
+     FROM alarms WHERE is_active = 1`,
+  );
+
+  const alarms: ScheduledAlarm[] = result.rows.map((r) => ({
+    id: String(r.id),
+    user_id: String(r.user_id),
+    target_user_id: (r.target_user_id as string | null) ?? null,
+    time: String(r.time),
+    repeat_days: (() => {
+      try {
+        const parsed: unknown = JSON.parse(String(r.repeat_days ?? '[]'));
+        return Array.isArray(parsed) ? parsed.filter((n): n is number => Number.isInteger(n)) : [];
+      } catch {
+        return [];
+      }
+    })(),
+    is_active: r.is_active === 1,
+    mode: r.mode === 'sound-only' ? 'sound-only' : 'tts',
+    voice_profile_id: (r.voice_profile_id as string | null) ?? null,
+    speaker_id: (r.speaker_id as string | null) ?? null,
+  }));
+
+  const firing = selectFiringAlarms(alarms, now);
+
+  console.warn(
+    JSON.stringify({
+      level: 'info',
+      at: 'scheduled',
+      now: now.toISOString(),
+      checked: alarms.length,
+      firing_count: firing.length,
+      firing_ids: firing.map((a) => a.id),
+    }),
+  );
+
+  // TODO: FCM delivery — firing[].user_id/target_user_id 로 푸시 전송
+}
+
+export default {
+  fetch: app.fetch,
+  scheduled,
+};

--- a/packages/backend/src/lib/scheduler.ts
+++ b/packages/backend/src/lib/scheduler.ts
@@ -1,0 +1,36 @@
+export type AlarmMode = 'sound-only' | 'tts';
+
+export interface ScheduledAlarm {
+  id: string;
+  user_id: string;
+  target_user_id?: string | null;
+  time: string;
+  repeat_days: number[];
+  is_active: boolean;
+  mode: AlarmMode;
+  voice_profile_id?: string | null;
+  speaker_id?: string | null;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function formatHHmm(now: Date): string {
+  return `${pad2(now.getUTCHours())}:${pad2(now.getUTCMinutes())}`;
+}
+
+export function shouldAlarmFire(alarm: ScheduledAlarm, now: Date): boolean {
+  if (!alarm.is_active) return false;
+  if (alarm.time !== formatHHmm(now)) return false;
+
+  const repeat = Array.isArray(alarm.repeat_days) ? alarm.repeat_days : [];
+  if (repeat.length === 0) return true;
+
+  const today = now.getUTCDay();
+  return repeat.includes(today);
+}
+
+export function selectFiringAlarms(alarms: ScheduledAlarm[], now: Date): ScheduledAlarm[] {
+  return alarms.filter((a) => shouldAlarmFire(a, now));
+}

--- a/packages/backend/src/routes/alarm.ts
+++ b/packages/backend/src/routes/alarm.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
+import { selectFiringAlarms, type ScheduledAlarm } from '../lib/scheduler';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALARM_MODES = ['sound-only', 'tts'] as const;
@@ -42,6 +43,49 @@ function normalizeAlarmRow(row: AlarmRow) {
 }
 
 const alarm = new Hono<AppEnv>();
+
+/** 디버그용 cron 틱 — 현재 UTC 시각 기준으로 발화 대상 알람을 반환 (푸시 전송은 하지 않음) */
+alarm.get('/tick', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const result = await db.execute({
+    sql: `SELECT id, user_id, target_user_id, time, repeat_days, is_active,
+                 mode, voice_profile_id, speaker_id
+          FROM alarms
+          WHERE (user_id = ? OR target_user_id = ?) AND is_active = 1`,
+    args: [userId, userId],
+  });
+
+  const alarms: ScheduledAlarm[] = (result.rows as AlarmRow[]).map((r) => {
+    const n = normalizeAlarmRow(r);
+    return {
+      id: String(r.id),
+      user_id: String(r.user_id),
+      target_user_id: (r.target_user_id as string | null) ?? null,
+      time: String(r.time),
+      repeat_days: n.repeat_days,
+      is_active: n.is_active,
+      mode: n.mode,
+      voice_profile_id: n.voice_profile_id,
+      speaker_id: n.speaker_id,
+    };
+  });
+
+  const now = new Date();
+  const firing = selectFiringAlarms(alarms, now);
+  return c.json({
+    now: now.toISOString(),
+    checked: alarms.length,
+    firing: firing.map((a) => ({
+      id: a.id,
+      time: a.time,
+      mode: a.mode,
+      voice_profile_id: a.voice_profile_id,
+      speaker_id: a.speaker_id,
+    })),
+  });
+});
 
 /** 알람 목록 조회 */
 alarm.get('/', async (c) => {

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -414,6 +414,59 @@ describe('PATCH /alarm/:id — 알람 수정', () => {
   });
 });
 
+describe('GET /alarm/tick — 발화 대상 조회', () => {
+  it('활성 알람 중 현재 시각과 일치하는 것만 반환', async () => {
+    // 현재 UTC 분 기준 HH:mm
+    const now = new Date();
+    const pad = (n: number) => (n < 10 ? `0${n}` : String(n));
+    const hhmm = `${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}`;
+
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        user_id: 'user-1',
+        target_user_id: null,
+        time: hhmm,
+        repeat_days: '[]',
+        is_active: 1,
+        mode: 'tts',
+        voice_profile_id: null,
+        speaker_id: null,
+      },
+      {
+        id: '00000000-0000-4000-8000-0000000000aa',
+        user_id: 'user-1',
+        target_user_id: null,
+        time: '23:58', // 거의 확실히 일치 안 함 (현재 시각과 다를 확률 매우 높음)
+        repeat_days: '[]',
+        is_active: 1,
+        mode: 'tts',
+        voice_profile_id: null,
+        speaker_id: null,
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/alarm/tick'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checked).toBe(2);
+    // 첫 번째는 현재 시각 매칭 → 발화
+    expect(body.firing.length).toBeGreaterThanOrEqual(1);
+    expect(body.firing[0].id).toBe(ID.alarm);
+  });
+
+  it('알람이 하나도 없으면 firing=[]', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/alarm/tick'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checked).toBe(0);
+    expect(body.firing).toEqual([]);
+  });
+});
+
 describe('DELETE /alarm/:id — 알람 삭제', () => {
   it('존재하지 않으면 404', async () => {
     mockDB.pushResult([], 0);

--- a/packages/backend/test/scheduler.test.ts
+++ b/packages/backend/test/scheduler.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatHHmm,
+  shouldAlarmFire,
+  selectFiringAlarms,
+  type ScheduledAlarm,
+} from '../src/lib/scheduler';
+
+function makeAlarm(partial: Partial<ScheduledAlarm> = {}): ScheduledAlarm {
+  return {
+    id: partial.id ?? 'a1',
+    user_id: partial.user_id ?? 'u1',
+    time: partial.time ?? '07:00',
+    repeat_days: partial.repeat_days ?? [],
+    is_active: partial.is_active ?? true,
+    mode: partial.mode ?? 'tts',
+    voice_profile_id: partial.voice_profile_id ?? null,
+    speaker_id: partial.speaker_id ?? null,
+    target_user_id: partial.target_user_id ?? null,
+  };
+}
+
+// 2026-04-21 (화요일, UTC). Date.getUTCDay() 화요일 = 2
+const tuesday0700 = new Date(Date.UTC(2026, 3, 21, 7, 0, 0));
+
+describe('formatHHmm', () => {
+  it('UTC 시/분을 2자리로 포맷한다', () => {
+    expect(formatHHmm(new Date(Date.UTC(2026, 3, 21, 9, 5, 30)))).toBe('09:05');
+    expect(formatHHmm(new Date(Date.UTC(2026, 3, 21, 23, 59, 0)))).toBe('23:59');
+  });
+});
+
+describe('shouldAlarmFire', () => {
+  it('시각 일치 + repeat_days 빈 배열이면 매일 발화', () => {
+    const alarm = makeAlarm({ time: '07:00', repeat_days: [] });
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(true);
+  });
+
+  it('시각 불일치면 발화 안 함', () => {
+    const alarm = makeAlarm({ time: '08:00' });
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(false);
+  });
+
+  it('repeat_days 에 오늘 요일 포함이면 발화', () => {
+    const alarm = makeAlarm({ time: '07:00', repeat_days: [1, 2, 3] });
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(true);
+  });
+
+  it('repeat_days 에 오늘 요일 미포함이면 발화 안 함', () => {
+    const alarm = makeAlarm({ time: '07:00', repeat_days: [0, 6] }); // 일·토만
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(false);
+  });
+
+  it('is_active=false 면 발화 안 함', () => {
+    const alarm = makeAlarm({ time: '07:00', is_active: false });
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(false);
+  });
+
+  it('분 단위 부분 일치는 거절 (HH:mm 전체 매칭)', () => {
+    const alarm = makeAlarm({ time: '07:30' });
+    expect(shouldAlarmFire(alarm, tuesday0700)).toBe(false);
+  });
+});
+
+describe('selectFiringAlarms', () => {
+  it('여러 알람 중 해당 시각·요일에 맞는 것만 추린다', () => {
+    const alarms: ScheduledAlarm[] = [
+      makeAlarm({ id: 'a', time: '07:00', repeat_days: [2] }), // 화요일 매칭
+      makeAlarm({ id: 'b', time: '07:00', is_active: false }), // 비활성
+      makeAlarm({ id: 'c', time: '08:00' }), // 시각 미일치
+      makeAlarm({ id: 'd', time: '07:00', repeat_days: [] }), // 매일
+      makeAlarm({ id: 'e', time: '07:00', repeat_days: [0, 6] }), // 주말만
+    ];
+    const fired = selectFiringAlarms(alarms, tuesday0700);
+    expect(fired.map((x) => x.id).sort()).toEqual(['a', 'd']);
+  });
+
+  it('빈 배열이면 빈 결과', () => {
+    expect(selectFiringAlarms([], tuesday0700)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 요약

알람이 **시간에 맞춰 발화**할 수 있는 기반을 추가했습니다. 순수 함수 스케줄러 + Cloudflare Workers Cron Trigger 진입점 + 디버그용 tick 엔드포인트.

## 변경 내역

- `src/lib/scheduler.ts` 신규 — DB/IO 의존성 없는 순수 함수
  - `shouldAlarmFire(alarm, now)`: HH:mm + repeat_days + is_active 체크
  - `selectFiringAlarms(alarms, now)`: 발화 대상 필터
  - `formatHHmm(now)`: UTC 기준 `HH:mm` 포맷
- `src/index.ts`: `scheduled(event, env)` 함수 추가 + `export default { fetch, scheduled }` — Workers Cron Trigger 진입점. 활성 알람 조회 → selectFiringAlarms → `console.warn` 로 `firing_ids` 로깅. 실 푸시 전송은 `// TODO: FCM delivery` 로 명시
- `routes/alarm.ts`: `GET /alarm/tick` — 인증된 유저의 활성 알람을 현재 UTC 시각 기준으로 드라이런, `{ now, checked, firing[] }` 반환
- vitest 11건 추가
  - scheduler: formatHHmm 2, shouldAlarmFire 6, selectFiringAlarms 2
  - alarm.tick: 현재시각 매칭/비매칭 분리, 빈 DB

## 테스트

- `npm test --workspaces` — 349건 통과 (backend 289→300, 나머지 동일)
- `npm run typecheck` / `npm run lint` — 0 error

## 리스크 / 팔로업

- 실제 `wrangler.toml` 의 `[triggers] crons = ["* * * * *"]` 등록과 FCM 발송은 Phase 4 후속 이슈에서 처리
- 스케줄러는 UTC 기준 — 타임존 처리는 클라이언트에서 HH:mm 저장 시 로컬 환산 가정. 사용자 타임존 필드 도입은 별도 이슈

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)