### PR TITLE
feat(backend): 가족 허용 설정 컬럼 + PATCH /user/me 토글 (#79)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -310,6 +310,14 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_plan_group_invites_status ON plan_group_invites(status)',
     ],
   },
+  {
+    id: 10,
+    name: 'user-allow-family-alarms',
+    statements: [
+      // 가족이 내게 알람을 추가할 수 있는지 여부 — 기본 false(0) 로 opt-in 설계
+      `ALTER TABLE users ADD COLUMN allow_family_alarms INTEGER NOT NULL DEFAULT 0`,
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -44,7 +44,10 @@ user.get('/me', async (c) => {
     ]);
 
     return c.json({
-      user: u,
+      user: {
+        ...u,
+        allow_family_alarms: Number(u.allow_family_alarms ?? 0) === 1,
+      },
       stats: {
         voice_profiles: Number(profileCount.rows[0]?.count ?? 0),
         alarms: Number(alarmCount.rows[0]?.count ?? 0),
@@ -55,6 +58,44 @@ user.get('/me', async (c) => {
     console.error(`GET /user/me failed: ${detail}`);
     return c.json({ error: 'Failed to fetch user info', detail }, 500);
   }
+});
+
+function toBoolFlag(raw: unknown): 0 | 1 | null {
+  if (raw === true || raw === 1 || raw === '1' || raw === 'true') return 1;
+  if (raw === false || raw === 0 || raw === '0' || raw === 'false') return 0;
+  return null;
+}
+
+/**
+ * PATCH /user/me { allow_family_alarms }
+ * 본인 프로필 토글 필드 업데이트. 현재는 allow_family_alarms 만 지원.
+ */
+user.patch('/me', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const body = await c.req
+    .json<{ allow_family_alarms?: unknown }>()
+    .catch(() => ({ allow_family_alarms: undefined }));
+
+  if (!('allow_family_alarms' in body) || body.allow_family_alarms === undefined) {
+    return c.json({ error: '변경할 필드가 없습니다' }, 400);
+  }
+  const flag = toBoolFlag(body.allow_family_alarms);
+  if (flag === null) {
+    return c.json({ error: 'allow_family_alarms 는 boolean 이어야 합니다' }, 400);
+  }
+
+  const result = await db.execute({
+    sql: `UPDATE users SET allow_family_alarms = ?, updated_at = datetime('now')
+          WHERE google_id = ?`,
+    args: [flag, userId],
+  });
+  if (result.rowsAffected === 0) {
+    return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+  }
+
+  return c.json({ success: true, allow_family_alarms: flag === 1 });
 });
 
 user.patch('/plan', async (c) => {

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -150,6 +150,14 @@ describe('migrations', () => {
     expect(all).toContain('idx_plan_group_invites_status');
   });
 
+  it('마이그레이션 #10 에서 users.allow_family_alarms 컬럼을 추가한다 (기본 0/false)', () => {
+    const m = migrations.find((x) => x.id === 10);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('ALTER TABLE users ADD COLUMN allow_family_alarms');
+    expect(all).toContain('INTEGER NOT NULL DEFAULT 0');
+  });
+
   it('마이그레이션 #6 에서 기본 플랜 3종(free / plus_personal / family) 을 시드한다', () => {
     const m = migrations.find((x) => x.id === 6);
     expect(m).toBeDefined();

--- a/packages/backend/test/user.test.ts
+++ b/packages/backend/test/user.test.ts
@@ -24,7 +24,16 @@ beforeEach(() => {
 
 describe('GET /user/me', () => {
   it('기존 사용자 반환', async () => {
-    mockDB.pushResult([{ id: 'u-1', google_id: 'user-1', email: 'user@test.com', name: 'Test', plan: 'free' }]);
+    mockDB.pushResult([
+      {
+        id: 'u-1',
+        google_id: 'user-1',
+        email: 'user@test.com',
+        name: 'Test',
+        plan: 'free',
+        allow_family_alarms: 0,
+      },
+    ]);
     mockDB.pushResult([{ count: 3 }]);
     mockDB.pushResult([{ count: 2 }]);
 
@@ -33,8 +42,29 @@ describe('GET /user/me', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.user.google_id).toBe('user-1');
+    expect(body.user.allow_family_alarms).toBe(false);
     expect(body.stats.voice_profiles).toBe(3);
     expect(body.stats.alarms).toBe(2);
+  });
+
+  it('allow_family_alarms=1 을 true 로 직렬화', async () => {
+    mockDB.pushResult([
+      {
+        id: 'u-1',
+        google_id: 'user-1',
+        email: 'user@test.com',
+        name: 'Test',
+        plan: 'free',
+        allow_family_alarms: 1,
+      },
+    ]);
+    mockDB.pushResult([{ count: 0 }]);
+    mockDB.pushResult([{ count: 0 }]);
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/user/me'));
+    const body = await res.json();
+    expect(body.user.allow_family_alarms).toBe(true);
   });
 
   it('신규 사용자 자동 생성', async () => {
@@ -50,6 +80,53 @@ describe('GET /user/me', () => {
     const body = await res.json();
     expect(body.user.google_id).toBe('user-1');
     expect(mockDB.calls[1].sql).toContain('INSERT INTO users');
+  });
+});
+
+describe('PATCH /user/me', () => {
+  it('allow_family_alarms=true 성공', async () => {
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/user/me', { allow_family_alarms: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.allow_family_alarms).toBe(true);
+    expect(mockDB.calls[0].sql).toContain('UPDATE users SET allow_family_alarms');
+    expect(mockDB.calls[0].args[0]).toBe(1);
+  });
+
+  it('allow_family_alarms=false 성공', async () => {
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/user/me', { allow_family_alarms: false }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.allow_family_alarms).toBe(false);
+    expect(mockDB.calls[0].args[0]).toBe(0);
+  });
+
+  it('필드 누락 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/user/me', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('변경할 필드');
+  });
+
+  it('잘못된 타입 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/user/me', { allow_family_alarms: 'yes' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('boolean');
+  });
+
+  it('존재하지 않는 사용자 → 404', async () => {
+    mockDB.pushResult([], 0);
+    const app = buildApp();
+    const res = await app.request(jsonReq('PATCH', '/user/me', { allow_family_alarms: true }));
+    expect(res.status).toBe(404);
   });
 });
 


### PR DESCRIPTION
## 요약
- 마이그레이션 #10 추가: `users.allow_family_alarms INTEGER NOT NULL DEFAULT 0`
- `GET /user/me` 응답에서 `allow_family_alarms` 를 boolean 으로 직렬화
- `PATCH /user/me` 엔드포인트 신규 추가 (현재는 `allow_family_alarms` 토글만 지원)
- 400 (필드 누락 / 잘못된 타입), 404 (사용자 없음) 에러 케이스 처리

## 테스트
- [x] `npm test` (386 passed)
- [x] `npm run typecheck` 통과
- [x] 마이그레이션 #10 단위 테스트 추가
- [x] `GET /user/me` allow_family_alarms 직렬화 (0→false, 1→true) 테스트 추가
- [x] `PATCH /user/me` happy path (true/false) + 필드 누락 400 + 잘못된 타입 400 + 404 테스트 추가

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)