### PR TITLE
feat(backend): 가족 알람 추가 API text 모드 (#81)

### DIFF
--- a/packages/backend/src/routes/family.ts
+++ b/packages/backend/src/routes/family.ts
@@ -495,4 +495,157 @@ family.delete('/groups/:groupId/members/:userId', async (c) => {
   return c.json({ success: true, removed_user_id: targetUserId });
 });
 
+const WAKE_AT_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+const MESSAGE_TEXT_MAX = 500;
+
+function normalizeRepeatDays(raw: unknown): number[] {
+  if (!Array.isArray(raw)) return [];
+  const filtered = raw
+    .filter((n): n is number => Number.isInteger(n) && n >= 0 && n <= 6)
+    .sort((a, b) => a - b);
+  return Array.from(new Set(filtered));
+}
+
+/**
+ * POST /family/alarms { recipient_user_id, wake_at, message_text, repeat_days?, voice_profile_id? }
+ * 같은 가족 그룹 멤버에게 text 모드 알람을 예약한다.
+ * - 수신자 allow_family_alarms=0 이면 403
+ * - 수신자 voice_profile 1개 이상 필요 (TTS mock)
+ * - messages INSERT → alarms INSERT (user_id=송신자 google_id, target_user_id=수신자 google_id)
+ */
+family.post('/alarms', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  type AlarmBody = {
+    recipient_user_id?: unknown;
+    wake_at?: unknown;
+    message_text?: unknown;
+    repeat_days?: unknown;
+    voice_profile_id?: unknown;
+  };
+  const body: AlarmBody = await c.req.json<AlarmBody>().catch(() => ({}) as AlarmBody);
+
+  const recipientPk =
+    typeof body.recipient_user_id === 'string' ? body.recipient_user_id.trim() : '';
+  const wakeAt = typeof body.wake_at === 'string' ? body.wake_at.trim() : '';
+  const messageText =
+    typeof body.message_text === 'string' ? body.message_text.trim() : '';
+
+  if (!recipientPk) {
+    return c.json({ error: 'recipient_user_id 가 필요합니다' }, 400);
+  }
+  if (!WAKE_AT_RE.test(wakeAt)) {
+    return c.json({ error: 'wake_at 는 HH:mm 형식이어야 합니다' }, 400);
+  }
+  if (messageText.length === 0) {
+    return c.json({ error: 'message_text 가 비어있습니다' }, 400);
+  }
+  if (messageText.length > MESSAGE_TEXT_MAX) {
+    return c.json({ error: `message_text 는 ${MESSAGE_TEXT_MAX}자 이하여야 합니다` }, 400);
+  }
+
+  const senderPk = await resolveUserPk(db, userId);
+  if (!senderPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+  if (senderPk === recipientPk) {
+    return c.json({ error: '자기 자신에게는 가족 알람을 보낼 수 없습니다' }, 400);
+  }
+
+  const senderGroupRes = await db.execute({
+    sql: `SELECT plan_group_id FROM plan_group_members WHERE user_id = ?`,
+    args: [senderPk],
+  });
+  if (senderGroupRes.rows.length === 0) {
+    return c.json({ error: '가족 그룹에 속해 있지 않습니다' }, 403);
+  }
+  const senderGroupIds = new Set(
+    senderGroupRes.rows.map((r) => String(r.plan_group_id)),
+  );
+
+  const recipientMemberRes = await db.execute({
+    sql: `SELECT plan_group_id FROM plan_group_members WHERE user_id = ?`,
+    args: [recipientPk],
+  });
+  const shared = recipientMemberRes.rows.find((r) =>
+    senderGroupIds.has(String(r.plan_group_id)),
+  );
+  if (!shared) {
+    return c.json({ error: '같은 가족 그룹의 멤버가 아닙니다' }, 403);
+  }
+
+  const recipientRes = await db.execute({
+    sql: `SELECT id, google_id, allow_family_alarms FROM users WHERE id = ?`,
+    args: [recipientPk],
+  });
+  if (recipientRes.rows.length === 0) {
+    return c.json({ error: '수신자를 찾을 수 없습니다' }, 404);
+  }
+  const recipient = recipientRes.rows[0];
+  if (Number(recipient.allow_family_alarms ?? 0) !== 1) {
+    return c.json({ error: '수신자가 가족 알람을 허용하지 않았습니다' }, 403);
+  }
+
+  let voiceProfileId =
+    typeof body.voice_profile_id === 'string' ? body.voice_profile_id.trim() : '';
+  if (voiceProfileId) {
+    const owned = await db.execute({
+      sql: `SELECT id FROM voice_profiles WHERE id = ? AND user_id = ?`,
+      args: [voiceProfileId, recipientPk],
+    });
+    if (owned.rows.length === 0) {
+      return c.json({ error: '지정한 voice_profile 이 수신자 소유가 아닙니다' }, 400);
+    }
+  } else {
+    const latest = await db.execute({
+      sql: `SELECT id FROM voice_profiles WHERE user_id = ?
+            ORDER BY created_at DESC LIMIT 1`,
+      args: [recipientPk],
+    });
+    if (latest.rows.length === 0) {
+      return c.json({ error: '수신자의 음성 프로필이 없습니다' }, 400);
+    }
+    voiceProfileId = String(latest.rows[0].id);
+  }
+
+  const repeatDays = normalizeRepeatDays(body.repeat_days);
+  const messageId = crypto.randomUUID();
+  const alarmId = crypto.randomUUID();
+
+  // TODO: real perso.ai/elevenlabs integration — audio_url 은 TTS 렌더링 완료 후 채움
+  await db.execute({
+    sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+          VALUES (?, ?, ?, ?, NULL, 'family')`,
+    args: [messageId, recipientPk, voiceProfileId, messageText],
+  });
+
+  await db.execute({
+    sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, repeat_days, mode)
+          VALUES (?, ?, ?, ?, ?, ?, 'tts')`,
+    args: [
+      alarmId,
+      userId,
+      String(recipient.google_id),
+      messageId,
+      wakeAt,
+      JSON.stringify(repeatDays),
+    ],
+  });
+
+  return c.json(
+    {
+      alarm: {
+        id: alarmId,
+        sender_user_id: senderPk,
+        recipient_user_id: recipientPk,
+        wake_at: wakeAt,
+        repeat_days: repeatDays,
+        mode: 'tts',
+        voice_profile_id: voiceProfileId,
+      },
+      message: { id: messageId, text: messageText, category: 'family' },
+    },
+    201,
+  );
+});
+
 export default family;

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -562,3 +562,181 @@ describe('POST /family/invites/:code/revoke', () => {
     expect(res.status).toBe(409);
   });
 });
