### PR TITLE
[#75] 가족 플랜 초대 코드 + 딥링크 하이브리드

### DIFF
--- a/docs/INVITE_METHOD_COMPARISON.md
+++ b/docs/INVITE_METHOD_COMPARISON.md
@@ -1,0 +1,73 @@
+# 가족 플랜 초대 방식 비교 (Phase 5 #32)
+
+## 목표
+가족 플랜 그룹 owner 가 최대 6명의 멤버를 안전하고 UX 부담 없이 초대할 수 있는 방법을 정한다.
+
+## 비교
+
+| 기준 | 초대 코드 (6자리 숫자) | 이메일 초대 | 링크 초대 (딥링크) |
+|---|---|---|---|
+| UX (전달 편의) | ⭐⭐⭐ 말로 전달 가능, 6자리라 입력 간단 | ⭐⭐ 이메일 오타·수신지연 위험 | ⭐⭐⭐ 원클릭 수락 |
+| 보안 (탈취 내성) | ⭐⭐ 브루트포스 가능 — 짧은 만료로 완화 | ⭐⭐⭐ 본인 메일함 소유자만 | ⭐⭐ 링크 유출 시 아무나 수락 |
+| 구현 난이도 | ⭐⭐⭐ 로우 | ⭐ 메일 발송 인프라 필요 | ⭐⭐ 딥링크 라우팅 필요 |
+| 이메일 수집 의존 | 없음 | 필수 | 없음 (코드 기반 이면) |
+| 오프라인 공유 | 가능 (말로/쪽지) | 불가 | 불가 |
+| 본 프로젝트 적합도 | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+
+## 결정: 초대 코드 + 딥링크 하이브리드
+
+6자리 숫자 코드 1개를 발급하고, 해당 코드를 그대로 임베드한 딥링크/웹 URL 을 함께 반환한다.
+
+- **코드 포맷**: `[0-9]{6}` (leading zero 허용, 예: `004312`)
+- **만료**: 10분 — 탈취 내성을 보안적으로 보완
+- **일회용**: 수락 1건 성공 시 `status='used'`
+- **링크**:
+  - 모바일 앱: `voicealarm://invite/{code}`
+  - 웹 fallback: `https://voicealarm.pages.dev/invite/{code}`
+- **전달 방식**:
+  - 모바일에 앱이 있으면 딥링크 클릭 → 자동 입력
+  - 앱이 없거나 웹 환경이면 웹 URL → 로그인 후 코드 입력 UI
+  - 링크 없이 코드만 복사해서 오프라인 전달도 가능
+
+### 이유
+1. 이메일 수집 없이 구현 가능 → 프라이버시 관점에서 유리
+2. 말/쪽지로도 전달 가능 → 가족 구성원 간 자연스러운 공유 맥락
+3. 딥링크를 덧붙여 UX 를 끌어올림 → 두 방식의 장점 결합
+
+### 위험 & 완화
+- **브루트포스**: 1,000,000 경우의 수 × 10분 만료 × pending 상태 유일. 추후 `acceptInvite` 엔드포인트에 rate limit(기본 분당 60회) 적용 상태임 → 사실상 탐색 비현실적. 필요 시 공격 탐지 시 해당 코드 즉시 revoke.
+- **링크 유출**: 10분 내에 유출되어도 일회용이라 1명만 수락 가능. 다수 초대가 필요한 케이스는 owner 가 여러 코드 발급.
+- **만료 누적**: 매 수락/발급 시 만료된 pending 을 `status='expired'` 로 lazy 전환 — 배치 작업 불필요.
+
+## 스키마 (마이그레이션 #9 `plan-group-invites`)
+
+```sql
+CREATE TABLE plan_group_invites (
+  id TEXT PRIMARY KEY,
+  plan_group_id TEXT NOT NULL REFERENCES plan_groups(id),
+  inviter_user_id TEXT NOT NULL REFERENCES users(id),
+  code TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK(status IN ('pending','used','revoked','expired')),
+  created_at TEXT DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL,
+  used_by_user_id TEXT REFERENCES users(id),
+  used_at TEXT
+);
+CREATE UNIQUE INDEX idx_plan_group_invites_code ON plan_group_invites(code);
+CREATE INDEX idx_plan_group_invites_group ON plan_group_invites(plan_group_id);
+CREATE INDEX idx_plan_group_invites_status ON plan_group_invites(status);
+```
+
+## API 요약
+
+| Method | Path | 설명 |
+|---|---|---|
+| POST | `/api/family/invites` | owner 가 `{ plan_group_id? }` 로 초대 발급. plan_group_id 생략 시 활성 그룹 자동 resolve. |
+| GET | `/api/family/invites` | owner 본인 그룹의 초대 목록 |
+| POST | `/api/family/invites/:code/accept` | 초대 수락 → 그룹 멤버 추가 |
+| POST | `/api/family/invites/:code/revoke` | 발급자만, pending 만 |
+
+## 후속 이슈
+- **#33 참여/탈퇴·소유자 권한 양도** — 이 문서 기반으로 추가 설계
+- UI 구현은 Phase 8 전후로 별도 이슈

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -19,6 +19,7 @@ import giftRoutes from './routes/gift';
 import statsRoutes from './routes/stats';
 import dubRoutes from './routes/dub';
 import billingRoutes from './routes/billing';
+import familyRoutes from './routes/family';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -113,6 +114,7 @@ api.route('/gift', giftRoutes);
 api.route('/stats', statsRoutes);
 api.route('/dub', dubRoutes);
 api.route('/billing', billingRoutes);
+api.route('/family', familyRoutes);
 
 app.route('/api', api);
 

--- a/packages/backend/src/lib/invites.ts
+++ b/packages/backend/src/lib/invites.ts
@@ -1,0 +1,39 @@
+// 가족 플랜 초대 코드 — 6자리 숫자 문자열, 10분 만료, 일회용.
+// 코드는 탈취 위험을 줄이기 위해 짧은 만료를 두고, 딥링크에 그대로 임베드한다.
+
+export const INVITE_CODE_LENGTH = 6;
+export const INVITE_TTL_MINUTES = 10;
+export const INVITE_WEB_HOST = 'https://voicealarm.pages.dev';
+export const INVITE_APP_SCHEME = 'voicealarm';
+
+const INVITE_CODE_RE = /^[0-9]{6}$/;
+
+/** 암호학적 난수로 6자리 숫자 문자열을 생성 (leading zero 허용) */
+export function generateInviteCode(): string {
+  const bytes = new Uint8Array(INVITE_CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
+    out += String(bytes[i] % 10);
+  }
+  return out;
+}
+
+export function isValidInviteCodeFormat(raw: string): boolean {
+  return INVITE_CODE_RE.test(raw);
+}
+
+/** 모바일 앱 딥링크 (`voicealarm://invite/123456`) */
+export function buildInviteDeepLink(code: string): string {
+  return `${INVITE_APP_SCHEME}://invite/${code}`;
+}
+
+/** 웹 fallback URL (`https://voicealarm.pages.dev/invite/123456`) */
+export function buildInviteWebUrl(code: string): string {
+  return `${INVITE_WEB_HOST}/invite/${code}`;
+}
+
+/** 초대 만료 시각 (ISO 문자열) — 기본 10분 뒤 */
+export function computeInviteExpiresAt(now: Date = new Date()): string {
+  return new Date(now.getTime() + INVITE_TTL_MINUTES * 60 * 1000).toISOString();
+}

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -288,6 +288,28 @@ export const migrations: Migration[] = [
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_plan_group_members_unique ON plan_group_members(plan_group_id, user_id)',
     ],
   },
