### PR TITLE
[Phase 5] #26 Plan·Subscription 모델 (#63)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -194,6 +194,47 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_alarms_speaker ON alarms(speaker_id)',
     ],
   },
+  {
+    id: 6,
+    name: 'plans-and-subscriptions',
+    statements: [
+      // plan_type: 'free'=무료, 'personal'=개인 1인, 'family'=가족 최대 6인
+      `CREATE TABLE IF NOT EXISTS plans (
+        id TEXT PRIMARY KEY,
+        key TEXT UNIQUE NOT NULL,
+        name TEXT NOT NULL,
+        plan_type TEXT NOT NULL CHECK(plan_type IN ('free','personal','family')),
+        period_days INTEGER NOT NULL DEFAULT 30,
+        max_members INTEGER NOT NULL DEFAULT 1,
+        price_krw INTEGER NOT NULL DEFAULT 0,
+        is_active INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT DEFAULT (datetime('now'))
+      )`,
+      // plan_group_id 는 #31 (가족 플랜 그룹) 에서 채움. 현재는 nullable.
+      `CREATE TABLE IF NOT EXISTS subscriptions (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES users(id),
+        plan_id TEXT NOT NULL REFERENCES plans(id),
+        plan_group_id TEXT,
+        status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','expired','cancelled')),
+        starts_at TEXT NOT NULL DEFAULT (datetime('now')),
+        expires_at TEXT NOT NULL,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )`,
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_plans_key ON plans(key)',
+      'CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id)',
+      'CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status)',
+      'CREATE INDEX IF NOT EXISTS idx_subscriptions_expires ON subscriptions(expires_at)',
+      // 기본 플랜 3개 시드 — 고정 UUID 로 재마이그레이션 시 중복 방지
+      `INSERT OR IGNORE INTO plans (id, key, name, plan_type, period_days, max_members, price_krw, is_active)
+        VALUES ('70000000-0000-4000-8000-000000000001', 'free', '무료', 'free', 36500, 1, 0, 1)`,
+      `INSERT OR IGNORE INTO plans (id, key, name, plan_type, period_days, max_members, price_krw, is_active)
+        VALUES ('70000000-0000-4000-8000-000000000002', 'plus_personal', '플러스 개인', 'personal', 30, 1, 4900, 1)`,
+      `INSERT OR IGNORE INTO plans (id, key, name, plan_type, period_days, max_members, price_krw, is_active)
+        VALUES ('70000000-0000-4000-8000-000000000003', 'family', '가족', 'family', 30, 6, 9900, 1)`,
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -83,4 +83,42 @@ describe('migrations', () => {
     expect(all).toContain('idx_alarms_voice_profile');
     expect(all).toContain('idx_alarms_speaker');
   });
+
+  it('마이그레이션 #6 에서 plans / subscriptions 테이블과 인덱스를 추가한다', () => {
+    const m = migrations.find((x) => x.id === 6);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS plans');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS subscriptions');
+    expect(all).toContain("CHECK(plan_type IN ('free','personal','family'))");
+    expect(all).toContain("CHECK(status IN ('active','expired','cancelled'))");
+    expect(all).toContain('period_days');
+    expect(all).toContain('max_members');
+    expect(all).toContain('price_krw');
+    expect(all).toContain('plan_group_id');
+    expect(all).toContain('expires_at');
+    expect(all).toContain('idx_plans_key');
+    expect(all).toContain('idx_subscriptions_user');
+    expect(all).toContain('idx_subscriptions_status');
+    expect(all).toContain('idx_subscriptions_expires');
+  });
+
+  it('마이그레이션 #6 에서 기본 플랜 3종(free / plus_personal / family) 을 시드한다', () => {
+    const m = migrations.find((x) => x.id === 6);
+    expect(m).toBeDefined();
+    const inserts = m!.statements.filter((s) => s.trim().startsWith('INSERT'));
+    expect(inserts.length).toBe(3);
+    const all = inserts.join('\n');
+    expect(all).toContain("'free'");
+    expect(all).toContain("'plus_personal'");
+    expect(all).toContain("'family'");
+    // 가족 플랜은 max_members=6, 30일 주기, 9900원
+    expect(all).toMatch(/'family',[^\n]*'family',\s*30,\s*6,\s*9900/);
+    // 개인 플랜은 4900원, 1인, 30일 주기
+    expect(all).toMatch(/'plus_personal',[^\n]*'personal',\s*30,\s*1,\s*4900/);
+    // INSERT OR IGNORE 로 재실행 안전성 확보
+    for (const stmt of inserts) {
+      expect(stmt).toContain('INSERT OR IGNORE');
+    }
+  });
 });


### PR DESCRIPTION
## 요약
- 마이그레이션 #6 추가 — `plans` / `subscriptions` 테이블과 관련 인덱스 4종
- 기본 플랜 3종 시드 — `free`(무기한/1인/0원), `plus_personal`(30일/1인/4900원), `family`(30일/6인/9900원)
- `users.plan` 컬럼은 백워드 호환을 위해 유지 (활성 subscription 동기화는 #27 결제 스텁에서 구현)

## 이 PR 에서 제외 (후속 이슈)
- 결제 엔드포인트·PG 연동 (#27)
- 이용권 코드 발급/등록 (#28~#30)
- 가족 플랜 그룹·초대·참여 (#31~#33)

## 테스트
- [x] `packages/backend/test/migrations.test.ts` 에 #6 검증 2건 추가 → 11건 그린
- [x] 백엔드 전체 302건 그린
- [x] `tsc --noEmit` 에러 없음

closes #63