+
+describe('POST /family/alarms (text mode)', () => {
+  function validBody(overrides: Record<string, unknown> = {}) {
+    return {
+      recipient_user_id: 'user-recipient',
+      wake_at: '07:30',
+      message_text: '일어나세요!',
+      ...overrides,
+    };
+  }
+
+  function queueHappyPath(opts: {
+    senderPk?: string;
+    recipientPk?: string;
+    recipientGoogleId?: string;
+    allowFamily?: number;
+    voiceProfileId?: string | null;
+  } = {}) {
+    const senderPk = opts.senderPk ?? 'user-sender';
+    const recipientPk = opts.recipientPk ?? 'user-recipient';
+    const recipientGoogleId = opts.recipientGoogleId ?? 'google-recipient';
+    const allow = opts.allowFamily ?? 1;
+    mockDB.pushResult([{ id: senderPk }]); // resolve sender pk
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]); // sender groups
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]); // recipient groups
+    mockDB.pushResult([
+      { id: recipientPk, google_id: recipientGoogleId, allow_family_alarms: allow },
+    ]); // recipient row
+    if (opts.voiceProfileId === null) {
+      mockDB.pushResult([]); // no voice profile
+    } else {
+      mockDB.pushResult([{ id: opts.voiceProfileId ?? 'vp-recipient-1' }]); // latest vp
+    }
+    mockDB.pushResult([], 1); // messages INSERT
+    mockDB.pushResult([], 1); // alarms INSERT
+  }
+
+  it('정상 — 수신자 가장 최근 voice_profile 자동 선택', async () => {
+    queueHappyPath();
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody({ repeat_days: [1, 3, 5] })));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm.voice_profile_id).toBe('vp-recipient-1');
+    expect(body.alarm.wake_at).toBe('07:30');
+    expect(body.alarm.repeat_days).toEqual([1, 3, 5]);
+    expect(body.message.text).toBe('일어나세요!');
+    expect(body.message.category).toBe('family');
+
+    const msgInsert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO messages'));
+    const alarmInsert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(msgInsert).toBeDefined();
+    expect(alarmInsert).toBeDefined();
+    expect(msgInsert?.args[1]).toBe('user-recipient');
+    expect(alarmInsert?.args[1]).toBe('google-sender');
+    expect(alarmInsert?.args[2]).toBe('google-recipient');
+  });
+
+  it('정상 — voice_profile_id 명시하면 소유권 검증 후 사용', async () => {
+    mockDB.pushResult([{ id: 'user-sender' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]);
+    mockDB.pushResult([
+      { id: 'user-recipient', google_id: 'google-recipient', allow_family_alarms: 1 },
+    ]);
+    mockDB.pushResult([{ id: 'vp-custom' }]); // voice_profile ownership check
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', validBody({ voice_profile_id: 'vp-custom' })),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm.voice_profile_id).toBe('vp-custom');
+  });
+
+  it('수신자 allow_family_alarms=0 → 403', async () => {
+    queueHappyPath({ allowFamily: 0 });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('허용');
+  });
+
+  it('송신자가 가족 그룹에 없으면 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-sender' }]); // sender pk
+    mockDB.pushResult([]); // sender has no groups
+
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('가족 그룹');
+  });
+
+  it('송신자/수신자가 다른 그룹이면 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-sender' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-A' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-B' }]);
+
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('같은 가족');
+  });
+
+  it('수신자가 존재하지 않으면 → 404', async () => {
+    mockDB.pushResult([{ id: 'user-sender' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]);
+    mockDB.pushResult([]); // no user row
+
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
+    expect(res.status).toBe(404);
+  });
+
+  it('recipient_user_id 누락 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', { wake_at: '07:30', message_text: '안녕' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('wake_at 포맷 오류 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq(
+        'POST',
+        '/family/alarms',
+        validBody({ wake_at: '7:30 AM' }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('HH:mm');
+  });
+
+  it('message_text 빈 문자열 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', validBody({ message_text: '   ' })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('message_text 500자 초과 → 400', async () => {
+    const app = buildApp('google-sender');
+    const long = 'a'.repeat(501);
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', validBody({ message_text: long })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('수신자에 voice_profile 이 없으면 → 400', async () => {
+    queueHappyPath({ voiceProfileId: null });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('음성 프로필');
+  });
+
+  it('자기 자신에게 보내면 → 400', async () => {
+    mockDB.pushResult([{ id: 'user-recipient' }]); // sender pk == recipient pk
+    const app = buildApp('google-recipient');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', validBody()),
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #81
- 요약: Phase 6 #35 — `POST /api/family/alarms` 구현. 가족 그룹 멤버에게 텍스트 기반 TTS 알람 예약.

## 변경 내용
- `POST /api/family/alarms { recipient_user_id, wake_at, message_text, repeat_days?, voice_profile_id? }`
- 검증 체인 (우선순위대로): 필수 필드/포맷 400 → 송신자 PK resolve → self-send 400 → 송신자 그룹 소속 403 → 같은 그룹 수신자 403 → 수신자 존재 404 → `allow_family_alarms=1` 403 → voice_profile 검증/매핑 400
- DB 쓰기: `messages` INSERT(category='family', audio_url=NULL) + `alarms` INSERT(user_id=송신자 google_id, target_user_id=수신자 google_id, mode='tts')
- `// TODO: real perso.ai/elevenlabs integration` 주석 — TTS 렌더링은 기존 tts 경로에서 후처리

## 검증
- [x] `npm test` (398 passed, +12)
- [x] `npm run typecheck` 통과
- [x] vitest 12건: 정상 2종 (voice_profile 자동/명시) + 403 (allow=0 / 그룹 밖 / 다른 그룹) + 404 (수신자 없음) + 400 (recipient 누락 / wake_at 포맷 / message_text 빈/초과 / voice_profile 없음 / self-send)

## 리스크 / 팔로업
- 알람 렌더링: 실제 TTS 합성은 아직 mock (audio_url=NULL). 기존 `/api/tts` 경로에서 채움.
- 동일 수신자·시간 중복 생성 방지 로직 없음 — UX/UI 단에서 확인 (Phase 6 #37/#38).
- repeat_days 빈 배열이면 1회성 알람이 되도록 기존 스케줄러와의 정합은 #35 범위 밖.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)