### PR TITLE
[Phase 5] #27 스텁 결제 엔드포인트 (#65)

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -18,6 +18,7 @@ import friendRoutes from './routes/friend';
 import giftRoutes from './routes/gift';
 import statsRoutes from './routes/stats';
 import dubRoutes from './routes/dub';
+import billingRoutes from './routes/billing';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -111,6 +112,7 @@ api.route('/friend', friendRoutes);
 api.route('/gift', giftRoutes);
 api.route('/stats', statsRoutes);
 api.route('/dub', dubRoutes);
+api.route('/billing', billingRoutes);
 
 app.route('/api', api);
 

--- a/packages/backend/src/routes/billing.ts
+++ b/packages/backend/src/routes/billing.ts
@@ -1,0 +1,152 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { getDB } from '../lib/db';
+
+const billing = new Hono<AppEnv>();
+
+const PAID_PLAN_TYPES = new Set(['personal', 'family']);
+
+function planTypeToUserPlan(planType: string): 'free' | 'plus' | 'family' {
+  if (planType === 'family') return 'family';
+  if (planType === 'personal') return 'plus';
+  return 'free';
+}
+
+/**
+ * POST /billing/checkout — 스텁 결제 엔드포인트.
+ * TODO: integrate real PG (TossPayments / Iamport) — currently stub 이며 결제 성공 여부를 항상 true 로 가정한다.
+ */
+billing.post('/checkout', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const body = await c.req
+    .json<{ plan_key?: unknown }>()
+    .catch(() => ({ plan_key: undefined }));
+
+  const planKey = typeof body.plan_key === 'string' ? body.plan_key.trim() : '';
+  if (!planKey) {
+    return c.json({ error: 'plan_key 는 필수입니다' }, 400);
+  }
+
+  const planRes = await db.execute({
+    sql: `SELECT id, key, name, plan_type, period_days, max_members, price_krw, is_active
+          FROM plans WHERE key = ?`,
+    args: [planKey],
+  });
+  if (planRes.rows.length === 0) {
+    return c.json({ error: '존재하지 않는 플랜입니다' }, 400);
+  }
+  const plan = planRes.rows[0];
+  if (Number(plan.is_active) !== 1) {
+    return c.json({ error: '비활성화된 플랜입니다' }, 400);
+  }
+  const planType = String(plan.plan_type);
+  if (!PAID_PLAN_TYPES.has(planType)) {
+    return c.json({ error: 'free 는 기본 플랜이라 결제 대상이 아닙니다' }, 400);
+  }
+
+  const userRes = await db.execute({
+    sql: 'SELECT id FROM users WHERE google_id = ?',
+    args: [userId],
+  });
+  if (userRes.rows.length === 0) {
+    return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+  }
+  const userPk = String(userRes.rows[0].id);
+
+  const subscriptionId = crypto.randomUUID();
+  const periodDays = Number(plan.period_days) || 30;
+  const startsAt = new Date();
+  const expiresAt = new Date(startsAt.getTime() + periodDays * 24 * 60 * 60 * 1000);
+
+  await db.execute({
+    sql: `INSERT INTO subscriptions (id, user_id, plan_id, status, starts_at, expires_at)
+          VALUES (?, ?, ?, 'active', ?, ?)`,
+    args: [
+      subscriptionId,
+      userPk,
+      String(plan.id),
+      startsAt.toISOString(),
+      expiresAt.toISOString(),
+    ],
+  });
+
+  const mirroredPlan = planTypeToUserPlan(planType);
+  await db.execute({
+    sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+    args: [mirroredPlan, userPk],
+  });
+
+  return c.json({
+    success: true,
+    checkout_stub: true,
+    subscription: {
+      id: subscriptionId,
+      user_id: userPk,
+      plan_id: String(plan.id),
+      status: 'active',
+      starts_at: startsAt.toISOString(),
+      expires_at: expiresAt.toISOString(),
+    },
+    plan: {
+      id: String(plan.id),
+      key: String(plan.key),
+      name: String(plan.name),
+      plan_type: planType,
+      period_days: periodDays,
+      max_members: Number(plan.max_members),
+      price_krw: Number(plan.price_krw),
+    },
+  });
+});
+
+/** GET /billing/subscription — 현재 사용자 활성 구독(+plan JOIN) 반환 */
+billing.get('/subscription', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const result = await db.execute({
+    sql: `SELECT s.id AS sub_id, s.user_id, s.plan_id, s.plan_group_id,
+                 s.status, s.starts_at, s.expires_at,
+                 p.key AS plan_key, p.name AS plan_name, p.plan_type,
+                 p.period_days, p.max_members, p.price_krw
+          FROM subscriptions s
+          JOIN users u ON u.id = s.user_id
+          JOIN plans p ON p.id = s.plan_id
+          WHERE u.google_id = ?
+            AND s.status = 'active'
+            AND s.expires_at > datetime('now')
+          ORDER BY s.starts_at DESC
+          LIMIT 1`,
+    args: [userId],
+  });
+
+  if (result.rows.length === 0) {
+    return c.json({ subscription: null, plan: null });
+  }
+
+  const r = result.rows[0];
+  return c.json({
+    subscription: {
+      id: String(r.sub_id),
+      user_id: String(r.user_id),
+      plan_id: String(r.plan_id),
+      plan_group_id: (r.plan_group_id as string | null) ?? null,
+      status: String(r.status),
+      starts_at: String(r.starts_at),
+      expires_at: String(r.expires_at),
+    },
+    plan: {
+      id: String(r.plan_id),
+      key: String(r.plan_key),
+      name: String(r.plan_name),
+      plan_type: String(r.plan_type),
+      period_days: Number(r.period_days),
+      max_members: Number(r.max_members),
+      price_krw: Number(r.price_krw),
+    },
+  });
+});
+
+export default billing;

