### PR TITLE
[#61] 알람 미리듣기 액션 라우터 + 🔈 버튼

### DIFF
--- a/apps/mobile/app/(tabs)/alarms.tsx
+++ b/apps/mobile/app/(tabs)/alarms.tsx
@@ -18,7 +18,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Colors, Spacing, BorderRadius, FontSize } from '../../src/constants/theme';
-import { getAlarms, updateAlarm, deleteAlarm } from '../../src/services/api';
+import { getAlarms, updateAlarm, deleteAlarm, getMessages, getVoiceProfiles } from '../../src/services/api';
+import { playAudio } from '../../src/services/audio';
 import { useAppStore } from '../../src/stores/useAppStore';
 import { DAYS_OF_WEEK } from '../../src/constants/presets';
 import { ErrorView } from '../../src/components/QueryStateView';
@@ -28,7 +29,12 @@ import { syncAlarmNotifications } from '../../src/services/notifications';
 import type { Alarm } from '../../src/types';
 import { getApiErrorMessage } from '../../src/types';
 import { parseRepeatDays } from '../../src/lib/alarmForm';
-import { getAlarmModeBadge } from '../../src/lib/alarmPlayback';
+import {
+  buildAlarmPreviewAction,
+  getAlarmModeBadge,
+  resolveAlarmPlayback,
+} from '../../src/lib/alarmPlayback';
+import type { Message, VoiceProfile } from '../../src/types';
 import { useToast } from '../../src/hooks/useToast';
 import { Toast } from '../../src/components/Toast';
 
@@ -100,6 +106,42 @@ export default function AlarmsScreen() {
     queryFn: getAlarms,
     enabled: isAuthenticated && isConnected,
   });
