### PR TITLE
[#77] 가족 플랜 참여/탈퇴 + 소유자 권한 양도

### DIFF
--- a/packages/backend/src/routes/family.ts
+++ b/packages/backend/src/routes/family.ts
@@ -287,4 +287,212 @@ family.post('/invites/:code/revoke', async (c) => {
   return c.json({ success: true, invite: { id: String(invite.id), status: 'revoked' } });
 });
 
+/** GET /family/groups/current — 내가 속한 가족 그룹 + 멤버 목록 + 내 role */
+family.get('/groups/current', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ group: null, members: [], role: null });
+
+  const groupRes = await db.execute({
+    sql: `SELECT pg.id, pg.owner_user_id, pg.plan_id, pg.max_members, pg.created_at,
+                 m.role AS my_role
+          FROM plan_group_members m
+          JOIN plan_groups pg ON pg.id = m.plan_group_id
+          WHERE m.user_id = ?
+          ORDER BY m.joined_at DESC
+          LIMIT 1`,
+    args: [userPk],
+  });
+  if (groupRes.rows.length === 0) {
+    return c.json({ group: null, members: [], role: null });
+  }
+  const g = groupRes.rows[0];
+  const groupId = String(g.id);
+
+  const membersRes = await db.execute({
+    sql: `SELECT m.id, m.user_id, m.role, m.joined_at,
+                 u.email, u.name, u.picture
+          FROM plan_group_members m
+          LEFT JOIN users u ON u.id = m.user_id
+          WHERE m.plan_group_id = ?
+          ORDER BY CASE m.role WHEN 'owner' THEN 0 ELSE 1 END, m.joined_at ASC`,
+    args: [groupId],
+  });
+
+  return c.json({
+    group: {
+      id: groupId,
+      owner_user_id: String(g.owner_user_id),
+      plan_id: String(g.plan_id),
+      max_members: Number(g.max_members),
+      created_at: String(g.created_at),
+    },
+    role: String(g.my_role),
+    members: membersRes.rows.map((r) => ({
+      id: String(r.id),
+      user_id: String(r.user_id),
+      role: String(r.role),
+      joined_at: String(r.joined_at),
+      email: (r.email as string | null) ?? null,
+      name: (r.name as string | null) ?? null,
+      picture: (r.picture as string | null) ?? null,
+    })),
+  });
+});
+
+/** POST /family/groups/:groupId/leave — 멤버 자진 탈퇴 (owner 는 거부) */
+family.post('/groups/:groupId/leave', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const groupId = c.req.param('groupId');
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  const memberRes = await db.execute({
+    sql: `SELECT id, role FROM plan_group_members
+          WHERE plan_group_id = ? AND user_id = ?`,
+    args: [groupId, userPk],
+  });
+  if (memberRes.rows.length === 0) {
+    return c.json({ error: '해당 그룹의 멤버가 아닙니다' }, 403);
+  }
+  const myRole = String(memberRes.rows[0].role);
+  if (myRole === 'owner') {
+    return c.json(
+      { error: '소유자는 탈퇴할 수 없습니다. 먼저 권한을 양도하거나 그룹을 해체하세요' },
+      409,
+    );
+  }
+
+  await db.execute({
+    sql: `DELETE FROM plan_group_members WHERE id = ?`,
+    args: [String(memberRes.rows[0].id)],
+  });
+
+  return c.json({ success: true, left_group_id: groupId });
+});
+
+/**
+ * POST /family/groups/:groupId/transfer-ownership { target_user_id }
+ * owner 전용. target 은 동일 그룹의 member 여야 함.
+ * two-step UPDATE: (1) 기존 owner → member 로 강등, (2) target → owner 승격.
+ * 중간 상태에서 owner 0명 이 되지만 app-level 만의 제약이므로 허용.
+ */
+family.post('/groups/:groupId/transfer-ownership', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const groupId = c.req.param('groupId');
+
+  const body = await c.req
+    .json<{ target_user_id?: unknown }>()
+    .catch(() => ({ target_user_id: undefined }));
+  const targetUserId =
+    typeof body.target_user_id === 'string' ? body.target_user_id.trim() : '';
+  if (!targetUserId) {
+    return c.json({ error: 'target_user_id 는 필수입니다' }, 400);
+  }
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  if (targetUserId === userPk) {
+    return c.json({ error: '자기 자신에게는 양도할 수 없습니다' }, 400);
+  }
+
+  const groupRes = await db.execute({
+    sql: `SELECT id, owner_user_id FROM plan_groups WHERE id = ?`,
+    args: [groupId],
+  });
+  if (groupRes.rows.length === 0) {
+    return c.json({ error: '존재하지 않는 그룹입니다' }, 404);
+  }
+  if (String(groupRes.rows[0].owner_user_id) !== userPk) {
+    return c.json({ error: '그룹 소유자만 양도할 수 있습니다' }, 403);
+  }
+
+  const targetMemberRes = await db.execute({
+    sql: `SELECT id, role FROM plan_group_members
+          WHERE plan_group_id = ? AND user_id = ?`,
+    args: [groupId, targetUserId],
+  });
+  if (targetMemberRes.rows.length === 0) {
+    return c.json({ error: '대상이 해당 그룹의 멤버가 아닙니다' }, 400);
+  }
+
+  // (1) 기존 owner → member 로 강등
+  await db.execute({
+    sql: `UPDATE plan_group_members SET role = 'member'
+          WHERE plan_group_id = ? AND user_id = ?`,
+    args: [groupId, userPk],
+  });
+  // (2) target → owner 승격
+  await db.execute({
+    sql: `UPDATE plan_group_members SET role = 'owner'
+          WHERE plan_group_id = ? AND user_id = ?`,
+    args: [groupId, targetUserId],
+  });
+  // (3) plan_groups.owner_user_id 갱신
+  await db.execute({
+    sql: `UPDATE plan_groups SET owner_user_id = ?, updated_at = datetime('now')
+          WHERE id = ?`,
+    args: [targetUserId, groupId],
+  });
+
+  return c.json({
+    success: true,
+    group: {
+      id: groupId,
+      owner_user_id: targetUserId,
+      previous_owner_user_id: userPk,
+    },
+  });
+});
+
+/** DELETE /family/groups/:groupId/members/:userId — owner 가 멤버를 제거 */
+family.delete('/groups/:groupId/members/:userId', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  const groupId = c.req.param('groupId');
+  const targetUserId = c.req.param('userId');
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  const groupRes = await db.execute({
+    sql: `SELECT id, owner_user_id FROM plan_groups WHERE id = ?`,
+    args: [groupId],
+  });
+  if (groupRes.rows.length === 0) {
+    return c.json({ error: '존재하지 않는 그룹입니다' }, 404);
+  }
+  if (String(groupRes.rows[0].owner_user_id) !== userPk) {
+    return c.json({ error: '그룹 소유자만 멤버를 제거할 수 있습니다' }, 403);
+  }
+  if (targetUserId === userPk) {
+    return c.json({ error: '자기 자신은 제거할 수 없습니다 (탈퇴·양도 사용)' }, 400);
+  }
+
+  const targetRes = await db.execute({
+    sql: `SELECT id, role FROM plan_group_members
+          WHERE plan_group_id = ? AND user_id = ?`,
+    args: [groupId, targetUserId],
+  });
+  if (targetRes.rows.length === 0) {
+    return c.json({ error: '대상이 해당 그룹의 멤버가 아닙니다' }, 404);
+  }
+  if (String(targetRes.rows[0].role) === 'owner') {
+    return c.json({ error: 'owner 는 제거할 수 없습니다' }, 400);
+  }
+
+  await db.execute({
+    sql: `DELETE FROM plan_group_members WHERE id = ?`,
+    args: [String(targetRes.rows[0].id)],
+  });
+
+  return c.json({ success: true, removed_user_id: targetUserId });
+});
+
 export default family;

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -294,6 +294,237 @@ describe('POST /family/invites/:code/accept', () => {
   });
 });
 
