### PR TITLE
[Phase 5] #29 코드 등록 API (#69)

### DIFF
--- a/packages/backend/src/routes/billing.ts
+++ b/packages/backend/src/routes/billing.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
-import { generateVoucherCode } from '../lib/vouchers';
+import { generateVoucherCode, hashVoucherCode, isValidVoucherCodeFormat } from '../lib/vouchers';
 
 const billing = new Hono<AppEnv>();
 
@@ -213,6 +213,138 @@ billing.get('/subscription', async (c) => {
       period_days: Number(r.period_days),
       max_members: Number(r.max_members),
       price_krw: Number(r.price_krw),
+    },
+  });
+});
+
+/**
+ * POST /billing/redeem — 이용권 코드 등록.
+ * 평문 코드를 해시로 변환해 voucher_codes 에서 lookup → 상태/만료/자기발급 검증 후
+ * status=used 로 전이하고 등록자에게 새 subscription 을 발행한다.
+ */
+billing.post('/redeem', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const body = await c.req
+    .json<{ code?: unknown }>()
+    .catch(() => ({ code: undefined }));
+
+  const raw = typeof body.code === 'string' ? body.code.trim().toUpperCase() : '';
+  if (!raw) {
+    return c.json({ error: 'code 는 필수입니다' }, 400);
+  }
+  if (!isValidVoucherCodeFormat(raw)) {
+    return c.json({ error: '잘못된 코드 형식입니다' }, 400);
+  }
+
+  const userRes = await db.execute({
+    sql: 'SELECT id FROM users WHERE google_id = ?',
+    args: [userId],
+  });
+  if (userRes.rows.length === 0) {
+    return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+  }
+  const userPk = String(userRes.rows[0].id);
+
+  const codeHash = await hashVoucherCode(raw);
+  const voucherRes = await db.execute({
+    sql: `SELECT id, code_hash, plan_id, issuer_user_id, status, expires_at
+          FROM voucher_codes WHERE code_hash = ?`,
+    args: [codeHash],
+  });
+  if (voucherRes.rows.length === 0) {
+    return c.json({ error: '해당 코드를 찾을 수 없습니다' }, 404);
+  }
+  const voucher = voucherRes.rows[0];
+  const status = String(voucher.status);
+  const voucherId = String(voucher.id);
+  const planId = String(voucher.plan_id);
+  const issuerUserId = String(voucher.issuer_user_id);
+
+  if (status === 'used') {
+    return c.json({ error: '이미 사용된 코드입니다' }, 409);
+  }
+  if (status === 'expired') {
+    return c.json({ error: '만료된 코드입니다' }, 409);
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(String(voucher.expires_at));
+  if (Number.isFinite(expiresAt.getTime()) && expiresAt.getTime() <= now.getTime()) {
+    await db.execute({
+      sql: `UPDATE voucher_codes SET status = 'expired' WHERE id = ?`,
+      args: [voucherId],
+    });
+    return c.json({ error: '만료된 코드입니다' }, 409);
+  }
+
+  if (issuerUserId === userPk) {
+    return c.json({ error: '본인이 발급한 코드는 등록할 수 없습니다' }, 400);
+  }
+
+  const planRes = await db.execute({
+    sql: `SELECT id, key, name, plan_type, period_days, max_members, price_krw
+          FROM plans WHERE id = ?`,
+    args: [planId],
+  });
+  if (planRes.rows.length === 0) {
+    return c.json({ error: '연결된 플랜을 찾을 수 없습니다' }, 404);
+  }
+  const plan = planRes.rows[0];
+  const planType = String(plan.plan_type);
+  const periodDays = Number(plan.period_days) || 30;
+  const startsAt = now;
+  const newExpiresAt = new Date(startsAt.getTime() + periodDays * 24 * 60 * 60 * 1000);
+
+  const subscriptionId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO subscriptions (id, user_id, plan_id, status, starts_at, expires_at)
+          VALUES (?, ?, ?, 'active', ?, ?)`,
+    args: [
+      subscriptionId,
+      userPk,
+      planId,
+      startsAt.toISOString(),
+      newExpiresAt.toISOString(),
+    ],
+  });
+
+  await db.execute({
+    sql: `UPDATE voucher_codes
+          SET status = 'used', redeemed_by_user_id = ?, used_at = ?
+          WHERE id = ? AND status = 'issued'`,
+    args: [userPk, startsAt.toISOString(), voucherId],
+  });
+
+  const mirroredPlan = planTypeToUserPlan(planType);
+  await db.execute({
+    sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+    args: [mirroredPlan, userPk],
+  });
+
+  return c.json({
+    success: true,
+    subscription: {
+      id: subscriptionId,
+      user_id: userPk,
+      plan_id: planId,
+      status: 'active',
+      starts_at: startsAt.toISOString(),
+      expires_at: newExpiresAt.toISOString(),
+    },
+    plan: {
+      id: planId,
+      key: String(plan.key),
+      name: String(plan.name),
+      plan_type: planType,
+      period_days: periodDays,
+      max_members: Number(plan.max_members),
+      price_krw: Number(plan.price_krw),
+    },
+    voucher: {
+      id: voucherId,
+      status: 'used',
     },
   });
 });

--- a/packages/backend/test/billing.test.ts
+++ b/packages/backend/test/billing.test.ts
@@ -10,6 +10,7 @@ vi.mock('../src/lib/db', () => ({
 }));
 
 import billingRoutes from '../src/routes/billing';
+import { hashVoucherCode } from '../src/lib/vouchers';
 
 const PLAN_PLUS = {
   id: '70000000-0000-4000-8000-000000000002',
@@ -294,5 +295,223 @@ describe('GET /billing/vouchers', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.vouchers).toEqual([]);
+  });
+});
+
+describe('POST /billing/redeem', () => {
+  const VALID_CODE = 'VA-ABCD-EFGH-JKLM';
+  const FUTURE = '2027-12-31T00:00:00.000Z';
+  const PAST = '2020-01-01T00:00:00.000Z';
+
+  it('유효 코드 → 200, voucher status=used, 새 subscription, users.plan=plus', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]); // SELECT user
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'issued',
+        expires_at: FUTURE,
+      },
+    ]); // SELECT voucher
+    mockDB.pushResult([PLAN_PLUS]); // SELECT plan
+    mockDB.pushResult([], 1); // INSERT subscription
+    mockDB.pushResult([], 1); // UPDATE voucher
+    mockDB.pushResult([], 1); // UPDATE users.plan
+
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.subscription.user_id).toBe('user-pk-2');
+    expect(body.subscription.plan_id).toBe(PLAN_PLUS.id);
+    expect(body.voucher.status).toBe('used');
+
+    const updateVoucher = mockDB.calls.find((c) =>
+      c.sql.includes("UPDATE voucher_codes") && c.sql.includes("status = 'used'"),
+    );
+    expect(updateVoucher?.args[0]).toBe('user-pk-2');
+
+    const updateUser = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
+    expect(updateUser?.args[0]).toBe('plus');
+  });
+
+  it('family 코드 등록 → users.plan=family', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-2',
+        code_hash: hash,
+        plan_id: PLAN_FAMILY.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'issued',
+        expires_at: FUTURE,
+      },
+    ]);
+    mockDB.pushResult([PLAN_FAMILY]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(200);
+    const updateUser = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
+    expect(updateUser?.args[0]).toBe('family');
+  });
+
+  it('code 누락 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/billing/redeem', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('code');
+  });
+
+  it('잘못된 포맷 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: 'INVALID-123' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('형식');
+  });
+
+  it('존재하지 않는 코드 → 404', async () => {
+    mockDB.pushResult([{ id: 'user-pk-2' }]); // user
+    mockDB.pushResult([]); // voucher not found
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain('찾을 수 없');
+  });
+
+  it('이미 사용된 코드 → 409', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'used',
+        expires_at: FUTURE,
+      },
+    ]);
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('이미 사용');
+  });
+
+  it('만료된 코드(status=expired) → 409', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'expired',
+        expires_at: PAST,
+      },
+    ]);
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('만료');
+  });
+
+  it('expires_at 지났지만 status=issued 인 경우 → 409 + expired 전환', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'issued',
+        expires_at: PAST,
+      },
+    ]);
+    mockDB.pushResult([], 1); // UPDATE voucher → expired
+
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(409);
+    const expireUpdate = mockDB.calls.find((c) =>
+      c.sql.includes("UPDATE voucher_codes SET status = 'expired'"),
+    );
+    expect(expireUpdate).toBeDefined();
+  });
+
+  it('본인이 발급한 코드 등록 시도 → 400', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'issued',
+        expires_at: FUTURE,
+      },
+    ]);
+    const app = buildApp('google-1');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('본인');
+  });
+
+  it('소문자 입력도 대문자로 정규화하여 동작', async () => {
+    const hash = await hashVoucherCode(VALID_CODE);
+    mockDB.pushResult([{ id: 'user-pk-2' }]);
+    mockDB.pushResult([
+      {
+        id: 'v-1',
+        code_hash: hash,
+        plan_id: PLAN_PLUS.id,
+        issuer_user_id: 'user-pk-1',
+        status: 'issued',
+        expires_at: FUTURE,
+      },
+    ]);
+    mockDB.pushResult([PLAN_PLUS]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp('google-2');
+    const res = await app.request(
+      jsonReq('POST', '/billing/redeem', { code: VALID_CODE.toLowerCase() }),
+    );
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## 요약
- `POST /api/billing/redeem` 신규 — 본문 `{ code }` 를 받아 이용권 등록
- 포맷 검증 → 사용자 조회 → `code_hash` lookup → 상태/만료/자기발급 검증 → 상태 전이 + 새 subscription 발행 + users.plan 동기화
- 소문자 입력도 대문자 정규화

## 에러 매트릭스
- code 누락 / 잘못된 포맷 → 400
- 존재하지 않는 코드 → 404
- `status='used'` / `status='expired'` → 409
- `expires_at` 지났지만 `status='issued'` → 409 + DB 에서 `expired` 로 자동 전환
- 발급자가 본인과 동일 → 400
- 성공 → 200 `{ subscription, plan, voucher: { status: 'used' } }`

## 테스트
- [x] `billing.test.ts` redeem 10건 추가 (기존 15→24건)
- [x] 백엔드 전체 326→336 그린, `tsc --noEmit` 에러 없음

## 후속 이슈
- #30 코드 공유 UI (모바일/웹)
- #31 가족 플랜 그룹 모델

closes #69