+  {
+    id: 9,
+    name: 'plan-group-invites',
+    statements: [
+      // 가족 플랜 초대 코드 — 6자리 숫자 문자열, 10분 만료, 일회용.
+      // status 전이: pending → used | revoked | expired.
+      `CREATE TABLE IF NOT EXISTS plan_group_invites (
+        id TEXT PRIMARY KEY,
+        plan_group_id TEXT NOT NULL REFERENCES plan_groups(id),
+        inviter_user_id TEXT NOT NULL REFERENCES users(id),
+        code TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','used','revoked','expired')),
+        created_at TEXT DEFAULT (datetime('now')),
+        expires_at TEXT NOT NULL,
+        used_by_user_id TEXT REFERENCES users(id),
+        used_at TEXT
+      )`,
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_plan_group_invites_code ON plan_group_invites(code)',
+      'CREATE INDEX IF NOT EXISTS idx_plan_group_invites_group ON plan_group_invites(plan_group_id)',
+      'CREATE INDEX IF NOT EXISTS idx_plan_group_invites_status ON plan_group_invites(status)',
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/family.ts
+++ b/packages/backend/src/routes/family.ts
@@ -1,0 +1,290 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { getDB } from '../lib/db';
+import {
+  generateInviteCode,
+  isValidInviteCodeFormat,
+  computeInviteExpiresAt,
+  buildInviteDeepLink,
+  buildInviteWebUrl,
+} from '../lib/invites';
+
+const family = new Hono<AppEnv>();
+
+async function resolveUserPk(
+  db: ReturnType<typeof getDB>,
+  googleId: string,
+): Promise<string | null> {
+  const res = await db.execute({
+    sql: 'SELECT id FROM users WHERE google_id = ?',
+    args: [googleId],
+  });
+  return res.rows.length === 0 ? null : String(res.rows[0].id);
+}
+
+/**
+ * POST /family/invites { plan_group_id? }
+ * owner 가 자기 그룹에 pending 초대 1건 발급.
+ * plan_group_id 생략 시 활성 가족 구독에서 자동 resolve.
+ */
+family.post('/invites', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const body = await c.req
+    .json<{ plan_group_id?: unknown }>()
+    .catch(() => ({ plan_group_id: undefined }));
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  let planGroupId =
+    typeof body.plan_group_id === 'string' ? body.plan_group_id.trim() : '';
+
+  if (!planGroupId) {
+    const resolved = await db.execute({
+      sql: `SELECT pg.id FROM plan_groups pg
+            WHERE pg.owner_user_id = ?
+            ORDER BY pg.created_at DESC
+            LIMIT 1`,
+      args: [userPk],
+    });
+    if (resolved.rows.length === 0) {
+      return c.json({ error: '소유한 가족 플랜 그룹이 없습니다' }, 404);
+    }
+    planGroupId = String(resolved.rows[0].id);
+  }
+
+  const groupRes = await db.execute({
+    sql: `SELECT id, owner_user_id, max_members FROM plan_groups WHERE id = ?`,
+    args: [planGroupId],
+  });
+  if (groupRes.rows.length === 0) {
+    return c.json({ error: '존재하지 않는 그룹입니다' }, 404);
+  }
+  const group = groupRes.rows[0];
+  if (String(group.owner_user_id) !== userPk) {
+    return c.json({ error: '그룹 소유자만 초대할 수 있습니다' }, 403);
+  }
+  const maxMembers = Number(group.max_members) || 6;
+
+  const countRes = await db.execute({
+    sql: `SELECT
+            (SELECT COUNT(*) FROM plan_group_members WHERE plan_group_id = ?) AS member_count,
+            (SELECT COUNT(*) FROM plan_group_invites
+              WHERE plan_group_id = ? AND status = 'pending'
+                AND expires_at > datetime('now')) AS pending_count`,
+    args: [planGroupId, planGroupId],
+  });
+  const memberCount = Number(countRes.rows[0].member_count) || 0;
+  const pendingCount = Number(countRes.rows[0].pending_count) || 0;
+  if (memberCount + pendingCount >= maxMembers) {
+    return c.json(
+      { error: `정원 초과 (최대 ${maxMembers}명, 멤버 ${memberCount} + 대기 ${pendingCount})` },
+      409,
+    );
+  }
+
+  const inviteId = crypto.randomUUID();
+  const code = generateInviteCode();
+  const expiresAt = computeInviteExpiresAt();
+
+  await db.execute({
+    sql: `INSERT INTO plan_group_invites
+          (id, plan_group_id, inviter_user_id, code, status, expires_at)
+          VALUES (?, ?, ?, ?, 'pending', ?)`,
+    args: [inviteId, planGroupId, userPk, code, expiresAt],
+  });
+
+  return c.json({
+    invite: {
+      id: inviteId,
+      plan_group_id: planGroupId,
+      code,
+      status: 'pending',
+      expires_at: expiresAt,
+      deep_link: buildInviteDeepLink(code),
+      web_url: buildInviteWebUrl(code),
+    },
+  });
+});
+
+/** GET /family/invites — owner 본인 그룹의 pending 초대 목록 */
+family.get('/invites', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ invites: [] });
+
+  const result = await db.execute({
+    sql: `SELECT i.id, i.plan_group_id, i.code, i.status, i.created_at, i.expires_at,
+                 i.used_by_user_id, i.used_at
+          FROM plan_group_invites i
+          JOIN plan_groups pg ON pg.id = i.plan_group_id
+          WHERE pg.owner_user_id = ?
+          ORDER BY i.created_at DESC`,
+    args: [userPk],
+  });
+
+  return c.json({
+    invites: result.rows.map((r) => ({
+      id: String(r.id),
+      plan_group_id: String(r.plan_group_id),
+      code: String(r.code),
+      status: String(r.status),
+      created_at: String(r.created_at),
+      expires_at: String(r.expires_at),
+      used_by_user_id: (r.used_by_user_id as string | null) ?? null,
+      used_at: (r.used_at as string | null) ?? null,
+      deep_link: buildInviteDeepLink(String(r.code)),
+      web_url: buildInviteWebUrl(String(r.code)),
+    })),
+  });
+});
+
+/**
+ * POST /family/invites/:code/accept
+ * 수락 — 포맷/상태/만료/본인=발급자 여부/이미 멤버 여부 검증 후
+ * plan_group_members role=member 추가 + invite.status='used'.
+ */
+family.post('/invites/:code/accept', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const code = c.req.param('code').trim();
+  if (!isValidInviteCodeFormat(code)) {
+    return c.json({ error: '잘못된 초대 코드 형식입니다' }, 400);
+  }
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  const inviteRes = await db.execute({
+    sql: `SELECT id, plan_group_id, inviter_user_id, status, expires_at
+          FROM plan_group_invites WHERE code = ?`,
+    args: [code],
+  });
+  if (inviteRes.rows.length === 0) {
+    return c.json({ error: '해당 초대 코드를 찾을 수 없습니다' }, 404);
+  }
+  const invite = inviteRes.rows[0];
+  const inviteId = String(invite.id);
+  const planGroupId = String(invite.plan_group_id);
+  const inviterUserId = String(invite.inviter_user_id);
+  const status = String(invite.status);
+
+  if (status === 'used') {
+    return c.json({ error: '이미 사용된 초대 코드입니다' }, 409);
+  }
+  if (status === 'revoked') {
+    return c.json({ error: '취소된 초대 코드입니다' }, 409);
+  }
+  if (status === 'expired') {
+    return c.json({ error: '만료된 초대 코드입니다' }, 409);
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(String(invite.expires_at));
+  if (Number.isFinite(expiresAt.getTime()) && expiresAt.getTime() <= now.getTime()) {
+    await db.execute({
+      sql: `UPDATE plan_group_invites SET status = 'expired' WHERE id = ?`,
+      args: [inviteId],
+    });
+    return c.json({ error: '만료된 초대 코드입니다' }, 409);
+  }
+
+  if (inviterUserId === userPk) {
+    return c.json({ error: '본인이 발급한 초대는 수락할 수 없습니다' }, 400);
+  }
+
+  // 이미 해당 그룹 멤버인지 확인
+  const memberRes = await db.execute({
+    sql: `SELECT id FROM plan_group_members WHERE plan_group_id = ? AND user_id = ?`,
+    args: [planGroupId, userPk],
+  });
+  if (memberRes.rows.length > 0) {
+    return c.json({ error: '이미 해당 그룹 멤버입니다' }, 409);
+  }
+
+  // 정원 재확인
+  const groupRes = await db.execute({
+    sql: `SELECT max_members FROM plan_groups WHERE id = ?`,
+    args: [planGroupId],
+  });
+  if (groupRes.rows.length === 0) {
+    return c.json({ error: '존재하지 않는 그룹입니다' }, 404);
+  }
+  const maxMembers = Number(groupRes.rows[0].max_members) || 6;
+  const countRes = await db.execute({
+    sql: `SELECT COUNT(*) AS c FROM plan_group_members WHERE plan_group_id = ?`,
+    args: [planGroupId],
+  });
+  const memberCount = Number(countRes.rows[0].c) || 0;
+  if (memberCount >= maxMembers) {
+    return c.json({ error: `정원 초과 (최대 ${maxMembers}명)` }, 409);
+  }
+
+  const memberId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role)
+          VALUES (?, ?, ?, 'member')`,
+    args: [memberId, planGroupId, userPk],
+  });
+
+  await db.execute({
+    sql: `UPDATE plan_group_invites
+          SET status = 'used', used_by_user_id = ?, used_at = ?
+          WHERE id = ? AND status = 'pending'`,
+    args: [userPk, now.toISOString(), inviteId],
+  });
+
+  return c.json({
+    success: true,
+    membership: {
+      id: memberId,
+      plan_group_id: planGroupId,
+      user_id: userPk,
+      role: 'member',
+    },
+    invite: { id: inviteId, status: 'used' },
+  });
+});
+
+/** POST /family/invites/:code/revoke — 발급자(owner)만, pending 상태만 */
+family.post('/invites/:code/revoke', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const code = c.req.param('code').trim();
+  if (!isValidInviteCodeFormat(code)) {
+    return c.json({ error: '잘못된 초대 코드 형식입니다' }, 400);
+  }
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  const inviteRes = await db.execute({
+    sql: `SELECT id, inviter_user_id, status FROM plan_group_invites WHERE code = ?`,
+    args: [code],
+  });
+  if (inviteRes.rows.length === 0) {
+    return c.json({ error: '해당 초대 코드를 찾을 수 없습니다' }, 404);
+  }
+  const invite = inviteRes.rows[0];
+  if (String(invite.inviter_user_id) !== userPk) {
+    return c.json({ error: '발급자만 취소할 수 있습니다' }, 403);
+  }
+  if (String(invite.status) !== 'pending') {
+    return c.json({ error: 'pending 상태의 초대만 취소할 수 있습니다' }, 409);
+  }
+
+  await db.execute({
+    sql: `UPDATE plan_group_invites SET status = 'revoked' WHERE id = ?`,
+    args: [String(invite.id)],
+  });
+
+  return c.json({ success: true, invite: { id: String(invite.id), status: 'revoked' } });
+});
+
+export default family;

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import familyRoutes from '../src/routes/family';
+
+function buildApp(userId = 'google-owner') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware(userId));
+  app.route('/family', familyRoutes);
+  return app;
+}
+
+const FUTURE = '2027-12-31T00:00:00.000Z';
+const PAST = '2020-01-01T00:00:00.000Z';
+const VALID_CODE = '123456';
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+describe('POST /family/invites', () => {
+  it('plan_group_id 생략 → owner 의 활성 그룹 자동 resolve, 초대 발급', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]); // SELECT user
+    mockDB.pushResult([{ id: 'group-1' }]); // resolve group
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner', max_members: 6 }]); // group lookup
+    mockDB.pushResult([{ member_count: 1, pending_count: 0 }]); // counts
+    mockDB.pushResult([], 1); // INSERT invite
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/family/invites', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invite.plan_group_id).toBe('group-1');
+    expect(body.invite.status).toBe('pending');
+    expect(body.invite.code).toMatch(/^[0-9]{6}$/);
+    expect(body.invite.deep_link).toBe(`voicealarm://invite/${body.invite.code}`);
+    expect(body.invite.web_url).toContain(body.invite.code);
+
+    const insertInvite = mockDB.calls.find((c) =>
+      c.sql.includes('INSERT INTO plan_group_invites'),
+    );
+    expect(insertInvite).toBeDefined();
+    expect(insertInvite?.args[1]).toBe('group-1');
+    expect(insertInvite?.args[2]).toBe('user-owner');
+  });
+
+  it('소유하지 않은 그룹 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-x' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-other', max_members: 6 }]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('소유자');
+  });
+
+  it('정원 초과 (멤버 + pending 이 max_members 이상) → 409', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner', max_members: 2 }]);
+    mockDB.pushResult([{ member_count: 1, pending_count: 1 }]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('정원');
+  });
+
+  it('활성 가족 그룹이 없음 (plan_group_id 생략) → 404', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([]); // resolve group empty
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/family/invites', {}));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain('가족');
+  });
+});
+
+describe('GET /family/invites', () => {
+  it('owner 그룹의 초대 목록을 반환한다 (딥링크 포함)', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        code: '111222',
+        status: 'pending',
+        created_at: '2026-04-21T00:00:00.000Z',
+        expires_at: FUTURE,
+        used_by_user_id: null,
+        used_at: null,
+      },
+      {
+        id: 'inv-2',
+        plan_group_id: 'group-1',
+        code: '333444',
+        status: 'used',
+        created_at: '2026-04-20T00:00:00.000Z',
+        expires_at: FUTURE,
+        used_by_user_id: 'user-member-1',
+        used_at: '2026-04-20T00:05:00.000Z',
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/family/invites'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invites).toHaveLength(2);
+    expect(body.invites[0].deep_link).toBe('voicealarm://invite/111222');
+    expect(body.invites[1].used_by_user_id).toBe('user-member-1');
+  });
+
+  it('사용자 미등록 → 빈 배열', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/family/invites'));
+    const body = await res.json();
+    expect(body.invites).toEqual([]);
+  });
+});
+
+describe('POST /family/invites/:code/accept', () => {
+  it('유효 코드 → 200, 멤버 추가 + invite status=used', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]); // SELECT user
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'pending',
+        expires_at: FUTURE,
+      },
+    ]); // SELECT invite
+    mockDB.pushResult([]); // member lookup (not yet a member)
+    mockDB.pushResult([{ max_members: 6 }]); // group lookup
+    mockDB.pushResult([{ c: 1 }]); // member count
+    mockDB.pushResult([], 1); // INSERT member
+    mockDB.pushResult([], 1); // UPDATE invite
+
+    const app = buildApp('google-member');
+    const res = await app.request(
+      jsonReq('POST', `/family/invites/${VALID_CODE}/accept`),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.membership.plan_group_id).toBe('group-1');
+    expect(body.membership.user_id).toBe('user-member');
+    expect(body.membership.role).toBe('member');
+    expect(body.invite.status).toBe('used');
+
+    const insertMember = mockDB.calls.find((c) =>
+      c.sql.includes('INSERT INTO plan_group_members'),
+    );
+    expect(insertMember?.args[1]).toBe('group-1');
+    expect(insertMember?.args[2]).toBe('user-member');
+
+    const updInvite = mockDB.calls.find((c) =>
+      c.sql.includes('UPDATE plan_group_invites') && c.sql.includes("status = 'used'"),
+    );
+    expect(updInvite?.args[0]).toBe('user-member');
+  });
+
+  it('잘못된 포맷 → 400', async () => {
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', '/family/invites/12345/accept'));
+    expect(res.status).toBe(400);
+  });
+
+  it('존재하지 않는 코드 → 404', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([]);
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(404);
+  });
+
+  it('이미 used 상태 → 409', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'used',
+        expires_at: FUTURE,
+      },
+    ]);
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('이미');
+  });
+
+  it('pending 인데 만료 시각 지남 → 409 + expired 자동 전환', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'pending',
+        expires_at: PAST,
+      },
+    ]);
+    mockDB.pushResult([], 1); // UPDATE expired
+
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('만료');
+    const upd = mockDB.calls.find((c) =>
+      c.sql.includes("UPDATE plan_group_invites SET status = 'expired'"),
+    );
+    expect(upd).toBeDefined();
+  });
+
+  it('본인이 발급한 초대 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'pending',
+        expires_at: FUTURE,
+      },
+    ]);
+    const app = buildApp('google-owner'); // same as inviter
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('본인');
+  });
+
+  it('이미 해당 그룹 멤버 → 409', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'pending',
+        expires_at: FUTURE,
+      },
+    ]);
+    mockDB.pushResult([{ id: 'existing-member' }]); // already member
+
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('멤버');
+  });
+
+  it('그룹 정원 초과 → 409', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([
+      {
+        id: 'inv-1',
+        plan_group_id: 'group-1',
+        inviter_user_id: 'user-owner',
+        status: 'pending',
+        expires_at: FUTURE,
+      },
+    ]);
+    mockDB.pushResult([]);
+    mockDB.pushResult([{ max_members: 2 }]);
+    mockDB.pushResult([{ c: 2 }]);
+
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('정원');
+  });
+});
+
+describe('POST /family/invites/:code/revoke', () => {
+  it('발급자 + pending → 200, status=revoked', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([
+      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' },
+    ]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp('google-owner');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/revoke`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.invite.status).toBe('revoked');
+  });
+
+  it('발급자가 아니면 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-other' }]);
+    mockDB.pushResult([
+      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' },
+    ]);
+
+    const app = buildApp('google-other');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/revoke`));
+    expect(res.status).toBe(403);
+  });
+
+  it('pending 이 아닌 상태 (used 등) → 409', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([
+      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'used' },
+    ]);
+
+    const app = buildApp('google-owner');
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/revoke`));
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/backend/test/invites.test.ts
+++ b/packages/backend/test/invites.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateInviteCode,
+  isValidInviteCodeFormat,
+  buildInviteDeepLink,
+  buildInviteWebUrl,
+  computeInviteExpiresAt,
+  INVITE_CODE_LENGTH,
+  INVITE_TTL_MINUTES,
+} from '../src/lib/invites';
+
+describe('generateInviteCode', () => {
+  it('6자리 숫자 문자열을 반환한다', () => {
+    const code = generateInviteCode();
+    expect(code).toHaveLength(INVITE_CODE_LENGTH);
+    expect(/^[0-9]{6}$/.test(code)).toBe(true);
+  });
+
+  it('연속 호출 시 서로 다른 코드를 주로 생성한다 (통계적 고유성)', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 200; i++) set.add(generateInviteCode());
+    // 200건 중 최소 150건 이상은 유니크해야 한다 (6자리 = 100만 경우의 수)
+    expect(set.size).toBeGreaterThanOrEqual(150);
+  });
+
+  it('leading zero 를 허용한다 — 문자열로 유지', () => {
+    let sawLeadingZero = false;
+    for (let i = 0; i < 500; i++) {
+      if (generateInviteCode().startsWith('0')) {
+        sawLeadingZero = true;
+        break;
+      }
+    }
+    expect(sawLeadingZero).toBe(true);
+  });
+});
+
+describe('isValidInviteCodeFormat', () => {
+  it('정확히 6자리 숫자만 true', () => {
+    expect(isValidInviteCodeFormat('123456')).toBe(true);
+    expect(isValidInviteCodeFormat('000001')).toBe(true);
+  });
+
+  it('길이가 다르거나 문자가 섞이면 false', () => {
+    expect(isValidInviteCodeFormat('12345')).toBe(false);
+    expect(isValidInviteCodeFormat('1234567')).toBe(false);
+    expect(isValidInviteCodeFormat('12345a')).toBe(false);
+    expect(isValidInviteCodeFormat('')).toBe(false);
+    expect(isValidInviteCodeFormat(' 123456')).toBe(false);
+  });
+});
+
+describe('buildInviteDeepLink / buildInviteWebUrl', () => {
+  it('딥링크는 voicealarm 스킴 + /invite/{code}', () => {
+    expect(buildInviteDeepLink('123456')).toBe('voicealarm://invite/123456');
+  });
+  it('웹 URL 은 voicealarm.pages.dev 호스트 + /invite/{code}', () => {
+    expect(buildInviteWebUrl('123456')).toBe('https://voicealarm.pages.dev/invite/123456');
+  });
+});
+
+describe('computeInviteExpiresAt', () => {
+  it('기본 TTL 이 10분이다', () => {
+    const now = new Date('2026-04-21T00:00:00Z');
+    const iso = computeInviteExpiresAt(now);
+    const exp = new Date(iso);
+    expect(exp.getTime() - now.getTime()).toBe(INVITE_TTL_MINUTES * 60 * 1000);
+  });
+});

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -134,6 +134,22 @@ describe('migrations', () => {
     expect(all).toContain('idx_plan_group_members_unique');
   });
 
+  it('마이그레이션 #9 에서 plan_group_invites 테이블과 인덱스를 추가한다', () => {
+    const m = migrations.find((x) => x.id === 9);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS plan_group_invites');
+    expect(all).toContain('plan_group_id TEXT NOT NULL REFERENCES plan_groups(id)');
+    expect(all).toContain('inviter_user_id TEXT NOT NULL REFERENCES users(id)');
+    expect(all).toContain('code TEXT NOT NULL UNIQUE');
+    expect(all).toContain("CHECK(status IN ('pending','used','revoked','expired'))");
+    expect(all).toContain('expires_at TEXT NOT NULL');
+    expect(all).toContain('used_by_user_id');
+    expect(all).toContain('idx_plan_group_invites_code');
+    expect(all).toContain('idx_plan_group_invites_group');
+    expect(all).toContain('idx_plan_group_invites_status');
+  });
+
   it('마이그레이션 #6 에서 기본 플랜 3종(free / plus_personal / family) 을 시드한다', () => {
     const m = migrations.find((x) => x.id === 6);
     expect(m).toBeDefined();


### PR DESCRIPTION
## 개요
- 이슈: #75
- 요약: TASK.md Phase 5 #32 — 3가지 초대 방식 비교 후 **초대 코드(6자리 숫자, 10분 만료, 일회용) + 딥링크 하이브리드** 채택. 마이그레이션 #9 + `lib/invites.ts` + `/family` 라우트 4종 + 결정 문서.

## 변경 내용
- **마이그레이션 #9 `plan-group-invites`**: `plan_group_invites` 테이블 (code UNIQUE, status CHECK `pending|used|revoked|expired`, expires_at, used_by_user_id) + 인덱스 3종
- **`src/lib/invites.ts`** 순수 함수 모듈: `generateInviteCode` (6자리, crypto.getRandomValues, leading zero 허용), `isValidInviteCodeFormat`, `buildInviteDeepLink` (`voicealarm://invite/{code}`), `buildInviteWebUrl` (`https://voicealarm.pages.dev/invite/{code}`), `computeInviteExpiresAt` (기본 10분)
- **`src/routes/family.ts`** 신규:
  - `POST /family/invites` — owner 가 초대 발급. plan_group_id 생략 시 본인 최신 그룹 자동 resolve. 멤버+pending 합이 max_members 이상이면 409.
  - `GET /family/invites` — owner 그룹 초대 목록 (deep_link/web_url 동반)
  - `POST /family/invites/:code/accept` — 포맷/상태/만료/자기발급/이미멤버/정원 6단 검증 후 `plan_group_members` role=`member` INSERT + invite status=`used`. 만료 시각 지났으나 status=pending 이면 409 + DB 에서 `expired` 자동 전환.
  - `POST /family/invites/:code/revoke` — 발급자 전용, pending 만 → status=`revoked`