--- a/packages/backend/test/billing.test.ts
+++ b/packages/backend/test/billing.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import billingRoutes from '../src/routes/billing';
+
+const PLAN_PLUS = {
+  id: '70000000-0000-4000-8000-000000000002',
+  key: 'plus_personal',
+  name: '플러스 개인',
+  plan_type: 'personal',
+  period_days: 30,
+  max_members: 1,
+  price_krw: 4900,
+  is_active: 1,
+};
+
+const PLAN_FAMILY = {
+  id: '70000000-0000-4000-8000-000000000003',
+  key: 'family',
+  name: '가족',
+  plan_type: 'family',
+  period_days: 30,
+  max_members: 6,
+  price_krw: 9900,
+  is_active: 1,
+};
+
+const PLAN_FREE = {
+  id: '70000000-0000-4000-8000-000000000001',
+  key: 'free',
+  name: '무료',
+  plan_type: 'free',
+  period_days: 36500,
+  max_members: 1,
+  price_krw: 0,
+  is_active: 1,
+};
+
+function buildApp(userId = 'google-1') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware(userId));
+  app.route('/billing', billingRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+describe('POST /billing/checkout', () => {
+  it('plus_personal → 200, subscription 생성 + users.plan=plus', async () => {
+    mockDB.pushResult([PLAN_PLUS]); // SELECT plan
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // SELECT user
+    mockDB.pushResult([], 1); // INSERT subscription
+    mockDB.pushResult([], 1); // UPDATE users.plan
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'plus_personal' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.checkout_stub).toBe(true);
+    expect(body.subscription.status).toBe('active');
+    expect(body.subscription.user_id).toBe('user-pk-1');
+    expect(body.plan.key).toBe('plus_personal');
+    expect(body.plan.price_krw).toBe(4900);
+
+    const updateCall = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
+    expect(updateCall?.args[0]).toBe('plus');
+    expect(updateCall?.args[1]).toBe('user-pk-1');
+  });
+
+  it('family → 200, users.plan=family', async () => {
+    mockDB.pushResult([PLAN_FAMILY]);
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'family' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plan.plan_type).toBe('family');
+    const updateCall = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
+    expect(updateCall?.args[0]).toBe('family');
+  });
+
+  it('subscription.expires_at 는 starts_at + period_days 후', async () => {
+    mockDB.pushResult([PLAN_PLUS]);
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'plus_personal' }),
+    );
+    const body = await res.json();
+    const starts = new Date(body.subscription.starts_at).getTime();
+    const expires = new Date(body.subscription.expires_at).getTime();
+    expect(expires - starts).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it('없는 plan_key → 400', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'nonexistent' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('존재하지 않는');
+  });
+
+  it('free plan_key → 400 (결제 대상 아님)', async () => {
+    mockDB.pushResult([PLAN_FREE]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'free' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('free');
+  });
+
+  it('plan_key 미지정 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/billing/checkout', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('plan_key');
+  });
+
+  it('비활성(is_active=0) 플랜 → 400', async () => {
+    mockDB.pushResult([{ ...PLAN_PLUS, is_active: 0 }]);
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'plus_personal' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('비활성');
+  });
+
+  it('사용자 행 없음 → 404', async () => {
+    mockDB.pushResult([PLAN_PLUS]);
+    mockDB.pushResult([]); // no user
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'plus_personal' }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /billing/subscription', () => {
+  it('활성 구독 있을 때 subscription + plan 반환', async () => {
+    mockDB.pushResult([
+      {
+        sub_id: 'sub-1',
+        user_id: 'user-pk-1',
+        plan_id: PLAN_PLUS.id,
+        plan_group_id: null,
+        status: 'active',
+        starts_at: '2026-04-21T00:00:00.000Z',
+        expires_at: '2026-05-21T00:00:00.000Z',
+        plan_key: 'plus_personal',
+        plan_name: '플러스 개인',
+        plan_type: 'personal',
+        period_days: 30,
+        max_members: 1,
+        price_krw: 4900,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/billing/subscription'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscription.id).toBe('sub-1');
+    expect(body.subscription.status).toBe('active');
+    expect(body.plan.key).toBe('plus_personal');
+    expect(body.plan.max_members).toBe(1);
+  });
+
+  it('활성 구독 없을 때 { subscription: null, plan: null }', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/billing/subscription'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscription).toBeNull();
+    expect(body.plan).toBeNull();
+  });
+
+  it('SQL 에 expires_at > datetime(now) 와 status active 조건 포함', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    await app.request(jsonReq('GET', '/billing/subscription'));
+    const sql = mockDB.calls[0].sql;
+    expect(sql).toContain("s.status = 'active'");
+    expect(sql).toContain("s.expires_at > datetime('now')");
+  });
+});


### PR DESCRIPTION
## 요약
- `POST /api/billing/checkout` 신규 — body `{ plan_key }`
  - plans 테이블 조회 → 사용자 조회(users.google_id→id) → subscriptions 행 생성 → users.plan 동기화
  - period_days 만큼 만료일 설정, status='active', plan_group_id 는 #31에서 채움
  - 실 PG 미연동 (`// TODO: integrate real PG`). 결제수단 받지 않음, 항상 성공 가정
- `GET /api/billing/subscription` 신규 — 활성 구독 + plans JOIN 반환. 없으면 `null`
- free 플랜, 존재하지 않는/비활성 plan_key, 없는 사용자 전부 적절한 에러 응답

## 테스트
- [x] `billing.test.ts` 11건 (checkout 8 + subscription 3) 전부 그린
- [x] 백엔드 전체 302→313 / 25 파일 그린
- [x] `tsc --noEmit` 에러 없음

## 후속 이슈
- #28 이용권 코드 발급 훅 — `/checkout` 완료 시 자동 생성
- #29 코드 등록 API, #30 코드 공유 UI, #31 가족 플랜 그룹

closes #65