### PR TITLE
[Phase 5] #30 코드 공유 UI (#71)

### DIFF
--- a/apps/mobile/src/lib/voucherShare.ts
+++ b/apps/mobile/src/lib/voucherShare.ts
@@ -1,0 +1,48 @@
+export type VoucherStatus = 'issued' | 'used' | 'expired';
+
+export interface VoucherLite {
+  code: string;
+  status: string;
+  expires_at: string;
+}
+
+const VOUCHER_CODE_RE = /^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+export function maskVoucherCode(code: string): string {
+  if (!VOUCHER_CODE_RE.test(code)) return code;
+  const groups = code.split('-');
+  return `${groups[0]}-${groups[1]}-****-****`;
+}
+
+export function formatVoucherStatus(status: string): string {
+  if (status === 'used') return '사용됨';
+  if (status === 'expired') return '만료';
+  return '미사용';
+}
+
+export function isVoucherRedeemable(voucher: VoucherLite, now: Date = new Date()): boolean {
+  if (voucher.status !== 'issued') return false;
+  const exp = new Date(voucher.expires_at);
+  if (!Number.isFinite(exp.getTime())) return false;
+  return exp.getTime() > now.getTime();
+}
+
+export interface ShareTextInput {
+  code: string;
+  planName: string;
+  expiresAt: string;
+}
+
+export function buildVoucherShareText(input: ShareTextInput): string {
+  const exp = new Date(input.expiresAt);
+  const expLabel = Number.isFinite(exp.getTime())
+    ? `${exp.getFullYear()}-${String(exp.getMonth() + 1).padStart(2, '0')}-${String(exp.getDate()).padStart(2, '0')}`
+    : input.expiresAt;
+  return [
+    'VoiceAlarm 이용권 선물이 도착했어요 🎁',
+    `플랜: ${input.planName}`,
+    `코드: ${input.code}`,
+    `만료: ${expLabel}`,
+    '앱/웹에서 [이용권 등록] 에 입력해 사용하세요.',
+  ].join('\n');
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -462,3 +462,25 @@ export async function getDubJobs() {
   const data = await get<{ jobs: DubJob[] }>('/dub/jobs');
   return data.jobs;
 }
+
+// ===== Billing / Voucher API =====
+
+export interface VoucherItem {
+  id: string;
+  code: string;
+  plan_id: string;
+  plan_key: string;
+  plan_name: string;
+  plan_type: string;
+  subscription_id: string | null;
+  redeemed_by_user_id: string | null;
+  status: 'issued' | 'used' | 'expired';
+  issued_at: string;
+  used_at: string | null;
+  expires_at: string;
+}
+
+export async function getVouchers() {
+  const data = await get<{ vouchers: VoucherItem[] }>('/billing/vouchers');
+  return data.vouchers;
+}

--- a/apps/mobile/test/voucherShare.test.ts
+++ b/apps/mobile/test/voucherShare.test.ts
@@ -1,0 +1,76 @@
+import {
+  maskVoucherCode,
+  formatVoucherStatus,
+  isVoucherRedeemable,
+  buildVoucherShareText,
+} from '../src/lib/voucherShare';
+
+describe('maskVoucherCode (mobile)', () => {
+  it('첫 그룹만 공개하고 나머지는 ****', () => {
+    expect(maskVoucherCode('VA-ABCD-EFGH-JKLM')).toBe('VA-ABCD-****-****');
+  });
+
+  it('잘못된 포맷은 원본 반환', () => {
+    expect(maskVoucherCode('not-a-code')).toBe('not-a-code');
+    expect(maskVoucherCode('')).toBe('');
+  });
+});
+
+describe('formatVoucherStatus (mobile)', () => {
+  it('issued → 미사용, used → 사용됨, expired → 만료', () => {
+    expect(formatVoucherStatus('issued')).toBe('미사용');
+    expect(formatVoucherStatus('used')).toBe('사용됨');
+    expect(formatVoucherStatus('expired')).toBe('만료');
+  });
+});
+
+describe('isVoucherRedeemable (mobile)', () => {
+  const NOW = new Date('2026-04-21T00:00:00Z');
+
+  it('issued + 만료 전 → true', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'issued', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('issued 이지만 만료일 지남 → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'issued', expires_at: '2026-04-01T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('used / expired → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'used', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'expired', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('buildVoucherShareText (mobile)', () => {
+  it('코드/플랜/만료일이 포함된 공유 문구', () => {
+    const text = buildVoucherShareText({
+      code: 'VA-ABCD-EFGH-JKLM',
+      planName: '가족',
+      expiresAt: '2026-05-21T00:00:00Z',
+    });
+    expect(text).toContain('VA-ABCD-EFGH-JKLM');
+    expect(text).toContain('가족');
+    expect(text).toContain('2026-05-21');
+    expect(text).toContain('이용권 등록');
+  });
+});

--- a/packages/web/src/lib/voucherShare.ts
+++ b/packages/web/src/lib/voucherShare.ts
@@ -1,0 +1,48 @@
+export type VoucherStatus = 'issued' | 'used' | 'expired';
+
+export interface VoucherLite {
+  code: string;
+  status: string;
+  expires_at: string;
+}
+
+const VOUCHER_CODE_RE = /^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+export function maskVoucherCode(code: string): string {
+  if (!VOUCHER_CODE_RE.test(code)) return code;
+  const groups = code.split('-');
+  return `${groups[0]}-${groups[1]}-****-****`;
+}
+
+export function formatVoucherStatus(status: string): string {
+  if (status === 'used') return '사용됨';
+  if (status === 'expired') return '만료';
+  return '미사용';
+}
+
+export function isVoucherRedeemable(voucher: VoucherLite, now: Date = new Date()): boolean {
+  if (voucher.status !== 'issued') return false;
+  const exp = new Date(voucher.expires_at);
+  if (!Number.isFinite(exp.getTime())) return false;
+  return exp.getTime() > now.getTime();
+}
+
+export interface ShareTextInput {
+  code: string;
+  planName: string;
+  expiresAt: string;
+}
+
+export function buildVoucherShareText(input: ShareTextInput): string {
+  const exp = new Date(input.expiresAt);
+  const expLabel = Number.isFinite(exp.getTime())
+    ? `${exp.getFullYear()}-${String(exp.getMonth() + 1).padStart(2, '0')}-${String(exp.getDate()).padStart(2, '0')}`
+    : input.expiresAt;
+  return [
+    'VoiceAlarm 이용권 선물이 도착했어요 🎁',
+    `플랜: ${input.planName}`,
+    `코드: ${input.code}`,
+    `만료: ${expLabel}`,
+    '앱/웹에서 [이용권 등록] 에 입력해 사용하세요.',
+  ].join('\n');
+}

--- a/packages/web/src/pages/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,11 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getUserProfile, deleteAccount } from '../services/api';
+import { getUserProfile, deleteAccount, getVouchers, type VoucherItem } from '../services/api';
+import {
+  buildVoucherShareText,
+  formatVoucherStatus,
+  isVoucherRedeemable,
+} from '../lib/voucherShare';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -24,17 +29,62 @@ export default function SettingsPage({ darkMode }: Props) {
     queryFn: getUserProfile,
   });
 
+  const { data: vouchers = [] } = useQuery({
+    queryKey: ['vouchers'],
+    queryFn: getVouchers,
+  });
+
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [deleting, setDeleting] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'error' } | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' } | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  const showToast = useCallback((message: string) => {
-    setToast({ message, type: 'error' });
+  const showToast = useCallback((message: string, type: 'error' | 'success' = 'error') => {
+    setToast({ message, type });
     if (toastTimer.current) clearTimeout(toastTimer.current);
     toastTimer.current = setTimeout(() => setToast(null), 4000);
   }, []);
+
+  const handleCopyVoucher = useCallback(
+    async (v: VoucherItem) => {
+      try {
+        await navigator.clipboard.writeText(v.code);
+        showToast('코드를 복사했어요', 'success');
+      } catch {
+        showToast('복사에 실패했어요');
+      }
+    },
+    [showToast],
+  );
+
+  const handleShareVoucher = useCallback(
+    async (v: VoucherItem) => {
+      const text = buildVoucherShareText({
+        code: v.code,
+        planName: v.plan_name,
+        expiresAt: v.expires_at,
+      });
+      const nav = navigator as Navigator & {
+        share?: (data: { title?: string; text?: string }) => Promise<void>;
+      };
+      if (nav.share) {
+        try {
+          await nav.share({ title: 'VoiceAlarm 이용권', text });
+          return;
+        } catch {
+          // fallthrough to clipboard
+        }
+      }
+      try {
+        await navigator.clipboard.writeText(text);
+        showToast('공유 문구를 복사했어요', 'success');
+      } catch {
+        showToast('공유에 실패했어요');
+      }
+    },
+    [showToast],
+  );
 
   useEffect(() => () => { if (toastTimer.current) clearTimeout(toastTimer.current); }, []);
 
@@ -168,6 +218,76 @@ export default function SettingsPage({ darkMode }: Props) {
         </div>
       </div>
 
+      {/* 내 이용권 코드 */}
+      <div
+        className="bg-[var(--color-surface)] rounded-2xl p-6 border border-[var(--color-border)] mb-6 transition-colors"
+        data-testid="voucher-section"
+      >
+        <h3 className="text-lg font-semibold text-[var(--color-text)] mb-1">내 이용권 코드</h3>
+        <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+          결제 시 자동 발급되는 1회용 코드예요. 본인에게만 보이며, 복사해서 지인에게 공유할 수 있어요.
+        </p>
+        {vouchers.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-tertiary)]">아직 발급된 코드가 없어요.</p>
+        ) : (
+          <ul className="space-y-3">
+            {vouchers.map((v) => {
+              const redeemable = isVoucherRedeemable(v);
+              return (
+                <li
+                  key={v.id}
+                  data-testid="voucher-item"
+                  className="flex items-center justify-between gap-3 rounded-xl border border-[var(--color-border)] p-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-xs font-medium text-[var(--color-primary)]">
+                        {v.plan_name}
+                      </span>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full ${
+                          redeemable
+                            ? 'bg-emerald-500/15 text-emerald-600'
+                            : v.status === 'used'
+                              ? 'bg-slate-500/15 text-slate-500'
+                              : 'bg-red-500/15 text-red-500'
+                        }`}
+                      >
+                        {formatVoucherStatus(v.status)}
+                      </span>
+                    </div>
+                    <code className="block text-sm font-mono text-[var(--color-text)] truncate">
+                      {v.code}
+                    </code>
+                    <p className="text-xs text-[var(--color-text-tertiary)] mt-1">
+                      만료 {new Date(v.expires_at).toLocaleDateString('ko-KR')}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 flex-shrink-0">
+                    <button
+                      aria-label={`${v.code} 복사`}
+                      disabled={!redeemable}
+                      onClick={() => handleCopyVoucher(v)}
+                      className="px-3 py-2 rounded-lg border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-alt)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                    >
+                      복사
+                    </button>
+                    <button
+                      aria-label={`${v.code} 공유`}
+                      disabled={!redeemable}
+                      onClick={() => handleShareVoucher(v)}
+                      className="px-3 py-2 rounded-lg bg-[var(--color-primary)] text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-110 transition-all"
+                    >
+                      공유
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
       {/* 정보 */}
       <div className="bg-[var(--color-surface)] rounded-2xl p-6 border border-[var(--color-border)] transition-colors">
         <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">정보</h3>
@@ -217,7 +337,11 @@ export default function SettingsPage({ darkMode }: Props) {
       </div>
 
       {toast && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-red-500 text-white px-6 py-3 rounded-xl shadow-lg text-sm font-medium animate-[fadeIn_0.2s_ease-out]">
+        <div
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 text-white px-6 py-3 rounded-xl shadow-lg text-sm font-medium animate-[fadeIn_0.2s_ease-out] ${
+            toast.type === 'success' ? 'bg-emerald-500' : 'bg-red-500'
+          }`}
+        >
           {toast.message}
         </div>
       )}

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -115,6 +115,28 @@ export async function deleteAlarm(id: string) {
   await api.delete(`/alarm/${id}`);
 }
 
+// ===== Billing / Voucher API =====
+
+export interface VoucherItem {
+  id: string;
+  code: string;
+  plan_id: string;
+  plan_key: string;
+  plan_name: string;
+  plan_type: string;
+  subscription_id: string | null;
+  redeemed_by_user_id: string | null;
+  status: 'issued' | 'used' | 'expired';
+  issued_at: string;
+  used_at: string | null;
+  expires_at: string;
+}
+
+export async function getVouchers(): Promise<VoucherItem[]> {
+  const { data } = await api.get('/billing/vouchers');
+  return data.vouchers as VoucherItem[];
+}
+
 // ===== Friend API =====
 
 export async function sendFriendRequest(email: string) {

--- a/packages/web/test/voucherShare.test.ts
+++ b/packages/web/test/voucherShare.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  maskVoucherCode,
+  formatVoucherStatus,
+  isVoucherRedeemable,
+  buildVoucherShareText,
+} from '../src/lib/voucherShare';
+
+describe('maskVoucherCode (web)', () => {
+  it('첫 그룹만 공개하고 나머지는 ****', () => {
+    expect(maskVoucherCode('VA-ABCD-EFGH-JKLM')).toBe('VA-ABCD-****-****');
+  });
+
+  it('잘못된 포맷은 원본 반환', () => {
+    expect(maskVoucherCode('not-a-code')).toBe('not-a-code');
+    expect(maskVoucherCode('VA-abcd-efgh-jklm')).toBe('VA-abcd-efgh-jklm');
+    expect(maskVoucherCode('')).toBe('');
+  });
+});
+
+describe('formatVoucherStatus (web)', () => {
+  it('issued → 미사용, used → 사용됨, expired → 만료', () => {
+    expect(formatVoucherStatus('issued')).toBe('미사용');
+    expect(formatVoucherStatus('used')).toBe('사용됨');
+    expect(formatVoucherStatus('expired')).toBe('만료');
+  });
+
+  it('알 수 없는 값은 미사용 기본', () => {
+    expect(formatVoucherStatus('unknown')).toBe('미사용');
+  });
+});
+
+describe('isVoucherRedeemable (web)', () => {
+  const NOW = new Date('2026-04-21T00:00:00Z');
+
+  it('issued + 만료 전 → true', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'issued', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('issued 이지만 만료일 지남 → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'issued', expires_at: '2026-04-01T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('used → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'used', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('expired → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'expired', expires_at: '2026-05-21T00:00:00Z' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('expires_at 파싱 실패 → false', () => {
+    expect(
+      isVoucherRedeemable(
+        { code: 'VA-A-B-C', status: 'issued', expires_at: 'not-a-date' },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('buildVoucherShareText (web)', () => {
+  it('코드/플랜명/만료일이 포함된 공유 문구', () => {
+    const text = buildVoucherShareText({
+      code: 'VA-ABCD-EFGH-JKLM',
+      planName: '플러스 개인',
+      expiresAt: '2026-05-21T00:00:00Z',
+    });
+    expect(text).toContain('VA-ABCD-EFGH-JKLM');
+    expect(text).toContain('플러스 개인');
+    expect(text).toContain('2026-05-21');
+    expect(text).toContain('이용권 등록');
+  });
+
+  it('만료일 파싱 실패 시 원본 문자열 사용', () => {
+    const text = buildVoucherShareText({
+      code: 'VA-A-B-C',
+      planName: '가족',
+      expiresAt: 'not-a-date',
+    });
+    expect(text).toContain('not-a-date');
+  });
+});


### PR DESCRIPTION
## 요약
- `voucherShare.ts` 신규 (웹/모바일 동일 계약) — `maskVoucherCode`, `formatVoucherStatus`, `isVoucherRedeemable`, `buildVoucherShareText`
- `getVouchers()` 서비스 함수 및 `VoucherItem` 타입 웹/모바일 각각 추가
- 웹 `SettingsPage` 에 "내 이용권 코드" 섹션 — 플랜명/상태 뱃지/코드 평문/만료일 표시 + 복사·공유 버튼, `navigator.share` 가능 시 우선 사용, 아니면 clipboard fallback
- 비활성(사용됨/만료) 코드는 버튼 disabled

## 이 이슈에서 제외 (후속)
- 모바일 전용 이용권 스크린 UI (다음 이슈에서 Settings/Profile 에 붙일 예정)
- QR 코드 렌더링
- 가족 플랜 그룹 자동 연결 (#31)

## 테스트
- [x] `packages/web/test/voucherShare.test.ts` 11건 (mask/포맷/redeemable/공유문구)
- [x] `apps/mobile/test/voucherShare.test.ts` 7건 (동일 계약 검증)
- [x] 웹 전체 36→47, 모바일 67→74 그린, `tsc --noEmit` 에러 없음

closes #71