+
+  const { data: messages } = useQuery({
+    queryKey: ['messages'],
+    queryFn: () => getMessages(),
+    enabled: isAuthenticated && isConnected,
+  });
+
+  const { data: voices } = useQuery({
+    queryKey: ['voiceProfiles'],
+    queryFn: getVoiceProfiles,
+    enabled: isAuthenticated && isConnected,
+  });
+
+  const handlePreview = useCallback(
+    async (alarm: Alarm) => {
+      const plan = resolveAlarmPlayback(
+        alarm,
+        (messages ?? []) as Message[],
+        (voices ?? []) as VoiceProfile[],
+      );
+      const action = buildAlarmPreviewAction(plan);
+      if (action.type === 'navigate') {
+        router.push({ pathname: action.path, params: action.params });
+      } else if (action.type === 'preview-audio') {
+        toast.show(action.caption || '미리듣기 재생');
+        try {
+          await playAudio(action.uri);
+        } catch {
+          toast.show('재생에 실패했어요. mock 파일이 아직 번들되지 않았을 수 있어요.');
+        }
+      } else {
+        toast.show(action.message);
+      }
+    },
+    [messages, voices, router, toast],
+  );
 
   const computeCountdown = useCallback(() => {
     const all = alarms ?? cachedAlarms;
@@ -250,15 +292,27 @@ export default function AlarmsScreen() {
               </Text>
             </View>
           </View>
-          <Switch
-            value={!!item.is_active}
-            onValueChange={(value) => toggleMutation.mutate({ id: item.id, is_active: value })}
-            trackColor={{
-              false: Colors.light.border,
-              true: Colors.light.primaryLight,
-            }}
-            thumbColor={item.is_active ? Colors.light.primary : '#f4f3f4'}
-          />
+          <View style={styles.alarmActions}>
+            <TouchableOpacity
+              style={styles.previewButton}
+              accessibilityLabel="미리듣기"
+              onPress={(e) => {
+                e.stopPropagation();
+                handlePreview(item);
+              }}
+            >
+              <Text style={styles.previewIcon}>🔈</Text>
+            </TouchableOpacity>
+            <Switch
+              value={!!item.is_active}
+              onValueChange={(value) => toggleMutation.mutate({ id: item.id, is_active: value })}
+              trackColor={{
+                false: Colors.light.border,
+                true: Colors.light.primaryLight,
+              }}
+              thumbColor={item.is_active ? Colors.light.primary : '#f4f3f4'}
+            />
+          </View>
         </TouchableOpacity>
       </Swipeable>
     );
@@ -476,6 +530,22 @@ const styles = StyleSheet.create({
     fontSize: FontSize.xs,
     color: Colors.light.primary,
     fontWeight: '600',
+  },
+  alarmActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  previewButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.light.surfaceVariant,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  previewIcon: {
+    fontSize: 18,
   },
   emptyState: {
     flex: 1,

--- a/apps/mobile/src/lib/alarmPlayback.ts
+++ b/apps/mobile/src/lib/alarmPlayback.ts
@@ -95,3 +95,63 @@ export function getAlarmModeBadge(mode: Alarm['mode']): { emoji: string; label: 
   if (mode === 'sound-only') return { emoji: '🔊', label: '원본' };
   return { emoji: '🗣️', label: 'TTS' };
 }
+
+export interface NavigatePreviewAction {
+  type: 'navigate';
+  path: '/player';
+  params: {
+    messageId: string;
+    text: string;
+    voiceName: string;
+    category: string;
+  };
+}
+
+export interface AudioPreviewAction {
+  type: 'preview-audio';
+  uri: string;
+  caption: string;
+  voiceName: string;
+}
+
+export interface ToastPreviewAction {
+  type: 'toast';
+  message: string;
+}
+
+export type PreviewAction =
+  | NavigatePreviewAction
+  | AudioPreviewAction
+  | ToastPreviewAction;
+
+export function buildAlarmPreviewAction(plan: PlaybackPlan): PreviewAction {
+  switch (plan.kind) {
+    case 'tts':
+      return {
+        type: 'navigate',
+        path: '/player',
+        params: {
+          messageId: plan.messageId,
+          text: plan.text,
+          voiceName: plan.voiceName,
+          category: plan.category,
+        },
+      };
+    case 'sound-only':
+      return {
+        type: 'preview-audio',
+        uri: plan.uri,
+        caption: `${plan.voiceName} 의 원본 샘플`,
+        voiceName: plan.voiceName,
+      };
+    case 'fallback':
+      return {
+        type: 'preview-audio',
+        uri: plan.uri,
+        caption: plan.reason,
+        voiceName: '',
+      };
+    case 'error':
+      return { type: 'toast', message: plan.reason };
+  }
+}

--- a/apps/mobile/test/alarmPlayback.test.ts
+++ b/apps/mobile/test/alarmPlayback.test.ts
@@ -1,8 +1,10 @@
 import {
   MOCK_DEFAULT_ALARM_URI,
   MOCK_VOICE_SAMPLE_URI,
+  buildAlarmPreviewAction,
   getAlarmModeBadge,
   resolveAlarmPlayback,
+  type PlaybackPlan,
 } from '../src/lib/alarmPlayback';
 import type { Alarm, Message, VoiceProfile } from '../src/types';
 
@@ -148,5 +150,101 @@ describe('getAlarmModeBadge', () => {
 
   it('undefined → TTS 기본', () => {
     expect(getAlarmModeBadge(undefined)).toEqual({ emoji: '🗣️', label: 'TTS' });
+  });
+});
+
+describe('buildAlarmPreviewAction', () => {
+  it('tts plan → navigate /player 액션, 파라미터 포함', () => {
+    const plan: PlaybackPlan = {
+      kind: 'tts',
+      messageId: 'm1',
+      text: '일어나자',
+      voiceName: '엄마',
+      category: 'morning',
+    };
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('navigate');
+    if (action.type === 'navigate') {
+      expect(action.path).toBe('/player');
+      expect(action.params).toEqual({
+        messageId: 'm1',
+        text: '일어나자',
+        voiceName: '엄마',
+        category: 'morning',
+      });
+    }
+  });
+
+  it('sound-only plan → preview-audio, uri=MOCK_VOICE_SAMPLE_URI + voiceName 캡션', () => {
+    const plan: PlaybackPlan = {
+      kind: 'sound-only',
+      voiceProfileId: 'v1',
+      voiceName: '아빠',
+      uri: MOCK_VOICE_SAMPLE_URI,
+    };
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('preview-audio');
+    if (action.type === 'preview-audio') {
+      expect(action.uri).toBe(MOCK_VOICE_SAMPLE_URI);
+      expect(action.caption).toContain('아빠');
+      expect(action.voiceName).toBe('아빠');
+    }
+  });
+
+  it('fallback plan → preview-audio, uri=MOCK_DEFAULT_ALARM_URI + 안내 캡션', () => {
+    const plan: PlaybackPlan = {
+      kind: 'fallback',
+      uri: MOCK_DEFAULT_ALARM_URI,
+      reason: '음성 프로필이 지정되지 않아 기본 알람 톤으로 재생합니다.',
+    };
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('preview-audio');
+    if (action.type === 'preview-audio') {
+      expect(action.uri).toBe(MOCK_DEFAULT_ALARM_URI);
+      expect(action.caption).toContain('지정되지');
+      expect(action.voiceName).toBe('');
+    }
+  });
+
+  it('error plan → toast 메시지로 전달', () => {
+    const plan: PlaybackPlan = { kind: 'error', reason: '재생할 메시지를 찾을 수 없습니다.' };
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('toast');
+    if (action.type === 'toast') expect(action.message).toContain('찾을 수 없');
+  });
+
+  it('resolve → action 엔드투엔드: tts 정상 경로', () => {
+    const plan = resolveAlarmPlayback(
+      {
+        mode: 'tts',
+        voice_profile_id: null,
+        message_id: 'm1',
+        message_text: '굿모닝',
+        voice_name: '엄마',
+        category: 'morning',
+      },
+      [],
+      [],
+    );
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('navigate');
+  });
+
+  it('resolve → action 엔드투엔드: sound-only voice 미지정 → fallback preview', () => {
+    const plan = resolveAlarmPlayback(
+      {
+        mode: 'sound-only',
+        voice_profile_id: null,
+        message_id: 'm1',
+        message_text: '텍스트',
+        voice_name: '엄마',
+        category: 'morning',
+      },
+      [],
+      [],
+    );
+    const action = buildAlarmPreviewAction(plan);
+    expect(action.type).toBe('preview-audio');
+    if (action.type === 'preview-audio') expect(action.uri).toBe(MOCK_DEFAULT_ALARM_URI);
   });
 });


### PR DESCRIPTION
## 개요
- 이슈: #61
- 요약: #59 의 재생 계획(resolver)을 실제 UI 액션으로 디스패치하는 `buildAlarmPreviewAction` 추가, 알람 카드에 🔈 미리듣기 버튼 노출.

## 변경 내용
- `alarmPlayback.ts` — `buildAlarmPreviewAction(plan)` 순수 함수, `navigate` / `preview-audio` / `toast` 판별 union
- `(tabs)/alarms.tsx` — 🔈 버튼 + `stopPropagation`, messages/voices 쿼리, resolver→action→`router/playAudio/toast` 분기. mock 파일 없을 때 안내 토스트.
- jest 6건 추가 (tts nav / sound-only preview / fallback preview / error toast / 엔드투엔드 2건) — 모바일 67, 전체 426.

## 검증
- [x] `npm run typecheck -w apps/mobile` 통과
- [x] `npm test` 통과 (backend 300 / shared 12 / voice 11 / web 36 / mobile 67 = 426)
- [x] `npm run lint` 0 errors

## 리스크 / 팔로업
- mock URI (`asset:///audio/...`) 실체 파일 번들은 후속 — 현재는 실패 시 안내 토스트로 degrade
- 노티피케이션 발화 시 자동 재생 트리거는 별도 이슈 (백그라운드 오디오 세션)
- speaker 별 세그먼트 오버레이는 Phase 6 이후