### PR TITLE
[#57] 모바일 알람 편집 화면 — mode 토글 및 voice_profile 연결

### DIFF
--- a/apps/mobile/app/(tabs)/alarms.tsx
+++ b/apps/mobile/app/(tabs)/alarms.tsx
@@ -27,13 +27,14 @@ import { cacheAlarms, getCachedAlarms } from '../../src/services/offlineCache';
 import { syncAlarmNotifications } from '../../src/services/notifications';
 import type { Alarm } from '../../src/types';
 import { getApiErrorMessage } from '../../src/types';
+import { parseRepeatDays } from '../../src/lib/alarmForm';
 import { useToast } from '../../src/hooks/useToast';
 import { Toast } from '../../src/components/Toast';
 
 function getNextFireMs(alarm: Alarm): number | null {
   if (!alarm.is_active) return null;
   const [h, m] = alarm.time.split(':').map(Number);
-  const days: number[] = JSON.parse(alarm.repeat_days || '[]');
+  const days = parseRepeatDays(alarm.repeat_days);
   const now = new Date();
   const todayMinutes = now.getHours() * 60 + now.getMinutes();
   const alarmMinutes = h * 60 + m;
@@ -208,7 +209,7 @@ export default function AlarmsScreen() {
   };
 
   const renderAlarm = ({ item }: { item: Alarm }) => {
-    const repeatDays = JSON.parse(item.repeat_days || '[]');
+    const repeatDays = parseRepeatDays(item.repeat_days);
     void tick;
     const nextFireMs = getNextFireMs(item);
     const perAlarmCountdown = nextFireMs !== null ? formatCountdown(nextFireMs) : null;

--- a/apps/mobile/app/alarm/create.tsx
+++ b/apps/mobile/app/alarm/create.tsx
@@ -24,10 +24,11 @@ import {
 } from '../../src/services/api';
 import { useAppStore } from '../../src/stores/useAppStore';
 import { syncAlarmNotifications } from '../../src/services/notifications';
-import type { Friend, Message, VoiceProfile } from '../../src/types';
+import type { AlarmMode, Friend, Message, VoiceProfile } from '../../src/types';
 import { getApiErrorMessage } from '../../src/types';
 import { useToast } from '../../src/hooks/useToast';
 import { Toast } from '../../src/components/Toast';
+import { validateAlarmForm } from '../../src/lib/alarmForm';
 
 export default function CreateAlarmScreen() {
   const router = useRouter();
@@ -48,6 +49,8 @@ export default function CreateAlarmScreen() {
   const [presetCategory, setPresetCategory] = useState<string>('morning');
   const [presetText, setPresetText] = useState<string | null>(null);
   const [presetVoiceId, setPresetVoiceId] = useState<string | null>(null);
+  const [mode, setMode] = useState<AlarmMode>('tts');
+  const [voiceProfileId, setVoiceProfileId] = useState<string | null>(null);
 
   const { data: messages } = useQuery({
     queryKey: ['messages'],
@@ -58,7 +61,7 @@ export default function CreateAlarmScreen() {
   const { data: voices } = useQuery({
     queryKey: ['voiceProfiles'],
     queryFn: getVoiceProfiles,
-    enabled: isAuthenticated && showPreset,
+    enabled: isAuthenticated,
   });
 
   const readyVoices = voices?.filter((v: VoiceProfile) => v.status === 'ready') ?? [];
@@ -111,20 +114,24 @@ export default function CreateAlarmScreen() {
   };
 
   const handleSubmit = () => {
-    if (!selectedMessageId) {
-      toast.show(t('alarmCreate.selectMessage'));
+    const time = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+    const validated = validateAlarmForm({
+      messageId: selectedMessageId,
+      time,
+      repeatDays,
+      mode,
+      voiceProfileId,
+      snoozeMinutes: snooze,
+      targetUserId,
+    });
+    if (!validated.ok) {
+      toast.show(validated.error);
       return;
     }
-
-    const time = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
-    createMutation.mutate({
-      message_id: selectedMessageId,
-      time,
-      repeat_days: repeatDays,
-      snooze_minutes: snooze,
-      ...(targetUserId ? { target_user_id: targetUserId } : {}),
-    });
+    createMutation.mutate(validated.payload);
   };
+
+  const soundOnlyInvalid = mode === 'sound-only' && !voiceProfileId;
 
   const quickSetDays = (type: 'daily' | 'weekday' | 'weekend') => {
     if (type === 'daily') setRepeatDays([0, 1, 2, 3, 4, 5, 6]);
@@ -242,6 +249,70 @@ export default function CreateAlarmScreen() {
           <Text style={styles.quickText}>{t('alarms.weekend')}</Text>
         </TouchableOpacity>
       </View>
+
+      {/* 재생 모드 */}
+      <Text style={styles.sectionTitle}>재생 모드</Text>
+      <View style={styles.modeRow}>
+        <TouchableOpacity
+          style={[styles.modeChip, mode === 'tts' && styles.modeChipActive]}
+          onPress={() => setMode('tts')}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: mode === 'tts' }}
+        >
+          <Text style={[styles.modeText, mode === 'tts' && styles.modeTextActive]}>
+            🗣️ TTS
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.modeChip, mode === 'sound-only' && styles.modeChipActive]}
+          onPress={() => setMode('sound-only')}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: mode === 'sound-only' }}
+        >
+          <Text style={[styles.modeText, mode === 'sound-only' && styles.modeTextActive]}>
+            🔊 원본
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {mode === 'sound-only' && (
+        <>
+          <Text style={styles.sectionTitle}>음성 프로필</Text>
+          {readyVoices.length === 0 ? (
+            <View style={styles.emptyVoiceBox}>
+              <Text style={styles.emptyVoiceText}>
+                원본 재생 모드는 등록된 음성 프로필이 필요해요.
+              </Text>
+            </View>
+          ) : (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.voiceRow}
+            >
+              {readyVoices.map((v: VoiceProfile) => {
+                const selected = voiceProfileId === v.id;
+                return (
+                  <TouchableOpacity
+                    key={v.id}
+                    style={[styles.voiceChip, selected && styles.voiceChipActive]}
+                    onPress={() => setVoiceProfileId(selected ? null : v.id)}
+                  >
+                    <Text style={[styles.voiceText, selected && styles.voiceTextActive]}>
+                      {v.name}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+          )}
+          {soundOnlyInvalid && (
+            <Text style={styles.voiceHint}>
+              원본 재생 모드에서는 음성 프로필을 지정해야 합니다.
+            </Text>
+          )}
+        </>
+      )}
 
       {/* 스누즈 */}
       <Text style={styles.sectionTitle}>{t('alarmCreate.snooze')}</Text>
@@ -392,10 +463,10 @@ export default function CreateAlarmScreen() {
       <TouchableOpacity
         style={[
           styles.createButton,
-          (!selectedMessageId || createMutation.isPending) && styles.disabled,
+          (!selectedMessageId || soundOnlyInvalid || createMutation.isPending) && styles.disabled,
         ]}
         onPress={handleSubmit}
-        disabled={!selectedMessageId || createMutation.isPending}
+        disabled={!selectedMessageId || soundOnlyInvalid || createMutation.isPending}
       >
         {createMutation.isPending ? (
           <ActivityIndicator color="#FFF" />
@@ -689,5 +760,71 @@ const styles = StyleSheet.create({
     color: '#FFF',
     fontSize: FontSize.md,
     fontWeight: '700',
+  },
+  modeRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  modeChip: {
+    flex: 1,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.light.surface,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    alignItems: 'center',
+  },
+  modeChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  modeText: {
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+    fontWeight: '600',
+  },
+  modeTextActive: {
+    color: '#FFF',
+  },
+  voiceRow: {
+    flexDirection: 'row',
+  },
+  voiceChip: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.light.surface,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    marginRight: Spacing.sm,
+  },
+  voiceChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  voiceText: {
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+    fontWeight: '600',
+  },
+  voiceTextActive: {
+    color: '#FFF',
+  },
+  voiceHint: {
+    fontSize: FontSize.sm,
+    color: Colors.light.error,
+    marginTop: Spacing.xs,
+  },
+  emptyVoiceBox: {
+    backgroundColor: Colors.light.surface,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderStyle: 'dashed',
+  },
+  emptyVoiceText: {
+    color: Colors.light.textSecondary,
+    fontSize: FontSize.sm,
   },
 });

--- a/apps/mobile/app/alarm/edit.tsx
+++ b/apps/mobile/app/alarm/edit.tsx
@@ -13,13 +13,20 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Colors, Spacing, BorderRadius, FontSize } from '../../src/constants/theme';
 import { DAYS_OF_WEEK } from '../../src/constants/presets';
-import { getMessages, getAlarm, getAlarms, updateAlarm } from '../../src/services/api';
+import {
+  getMessages,
+  getAlarm,
+  getAlarms,
+  updateAlarm,
+  getVoiceProfiles,
+} from '../../src/services/api';
 import { useAppStore } from '../../src/stores/useAppStore';
 import { syncAlarmNotifications } from '../../src/services/notifications';
-import type { Message } from '../../src/types';
+import type { AlarmMode, Message, VoiceProfile } from '../../src/types';
 import { getApiErrorMessage } from '../../src/types';
 import { useToast } from '../../src/hooks/useToast';
 import { Toast } from '../../src/components/Toast';
+import { parseRepeatDays, validateAlarmForm } from '../../src/lib/alarmForm';
 
 export default function EditAlarmScreen() {
   const router = useRouter();
@@ -34,6 +41,8 @@ export default function EditAlarmScreen() {
   const [repeatDays, setRepeatDays] = useState<number[]>([]);
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [snooze, setSnooze] = useState(5);
+  const [mode, setMode] = useState<AlarmMode>('tts');
+  const [voiceProfileId, setVoiceProfileId] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   const { data: alarm } = useQuery({
@@ -48,14 +57,25 @@ export default function EditAlarmScreen() {
     enabled: isAuthenticated,
   });
 
+  const { data: voices } = useQuery({
+    queryKey: ['voiceProfiles'],
+    queryFn: getVoiceProfiles,
+    enabled: isAuthenticated,
+  });
+
+  const readyVoices: VoiceProfile[] =
+    voices?.filter((v: VoiceProfile) => v.status === 'ready') ?? [];
+
   useEffect(() => {
     if (alarm && !loaded) {
       const [h, m] = alarm.time.split(':').map(Number);
       setHour(h);
       setMinute(m);
-      setRepeatDays(JSON.parse(alarm.repeat_days || '[]'));
+      setRepeatDays(parseRepeatDays(alarm.repeat_days));
       setSelectedMessageId(alarm.message_id);
       setSnooze(alarm.snooze_minutes);
+      setMode(alarm.mode === 'sound-only' ? 'sound-only' : 'tts');
+      setVoiceProfileId(alarm.voice_profile_id ?? null);
       setLoaded(true);
     }
   }, [alarm, loaded]);
@@ -66,6 +86,8 @@ export default function EditAlarmScreen() {
       repeat_days?: number[];
       snooze_minutes?: number;
       message_id?: string;
+      mode?: AlarmMode;
+      voice_profile_id?: string | null;
     }) => updateAlarm(id!, params),
     onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['alarms'] });
@@ -85,19 +107,31 @@ export default function EditAlarmScreen() {
   };
 
   const handleSubmit = () => {
-    if (!selectedMessageId) {
-      toast.show(t('alarmCreate.selectMessage'));
+    const time = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+    const validated = validateAlarmForm({
+      messageId: selectedMessageId,
+      time,
+      repeatDays,
+      mode,
+      voiceProfileId,
+      snoozeMinutes: snooze,
+    });
+    if (!validated.ok) {
+      toast.show(validated.error);
       return;
     }
-
-    const time = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+    const { payload } = validated;
     editMutation.mutate({
-      message_id: selectedMessageId,
-      time,
-      repeat_days: repeatDays,
-      snooze_minutes: snooze,
+      message_id: payload.message_id,
+      time: payload.time,
+      repeat_days: payload.repeat_days,
+      snooze_minutes: payload.snooze_minutes,
+      mode: payload.mode,
+      voice_profile_id: payload.voice_profile_id ?? null,
     });
   };
+
+  const soundOnlyInvalid = mode === 'sound-only' && !voiceProfileId;
 
   const quickSetDays = (type: 'daily' | 'weekday' | 'weekend') => {
     if (type === 'daily') setRepeatDays([0, 1, 2, 3, 4, 5, 6]);
@@ -181,6 +215,70 @@ export default function EditAlarmScreen() {
         </TouchableOpacity>
       </View>
 
+      {/* 재생 모드 */}
+      <Text style={styles.sectionTitle}>재생 모드</Text>
+      <View style={styles.modeRow}>
+        <TouchableOpacity
+          style={[styles.modeChip, mode === 'tts' && styles.modeChipActive]}
+          onPress={() => setMode('tts')}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: mode === 'tts' }}
+        >
+          <Text style={[styles.modeText, mode === 'tts' && styles.modeTextActive]}>
+            🗣️ TTS
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.modeChip, mode === 'sound-only' && styles.modeChipActive]}
+          onPress={() => setMode('sound-only')}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: mode === 'sound-only' }}
+        >
+          <Text style={[styles.modeText, mode === 'sound-only' && styles.modeTextActive]}>
+            🔊 원본
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {mode === 'sound-only' && (
+        <>
+          <Text style={styles.sectionTitle}>음성 프로필</Text>
+          {readyVoices.length === 0 ? (
+            <View style={styles.emptyVoiceBox}>
+              <Text style={styles.emptyVoiceText}>
+                원본 재생 모드는 등록된 음성 프로필이 필요해요.
+              </Text>
+            </View>
+          ) : (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.voiceRow}
+            >
+              {readyVoices.map((v) => {
+                const selected = voiceProfileId === v.id;
+                return (
+                  <TouchableOpacity
+                    key={v.id}
+                    style={[styles.voiceChip, selected && styles.voiceChipActive]}
+                    onPress={() => setVoiceProfileId(selected ? null : v.id)}
+                  >
+                    <Text style={[styles.voiceText, selected && styles.voiceTextActive]}>
+                      {v.name}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+          )}
+          {soundOnlyInvalid && (
+            <Text style={styles.voiceHint}>
+              원본 재생 모드에서는 음성 프로필을 지정해야 합니다.
+            </Text>
+          )}
+        </>
+      )}
+
       {/* 스누즈 */}
       <Text style={styles.sectionTitle}>{t('alarmCreate.snooze')}</Text>
       <View style={styles.snoozeRow}>
@@ -232,10 +330,10 @@ export default function EditAlarmScreen() {
       <TouchableOpacity
         style={[
           styles.saveButton,
-          (!selectedMessageId || editMutation.isPending) && styles.disabled,
+          (!selectedMessageId || soundOnlyInvalid || editMutation.isPending) && styles.disabled,
         ]}
         onPress={handleSubmit}
-        disabled={!selectedMessageId || editMutation.isPending}
+        disabled={!selectedMessageId || soundOnlyInvalid || editMutation.isPending}
       >
         {editMutation.isPending ? (
           <ActivityIndicator color="#FFF" />
@@ -446,5 +544,71 @@ const styles = StyleSheet.create({
     color: '#FFF',
     fontSize: FontSize.lg,
     fontWeight: '700',
+  },
+  modeRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  modeChip: {
+    flex: 1,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.light.surface,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    alignItems: 'center',
+  },
+  modeChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  modeText: {
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+    fontWeight: '600',
+  },
+  modeTextActive: {
+    color: '#FFF',
+  },
+  voiceRow: {
+    flexDirection: 'row',
+  },
+  voiceChip: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.light.surface,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    marginRight: Spacing.sm,
+  },
+  voiceChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  voiceText: {
+    fontSize: FontSize.md,
+    color: Colors.light.text,
+    fontWeight: '600',
+  },
+  voiceTextActive: {
+    color: '#FFF',
+  },
+  voiceHint: {
+    fontSize: FontSize.sm,
+    color: Colors.light.error,
+    marginTop: Spacing.xs,
+  },
+  emptyVoiceBox: {
+    backgroundColor: Colors.light.surface,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderStyle: 'dashed',
+  },
+  emptyVoiceText: {
+    color: Colors.light.textSecondary,
+    fontSize: FontSize.sm,
   },
 });

--- a/apps/mobile/src/lib/alarmForm.ts
+++ b/apps/mobile/src/lib/alarmForm.ts
@@ -1,0 +1,77 @@
+export type AlarmMode = 'tts' | 'sound-only';
+
+export interface AlarmFormInput {
+  messageId: string | null;
+  time: string;
+  repeatDays: number[];
+  mode: AlarmMode;
+  voiceProfileId?: string | null;
+  speakerId?: string | null;
+  snoozeMinutes?: number;
+  targetUserId?: string | null;
+}
+
+export interface AlarmCreatePayload {
+  message_id: string;
+  time: string;
+  repeat_days: number[];
+  mode: AlarmMode;
+  voice_profile_id?: string;
+  speaker_id?: string;
+  snooze_minutes?: number;
+  target_user_id?: string;
+}
+
+export type ValidationResult =
+  | { ok: true; payload: AlarmCreatePayload }
+  | { ok: false; error: string };
+
+export function validateAlarmForm(input: AlarmFormInput): ValidationResult {
+  if (!input.messageId) {
+    return { ok: false, error: '메시지를 선택해주세요.' };
+  }
+  if (!/^\d{2}:\d{2}$/.test(input.time)) {
+    return { ok: false, error: '시간 형식이 올바르지 않습니다.' };
+  }
+  if (input.mode !== 'tts' && input.mode !== 'sound-only') {
+    return { ok: false, error: '재생 모드가 올바르지 않습니다.' };
+  }
+  if (input.mode === 'sound-only' && !input.voiceProfileId) {
+    return {
+      ok: false,
+      error: '원본 재생 모드에서는 음성 프로필을 지정해야 합니다.',
+    };
+  }
+  return { ok: true, payload: buildCreatePayload(input) };
+}
+
+export function buildCreatePayload(input: AlarmFormInput): AlarmCreatePayload {
+  const payload: AlarmCreatePayload = {
+    message_id: input.messageId ?? '',
+    time: input.time,
+    repeat_days: Array.isArray(input.repeatDays) ? input.repeatDays : [],
+    mode: input.mode,
+  };
+  if (input.voiceProfileId) payload.voice_profile_id = input.voiceProfileId;
+  if (input.speakerId) payload.speaker_id = input.speakerId;
+  if (typeof input.snoozeMinutes === 'number') payload.snooze_minutes = input.snoozeMinutes;
+  if (input.targetUserId) payload.target_user_id = input.targetUserId;
+  return payload;
+}
+
+export function parseRepeatDays(raw: unknown): number[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((n): n is number => Number.isInteger(n));
+  }
+  if (typeof raw === 'string' && raw.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((n): n is number => Number.isInteger(n));
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -276,6 +276,9 @@ export async function createAlarm(params: {
   repeat_days?: number[];
   snooze_minutes?: number;
   target_user_id?: string;
+  mode?: 'tts' | 'sound-only';
+  voice_profile_id?: string;
+  speaker_id?: string;
 }) {
   const data = await post<{ alarm: Alarm }>('/alarm', params);
   return data.alarm;
@@ -289,6 +292,9 @@ export async function updateAlarm(
     is_active?: boolean;
     snooze_minutes?: number;
     message_id?: string;
+    mode?: 'tts' | 'sound-only';
+    voice_profile_id?: string | null;
+    speaker_id?: string | null;
   },
 ) {
   await patch(`/alarm/${id}`, params);

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -1,6 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import type { Alarm } from '../types';
+import { parseRepeatDays } from '../lib/alarmForm';
 
 const ALARM_CATEGORY = 'alarm';
 const SNOOZE_ACTION = 'snooze';
@@ -54,7 +55,7 @@ export async function syncAlarmNotifications(alarms: Alarm[]): Promise<void> {
 
   for (const alarm of activeAlarms) {
     const [hour, minute] = alarm.time.split(':').map(Number);
-    const repeatDays: number[] = JSON.parse(alarm.repeat_days || '[]');
+    const repeatDays = parseRepeatDays(alarm.repeat_days);
     const title = alarm.voice_name ? `🗣️ ${alarm.voice_name}` : '⏰ VoiceAlarm';
     const body = alarm.message_text || 'Alarm';
     const notificationData = {

--- a/apps/mobile/src/types.ts
+++ b/apps/mobile/src/types.ts
@@ -22,17 +22,23 @@ export interface Message {
   voice_name?: string;
 }
 
+export type AlarmMode = 'tts' | 'sound-only';
+
 export interface Alarm {
   id: string;
   user_id: string;
   target_user_id: string | null;
   message_id: string;
   time: string;
-  repeat_days: string;
+  // 백엔드 정규화로 배열이 오지만 과거 응답 호환을 위해 string 도 허용
+  repeat_days: number[] | string;
   is_active: boolean;
   snooze_minutes: number;
   created_at: string;
   updated_at: string;
+  mode?: AlarmMode;
+  voice_profile_id?: string | null;
+  speaker_id?: string | null;
   message_text?: string;
   voice_name?: string;
   category?: string;

--- a/apps/mobile/test/alarmForm.test.ts
+++ b/apps/mobile/test/alarmForm.test.ts
@@ -1,0 +1,128 @@
+import {
+  buildCreatePayload,
+  parseRepeatDays,
+  validateAlarmForm,
+  type AlarmFormInput,
+} from '../src/lib/alarmForm';
+
+const baseInput: AlarmFormInput = {
+  messageId: '10000000-0000-4000-8000-000000000001',
+  time: '07:00',
+  repeatDays: [],
+  mode: 'tts',
+};
+
+describe('buildCreatePayload', () => {
+  it('기본 TTS 모드 — voice_profile_id/speaker_id 제외', () => {
+    const payload = buildCreatePayload(baseInput);
+    expect(payload).toEqual({
+      message_id: baseInput.messageId,
+      time: '07:00',
+      repeat_days: [],
+      mode: 'tts',
+    });
+  });
+
+  it('sound-only + voice_profile_id 포함', () => {
+    const payload = buildCreatePayload({
+      ...baseInput,
+      mode: 'sound-only',
+      voiceProfileId: '40000000-0000-4000-8000-000000000001',
+      speakerId: '50000000-0000-4000-8000-000000000001',
+    });
+    expect(payload.mode).toBe('sound-only');
+    expect(payload.voice_profile_id).toBe('40000000-0000-4000-8000-000000000001');
+    expect(payload.speaker_id).toBe('50000000-0000-4000-8000-000000000001');
+  });
+
+  it('snoozeMinutes 가 숫자면 포함', () => {
+    const payload = buildCreatePayload({ ...baseInput, snoozeMinutes: 10 });
+    expect(payload.snooze_minutes).toBe(10);
+  });
+
+  it('targetUserId 지정 시 포함', () => {
+    const payload = buildCreatePayload({
+      ...baseInput,
+      targetUserId: '20000000-0000-4000-8000-000000000001',
+    });
+    expect(payload.target_user_id).toBe('20000000-0000-4000-8000-000000000001');
+  });
+
+  it('repeat_days 가 배열이 아닐 때도 빈 배열로 안전하게 처리', () => {
+    // @ts-expect-error — intentional 잘못된 입력
+    const payload = buildCreatePayload({ ...baseInput, repeatDays: null });
+    expect(payload.repeat_days).toEqual([]);
+  });
+});
+
+describe('validateAlarmForm', () => {
+  it('메시지 미선택이면 에러', () => {
+    const res = validateAlarmForm({ ...baseInput, messageId: null });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('메시지');
+  });
+
+  it('잘못된 시간 형식이면 에러', () => {
+    const res = validateAlarmForm({ ...baseInput, time: '7am' });
+    expect(res.ok).toBe(false);
+  });
+
+  it('mode 가 허용값 밖이면 에러', () => {
+    // @ts-expect-error — intentional 잘못된 모드
+    const res = validateAlarmForm({ ...baseInput, mode: 'video' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('재생 모드');
+  });
+
+  it('sound-only + voice_profile_id 누락이면 에러', () => {
+    const res = validateAlarmForm({ ...baseInput, mode: 'sound-only' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('음성 프로필');
+  });
+
+  it('정상 TTS → ok + payload', () => {
+    const res = validateAlarmForm(baseInput);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.payload.mode).toBe('tts');
+  });
+
+  it('정상 sound-only + voice_profile_id → ok', () => {
+    const res = validateAlarmForm({
+      ...baseInput,
+      mode: 'sound-only',
+      voiceProfileId: '40000000-0000-4000-8000-000000000001',
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.payload.mode).toBe('sound-only');
+      expect(res.payload.voice_profile_id).toBe('40000000-0000-4000-8000-000000000001');
+    }
+  });
+});
+
+describe('parseRepeatDays', () => {
+  it('배열을 그대로 반환', () => {
+    expect(parseRepeatDays([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('JSON 문자열을 파싱', () => {
+    expect(parseRepeatDays('[0,6]')).toEqual([0, 6]);
+  });
+
+  it('빈 문자열은 빈 배열', () => {
+    expect(parseRepeatDays('')).toEqual([]);
+  });
+
+  it('잘못된 JSON 은 빈 배열', () => {
+    expect(parseRepeatDays('{not-json')).toEqual([]);
+  });
+
+  it('null / undefined 는 빈 배열', () => {
+    expect(parseRepeatDays(null)).toEqual([]);
+    expect(parseRepeatDays(undefined)).toEqual([]);
+  });
+
+  it('배열 안 정수가 아닌 값은 필터링', () => {
+    expect(parseRepeatDays([1, '2', 3.5, null, 4])).toEqual([1, 4]);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #57
- 요약: 모바일 알람 생성/편집 화면에 `mode` (🗣 TTS / 🔊 원본) 토글과 음성 프로필 picker 추가. 백엔드 정규화(#20) 이후 배열로 내려오는 `repeat_days` 를 안전 파싱.

## 변경 내용
- `apps/mobile/src/lib/alarmForm.ts` 순수 함수 헬퍼 추가 (web 과 동일 계약)
- `Alarm` 타입 확장 (`mode` / `voice_profile_id` / `speaker_id`, `repeat_days: number[] | string`)
- `createAlarm` / `updateAlarm` 시그니처에 옵션 필드 허용
- `app/alarm/create.tsx` / `app/alarm/edit.tsx` 에 모드 radio + 음성 프로필 picker UI 추가, sound-only 시 제출 버튼 비활성
- 세 곳의 `JSON.parse(alarm.repeat_days)` 호출을 `parseRepeatDays` 로 안전하게 교체
- jest 17건 신설 — 모바일 테스트 총 50건

## 검증
- [x] `npm run typecheck -w apps/mobile` 통과
- [x] `npm test` 통과 (mobile 50 / web 36 / backend 300 / shared 12 / voice 11 = 409건)
- [x] 루트 `npm run lint` 통과 (0 errors, 기존 warning 유지)

## 리스크 / 팔로업
- sound-only 실재생 / speaker picker UI 는 다음 이슈(#24)에서 다룸
- `Alarm.repeat_days` 타입이 `number[] | string` 이 된 것은 과거 응답 호환용 — Phase 10 에서 단일 타입으로 좁히는 것을 고려