### PR TITLE
feat(mobile): 가족 알람 예약 화면 추가 (#87)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ function TabIcon({ name, focused }: { name: string; focused: boolean }) {
     voices: '🎙️',
     alarms: '⏰',
     friends: '👥',
+    family: '👨‍👩‍👧',
     library: '📚',
     settings: '⚙️',
   };
@@ -57,6 +58,13 @@ export default function TabLayout() {
         options={{
           title: t('tab.friends'),
           tabBarIcon: ({ focused }) => <TabIcon name="friends" focused={focused} />,
+        }}
+      />
+      <Tabs.Screen
+        name="family"
+        options={{
+          title: t('tab.family'),
+          tabBarIcon: ({ focused }) => <TabIcon name="family" focused={focused} />,
         }}
       />
       <Tabs.Screen

--- a/apps/mobile/app/(tabs)/family.tsx
+++ b/apps/mobile/app/(tabs)/family.tsx
@@ -1,0 +1,415 @@
+import { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  createFamilyAlarmText,
+  getFamilyGroupCurrent,
+  getUserProfile,
+  type FamilyGroupMember,
+} from '../../src/services/api';
+import {
+  buildMemberDisplayName,
+  filterFamilyAlarmRecipients,
+  validateFamilyAlarmForm,
+} from '../../src/lib/familyAlarmForm';
+import { Colors, Spacing, BorderRadius, FontSize } from '../../src/constants/theme';
+import { getApiErrorMessage } from '../../src/types';
+
+const WEEKDAYS: { label: string; value: number }[] = [
+  { label: '일', value: 0 },
+  { label: '월', value: 1 },
+  { label: '화', value: 2 },
+  { label: '수', value: 3 },
+  { label: '목', value: 4 },
+  { label: '금', value: 5 },
+  { label: '토', value: 6 },
+];
+
+export default function FamilyScreen() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const { data: group, isLoading: loadingGroup } = useQuery({
+    queryKey: ['familyGroupCurrent'],
+    queryFn: getFamilyGroupCurrent,
+  });
+
+  const { data: profile } = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getUserProfile,
+  });
+  const selfUserId = profile?.id ?? '';
+
+  const [recipientUserId, setRecipientUserId] = useState<string | null>(null);
+  const [wakeAt, setWakeAt] = useState('07:30');
+  const [messageText, setMessageText] = useState('');
+  const [repeatDays, setRepeatDays] = useState<number[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const allowedRecipients = useMemo(
+    () => filterFamilyAlarmRecipients(group?.members ?? [], selfUserId),
+    [group, selfUserId],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: createFamilyAlarmText,
+    onSuccess: (res) => {
+      setSuccessMsg(`알람이 예약되었습니다 (${res.alarm.wake_at}).`);
+      setFormError(null);
+      setMessageText('');
+      queryClient.invalidateQueries({ queryKey: ['alarms'] });
+    },
+    onError: (err: unknown) => {
+      setFormError(getApiErrorMessage(err, '알람 예약에 실패했습니다.'));
+      setSuccessMsg(null);
+    },
+  });
+
+  function toggleDay(d: number) {
+    setRepeatDays((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d].sort((a, b) => a - b),
+    );
+  }
+
+  function handleSubmit() {
+    setSuccessMsg(null);
+    const res = validateFamilyAlarmForm({
+      recipientUserId,
+      wakeAt,
+      messageText,
+      repeatDays,
+    });
+    if (!res.ok) {
+      setFormError(res.error);
+      return;
+    }
+    setFormError(null);
+    createMutation.mutate(res.payload);
+  }
+
+  if (loadingGroup) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top']}>
+        <View style={styles.centerContainer} accessibilityRole="progressbar">
+          <ActivityIndicator size="large" color={Colors.light.primary} />
+          <Text style={styles.loadingText}>가족 그룹을 불러오는 중…</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!group?.group) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top']}>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <Text style={styles.title}>{t('tab.family', '가족 알람')}</Text>
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyTitle}>아직 가족 그룹이 없어요</Text>
+            <Text style={styles.emptyDesc}>
+              설정에서 가족 플랜을 결제하거나 초대 코드를 입력해 참여해 주세요.
+            </Text>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <Text style={styles.title}>{t('tab.family', '가족 알람')}</Text>
+
+        <Text style={styles.sectionTitle}>가족 그룹 멤버</Text>
+        <View style={styles.memberList}>
+          {group.members.map((m) => (
+            <MemberRow key={m.id} member={m} isSelf={m.user_id === selfUserId} />
+          ))}
+        </View>
+
+        {allowedRecipients.length === 0 ? (
+          <View style={styles.infoCard} accessibilityRole="alert">
+            <Text style={styles.infoText}>
+              가족 알람을 허용한 멤버가 없습니다. 각자 설정에서 '가족이 내게 알람 추가 허용'을 켜야
+              알람을 예약할 수 있습니다.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.formCard}>
+            <Text style={styles.formLabel}>수신자</Text>
+            <View style={styles.recipientRow}>
+              {allowedRecipients.map((m) => {
+                const active = recipientUserId === m.user_id;
+                return (
+                  <TouchableOpacity
+                    key={m.user_id}
+                    onPress={() => setRecipientUserId(m.user_id)}
+                    style={[styles.recipientChip, active && styles.recipientChipActive]}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                  >
+                    <Text
+                      style={[
+                        styles.recipientChipText,
+                        active && styles.recipientChipTextActive,
+                      ]}
+                    >
+                      {buildMemberDisplayName(m)}
+                      {m.role === 'owner' ? ' (소유자)' : ''}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <Text style={styles.formLabel}>기상 시간 (HH:mm)</Text>
+            <TextInput
+              value={wakeAt}
+              onChangeText={setWakeAt}
+              placeholder="07:30"
+              placeholderTextColor={Colors.light.textTertiary}
+              maxLength={5}
+              keyboardType="numbers-and-punctuation"
+              style={styles.input}
+              accessibilityLabel="기상 시간"
+            />
+
+            <Text style={styles.formLabel}>메시지 (최대 500자)</Text>
+            <TextInput
+              value={messageText}
+              onChangeText={setMessageText}
+              placeholder="예: 좋은 아침! 오늘도 힘내자"
+              placeholderTextColor={Colors.light.textTertiary}
+              multiline
+              numberOfLines={3}
+              maxLength={500}
+              style={[styles.input, styles.textarea]}
+              accessibilityLabel="알람 메시지 내용"
+            />
+            <Text style={styles.counter}>{messageText.length}/500</Text>
+
+            <Text style={styles.formLabel}>반복 요일 (선택)</Text>
+            <View style={styles.daysRow}>
+              {WEEKDAYS.map(({ label, value }) => {
+                const active = repeatDays.includes(value);
+                return (
+                  <TouchableOpacity
+                    key={value}
+                    onPress={() => toggleDay(value)}
+                    style={[styles.dayPill, active && styles.dayPillActive]}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                  >
+                    <Text style={[styles.dayText, active && styles.dayTextActive]}>{label}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            {formError ? (
+              <Text style={styles.errorText} accessibilityRole="alert">
+                {formError}
+              </Text>
+            ) : null}
+            {successMsg ? (
+              <Text style={styles.successText} accessibilityRole="text">
+                {successMsg}
+              </Text>
+            ) : null}
+
+            <TouchableOpacity
+              style={[styles.submitBtn, createMutation.isPending && styles.submitBtnDisabled]}
+              onPress={handleSubmit}
+              disabled={createMutation.isPending}
+              accessibilityRole="button"
+            >
+              <Text style={styles.submitText}>
+                {createMutation.isPending ? '예약 중…' : '알람 예약'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function MemberRow({ member, isSelf }: { member: FamilyGroupMember; isSelf: boolean }) {
+  const label = buildMemberDisplayName(member);
+  const roleBadge = member.role === 'owner' ? '소유자' : '멤버';
+  return (
+    <View style={styles.memberRow}>
+      <View style={styles.memberAvatar}>
+        <Text style={styles.memberAvatarText}>{label.slice(0, 1).toUpperCase()}</Text>
+      </View>
+      <View style={styles.memberInfo}>
+        <View style={styles.memberNameRow}>
+          <Text style={styles.memberName} numberOfLines={1}>
+            {label}
+          </Text>
+          {isSelf && <Text style={styles.memberSelfTag}>(나)</Text>}
+        </View>
+        <Text style={styles.memberRole}>{roleBadge}</Text>
+      </View>
+      <View
+        style={[
+          styles.allowBadge,
+          member.allow_family_alarms ? styles.allowBadgeOn : styles.allowBadgeOff,
+        ]}
+      >
+        <Text
+          style={[
+            styles.allowBadgeText,
+            member.allow_family_alarms ? styles.allowBadgeTextOn : styles.allowBadgeTextOff,
+          ]}
+        >
+          {member.allow_family_alarms ? '알람 허용' : '알람 거부'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: Colors.light.background },
+  scrollContent: { padding: Spacing.md, paddingBottom: Spacing.xxl },
+  centerContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: Spacing.md },
+  loadingText: { color: Colors.light.textSecondary, fontSize: FontSize.sm },
+  title: {
+    fontSize: FontSize.xxl,
+    fontWeight: '800',
+    color: Colors.light.text,
+    marginBottom: Spacing.md,
+  },
+  sectionTitle: {
+    fontSize: FontSize.lg,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: Spacing.sm,
+  },
+  memberList: { gap: Spacing.sm, marginBottom: Spacing.lg },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    padding: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.light.surface,
+  },
+  memberAvatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.light.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  memberAvatarText: { color: '#FFFFFF', fontWeight: '700' },
+  memberInfo: { flex: 1, minWidth: 0 },
+  memberNameRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  memberName: { fontWeight: '600', color: Colors.light.text, fontSize: FontSize.md },
+  memberSelfTag: { fontSize: FontSize.xs, color: Colors.light.textTertiary },
+  memberRole: { fontSize: FontSize.xs, color: Colors.light.textSecondary },
+  allowBadge: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 4,
+    borderRadius: BorderRadius.full,
+  },
+  allowBadgeOn: { backgroundColor: '#DCFCE7' },
+  allowBadgeOff: { backgroundColor: Colors.light.border },
+  allowBadgeText: { fontSize: FontSize.xs, fontWeight: '700' },
+  allowBadgeTextOn: { color: Colors.light.success },
+  allowBadgeTextOff: { color: Colors.light.textTertiary },
+  emptyCard: {
+    padding: Spacing.lg,
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.lg,
+    gap: Spacing.sm,
+  },
+  emptyTitle: { fontSize: FontSize.lg, fontWeight: '700', color: Colors.light.text },
+  emptyDesc: { color: Colors.light.textSecondary, fontSize: FontSize.sm, lineHeight: 20 },
+  infoCard: {
+    padding: Spacing.md,
+    backgroundColor: Colors.light.surfaceVariant,
+    borderRadius: BorderRadius.lg,
+  },
+  infoText: { color: Colors.light.textSecondary, fontSize: FontSize.sm, lineHeight: 20 },
+  formCard: {
+    padding: Spacing.md,
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.lg,
+    gap: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+  },
+  formLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: '600',
+    color: Colors.light.text,
+    marginTop: Spacing.xs,
+  },
+  recipientRow: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.xs },
+  recipientChip: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 6,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.light.surfaceVariant,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+  },
+  recipientChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  recipientChipText: { fontSize: FontSize.sm, color: Colors.light.text, fontWeight: '600' },
+  recipientChipTextActive: { color: '#FFFFFF' },
+  input: {
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.sm,
+    backgroundColor: Colors.light.surfaceVariant,
+    color: Colors.light.text,
+    fontSize: FontSize.md,
+  },
+  textarea: { minHeight: 80, textAlignVertical: 'top' },
+  counter: {
+    textAlign: 'right',
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
+  },
+  daysRow: { flexDirection: 'row', gap: 6 },
+  dayPill: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: Colors.light.surfaceVariant,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dayPillActive: { backgroundColor: Colors.light.primary },
+  dayText: { fontSize: FontSize.sm, color: Colors.light.textSecondary, fontWeight: '700' },
+  dayTextActive: { color: '#FFFFFF' },
+  errorText: { color: Colors.light.error, fontSize: FontSize.sm },
+  successText: { color: Colors.light.success, fontSize: FontSize.sm },
+  submitBtn: {
+    marginTop: Spacing.sm,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.light.primary,
+    alignItems: 'center',
+  },
+  submitBtnDisabled: { opacity: 0.6 },
+  submitText: { color: '#FFFFFF', fontWeight: '700', fontSize: FontSize.md },
+});

--- a/apps/mobile/src/i18n/en.json
+++ b/apps/mobile/src/i18n/en.json
@@ -36,6 +36,7 @@
     "voices": "Voices",
     "alarms": "Alarms",
     "friends": "Friends",
+    "family": "Family",
     "library": "Library",
     "settings": "Settings"
   },

--- a/apps/mobile/src/i18n/ko.json
+++ b/apps/mobile/src/i18n/ko.json
@@ -36,6 +36,7 @@
     "voices": "음성",
     "alarms": "알람",
     "friends": "친구",
+    "family": "가족",
     "library": "보관함",
     "settings": "설정"
   },

--- a/apps/mobile/src/lib/familyAlarmForm.ts
+++ b/apps/mobile/src/lib/familyAlarmForm.ts
@@ -1,0 +1,62 @@
+import type { FamilyGroupMember, FamilyAlarmCreatePayload } from '../services/api';
+
+export interface FamilyAlarmFormInput {
+  recipientUserId: string | null;
+  wakeAt: string;
+  messageText: string;
+  repeatDays: number[];
+  voiceProfileId?: string | null;
+}
+
+export type ValidationResult =
+  | { ok: true; payload: FamilyAlarmCreatePayload }
+  | { ok: false; error: string };
+
+export function filterFamilyAlarmRecipients(
+  members: FamilyGroupMember[],
+  selfUserId: string,
+): FamilyGroupMember[] {
+  return members
+    .filter((m) => m.user_id !== selfUserId && m.allow_family_alarms)
+    .slice()
+    .sort((a, b) => {
+      if (a.role !== b.role) return a.role === 'owner' ? -1 : 1;
+      return a.joined_at.localeCompare(b.joined_at);
+    });
+}
+
+export function validateFamilyAlarmForm(input: FamilyAlarmFormInput): ValidationResult {
+  if (!input.recipientUserId) {
+    return { ok: false, error: '수신자를 선택해주세요.' };
+  }
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(input.wakeAt)) {
+    return { ok: false, error: '시간 형식이 올바르지 않습니다 (HH:mm).' };
+  }
+  const text = input.messageText.trim();
+  if (text.length === 0) {
+    return { ok: false, error: '메시지를 입력해주세요.' };
+  }
+  if (text.length > 500) {
+    return { ok: false, error: '메시지는 500자 이하여야 합니다.' };
+  }
+
+  const payload: FamilyAlarmCreatePayload = {
+    recipient_user_id: input.recipientUserId,
+    wake_at: input.wakeAt,
+    message_text: text,
+  };
+  const days = Array.isArray(input.repeatDays)
+    ? Array.from(new Set(input.repeatDays.filter((n) => Number.isInteger(n) && n >= 0 && n <= 6)))
+        .sort((a, b) => a - b)
+    : [];
+  if (days.length > 0) payload.repeat_days = days;
+  if (input.voiceProfileId) payload.voice_profile_id = input.voiceProfileId;
+
+  return { ok: true, payload };
+}
+
+export function buildMemberDisplayName(m: FamilyGroupMember): string {
+  if (m.name && m.name.trim().length > 0) return m.name;
+  if (m.email) return m.email;
+  return '이름 미지정';
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -484,3 +484,57 @@ export async function getVouchers() {
   const data = await get<{ vouchers: VoucherItem[] }>('/billing/vouchers');
   return data.vouchers;
 }
+
+// ===== Family Group / Family Alarm API =====
+
+export interface FamilyGroupMember {
+  id: string;
+  user_id: string;
+  role: 'owner' | 'member';
+  joined_at: string;
+  email: string | null;
+  name: string | null;
+  picture: string | null;
+  allow_family_alarms: boolean;
+}
+
+export interface FamilyGroupCurrent {
+  group: {
+    id: string;
+    owner_user_id: string;
+    plan_id: string;
+    max_members: number;
+    created_at: string;
+  } | null;
+  role: 'owner' | 'member' | null;
+  members: FamilyGroupMember[];
+}
+
+export interface FamilyAlarmCreatePayload {
+  recipient_user_id: string;
+  wake_at: string;
+  message_text: string;
+  repeat_days?: number[];
+  voice_profile_id?: string;
+}
+
+export interface FamilyAlarmCreateResponse {
+  alarm: {
+    id: string;
+    sender_user_id: string;
+    recipient_user_id: string;
+    wake_at: string;
+    repeat_days: number[];
+    mode: 'tts';
+    voice_profile_id: string;
+  };
+  message: { id: string; text: string; category: string };
+}
+
+export async function getFamilyGroupCurrent() {
+  return get<FamilyGroupCurrent>('/family/groups/current');
+}
+
+export async function createFamilyAlarmText(payload: FamilyAlarmCreatePayload) {
+  return post<FamilyAlarmCreateResponse>('/family/alarms', payload);
+}

--- a/apps/mobile/test/familyAlarmForm.test.ts
+++ b/apps/mobile/test/familyAlarmForm.test.ts
@@ -1,0 +1,139 @@
+import {
+  buildMemberDisplayName,
+  filterFamilyAlarmRecipients,
+  validateFamilyAlarmForm,
+  type FamilyAlarmFormInput,
+} from '../src/lib/familyAlarmForm';
+import type { FamilyGroupMember } from '../src/services/api';
+
+function m(overrides: Partial<FamilyGroupMember> & { user_id: string }): FamilyGroupMember {
+  return {
+    id: `pgm-${overrides.user_id}`,
+    role: 'member',
+    joined_at: '2026-01-01T00:00:00.000Z',
+    email: null,
+    name: null,
+    picture: null,
+    allow_family_alarms: true,
+    ...overrides,
+  };
+}
+
+describe('filterFamilyAlarmRecipients', () => {
+  it('자기 자신을 제외한다', () => {
+    const members = [m({ user_id: 'self' }), m({ user_id: 'other' })];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result).toHaveLength(1);
+    expect(result[0].user_id).toBe('other');
+  });
+
+  it('allow_family_alarms=false 는 제외한다', () => {
+    const members = [
+      m({ user_id: 'a', allow_family_alarms: true }),
+      m({ user_id: 'b', allow_family_alarms: false }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['a']);
+  });
+
+  it('owner 를 member 보다 먼저 정렬한다', () => {
+    const members = [
+      m({ user_id: 'm1', role: 'member', joined_at: '2026-01-01T00:00:00.000Z' }),
+      m({ user_id: 'o1', role: 'owner', joined_at: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['o1', 'm1']);
+  });
+
+  it('같은 역할 내에서는 joined_at 오름차순', () => {
+    const members = [
+      m({ user_id: 'b', role: 'member', joined_at: '2026-03-01T00:00:00.000Z' }),
+      m({ user_id: 'a', role: 'member', joined_at: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const result = filterFamilyAlarmRecipients(members, 'self');
+    expect(result.map((r) => r.user_id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('validateFamilyAlarmForm', () => {
+  const base: FamilyAlarmFormInput = {
+    recipientUserId: 'user-x',
+    wakeAt: '07:30',
+    messageText: '안녕',
+    repeatDays: [],
+  };
+
+  it('정상 입력 → payload 반환', () => {
+    const result = validateFamilyAlarmForm({ ...base, repeatDays: [1, 3, 5] });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload).toEqual({
+      recipient_user_id: 'user-x',
+      wake_at: '07:30',
+      message_text: '안녕',
+      repeat_days: [1, 3, 5],
+    });
+  });
+
+  it('공백 문자 포함 메시지는 trim 됨', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: '  hi  ' });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.message_text).toBe('hi');
+  });
+
+  it('repeatDays 중복·범위 밖 제거 + 정렬', () => {
+    const result = validateFamilyAlarmForm({ ...base, repeatDays: [5, 1, 1, 7, -1, 3] });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.repeat_days).toEqual([1, 3, 5]);
+  });
+
+  it('빈 repeatDays 는 payload 에서 생략', () => {
+    const result = validateFamilyAlarmForm(base);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.repeat_days).toBeUndefined();
+  });
+
+  it('recipientUserId 없으면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, recipientUserId: null });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('수신자');
+  });
+
+  it('wakeAt 포맷 오류면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, wakeAt: '7:30' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('messageText 공백만이면 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: '   ' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('메시지');
+  });
+
+  it('messageText 500자 초과 에러', () => {
+    const result = validateFamilyAlarmForm({ ...base, messageText: 'a'.repeat(501) });
+    expect(result.ok).toBe(false);
+  });
+
+  it('voiceProfileId 전달 시 payload 에 포함', () => {
+    const result = validateFamilyAlarmForm({ ...base, voiceProfileId: 'vp-1' });
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.payload.voice_profile_id).toBe('vp-1');
+  });
+});
+
+describe('buildMemberDisplayName', () => {
+  it('name 이 있으면 name 사용', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', name: 'Alice' }))).toBe('Alice');
+  });
+  it('name 없고 email 있으면 email', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', email: 'a@b.com' }))).toBe('a@b.com');
+  });
+  it('둘 다 없으면 이름 미지정', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a' }))).toBe('이름 미지정');
+  });
+  it('name 이 빈 문자열이면 email fallback', () => {
+    expect(buildMemberDisplayName(m({ user_id: 'a', name: '   ', email: 'x@y.com' }))).toBe(
+      'x@y.com',
+    );
+  });
+});