+describe('GET /family/groups/current', () => {
+  it('멤버십 + 멤버 목록 반환', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([
+      {
+        id: 'group-1',
+        owner_user_id: 'user-owner',
+        plan_id: 'plan-family',
+        max_members: 6,
+        created_at: '2026-04-21T00:00:00.000Z',
+        my_role: 'member',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: 'm-owner',
+        user_id: 'user-owner',
+        role: 'owner',
+        joined_at: '2026-04-21T00:00:00.000Z',
+        email: 'owner@x.com',
+        name: 'Owner',
+        picture: null,
+      },
+      {
+        id: 'm-mem',
+        user_id: 'user-member',
+        role: 'member',
+        joined_at: '2026-04-21T00:05:00.000Z',
+        email: 'm@x.com',
+        name: 'Member',
+        picture: null,
+      },
+    ]);
+
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('GET', '/family/groups/current'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.group.id).toBe('group-1');
+    expect(body.group.owner_user_id).toBe('user-owner');
+    expect(body.role).toBe('member');
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0].role).toBe('owner');
+  });
+
+  it('소속 그룹 없음 → null 응답', async () => {
+    mockDB.pushResult([{ id: 'user-x' }]);
+    mockDB.pushResult([]);
+    const app = buildApp('google-x');
+    const res = await app.request(jsonReq('GET', '/family/groups/current'));
+    const body = await res.json();
+    expect(body.group).toBeNull();
+    expect(body.members).toEqual([]);
+  });
+});
+
+describe('POST /family/groups/:groupId/leave', () => {
+  it('member 탈퇴 → 200 + plan_group_members DELETE', async () => {
+    mockDB.pushResult([{ id: 'user-member' }]);
+    mockDB.pushResult([{ id: 'm-1', role: 'member' }]);
+    mockDB.pushResult([], 1); // DELETE
+
+    const app = buildApp('google-member');
+    const res = await app.request(jsonReq('POST', '/family/groups/group-1/leave'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.left_group_id).toBe('group-1');
+
+    const del = mockDB.calls.find((c) => c.sql.includes('DELETE FROM plan_group_members'));
+    expect(del?.args[0]).toBe('m-1');
+  });
+
+  it('owner 가 탈퇴 시도 → 409 (양도/해체 먼저)', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'm-o', role: 'owner' }]);
+
+    const app = buildApp('google-owner');
+    const res = await app.request(jsonReq('POST', '/family/groups/group-1/leave'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('소유자');
+  });
+
+  it('그룹 멤버 아님 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-x' }]);
+    mockDB.pushResult([]);
+    const app = buildApp('google-x');
+    const res = await app.request(jsonReq('POST', '/family/groups/group-1/leave'));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /family/groups/:groupId/transfer-ownership', () => {
+  it('정상 양도 → 200, UPDATE 순서는 (owner→member) 먼저 후 (target→owner)', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'm-target', role: 'member' }]);
+    mockDB.pushResult([], 1); // UPDATE self → member
+    mockDB.pushResult([], 1); // UPDATE target → owner
+    mockDB.pushResult([], 1); // UPDATE plan_groups.owner_user_id
+
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {
+        target_user_id: 'user-target',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.group.owner_user_id).toBe('user-target');
+    expect(body.group.previous_owner_user_id).toBe('user-owner');
+
+    const updates = mockDB.calls.filter((c) => c.sql.includes('UPDATE plan_group_members'));
+    expect(updates).toHaveLength(2);
+    // (1) 기존 owner 강등이 먼저
+    expect(updates[0].sql).toContain("role = 'member'");
+    expect(updates[0].args[1]).toBe('user-owner');
+    // (2) target 승격이 나중
+    expect(updates[1].sql).toContain("role = 'owner'");
+    expect(updates[1].args[1]).toBe('user-target');
+
+    const groupUpd = mockDB.calls.find((c) => c.sql.includes('UPDATE plan_groups SET owner_user_id'));
+    expect(groupUpd?.args[0]).toBe('user-target');
+  });
+
+  it('target_user_id 누락 → 400', async () => {
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {}),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('self-양도 시도 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {
+        target_user_id: 'user-owner',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('자기');
+  });
+
+  it('owner 아님 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-other' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    const app = buildApp('google-other');
+    const res = await app.request(
+      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {
+        target_user_id: 'user-target',
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('target 이 그룹 멤버 아님 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    mockDB.pushResult([]); // target 조회 empty
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {
+        target_user_id: 'user-target',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('멤버');
+  });
+});
+
+describe('DELETE /family/groups/:groupId/members/:userId', () => {
+  it('owner 가 member 제거 → 200 + DELETE 호출', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'm-target', role: 'member' }]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      new Request('http://localhost/family/groups/group-1/members/user-target', {
+        method: 'DELETE',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.removed_user_id).toBe('user-target');
+  });
+
+  it('owner 본인 제거 시도 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      new Request('http://localhost/family/groups/group-1/members/user-owner', {
+        method: 'DELETE',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('owner 아님 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-other' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    const app = buildApp('google-other');
+    const res = await app.request(
+      new Request('http://localhost/family/groups/group-1/members/user-target', {
+        method: 'DELETE',
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('대상 owner 는 제거 불가 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-owner' }]);
+    mockDB.pushResult([{ id: 'm-x', role: 'owner' }]);
+    const app = buildApp('google-owner');
+    const res = await app.request(
+      new Request('http://localhost/family/groups/group-1/members/user-co-owner', {
+        method: 'DELETE',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
 describe('POST /family/invites/:code/revoke', () => {
   it('발급자 + pending → 200, status=revoked', async () => {
     mockDB.pushResult([{ id: 'user-owner' }]);


### PR DESCRIPTION
## 개요
- 이슈: #77
- 요약: TASK.md Phase 5 #33 — 가족 플랜 그룹 수명 주기 완결 (참여는 #32 accept, 이 PR 은 탈퇴·양도·강제 제거).

## 변경 내용
- **`GET /family/groups/current`**: 내가 속한 가족 그룹 + 멤버 전체(owner 먼저 정렬, 이메일/이름/사진 포함) + 내 role 반환. 소속 없으면 `{ group:null, members:[], role:null }`.
- **`POST /family/groups/:groupId/leave`**: 멤버 자진 탈퇴 → plan_group_members DELETE. owner 면 409 (양도/해체 먼저 요구). 그룹 멤버 아니면 403.
- **`POST /family/groups/:groupId/transfer-ownership { target_user_id }`**: owner 전용 권한 양도.
  - 검증: target 필수 / self-양도 금지 / 본인이 owner 인지 / target 이 동일 그룹 멤버인지
  - 실행 순서: (1) 기존 owner → member 강등 → (2) target → owner 승격 → (3) plan_groups.owner_user_id 갱신. 중간 상태에서 owner 0명이 잠시 존재하지만 owner 2명 상태는 회피.
- **`DELETE /family/groups/:groupId/members/:userId`**: owner 가 멤버를 강제 제거. 자기 자신 400, 대상이 owner 이면 400.

## 검증
- [x] `npm -w @voicealarm/backend run test` — 365→379 그린 (28 파일)
- [x] `npm -w @voicealarm/backend run typecheck` — 0 에러
- [ ] `npm run lint` — backend 에 lint 스크립트 없음
- [x] two-step UPDATE 순서가 owner 2명 상태를 피하도록 테스트에서 명시 검증

## 리스크 / 팔로업
- 양도 중간에 장애 발생 시 owner 0명으로 정지 가능. libsql-web 환경에서 트랜잭션 제약상 수용 — 필요 시 admin 복구 엔드포인트 후속.
- 그룹 해체(`DELETE /family/groups/:id`) 는 후속 이슈. 현재는 owner 가 탈퇴하려면 양도가 필수.
- 가족 알람 상호작용(Phase 6)에서 멤버 제거/탈퇴 시 기존 예약 알람 처리 정책 결정 필요.