- **`index.ts`**: `api.route('/family', familyRoutes)` 등록 (인증 + rate limit + private cache 적용)
- **`docs/INVITE_METHOD_COMPARISON.md`**: 3가지 방식 비교표 + 결정 이유 + 스키마/API 요약 + 브루트포스·링크유출 리스크 완화 기술
- **vitest +26건**:
  - `test/migrations.test.ts` — 마이그레이션 #9 스키마 검증 1건
  - `test/invites.test.ts` — 코드 생성/포맷/딥링크/TTL 6건
  - `test/family.test.ts` — /invites POST 4건, GET 2건, accept 8건, revoke 3건 = 17건
  - 백엔드 339→365 / 28 파일 그린

## 검증
- [x] `npm -w @voicealarm/backend run test` — 339→365 그린
- [x] `npm -w @voicealarm/backend run typecheck` — 0 에러
- [ ] `npm run lint` — backend 에 lint 스크립트 없음
- [x] 결정 문서 (`docs/INVITE_METHOD_COMPARISON.md`) 기록

## 리스크 / 팔로업
- 브루트포스: 6자리 = 100만 경우 × 10분 만료 + 일회용 + 분당 60 req rate limit → 실용적으로 안전. 공격 탐지 시 owner 가 revoke.
- 링크 유출: 딥링크 유출되어도 10분 × 1회 성공 후 즉시 used. 다수 초대는 여러 코드 발급 필요.
- 모바일 앱 scheme 설정(`app.json`) 및 웹 `/invite/:code` 라우트 UI 는 별도 이슈 (Phase 8).
- #33 참여/탈퇴·소유자 권한 양도 후속.