### PR TITLE
[#59] 알람 재생 resolver (sound-only mock) + 모드 뱃지

### DIFF
--- a/apps/mobile/app/(tabs)/alarms.tsx
+++ b/apps/mobile/app/(tabs)/alarms.tsx
@@ -28,6 +28,7 @@ import { syncAlarmNotifications } from '../../src/services/notifications';
 import type { Alarm } from '../../src/types';
 import { getApiErrorMessage } from '../../src/types';
 import { parseRepeatDays } from '../../src/lib/alarmForm';
+import { getAlarmModeBadge } from '../../src/lib/alarmPlayback';
 import { useToast } from '../../src/hooks/useToast';
 import { Toast } from '../../src/components/Toast';
 
@@ -239,6 +240,11 @@ export default function AlarmsScreen() {
             </View>
             <View style={styles.alarmMeta}>
               <Text style={[styles.alarmVoice, !item.is_active && styles.textInactive]}>🗣️ {item.voice_name}</Text>
+              <View style={styles.modeBadge}>
+                <Text style={styles.modeBadgeText}>
+                  {getAlarmModeBadge(item.mode).emoji} {getAlarmModeBadge(item.mode).label}
+                </Text>
+              </View>
               <Text style={[styles.alarmMessage, !item.is_active && styles.textInactive]} numberOfLines={1}>
                 "{item.message_text}"
               </Text>
@@ -457,6 +463,19 @@ const styles = StyleSheet.create({
     fontSize: FontSize.sm,
     color: Colors.light.textSecondary,
     marginTop: 2,
+  },
+  modeBadge: {
+    alignSelf: 'flex-start',
+    marginTop: 4,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.light.surfaceVariant,
+  },
+  modeBadgeText: {
+    fontSize: FontSize.xs,
+    color: Colors.light.primary,
+    fontWeight: '600',
   },
   emptyState: {
     flex: 1,

--- a/apps/mobile/src/lib/alarmPlayback.ts
+++ b/apps/mobile/src/lib/alarmPlayback.ts
@@ -1,0 +1,97 @@
+import type { Alarm, AlarmMode, Message, VoiceProfile } from '../types';
+
+// TODO: real perso.ai voice sample URL — 현재는 번들된 mock 파일 경로
+export const MOCK_VOICE_SAMPLE_URI = 'asset:///audio/mock-voice-sample.mp3';
+export const MOCK_DEFAULT_ALARM_URI = 'asset:///audio/mock-default-alarm.mp3';
+
+export interface TtsPlaybackPlan {
+  kind: 'tts';
+  messageId: string;
+  text: string;
+  voiceName: string;
+  category: string;
+}
+
+export interface SoundOnlyPlaybackPlan {
+  kind: 'sound-only';
+  voiceProfileId: string;
+  voiceName: string;
+  uri: string;
+}
+
+export interface FallbackPlaybackPlan {
+  kind: 'fallback';
+  uri: string;
+  reason: string;
+}
+
+export interface ErrorPlaybackPlan {
+  kind: 'error';
+  reason: string;
+}
+
+export type PlaybackPlan =
+  | TtsPlaybackPlan
+  | SoundOnlyPlaybackPlan
+  | FallbackPlaybackPlan
+  | ErrorPlaybackPlan;
+
+export function resolveAlarmPlayback(
+  alarm: Pick<Alarm, 'mode' | 'voice_profile_id' | 'message_id' | 'message_text' | 'voice_name' | 'category'>,
+  messages: Pick<Message, 'id' | 'text' | 'voice_name' | 'category'>[],
+  voices: Pick<VoiceProfile, 'id' | 'name' | 'status'>[],
+): PlaybackPlan {
+  const mode: AlarmMode = alarm.mode === 'sound-only' ? 'sound-only' : 'tts';
+
+  if (mode === 'sound-only') {
+    const profileId = alarm.voice_profile_id ?? null;
+    if (!profileId) {
+      return {
+        kind: 'fallback',
+        uri: MOCK_DEFAULT_ALARM_URI,
+        reason: '음성 프로필이 지정되지 않아 기본 알람 톤으로 재생합니다.',
+      };
+    }
+    const profile = voices.find((v) => v.id === profileId);
+    if (!profile) {
+      return {
+        kind: 'fallback',
+        uri: MOCK_DEFAULT_ALARM_URI,
+        reason: '연결된 음성 프로필을 찾을 수 없어 기본 알람 톤으로 재생합니다.',
+      };
+    }
+    if (profile.status !== 'ready') {
+      return {
+        kind: 'fallback',
+        uri: MOCK_DEFAULT_ALARM_URI,
+        reason: '음성 프로필이 아직 준비되지 않아 기본 알람 톤으로 재생합니다.',
+      };
+    }
+    return {
+      kind: 'sound-only',
+      voiceProfileId: profile.id,
+      voiceName: profile.name,
+      uri: MOCK_VOICE_SAMPLE_URI,
+    };
+  }
+
+  const message = messages.find((m) => m.id === alarm.message_id);
+  const text = message?.text ?? alarm.message_text ?? '';
+  const voiceName = message?.voice_name ?? alarm.voice_name ?? '';
+  const category = message?.category ?? alarm.category ?? '';
+  if (!alarm.message_id || !text) {
+    return { kind: 'error', reason: '재생할 메시지를 찾을 수 없습니다.' };
+  }
+  return {
+    kind: 'tts',
+    messageId: alarm.message_id,
+    text,
+    voiceName,
+    category,
+  };
+}
+
+export function getAlarmModeBadge(mode: Alarm['mode']): { emoji: string; label: string } {
+  if (mode === 'sound-only') return { emoji: '🔊', label: '원본' };
+  return { emoji: '🗣️', label: 'TTS' };
+}

--- a/apps/mobile/test/alarmPlayback.test.ts
+++ b/apps/mobile/test/alarmPlayback.test.ts
@@ -1,0 +1,152 @@
+import {
+  MOCK_DEFAULT_ALARM_URI,
+  MOCK_VOICE_SAMPLE_URI,
+  getAlarmModeBadge,
+  resolveAlarmPlayback,
+} from '../src/lib/alarmPlayback';
+import type { Alarm, Message, VoiceProfile } from '../src/types';
+
+const MSG: Message = {
+  id: '10000000-0000-4000-8000-000000000001',
+  user_id: 'u1',
+  voice_profile_id: '40000000-0000-4000-8000-000000000001',
+  text: '좋은 아침이야',
+  audio_url: null,
+  category: 'morning',
+  is_preset: false,
+  created_at: '2026-04-21T00:00:00Z',
+  voice_name: '엄마',
+};
+
+const READY_VOICE: VoiceProfile = {
+  id: '40000000-0000-4000-8000-000000000001',
+  user_id: 'u1',
+  name: '엄마',
+  perso_voice_id: null,
+  elevenlabs_voice_id: null,
+  avatar_url: null,
+  status: 'ready',
+  created_at: '2026-04-21T00:00:00Z',
+  updated_at: '2026-04-21T00:00:00Z',
+};
+
+const PROCESSING_VOICE: VoiceProfile = { ...READY_VOICE, id: '40000000-0000-4000-8000-000000000002', status: 'processing' };
+
+const BASE_ALARM: Alarm = {
+  id: 'a1',
+  user_id: 'u1',
+  target_user_id: null,
+  message_id: MSG.id,
+  time: '07:00',
+  repeat_days: [],
+  is_active: true,
+  snooze_minutes: 5,
+  created_at: '2026-04-21T00:00:00Z',
+  updated_at: '2026-04-21T00:00:00Z',
+  mode: 'tts',
+  voice_profile_id: null,
+  speaker_id: null,
+};
+
+describe('resolveAlarmPlayback', () => {
+  it('tts 모드 — 메시지 매칭 시 kind=tts 반환', () => {
+    const plan = resolveAlarmPlayback(BASE_ALARM, [MSG], [READY_VOICE]);
+    expect(plan.kind).toBe('tts');
+    if (plan.kind === 'tts') {
+      expect(plan.text).toBe('좋은 아침이야');
+      expect(plan.voiceName).toBe('엄마');
+      expect(plan.category).toBe('morning');
+    }
+  });
+
+  it('tts 모드 — 메시지 누락 시 alarm.message_text fallback', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, message_text: '캐시된 텍스트', voice_name: '아빠', category: 'night' },
+      [],
+      [],
+    );
+    expect(plan.kind).toBe('tts');
+    if (plan.kind === 'tts') {
+      expect(plan.text).toBe('캐시된 텍스트');
+      expect(plan.voiceName).toBe('아빠');
+    }
+  });
+
+  it('tts 모드 — 메시지도 message_text 도 없으면 error', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, message_id: '' as string, message_text: undefined },
+      [],
+      [],
+    );
+    expect(plan.kind).toBe('error');
+  });
+
+  it('sound-only + ready voice_profile → uri=MOCK_VOICE_SAMPLE_URI', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, mode: 'sound-only', voice_profile_id: READY_VOICE.id },
+      [MSG],
+      [READY_VOICE],
+    );
+    expect(plan.kind).toBe('sound-only');
+    if (plan.kind === 'sound-only') {
+      expect(plan.uri).toBe(MOCK_VOICE_SAMPLE_URI);
+      expect(plan.voiceName).toBe('엄마');
+    }
+  });
+
+  it('sound-only + voice_profile_id 누락 → fallback', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, mode: 'sound-only', voice_profile_id: null },
+      [MSG],
+      [READY_VOICE],
+    );
+    expect(plan.kind).toBe('fallback');
+    if (plan.kind === 'fallback') {
+      expect(plan.uri).toBe(MOCK_DEFAULT_ALARM_URI);
+      expect(plan.reason).toContain('지정되지');
+    }
+  });
+
+  it('sound-only + 매칭 안 되는 profile id → fallback', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, mode: 'sound-only', voice_profile_id: 'unknown' },
+      [MSG],
+      [READY_VOICE],
+    );
+    expect(plan.kind).toBe('fallback');
+    if (plan.kind === 'fallback') expect(plan.reason).toContain('찾을 수 없어');
+  });
+
+  it('sound-only + processing 상태 voice → fallback (준비되지 않음)', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, mode: 'sound-only', voice_profile_id: PROCESSING_VOICE.id },
+      [MSG],
+      [PROCESSING_VOICE],
+    );
+    expect(plan.kind).toBe('fallback');
+    if (plan.kind === 'fallback') expect(plan.reason).toContain('준비');
+  });
+
+  it('mode 미지정(undefined) 이면 tts 로 기본 해석', () => {
+    const plan = resolveAlarmPlayback(
+      { ...BASE_ALARM, mode: undefined },
+      [MSG],
+      [READY_VOICE],
+    );
+    expect(plan.kind).toBe('tts');
+  });
+});
+
+describe('getAlarmModeBadge', () => {
+  it('sound-only → 🔊 원본', () => {
+    expect(getAlarmModeBadge('sound-only')).toEqual({ emoji: '🔊', label: '원본' });
+  });
+
+  it('tts → 🗣️ TTS', () => {
+    expect(getAlarmModeBadge('tts')).toEqual({ emoji: '🗣️', label: 'TTS' });
+  });
+
+  it('undefined → TTS 기본', () => {
+    expect(getAlarmModeBadge(undefined)).toEqual({ emoji: '🗣️', label: 'TTS' });
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #59
- 요약: 알람 발화 시 재생 소스를 결정하는 순수 함수 `resolveAlarmPlayback` 와 모드 뱃지 헬퍼 추가. sound-only 는 전부 mock URI 로 라우팅 (실 perso.ai 호출 금지).

## 변경 내용
- `apps/mobile/src/lib/alarmPlayback.ts` — `resolveAlarmPlayback`, `getAlarmModeBadge`, `MOCK_VOICE_SAMPLE_URI` / `MOCK_DEFAULT_ALARM_URI`
- sound-only 분기 — voice_profile 미지정 / 미매칭 / `processing|failed` 상태 모두 기본 알람 톤 fallback
- tts 분기 — 메시지 매칭 우선, 미매칭 시 `alarm.message_text` fallback, 둘 다 없으면 error
- `(tabs)/alarms.tsx` 알람 카드에 모드 뱃지 노출
- jest 11건 추가 — resolveAlarmPlayback 8 / getAlarmModeBadge 3

## 검증
- [x] `npm run typecheck -w apps/mobile` 통과
- [x] `npm test` 통과 (backend 300 / shared 12 / voice 11 / web 36 / mobile 61 = 420)
- [x] `npm run lint` 0 errors

## 리스크 / 팔로업
- mock URI 실체(번들 `asset:///audio/...`) 는 실제 오디오 파일 번들 이슈에서 생성 — 현재는 URI 문자열만 계약됨
- 노티피케이션 → 자동 재생 트리거는 다음 이슈(#25) 범위
- speaker_id 별 세그먼트 재생은 후속