### PR TITLE
feat(web): 가족 알람 편집 화면 + 백엔드 allow_family_alarms 노출 (#85)

### DIFF
--- a/packages/backend/src/routes/family.ts
+++ b/packages/backend/src/routes/family.ts
@@ -313,7 +313,7 @@ family.get('/groups/current', async (c) => {
 
   const membersRes = await db.execute({
     sql: `SELECT m.id, m.user_id, m.role, m.joined_at,
-                 u.email, u.name, u.picture
+                 u.email, u.name, u.picture, u.allow_family_alarms
           FROM plan_group_members m
           LEFT JOIN users u ON u.id = m.user_id
           WHERE m.plan_group_id = ?
@@ -338,6 +338,7 @@ family.get('/groups/current', async (c) => {
       email: (r.email as string | null) ?? null,
       name: (r.name as string | null) ?? null,
       picture: (r.picture as string | null) ?? null,
+      allow_family_alarms: Number(r.allow_family_alarms ?? 0) === 1,
     })),
   });
 });

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -316,6 +316,7 @@ describe('GET /family/groups/current', () => {
         email: 'owner@x.com',
         name: 'Owner',
         picture: null,
+        allow_family_alarms: 1,
       },
       {
         id: 'm-mem',
@@ -325,6 +326,7 @@ describe('GET /family/groups/current', () => {
         email: 'm@x.com',
         name: 'Member',
         picture: null,
+        allow_family_alarms: 0,
       },
     ]);
 
@@ -337,6 +339,8 @@ describe('GET /family/groups/current', () => {
     expect(body.role).toBe('member');
     expect(body.members).toHaveLength(2);
     expect(body.members[0].role).toBe('owner');
+    expect(body.members[0].allow_family_alarms).toBe(true);
+    expect(body.members[1].allow_family_alarms).toBe(false);
   });
 
   it('소속 그룹 없음 → null 응답', async () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,14 +11,24 @@ const AlarmsPage = lazy(() => import('./pages/AlarmsPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const FriendsPage = lazy(() => import('./pages/FriendsPage'));
 const GiftsPage = lazy(() => import('./pages/GiftsPage'));
+const FamilyAlarmsPage = lazy(() => import('./pages/FamilyAlarmsPage'));
 
-type Page = 'dashboard' | 'voices' | 'messages' | 'alarms' | 'friends' | 'gifts' | 'settings';
+type Page =
+  | 'dashboard'
+  | 'voices'
+  | 'messages'
+  | 'alarms'
+  | 'family'
+  | 'friends'
+  | 'gifts'
+  | 'settings';
 
 const NAV_ITEMS: { key: Page; label: string; emoji: string }[] = [
   { key: 'dashboard', label: '대시보드', emoji: '📊' },
   { key: 'voices', label: '음성 관리', emoji: '🎙️' },
   { key: 'messages', label: '메시지', emoji: '💌' },
   { key: 'alarms', label: '알람 설정', emoji: '⏰' },
+  { key: 'family', label: '가족 알람', emoji: '🏠' },
   { key: 'friends', label: '친구', emoji: '👥' },
   { key: 'gifts', label: '선물', emoji: '🎁' },
   { key: 'settings', label: '설정', emoji: '⚙️' },
@@ -59,6 +69,8 @@ export default function App() {
         return <MessagesPage />;
       case 'alarms':
         return <AlarmsPage />;
+      case 'family':
+        return <FamilyAlarmsPage />;
       case 'friends':
         return <FriendsPage />;
       case 'gifts':

--- a/packages/web/src/lib/familyAlarmForm.ts
+++ b/packages/web/src/lib/familyAlarmForm.ts
@@ -1,0 +1,68 @@
+import type { FamilyGroupMember, FamilyAlarmCreatePayload } from '../services/api';
+
+export interface FamilyAlarmFormInput {
+  recipientUserId: string | null;
+  wakeAt: string;
+  messageText: string;
+  repeatDays: number[];
+  voiceProfileId?: string | null;
+}
+
+export type ValidationResult =
+  | { ok: true; payload: FamilyAlarmCreatePayload }
+  | { ok: false; error: string };
+
+/**
+ * 알람 수신 가능한 멤버 목록을 반환한다.
+ * - 자기 자신 제외
+ * - allow_family_alarms=true 만 포함
+ * - owner → member 순, 그 다음 joined_at 오름차순
+ */
+export function filterFamilyAlarmRecipients(
+  members: FamilyGroupMember[],
+  selfUserId: string,
+): FamilyGroupMember[] {
+  return members
+    .filter((m) => m.user_id !== selfUserId && m.allow_family_alarms)
+    .slice()
+    .sort((a, b) => {
+      if (a.role !== b.role) return a.role === 'owner' ? -1 : 1;
+      return a.joined_at.localeCompare(b.joined_at);
+    });
+}
+
+export function validateFamilyAlarmForm(input: FamilyAlarmFormInput): ValidationResult {
+  if (!input.recipientUserId) {
+    return { ok: false, error: '수신자를 선택해주세요.' };
+  }
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(input.wakeAt)) {
+    return { ok: false, error: '시간 형식이 올바르지 않습니다 (HH:mm).' };
+  }
+  const text = input.messageText.trim();
+  if (text.length === 0) {
+    return { ok: false, error: '메시지를 입력해주세요.' };
+  }
+  if (text.length > 500) {
+    return { ok: false, error: '메시지는 500자 이하여야 합니다.' };
+  }
+
+  const payload: FamilyAlarmCreatePayload = {
+    recipient_user_id: input.recipientUserId,
+    wake_at: input.wakeAt,
+    message_text: text,
+  };
+  const days = Array.isArray(input.repeatDays)
+    ? Array.from(new Set(input.repeatDays.filter((n) => Number.isInteger(n) && n >= 0 && n <= 6)))
+        .sort((a, b) => a - b)
+    : [];
+  if (days.length > 0) payload.repeat_days = days;
+  if (input.voiceProfileId) payload.voice_profile_id = input.voiceProfileId;
+
+  return { ok: true, payload };
+}
+
+export function buildMemberDisplayName(m: FamilyGroupMember): string {
+  if (m.name && m.name.trim().length > 0) return m.name;
+  if (m.email) return m.email;
+  return '이름 미지정';
+}

--- a/packages/web/src/pages/FamilyAlarmsPage.tsx
+++ b/packages/web/src/pages/FamilyAlarmsPage.tsx
@@ -1,0 +1,259 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createFamilyAlarmText,
+  getFamilyGroupCurrent,
+  getUserProfile,
+  type FamilyGroupMember,
+} from '../services/api';
+import {
+  buildMemberDisplayName,
+  filterFamilyAlarmRecipients,
+  validateFamilyAlarmForm,
+} from '../lib/familyAlarmForm';
+import { getApiErrorMessage } from '../types';
+
+const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+export default function FamilyAlarmsPage() {
+  const queryClient = useQueryClient();
+
+  const { data: group, isLoading: loadingGroup } = useQuery({
+    queryKey: ['familyGroupCurrent'],
+    queryFn: getFamilyGroupCurrent,
+  });
+
+  const { data: profile } = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getUserProfile,
+  });
+  const selfUserId = (profile?.user?.id as string | undefined) ?? '';
+
+  const [recipientUserId, setRecipientUserId] = useState<string | null>(null);
+  const [wakeAt, setWakeAt] = useState('07:30');
+  const [messageText, setMessageText] = useState('');
+  const [repeatDays, setRepeatDays] = useState<number[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const allowedRecipients = useMemo(
+    () => filterFamilyAlarmRecipients(group?.members ?? [], selfUserId),
+    [group, selfUserId],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: createFamilyAlarmText,
+    onSuccess: (res) => {
+      setSuccessMsg(`알람이 예약되었습니다 (${res.alarm.wake_at}).`);
+      setFormError(null);
+      setMessageText('');
+      queryClient.invalidateQueries({ queryKey: ['alarms'] });
+    },
+    onError: (err: unknown) => {
+      setFormError(getApiErrorMessage(err, '알람 예약에 실패했습니다.'));
+      setSuccessMsg(null);
+    },
+  });
+
+  function toggleDay(d: number) {
+    setRepeatDays((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d].sort((a, b) => a - b),
+    );
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSuccessMsg(null);
+    const res = validateFamilyAlarmForm({
+      recipientUserId,
+      wakeAt,
+      messageText,
+      repeatDays,
+    });
+    if (!res.ok) {
+      setFormError(res.error);
+      return;
+    }
+    setFormError(null);
+    createMutation.mutate(res.payload);
+  }
+
+  if (loadingGroup) {
+    return (
+      <div
+        className="flex items-center justify-center h-64"
+        role="status"
+        aria-label="가족 그룹 불러오는 중"
+      >
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  if (!group?.group) {
+    return (
+      <section aria-labelledby="family-empty-title" className="max-w-xl">
+        <h1 id="family-empty-title" className="text-2xl font-bold mb-3">
+          가족 알람
+        </h1>
+        <p className="text-[var(--color-text-secondary)] mb-4">
+          아직 가족 그룹에 속해 있지 않습니다. 가족 플랜을 결제하거나 초대 코드를 입력해 참여해
+          주세요.
+        </p>
+        <p className="text-sm text-[var(--color-text-tertiary)]">
+          설정 페이지에서 구독/초대 관리를 할 수 있습니다.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="family-alarms-title" className="max-w-3xl">
+      <h1 id="family-alarms-title" className="text-2xl font-bold mb-4">
+        가족 알람 예약
+      </h1>
+
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-2">가족 그룹 멤버</h2>
+        <ul className="grid gap-2">
+          {group.members.map((m) => (
+            <MemberRow key={m.id} member={m} isSelf={m.user_id === selfUserId} />
+          ))}
+        </ul>
+      </div>
+
+      {allowedRecipients.length === 0 ? (
+        <div
+          role="status"
+          className="p-4 rounded-xl bg-[var(--color-surface-alt)] text-[var(--color-text-secondary)]"
+        >
+          가족 알람을 허용한 멤버가 없습니다. 각자 설정에서 '가족이 내게 알람 추가 허용'을 켜야
+          알람을 예약할 수 있습니다.
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          aria-label="가족 알람 예약 폼"
+          className="grid gap-4 p-4 border border-[var(--color-border)] rounded-xl bg-[var(--color-surface)]"
+        >
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">수신자</span>
+            <select
+              value={recipientUserId ?? ''}
+              onChange={(e) => setRecipientUserId(e.target.value || null)}
+              className="px-3 py-2 rounded-lg bg-[var(--color-surface-alt)] border border-[var(--color-border)]"
+              aria-label="알람 수신자"
+            >
+              <option value="">수신자 선택</option>
+              {allowedRecipients.map((m) => (
+                <option key={m.user_id} value={m.user_id}>
+                  {buildMemberDisplayName(m)}
+                  {m.role === 'owner' ? ' (소유자)' : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">기상 시간</span>
+            <input
+              type="time"
+              value={wakeAt}
+              onChange={(e) => setWakeAt(e.target.value)}
+              className="px-3 py-2 rounded-lg bg-[var(--color-surface-alt)] border border-[var(--color-border)]"
+              aria-label="기상 시간 (HH:mm)"
+            />
+          </label>
+
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">메시지 (최대 500자)</span>
+            <textarea
+              value={messageText}
+              onChange={(e) => setMessageText(e.target.value)}
+              rows={3}
+              maxLength={500}
+              placeholder="예: 좋은 아침! 오늘도 힘내자 💪"
+              className="px-3 py-2 rounded-lg bg-[var(--color-surface-alt)] border border-[var(--color-border)]"
+              aria-label="알람 메시지 내용"
+            />
+            <span className="text-xs text-[var(--color-text-tertiary)] text-right">
+              {messageText.length}/500
+            </span>
+          </label>
+
+          <fieldset className="grid gap-1">
+            <legend className="text-sm font-medium mb-1">반복 요일 (선택)</legend>
+            <div className="flex gap-1 flex-wrap">
+              {DAYS.map((day, idx) => (
+                <button
+                  type="button"
+                  key={day}
+                  aria-pressed={repeatDays.includes(idx)}
+                  onClick={() => toggleDay(idx)}
+                  className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${
+                    repeatDays.includes(idx)
+                      ? 'bg-[var(--color-primary)] text-white'
+                      : 'bg-[var(--color-surface-alt)] text-[var(--color-text-secondary)]'
+                  }`}
+                >
+                  {day}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          {formError && (
+            <div role="alert" className="text-sm text-red-500">
+              {formError}
+            </div>
+          )}
+          {successMsg && (
+            <div role="status" className="text-sm text-emerald-500">
+              {successMsg}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={createMutation.isPending}
+            className="px-4 py-2 rounded-xl bg-[var(--color-primary)] text-white font-semibold disabled:opacity-60"
+          >
+            {createMutation.isPending ? '예약 중…' : '알람 예약'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function MemberRow({ member, isSelf }: { member: FamilyGroupMember; isSelf: boolean }) {
+  const label = buildMemberDisplayName(member);
+  const roleBadge = member.role === 'owner' ? '소유자' : '멤버';
+  return (
+    <li className="flex items-center justify-between gap-3 p-3 rounded-lg bg-[var(--color-surface-alt)]">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="w-8 h-8 rounded-full bg-[var(--color-primary)]/20 flex items-center justify-center text-sm font-semibold text-[var(--color-primary)]">
+          {label.slice(0, 1).toUpperCase()}
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="font-medium truncate">{label}</span>
+            {isSelf && (
+              <span className="text-xs text-[var(--color-text-tertiary)]">(나)</span>
+            )}
+          </div>
+          <div className="text-xs text-[var(--color-text-tertiary)]">{roleBadge}</div>
+        </div>
+      </div>
+      <span
+        className={`text-xs font-semibold px-2 py-1 rounded-full ${
+          member.allow_family_alarms
+            ? 'bg-emerald-500/15 text-emerald-500'
+            : 'bg-[var(--color-border)] text-[var(--color-text-tertiary)]'
+        }`}
+      >
+        {member.allow_family_alarms ? '알람 허용' : '알람 거부'}
+      </span>
+    </li>
+  );
+}

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -378,4 +378,60 @@ function normalizeSpeaker(raw: Record<string, unknown>): Speaker {
   };
 }
 
+export interface FamilyGroupMember {
+  id: string;
+  user_id: string;
+  role: 'owner' | 'member';
+  joined_at: string;
+  email: string | null;
+  name: string | null;
+  picture: string | null;
+  allow_family_alarms: boolean;
+}
+
+export interface FamilyGroupCurrent {
+  group: {
+    id: string;
+    owner_user_id: string;
+    plan_id: string;
+    max_members: number;
+    created_at: string;
+  } | null;
+  role: 'owner' | 'member' | null;
+  members: FamilyGroupMember[];
+}
+
+export async function getFamilyGroupCurrent(): Promise<FamilyGroupCurrent> {
+  const { data } = await api.get<FamilyGroupCurrent>('/family/groups/current');
+  return data;
+}
+
+export interface FamilyAlarmCreatePayload {
+  recipient_user_id: string;
+  wake_at: string;
+  message_text: string;
+  repeat_days?: number[];
+  voice_profile_id?: string;
+}
+
+export interface FamilyAlarmCreateResponse {
+  alarm: {
+    id: string;
+    sender_user_id: string;
+    recipient_user_id: string;
+    wake_at: string;
+    repeat_days: number[];
+    mode: 'tts';
+    voice_profile_id: string;
+  };
+  message: { id: string; text: string; category: string };
+}
+
+export async function createFamilyAlarmText(
+  payload: FamilyAlarmCreatePayload,
+): Promise<FamilyAlarmCreateResponse> {
+  const { data } = await api.post<FamilyAlarmCreateResponse>('/family/alarms', payload);
+  return data;
+}
+
 export default api;

--- a/packages/web/test/familyAlarmForm.test.ts
+++ b/packages/web/test/familyAlarmForm.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMemberDisplayName,
+  filterFamilyAlarmRecipients,
+  validateFamilyAlarmForm,
+  type FamilyAlarmFormInput,
+} from '../src/lib/familyAlarmForm';
+import type { FamilyGroupMember } from '../src/services/api';
+
+function m(overrides: Partial<FamilyGroupMember> & { user_id: string }): FamilyGroupMember {
+  return {
+    id: `pgm-${overrides.user_id}`,
+    user_id: overrides.user_id,
+    role: 'member',
+    joined_at: '2026-01-01T00:00:00.000Z',
+    email: null,
+    name: null,
+    picture: null,
+    allow_family_alarms: true,
+    ...overrides,
+  };
+}
+
+describe('filterFamilyAlarmRecipients', () => {
+  it('자기 자신을 제외한다', () => {
+    const members = [m({ user_id: 'self' }), m({ user_id: 'other' })];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result).toHaveLength(1);
+    expect(result[0].user_id).toBe('other');
+  });
+
+  it('allow_family_alarms=false 는 제외한다', () => {
+    const members = [
+      m({ user_id: 'a', allow_family_alarms: true }),
+      m({ user_id: 'b', allow_family_alarms: false }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['a']);
+  });
+
+  it('owner 를 member 보다 먼저 정렬한다', () => {
+    const members = [
+      m({ user_id: 'm1', role: 'member', joined_at: '2026-01-01T00:00:00.000Z' }),
+      m({ user_id: 'o1', role: 'owner', joined_at: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['o1', 'm1']);
+  });
+
+  it('같은 역할 내에서는 joined_at 오름차순', () => {
+    const members = [
+      m({ user_id: 'b', role: 'member', joined_at: '2026-03-01T00:00:00.000Z' }),
+      m({ user_id: 'a', role: 'member', joined_at: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('validateFamilyAlarmForm', () => {
+  const base: FamilyAlarmFormInput = {
+    recipientUserId: 'user-x',
+    wakeAt: '07:30',
+    messageText: '안녕',
+    repeatDays: [],
+  };
+
+  it('정상 입력 → payload 반환', () => {
+    const result = validateFamilyAlarmForm({ ...base, repeatDays: [1, 3, 5] });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload).toEqual({
+      recipient_user_id: 'user-x',
+      wake_at: '07:30',
+      message_text: '안녕',
+      repeat_days: [1, 3, 5],
+    });
+  });
+
+  it('공백 문자 포함 메시지는 trim 됨', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: '  hi  ' });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.message_text).toBe('hi');
+  });
+
+  it('repeatDays 중복·범위 밖 제거 + 정렬', () => {
+    const result = validateFamilyAlarmForm({ ...base, repeatDays: [5, 1, 1, 7, -1, 3] });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.repeat_days).toEqual([1, 3, 5]);
+  });
+
+  it('빈 repeatDays 는 payload 에서 생략', () => {
+    const result = validateFamilyAlarmForm(base);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.repeat_days).toBeUndefined();
+  });
+
+  it('recipientUserId 없으면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, recipientUserId: null });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('수신자');
+  });
+
+  it('wakeAt 포맷 오류면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, wakeAt: '7:30' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('messageText 공백만이면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: '   ' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('메시지');
+  });
+
+  it('messageText 500자 초과 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: 'a'.repeat(501) });
+    expect(result.ok).toBe(false);
+  });
+
+  it('voiceProfileId 전달 시 payload 에 포함', () => {
+    const result = validateFamilyAlarmForm({ ...base, voiceProfileId: 'vp-1' });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.voice_profile_id).toBe('vp-1');
+  });
+});
+
+describe('buildMemberDisplayName', () => {
+  it('name 이 있으면 name 사용', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', name: 'Alice' }))).toBe('Alice');
+  });
+  it('name 없고 email 있으면 email', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', email: 'a@b.com' }))).toBe('a@b.com');
+  });
+  it('둘 다 없으면 이름 미지정', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a' }))).toBe('이름 미지정');
+  });
+  it('name 이 빈 문자열이면 email fallback', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', name: '   ', email: 'x@y.com' }))).toBe(
+      'x@y.com',
+    );
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #85
- 요약: Phase 6 #37 — 웹 가족 알람 편집 화면(`🏠 가족 알람` 탭) + 순수 폼 헬퍼 + 백엔드 members 응답에 `allow_family_alarms` 노출.

## 변경 내용
### Web
- `packages/web/src/lib/familyAlarmForm.ts` — 순수 함수 3종: `filterFamilyAlarmRecipients`, `validateFamilyAlarmForm`, `buildMemberDisplayName`
- `packages/web/src/pages/FamilyAlarmsPage.tsx` — 3 상태 UI (loading / 그룹 없음 / 그룹 있음+폼), 멤버 카드에 owner/멤버·허용/거부 뱃지, 수신자 select·시간·메시지·반복요일, react-query mutation 성공/에러 메시지
- `packages/web/src/services/api.ts` — `getFamilyGroupCurrent`, `createFamilyAlarmText`, `FamilyGroupMember`(allow_family_alarms 포함), `FamilyAlarmCreatePayload` 타입 추가
- `App.tsx` — `가족 알람` 탭 🏠 추가 + 라우팅
- `packages/web/test/familyAlarmForm.test.ts` — 순수 함수 17건

### Backend
- `GET /api/family/groups/current` members 응답에 `allow_family_alarms: boolean` 추가 (u.allow_family_alarms SELECT + Number→boolean 정규화)
- 기존 테스트 1건 업데이트하여 필드 포함 검증

## 검증
- [x] web `npm test` (64 passed, +17)
- [x] web `npm run typecheck` 통과
- [x] backend `npm test` (409 passed)
- [x] backend `npm run typecheck` 통과

## 리스크 / 팔로업
- voice 모드 UI 는 #37 범위 밖 — `FamilyAlarmsPage` 에 확장 예정
- 수신자가 voice_profile 이 없을 때의 에러는 서버 `400` 으로만 노출 (UI 에서 pre-check 미구현)
- 초대/탈퇴/양도 UI 는 별도 페이지로 분리 예정

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)