### PR DESCRIPTION
## 요약
Phase 6 #38 — 모바일(React Native/Expo) 앱에서 가족 그룹 멤버에게 텍스트 알람을 예약할 수 있는 `가족` 탭을 추가합니다. 웹 대시보드(#37)와 동일한 폼/검증 계약을 재사용합니다.

## 주요 변경
- `apps/mobile/app/(tabs)/family.tsx` 신규 탭 스크린
  - 3-state UI: 로딩 / 그룹 없음 / 그룹 멤버 + 예약 폼
  - 수신자 칩 선택, 기상 시간 HH:mm, 메시지 500자, 반복 요일 토글
  - TanStack Query mutation 으로 `createFamilyAlarmText` 호출, 에러/성공 메시지
- `apps/mobile/src/lib/familyAlarmForm.ts` 순수 헬퍼
  - `filterFamilyAlarmRecipients` — self 제외, `allow_family_alarms=true` 만, owner→member 후 joined_at 오름차순
  - `validateFamilyAlarmForm` — HH:mm / trim / 500자 / repeatDays dedup+sort
  - `buildMemberDisplayName` — name → email → '이름 미지정'
- `apps/mobile/src/services/api.ts` — `FamilyGroupMember`/`FamilyGroupCurrent`/`FamilyAlarmCreatePayload`/`FamilyAlarmCreateResponse` 타입 + 두 엔드포인트
- `apps/mobile/app/(tabs)/_layout.tsx` — `family` 탭 등록 (아이콘 👨‍👩‍👧)
- i18n `ko.json`/`en.json` — `tab.family`
- jest 테스트 17개 신규 (familyAlarmForm)

## 테스트
- [x] mobile jest: 9 suites / 91 tests — 모두 그린 (familyAlarmForm 신규 17 포함)
- [x] mobile tsc --noEmit: 에러 없음
- [x] backend vitest: 28 files / 409 tests — 그린 유지
- [x] web vitest: 8 files / 64 tests — 그린 유지
- [x] Perso.ai/ElevenLabs/결제 PG 실호출 없음 (텍스트 모드 전용)

Closes #87