### PR TITLE
[Phase 5] #28 이용권 코드 발급 (#67)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -235,6 +235,30 @@ export const migrations: Migration[] = [
         VALUES ('70000000-0000-4000-8000-000000000003', 'family', '가족', 'family', 30, 6, 9900, 1)`,
     ],
   },
+  {
+    id: 7,
+    name: 'voucher-codes',
+    statements: [
+      // code: plaintext 'VA-XXXX-XXXX-XXXX' (발급자 본인에게만 노출)
+      // code_hash: SHA-256(code) hex — 등록 시 lookup 용 (#29)
+      `CREATE TABLE IF NOT EXISTS voucher_codes (
+        id TEXT PRIMARY KEY,
+        code TEXT NOT NULL UNIQUE,
+        code_hash TEXT NOT NULL UNIQUE,
+        plan_id TEXT NOT NULL REFERENCES plans(id),
+        issuer_user_id TEXT NOT NULL REFERENCES users(id),
+        issuer_subscription_id TEXT REFERENCES subscriptions(id),
+        redeemed_by_user_id TEXT REFERENCES users(id),
+        status TEXT NOT NULL DEFAULT 'issued' CHECK(status IN ('issued','used','expired')),
+        issued_at TEXT NOT NULL DEFAULT (datetime('now')),
+        used_at TEXT,
+        expires_at TEXT NOT NULL
+      )`,
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_voucher_codes_hash ON voucher_codes(code_hash)',
+      'CREATE INDEX IF NOT EXISTS idx_voucher_codes_issuer ON voucher_codes(issuer_user_id)',
+      'CREATE INDEX IF NOT EXISTS idx_voucher_codes_status ON voucher_codes(status)',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/lib/vouchers.ts
+++ b/packages/backend/src/lib/vouchers.ts
@@ -1,0 +1,49 @@
+// 이용권 코드 생성/해시 — 포맷 'VA-XXXX-XXXX-XXXX' (X = A-Z0-9 혼합, 12자)
+// 시각적 혼동 방지를 위해 0/O/1/I/L 은 제외.
+
+const VOUCHER_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const GROUP_SIZE = 4;
+const GROUP_COUNT = 3;
+
+export interface GeneratedVoucher {
+  code: string;
+  hash: string;
+}
+
+function randomGroup(): string {
+  const bytes = new Uint8Array(GROUP_SIZE);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (let i = 0; i < GROUP_SIZE; i++) {
+    out += VOUCHER_ALPHABET[bytes[i] % VOUCHER_ALPHABET.length];
+  }
+  return out;
+}
+
+/** 'VA-XXXX-XXXX-XXXX' 형태 평문 코드 생성 */
+export function generateVoucherCodePlain(): string {
+  const groups: string[] = [];
+  for (let i = 0; i < GROUP_COUNT; i++) groups.push(randomGroup());
+  return `VA-${groups.join('-')}`;
+}
+
+export async function hashVoucherCode(code: string): Promise<string> {
+  const buf = new TextEncoder().encode(code);
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** 평문+해시 페어 생성 — 등록 시 lookup 에 hash 사용, 발급자 UI 는 평문 */
+export async function generateVoucherCode(): Promise<GeneratedVoucher> {
+  const code = generateVoucherCodePlain();
+  const hash = await hashVoucherCode(code);
+  return { code, hash };
+}
+
+const VOUCHER_CODE_RE = /^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+export function isValidVoucherCodeFormat(raw: string): boolean {
+  return VOUCHER_CODE_RE.test(raw);
+}

--- a/packages/backend/src/routes/billing.ts
+++ b/packages/backend/src/routes/billing.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
+import { generateVoucherCode } from '../lib/vouchers';
 
 const billing = new Hono<AppEnv>();
 
@@ -78,6 +79,25 @@ billing.post('/checkout', async (c) => {
     args: [mirroredPlan, userPk],
   });
 
+  // 1회용 이용권 코드 자동 발급 (#28)
+  const voucherId = crypto.randomUUID();
+  const { code: voucherCode, hash: voucherHash } = await generateVoucherCode();
+  await db.execute({
+    sql: `INSERT INTO voucher_codes
+          (id, code, code_hash, plan_id, issuer_user_id, issuer_subscription_id, status, issued_at, expires_at)
+          VALUES (?, ?, ?, ?, ?, ?, 'issued', ?, ?)`,
+    args: [
+      voucherId,
+      voucherCode,
+      voucherHash,
+      String(plan.id),
+      userPk,
+      subscriptionId,
+      startsAt.toISOString(),
+      expiresAt.toISOString(),
+    ],
+  });
+
   return c.json({
     success: true,
     checkout_stub: true,
@@ -98,6 +118,54 @@ billing.post('/checkout', async (c) => {
       max_members: Number(plan.max_members),
       price_krw: Number(plan.price_krw),
     },
+    voucher: {
+      id: voucherId,
+      code: voucherCode,
+      expires_at: expiresAt.toISOString(),
+    },
+  });
+});
+
+/** GET /billing/vouchers — 내가 발급한 이용권 코드 목록 (발급자에게만 평문 노출) */
+billing.get('/vouchers', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const userRes = await db.execute({
+    sql: 'SELECT id FROM users WHERE google_id = ?',
+    args: [userId],
+  });
+  if (userRes.rows.length === 0) {
+    return c.json({ vouchers: [] });
+  }
+  const userPk = String(userRes.rows[0].id);
+
+  const result = await db.execute({
+    sql: `SELECT v.id, v.code, v.plan_id, v.issuer_subscription_id, v.redeemed_by_user_id,
+                 v.status, v.issued_at, v.used_at, v.expires_at,
+                 p.key AS plan_key, p.name AS plan_name, p.plan_type
+          FROM voucher_codes v
+          JOIN plans p ON p.id = v.plan_id
+          WHERE v.issuer_user_id = ?
+          ORDER BY v.issued_at DESC`,
+    args: [userPk],
+  });
+
+  return c.json({
+    vouchers: result.rows.map((r) => ({
+      id: String(r.id),
+      code: String(r.code),
+      plan_id: String(r.plan_id),
+      plan_key: String(r.plan_key),
+      plan_name: String(r.plan_name),
+      plan_type: String(r.plan_type),
+      subscription_id: (r.issuer_subscription_id as string | null) ?? null,
+      redeemed_by_user_id: (r.redeemed_by_user_id as string | null) ?? null,
+      status: String(r.status),
+      issued_at: String(r.issued_at),
+      used_at: (r.used_at as string | null) ?? null,
+      expires_at: String(r.expires_at),
+    })),
   });
 });
 

--- a/packages/backend/test/billing.test.ts
+++ b/packages/backend/test/billing.test.ts
@@ -56,11 +56,12 @@ beforeEach(() => {
 });
 
 describe('POST /billing/checkout', () => {
-  it('plus_personal → 200, subscription 생성 + users.plan=plus', async () => {
+  it('plus_personal → 200, subscription 생성 + users.plan=plus + voucher 발급', async () => {
     mockDB.pushResult([PLAN_PLUS]); // SELECT plan
     mockDB.pushResult([{ id: 'user-pk-1' }]); // SELECT user
     mockDB.pushResult([], 1); // INSERT subscription
     mockDB.pushResult([], 1); // UPDATE users.plan
+    mockDB.pushResult([], 1); // INSERT voucher_code
 
     const app = buildApp();
     const res = await app.request(
@@ -74,15 +75,24 @@ describe('POST /billing/checkout', () => {
     expect(body.subscription.user_id).toBe('user-pk-1');
     expect(body.plan.key).toBe('plus_personal');
     expect(body.plan.price_krw).toBe(4900);
+    expect(body.voucher.code).toMatch(/^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(body.voucher.expires_at).toBe(body.subscription.expires_at);
 
     const updateCall = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
     expect(updateCall?.args[0]).toBe('plus');
     expect(updateCall?.args[1]).toBe('user-pk-1');
+
+    const insertVoucher = mockDB.calls.find((c) => c.sql.includes('INSERT INTO voucher_codes'));
+    expect(insertVoucher).toBeDefined();
+    expect(insertVoucher?.args[1]).toBe(body.voucher.code);
+    // code_hash 는 SHA-256 hex
+    expect(String(insertVoucher?.args[2])).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('family → 200, users.plan=family', async () => {
+  it('family → 200, users.plan=family, voucher 는 family plan_id 로 발급', async () => {
     mockDB.pushResult([PLAN_FAMILY]);
     mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
@@ -95,11 +105,14 @@ describe('POST /billing/checkout', () => {
     expect(body.plan.plan_type).toBe('family');
     const updateCall = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
     expect(updateCall?.args[0]).toBe('family');
+    const insertVoucher = mockDB.calls.find((c) => c.sql.includes('INSERT INTO voucher_codes'));
+    expect(insertVoucher?.args[3]).toBe(PLAN_FAMILY.id);
   });
 
   it('subscription.expires_at 는 starts_at + period_days 후', async () => {
     mockDB.pushResult([PLAN_PLUS]);
     mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
@@ -211,5 +224,75 @@ describe('GET /billing/subscription', () => {
     const sql = mockDB.calls[0].sql;
     expect(sql).toContain("s.status = 'active'");
     expect(sql).toContain("s.expires_at > datetime('now')");
+  });
+});
+
+describe('GET /billing/vouchers', () => {
+  it('발급한 코드 목록을 반환 (평문 포함, 발급자 본인)', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // SELECT user
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        code: 'VA-ABCD-EFGH-JKLM',
+        plan_id: PLAN_PLUS.id,
+        issuer_subscription_id: 'sub-1',
+        redeemed_by_user_id: null,
+        status: 'issued',
+        issued_at: '2026-04-21T00:00:00.000Z',
+        used_at: null,
+        expires_at: '2026-05-21T00:00:00.000Z',
+        plan_key: 'plus_personal',
+        plan_name: '플러스 개인',
+        plan_type: 'personal',
+      },
+      {
+        id: 'v2',
+        code: 'VA-NPQR-STUV-WXYZ',
+        plan_id: PLAN_FAMILY.id,
+        issuer_subscription_id: 'sub-2',
+        redeemed_by_user_id: 'user-pk-2',
+        status: 'used',
+        issued_at: '2026-04-15T00:00:00.000Z',
+        used_at: '2026-04-16T00:00:00.000Z',
+        expires_at: '2026-05-15T00:00:00.000Z',
+        plan_key: 'family',
+        plan_name: '가족',
+        plan_type: 'family',
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/billing/vouchers'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vouchers).toHaveLength(2);
+    expect(body.vouchers[0].code).toBe('VA-ABCD-EFGH-JKLM');
+    expect(body.vouchers[0].status).toBe('issued');
+    expect(body.vouchers[0].plan_key).toBe('plus_personal');
+    expect(body.vouchers[1].status).toBe('used');
+    expect(body.vouchers[1].redeemed_by_user_id).toBe('user-pk-2');
+
+    const listCall = mockDB.calls.find((c) => c.sql.includes('FROM voucher_codes'));
+    expect(listCall?.args[0]).toBe('user-pk-1');
+    expect(listCall?.sql).toContain('v.issuer_user_id = ?');
+  });
+
+  it('사용자 없으면 빈 배열', async () => {
+    mockDB.pushResult([]); // no user
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/billing/vouchers'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vouchers).toEqual([]);
+  });
+
+  it('발급한 코드가 없으면 빈 배열', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/billing/vouchers'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.vouchers).toEqual([]);
   });
 });

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -103,6 +103,22 @@ describe('migrations', () => {
     expect(all).toContain('idx_subscriptions_expires');
   });
 
+  it('마이그레이션 #7 에서 voucher_codes 테이블과 인덱스를 추가한다', () => {
+    const m = migrations.find((x) => x.id === 7);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS voucher_codes');
+    expect(all).toContain('code TEXT NOT NULL UNIQUE');
+    expect(all).toContain('code_hash TEXT NOT NULL UNIQUE');
+    expect(all).toContain("CHECK(status IN ('issued','used','expired'))");
+    expect(all).toContain('issuer_user_id');
+    expect(all).toContain('redeemed_by_user_id');
+    expect(all).toContain('expires_at');
+    expect(all).toContain('idx_voucher_codes_hash');
+    expect(all).toContain('idx_voucher_codes_issuer');
+    expect(all).toContain('idx_voucher_codes_status');
+  });
+
   it('마이그레이션 #6 에서 기본 플랜 3종(free / plus_personal / family) 을 시드한다', () => {
     const m = migrations.find((x) => x.id === 6);
     expect(m).toBeDefined();

--- a/packages/backend/test/vouchers.test.ts
+++ b/packages/backend/test/vouchers.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateVoucherCode,
+  generateVoucherCodePlain,
+  hashVoucherCode,
+  isValidVoucherCodeFormat,
+} from '../src/lib/vouchers';
+
+describe('generateVoucherCodePlain', () => {
+  it('VA-XXXX-XXXX-XXXX 포맷을 따른다', () => {
+    for (let i = 0; i < 20; i++) {
+      const code = generateVoucherCodePlain();
+      expect(code).toMatch(/^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    }
+  });
+
+  it('시각적 혼동 문자 (0/O/1/I/L) 를 포함하지 않는다', () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateVoucherCodePlain();
+      expect(code).not.toMatch(/[01OIL]/);
+    }
+  });
+
+  it('충분히 고유하다 (100회 생성 시 중복 없음)', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 100; i++) set.add(generateVoucherCodePlain());
+    expect(set.size).toBe(100);
+  });
+});
+
+describe('hashVoucherCode', () => {
+  it('동일 입력 → 동일 hash (결정성)', async () => {
+    const h1 = await hashVoucherCode('VA-ABCD-EFGH-JKLM');
+    const h2 = await hashVoucherCode('VA-ABCD-EFGH-JKLM');
+    expect(h1).toBe(h2);
+  });
+
+  it('다른 입력 → 다른 hash', async () => {
+    const h1 = await hashVoucherCode('VA-ABCD-EFGH-JKLM');
+    const h2 = await hashVoucherCode('VA-ABCD-EFGH-JKLN');
+    expect(h1).not.toBe(h2);
+  });
+
+  it('SHA-256 hex 문자열 (64자)', async () => {
+    const h = await hashVoucherCode('VA-ABCD-EFGH-JKLM');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('generateVoucherCode', () => {
+  it('code + hash 페어 반환, hash 는 hashVoucherCode(code) 와 동일', async () => {
+    const { code, hash } = await generateVoucherCode();
+    expect(code).toMatch(/^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    const expectedHash = await hashVoucherCode(code);
+    expect(hash).toBe(expectedHash);
+  });
+});
+
+describe('isValidVoucherCodeFormat', () => {
+  it('정상 포맷 → true', () => {
+    expect(isValidVoucherCodeFormat('VA-ABCD-EFGH-JKLM')).toBe(true);
+    expect(isValidVoucherCodeFormat('VA-2345-6789-ABCD')).toBe(true);
+  });
+
+  it('잘못된 포맷 → false', () => {
+    expect(isValidVoucherCodeFormat('')).toBe(false);
+    expect(isValidVoucherCodeFormat('ABCD-EFGH-JKLM')).toBe(false);
+    expect(isValidVoucherCodeFormat('VA-ABC-EFGH-JKLM')).toBe(false);
+    expect(isValidVoucherCodeFormat('VA-abcd-efgh-jklm')).toBe(false);
+    expect(isValidVoucherCodeFormat('VA-ABCD-EFGH')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 요약
- 마이그레이션 #7 — `voucher_codes` 테이블 및 인덱스 3종
- `lib/vouchers.ts` — VA-XXXX-XXXX-XXXX 포맷 생성 + SHA-256 hash 페어
- `/api/billing/checkout` 훅 — subscription 생성 직후 voucher 자동 발급, 응답에 `voucher.code` 평문 노출
- `GET /api/billing/vouchers` — 발급자 본인 코드 목록 (plan JOIN)

## 설계 선택
- 평문 `code` + hash 동시 저장: 발급자 UI 재조회·공유를 지원하면서 #29 등록 API 에서는 `code_hash` UNIQUE 인덱스로 O(1) lookup
- 문자 집합에서 0/O/1/I/L 제외 (OCR/손글씨 혼동 방지, 사용자가 직접 입력 가능)
- 만료는 구독 만료일과 동일 (구독이 살아있는 동안만 양도 가능)

## 테스트
- [x] `vouchers.test.ts` 10건 (포맷/hash 결정성/혼동문자 회피/고유성)
- [x] `billing.test.ts` 15건 (checkout 에 voucher, vouchers 목록 3건)
- [x] `migrations.test.ts` 12건 (#7 검증 추가)
- [x] 백엔드 전체 313→326 그린, `tsc --noEmit` 에러 없음

## 후속 이슈
- #29 코드 등록 API (hash lookup 으로 redeem, status issued→used)
- #30 모바일/웹 공유 UI (QR/복사/링크)

closes #67