### PR TITLE
feat(backend): 가족 알람 추가 API voice 모드 (#83)

### DIFF
--- a/packages/backend/src/routes/family.ts
+++ b/packages/backend/src/routes/family.ts
@@ -648,4 +648,186 @@ family.post('/alarms', async (c) => {
   );
 });
 
+const DUB_LANGUAGES = ['ko', 'en', 'ja', 'zh'] as const;
+type DubLanguage = (typeof DUB_LANGUAGES)[number];
+const LABEL_MAX = 200;
+const DEFAULT_VOICE_LABEL = '가족이 보낸 음성';
+
+/**
+ * POST /family/alarms/voice
+ * { recipient_user_id, wake_at, voice_upload_id, label?, dub_target_language?, repeat_days? }
+ *
+ * 같은 가족 그룹 멤버에게 '송신자 음성(또는 더빙 mock)' 기반 sound-only 알람을 예약한다.
+ * - 송신자가 소유한 voice_uploads row 참조
+ * - dub_target_language 있으면 dub_jobs INSERT (status='processing') + audio_url NULL
+ * - 없으면 audio_url = voice_uploads.object_key (원본 재생)
+ */
+family.post('/alarms/voice', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  type VoiceBody = {
+    recipient_user_id?: unknown;
+    wake_at?: unknown;
+    voice_upload_id?: unknown;
+    label?: unknown;
+    dub_target_language?: unknown;
+    repeat_days?: unknown;
+  };
+  const body: VoiceBody = await c.req.json<VoiceBody>().catch(() => ({}) as VoiceBody);
+
+  const recipientPk =
+    typeof body.recipient_user_id === 'string' ? body.recipient_user_id.trim() : '';
+  const wakeAt = typeof body.wake_at === 'string' ? body.wake_at.trim() : '';
+  const voiceUploadId =
+    typeof body.voice_upload_id === 'string' ? body.voice_upload_id.trim() : '';
+
+  if (!recipientPk) {
+    return c.json({ error: 'recipient_user_id 가 필요합니다' }, 400);
+  }
+  if (!WAKE_AT_RE.test(wakeAt)) {
+    return c.json({ error: 'wake_at 는 HH:mm 형식이어야 합니다' }, 400);
+  }
+  if (!voiceUploadId) {
+    return c.json({ error: 'voice_upload_id 가 필요합니다' }, 400);
+  }
+
+  const rawLabel = typeof body.label === 'string' ? body.label.trim() : '';
+  if (rawLabel.length > LABEL_MAX) {
+    return c.json({ error: `label 은 ${LABEL_MAX}자 이하여야 합니다` }, 400);
+  }
+  const label = rawLabel.length > 0 ? rawLabel : DEFAULT_VOICE_LABEL;
+
+  let dubTarget: DubLanguage | null = null;
+  if (body.dub_target_language !== undefined && body.dub_target_language !== null) {
+    const raw = typeof body.dub_target_language === 'string' ? body.dub_target_language : '';
+    if (!DUB_LANGUAGES.includes(raw as DubLanguage)) {
+      return c.json(
+        { error: `dub_target_language 는 ${DUB_LANGUAGES.join('|')} 중 하나여야 합니다` },
+        400,
+      );
+    }
+    dubTarget = raw as DubLanguage;
+  }
+
+  const senderPk = await resolveUserPk(db, userId);
+  if (!senderPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+  if (senderPk === recipientPk) {
+    return c.json({ error: '자기 자신에게는 가족 알람을 보낼 수 없습니다' }, 400);
+  }
+
+  const senderGroupRes = await db.execute({
+    sql: `SELECT plan_group_id FROM plan_group_members WHERE user_id = ?`,
+    args: [senderPk],
+  });
+  if (senderGroupRes.rows.length === 0) {
+    return c.json({ error: '가족 그룹에 속해 있지 않습니다' }, 403);
+  }
+  const senderGroupIds = new Set(
+    senderGroupRes.rows.map((r) => String(r.plan_group_id)),
+  );
+  const recipientMemberRes = await db.execute({
+    sql: `SELECT plan_group_id FROM plan_group_members WHERE user_id = ?`,
+    args: [recipientPk],
+  });
+  const shared = recipientMemberRes.rows.find((r) =>
+    senderGroupIds.has(String(r.plan_group_id)),
+  );
+  if (!shared) {
+    return c.json({ error: '같은 가족 그룹의 멤버가 아닙니다' }, 403);
+  }
+
+  const recipientRes = await db.execute({
+    sql: `SELECT id, google_id, allow_family_alarms FROM users WHERE id = ?`,
+    args: [recipientPk],
+  });
+  if (recipientRes.rows.length === 0) {
+    return c.json({ error: '수신자를 찾을 수 없습니다' }, 404);
+  }
+  const recipient = recipientRes.rows[0];
+  if (Number(recipient.allow_family_alarms ?? 0) !== 1) {
+    return c.json({ error: '수신자가 가족 알람을 허용하지 않았습니다' }, 403);
+  }
+
+  const uploadRes = await db.execute({
+    sql: `SELECT id, user_id, object_key FROM voice_uploads WHERE id = ?`,
+    args: [voiceUploadId],
+  });
+  if (uploadRes.rows.length === 0) {
+    return c.json({ error: '음성 업로드를 찾을 수 없습니다' }, 400);
+  }
+  if (String(uploadRes.rows[0].user_id) !== senderPk) {
+    return c.json({ error: '업로드 소유자가 아닙니다' }, 400);
+  }
+  const objectKey = String(uploadRes.rows[0].object_key);
+
+  const latestVp = await db.execute({
+    sql: `SELECT id FROM voice_profiles WHERE user_id = ?
+          ORDER BY created_at DESC LIMIT 1`,
+    args: [recipientPk],
+  });
+  if (latestVp.rows.length === 0) {
+    return c.json({ error: '수신자의 음성 프로필이 없습니다' }, 400);
+  }
+  const voiceProfileId = String(latestVp.rows[0].id);
+
+  const repeatDays = normalizeRepeatDays(body.repeat_days);
+  const messageId = crypto.randomUUID();
+  const alarmId = crypto.randomUUID();
+  const audioUrl = dubTarget ? null : objectKey;
+
+  // TODO: real perso.ai/elevenlabs integration — 더빙은 dub_jobs 에만 기록, 실제 변환은 기존 dub 라우트에서
+  await db.execute({
+    sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+          VALUES (?, ?, ?, ?, ?, 'family-voice')`,
+    args: [messageId, recipientPk, voiceProfileId, label, audioUrl],
+  });
+
+  await db.execute({
+    sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, repeat_days, mode)
+          VALUES (?, ?, ?, ?, ?, ?, 'sound-only')`,
+    args: [
+      alarmId,
+      userId,
+      String(recipient.google_id),
+      messageId,
+      wakeAt,
+      JSON.stringify(repeatDays),
+    ],
+  });
+
+  let dubJob: { id: string; target_language: DubLanguage; status: 'processing' } | null = null;
+  if (dubTarget) {
+    const dubJobId = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO dub_jobs (id, user_id, source_language, target_language, status, result_message_id)
+            VALUES (?, ?, ?, ?, 'processing', ?)`,
+      args: [dubJobId, userId, 'auto', dubTarget, messageId],
+    });
+    dubJob = { id: dubJobId, target_language: dubTarget, status: 'processing' };
+  }
+
+  return c.json(
+    {
+      alarm: {
+        id: alarmId,
+        sender_user_id: senderPk,
+        recipient_user_id: recipientPk,
+        wake_at: wakeAt,
+        repeat_days: repeatDays,
+        mode: 'sound-only',
+        voice_upload_id: voiceUploadId,
+      },
+      message: {
+        id: messageId,
+        text: label,
+        category: 'family-voice',
+        audio_url: audioUrl,
+      },
+      dub_job: dubJob,
+    },
+    201,
+  );
+});
+
 export default family;

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -740,3 +740,174 @@ describe('POST /family/alarms (text mode)', () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('POST /family/alarms/voice', () => {
+  function voiceBody(overrides: Record<string, unknown> = {}) {
+    return {
+      recipient_user_id: 'user-recipient',
+      wake_at: '08:00',
+      voice_upload_id: 'upload-1',
+      ...overrides,
+    };
+  }
+
+  function queueVoiceHappyPath(opts: {
+    allowFamily?: number;
+    dub?: boolean;
+    noVoiceProfile?: boolean;
+    uploadOwner?: string;
+    uploadMissing?: boolean;
+  } = {}) {
+    mockDB.pushResult([{ id: 'user-sender' }]); // sender pk
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]); // sender groups
+    mockDB.pushResult([{ plan_group_id: 'group-1' }]); // recipient groups
+    mockDB.pushResult([
+      {
+        id: 'user-recipient',
+        google_id: 'google-recipient',
+        allow_family_alarms: opts.allowFamily ?? 1,
+      },
+    ]); // recipient
+    if (opts.uploadMissing) {
+      mockDB.pushResult([]); // upload missing
+    } else {
+      mockDB.pushResult([
+        {
+          id: 'upload-1',
+          user_id: opts.uploadOwner ?? 'user-sender',
+          object_key: 'uploads/alice/hi.m4a',
+        },
+      ]);
+    }
+    if (opts.noVoiceProfile) {
+      mockDB.pushResult([]); // no profile
+    } else {
+      mockDB.pushResult([{ id: 'vp-recipient-1' }]);
+    }
+    mockDB.pushResult([], 1); // messages INSERT
+    mockDB.pushResult([], 1); // alarms INSERT
+    if (opts.dub) mockDB.pushResult([], 1); // dub_jobs INSERT
+  }
+
+  it('정상 — 더빙 없음, audio_url 에 object_key 채움', async () => {
+    queueVoiceHappyPath();
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody({ repeat_days: [0, 6] })));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.alarm.mode).toBe('sound-only');
+    expect(body.alarm.voice_upload_id).toBe('upload-1');
+    expect(body.alarm.repeat_days).toEqual([0, 6]);
+    expect(body.message.audio_url).toBe('uploads/alice/hi.m4a');
+    expect(body.message.category).toBe('family-voice');
+    expect(body.message.text).toBe('가족이 보낸 음성');
+    expect(body.dub_job).toBeNull();
+
+    const msgInsert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO messages'));
+    const alarmInsert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(msgInsert?.args[4]).toBe('uploads/alice/hi.m4a'); // audio_url
+    expect(alarmInsert?.args[1]).toBe('google-sender');
+    expect(alarmInsert?.args[2]).toBe('google-recipient');
+  });
+
+  it('정상 — 커스텀 label 허용', async () => {
+    queueVoiceHappyPath();
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', voiceBody({ label: '엄마의 아침 인사' })),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.message.text).toBe('엄마의 아침 인사');
+  });
+
+  it('정상 — dub_target_language 주면 dub_jobs INSERT + audio_url NULL', async () => {
+    queueVoiceHappyPath({ dub: true });
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', voiceBody({ dub_target_language: 'en' })),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.message.audio_url).toBeNull();
+    expect(body.dub_job).toMatchObject({ target_language: 'en', status: 'processing' });
+    expect(body.dub_job.id).toBeTruthy();
+
+    const dubInsert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO dub_jobs'));
+    expect(dubInsert).toBeDefined();
+    expect(dubInsert?.args[3]).toBe('en');
+    expect(dubInsert?.args[4]).toBe(body.message.id); // result_message_id
+  });
+
+  it('dub_target_language 가 허용 목록 밖 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', voiceBody({ dub_target_language: 'fr' })),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('dub_target_language');
+  });
+
+  it('수신자 allow_family_alarms=0 → 403', async () => {
+    queueVoiceHappyPath({ allowFamily: 0 });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody()));
+    expect(res.status).toBe(403);
+  });
+
+  it('voice_upload 이 송신자 소유가 아니면 → 400', async () => {
+    queueVoiceHappyPath({ uploadOwner: 'user-other' });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody()));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('소유자');
+  });
+
+  it('voice_upload 이 없으면 → 400', async () => {
+    queueVoiceHappyPath({ uploadMissing: true });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody()));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('음성 업로드');
+  });
+
+  it('수신자에 voice_profile 없으면 → 400', async () => {
+    queueVoiceHappyPath({ noVoiceProfile: true });
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody()));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('음성 프로필');
+  });
+
+  it('다른 그룹 수신자 → 403', async () => {
+    mockDB.pushResult([{ id: 'user-sender' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-A' }]);
+    mockDB.pushResult([{ plan_group_id: 'group-B' }]);
+    const app = buildApp('google-sender');
+    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody()));
+    expect(res.status).toBe(403);
+  });
+
+  it('wake_at 포맷 오류 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', voiceBody({ wake_at: '25:00' })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('voice_upload_id 누락 → 400', async () => {
+    const app = buildApp('google-sender');
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', {
+        recipient_user_id: 'user-recipient',
+        wake_at: '08:00',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #83
- 요약: Phase 6 #36 — `POST /api/family/alarms/voice` 구현. 송신자 voice_upload 참조 + 선택적 mock 더빙 dub_jobs 연결.

## 변경 내용
- 신규 엔드포인트 `POST /api/family/alarms/voice { recipient_user_id, wake_at, voice_upload_id, label?, dub_target_language?, repeat_days? }`
- 검증: 필드/포맷(400) → 송신자 PK → self-send 400 → 송신자 그룹 403 → 같은 그룹 수신자 403 → 수신자 404 → allow_family_alarms=1 403 → voice_upload 존재·소유 400 → 수신자 voice_profile 400
- 더빙 경로: `dub_target_language ∈ {ko,en,ja,zh}` 이면 `dub_jobs` INSERT (status='processing', result_message_id=새 message.id) + `audio_url=NULL`
- 원본 경로: `audio_url = voice_uploads.object_key`
- `messages.category='family-voice'`, `alarms.mode='sound-only'`
- `// TODO: real perso.ai/elevenlabs integration` 주석 — 실제 더빙 변환은 기존 `/api/dub` 경로에서 처리

## 검증
- [x] `npm test` (409 passed, +11)
- [x] `npm run typecheck` 통과
- [x] vitest 11건: 정상(기본/라벨/더빙) + 400(dub invalid / upload 미소유 / upload 없음 / voice_profile 없음 / wake_at 포맷 / upload_id 누락) + 403(allow=0 / 다른 그룹)

## 리스크 / 팔로업
- 실제 perso.ai 더빙 호출은 mock — `dub_jobs.status` 는 'processing' 만 쓰고 완료 전환은 `/api/dub` 라우트에 위임
- 업로드한 원본 오디오 재생 경로는 `object_key` 가 public URL 이 아닐 경우 서명 URL 변환 미구현(현재는 raw key)
- 수신자 장치에서의 재생 UX/UI 는 Phase 6 #38/#39

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)