### PR TITLE
feat(backend): 경험치 규칙 문서 + 순수 함수 추가 (#93)

### DIFF
--- a/docs/XP_RULES.md
+++ b/docs/XP_RULES.md
@@ -1,0 +1,102 @@
+# 경험치(XP) 규칙
+
+Phase 7 게이미피케이션에서 캐릭터가 획득하는 XP·애정도 규칙을 정의한다. 이 문서가 **단일 사실 소스(SSOT)** 이며, 실제 로직은 `packages/backend/src/lib/xpRules.ts` 에 이 문서와 동일한 수치로 구현한다.
+
+## 배경
+
+- Phase 7 #40 (#91) 에서 `characters` 테이블과 XP→레벨 임계 공식(`100 * (n-1)^2`)을 도입.
+- #42 XP 지급 API 를 만들기 전에 "어떤 행동이 몇 XP 를 주는가" 를 한곳에서 결정해야 향후 밸런싱이 쉬움.
+- 목표: **MVP 수준에서 일관된 피드백 루프** — 알람을 끝까지 듣는 긍정 행동을 장려, 강제 종료·스팸성 지급은 차단.
+
+## 이벤트 → XP / 애정도 매핑
+
+| 이벤트 (`XpEvent`)        | XP | 애정도 | 의미                                        |
+| ------------------------- | -- | ------ | ------------------------------------------- |
+| `alarm_completed`         | 30 | 2      | 알람을 끝까지 듣고 정상 종료                |
+| `alarm_snoozed`           | 5  | 0      | 스누즈 버튼 — 소량만 지급, 애정도는 없음    |
+| `alarm_dismissed`         | 0  | 0      | 강제 종료 / 재생 없이 무시                  |
+| `family_alarm_received`   | 10 | 3      | 가족이 보낸 알람을 성공적으로 수신·재생     |
+| `friend_invited`          | 50 | 5      | 친구 초대가 수락됨 (성장 초반 부스터)       |
+
+### 설계 근거
+
+- **30 vs 5 vs 0**: 정상 완료(30)는 스누즈(5)의 6배. 스누즈를 계속 눌러 XP 파밍하는 유인을 막고, 강제 종료는 보상 없음.
+- **가족 알람 10·3**: 개인 알람(30/2)보다 적지만 **애정도는 더 크다**. 게이미피케이션이 관계 기반 앱 본질과 맞닿도록 — 가족 간 교류가 잦을수록 감정 척도(affection)가 빨리 올라감.
+- **친구 초대 50·5**: 1회성 부스터. 네트워크 효과를 초기에 유도.
+
+## 일일 XP 캡
+
+- `DAILY_XP_CAP = 200 XP`
+- 오늘 이미 획득한 XP(=`alreadyEarnedToday`) 기준. 자정(사용자 로컬) 기준 리셋은 #42 API 구현 시 DB 쪽에서 관리.
+- **정확한 반감 규칙**: 지급 요청 XP 가 남은 캡을 넘으면 **남은 몫만 지급**하고 `capped=true` 플래그를 리턴. 예시:
+  - `already=190, earned=30` → `grantedXp=10, capped=true`
+  - `already=200, earned=30` → `grantedXp=0, capped=true`
+  - `already=0, earned=30` → `grantedXp=30, capped=false`
+
+### 왜 **애정도는 캡이 없는가**
+
+- XP 캡은 "레벨 인플레이션 방지" 목적이라 의도적으로 엄격.
+- 애정도는 **관계 상태 표현** 척도 — 가족/친구와 교류하는 날은 그 크기만큼 반영돼야 직관적. (ex. 가족 알람을 하루 10번 받으면 XP 는 캡에 막혀도 애정도는 30 증가)
+- 악용 가능성은 이벤트 발행 조건(수신자 측 재생 성공 등) 에서 방어.
+
+## 순수 함수 계약
+
+`packages/backend/src/lib/xpRules.ts` 에서 제공:
+
+```ts
+type XpEvent =
+  | 'alarm_completed'
+  | 'alarm_snoozed'
+  | 'alarm_dismissed'
+  | 'family_alarm_received'
+  | 'friend_invited';
+
+const DAILY_XP_CAP = 200;
+
+function computeXpForEvent(event: XpEvent): number;
+function computeAffectionForEvent(event: XpEvent): number;
+function isXpEvent(value: unknown): value is XpEvent;
+
+interface DailyCapResult {
+  grantedXp: number;
+  capped: boolean;
+  remainingCap: number;
+}
+function applyDailyXpCap(
+  earned: number,
+  alreadyEarnedToday: number,
+  cap?: number,
+): DailyCapResult;
+
+interface GrantResult {
+  xp: DailyCapResult;
+  affection: number;
+  event: XpEvent;
+}
+function computeGrant(
+  event: XpEvent,
+  alreadyEarnedToday: number,
+  cap?: number,
+): GrantResult;
+```
+
+## 엣지 케이스·방어
+
+- `earned` 가 0 이하이거나 `NaN` → `grantedXp=0, capped=false`. 캡을 건드리지 않는다.
+- `alreadyEarnedToday` 가 음수 → 0 으로 간주.
+- `cap` 이 비유한이면 0 으로 처리 → 모든 지급이 차단됨. (0 은 테스트 시나리오용)
+- `computeXpForEvent` 는 화이트리스트 외 값은 TS 컴파일 단에서 차단. 런타임 입력은 `isXpEvent` 가드로 방어.
+
+## 다음 단계 (#42 범위)
+
+1. `POST /api/characters/xp { event, occurred_at?, client_nonce? }` 라우트 신설.
+2. 서버가 `alreadyEarnedToday` 를 DB 에서 조회(`characters.daily_xp` 또는 별도 `character_xp_logs` 테이블) → `computeGrant` 호출 → 트랜잭션으로 `xp += grantedXp, affection += affection` 업데이트.
+3. `characters.level`·`stage` 는 응답 시 `computeLevelFromXp`/`computeStageFromLevel` 로 재계산 + DB 에도 동기화.
+4. 중복 지급 방지 — `(user_id, client_nonce)` 유니크 인덱스로 idempotent.
+
+## 향후 조정 여지 (Phase 10)
+
+- 요일 보너스 / 주간 미션 / 연속 일 수 보너스.
+- `alarm_snoozed` 를 0 으로 강등할지 모니터링 (스누즈 남용 시).
+- `family_alarm_received` 를 `family_alarm_opened` vs `...replayed` 로 세분화.
+- 국가별 아침 시간대 보정 (04~07시 정상 완료 시 +α 등).

--- a/packages/backend/src/lib/xpRules.ts
+++ b/packages/backend/src/lib/xpRules.ts
@@ -1,0 +1,103 @@
+export type XpEvent =
+  | 'alarm_completed'
+  | 'alarm_snoozed'
+  | 'alarm_dismissed'
+  | 'family_alarm_received'
+  | 'friend_invited';
+
+export const DAILY_XP_CAP = 200;
+
+const XP_TABLE: Record<XpEvent, number> = {
+  alarm_completed: 30,
+  alarm_snoozed: 5,
+  alarm_dismissed: 0,
+  family_alarm_received: 10,
+  friend_invited: 50,
+};
+
+const AFFECTION_TABLE: Record<XpEvent, number> = {
+  alarm_completed: 2,
+  alarm_snoozed: 0,
+  alarm_dismissed: 0,
+  family_alarm_received: 3,
+  friend_invited: 5,
+};
+
+export function isXpEvent(value: unknown): value is XpEvent {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(XP_TABLE, value)
+  );
+}
+
+export function computeXpForEvent(event: XpEvent): number {
+  return XP_TABLE[event];
+}
+
+export function computeAffectionForEvent(event: XpEvent): number {
+  return AFFECTION_TABLE[event];
+}
+
+export interface DailyCapResult {
+  grantedXp: number;
+  capped: boolean;
+  remainingCap: number;
+}
+
+/**
+ * 일일 XP 캡 적용.
+ * - earned 가 0 이하이거나 비유한이면 0 지급 (capped=false).
+ * - alreadyEarnedToday 가 이미 cap 이상이면 0 지급 (capped=true).
+ * - 합산이 cap 을 넘기면 남은 몫만 지급 (capped=true).
+ */
+export function applyDailyXpCap(
+  earned: number,
+  alreadyEarnedToday: number,
+  cap: number = DAILY_XP_CAP,
+): DailyCapResult {
+  const safeEarned = Number.isFinite(earned) && earned > 0 ? Math.floor(earned) : 0;
+  const safeAlready =
+    Number.isFinite(alreadyEarnedToday) && alreadyEarnedToday > 0
+      ? Math.floor(alreadyEarnedToday)
+      : 0;
+  const safeCap = Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : 0;
+
+  const remainingCap = Math.max(safeCap - safeAlready, 0);
+
+  if (safeEarned === 0) {
+    return { grantedXp: 0, capped: false, remainingCap };
+  }
+  if (remainingCap === 0) {
+    return { grantedXp: 0, capped: true, remainingCap: 0 };
+  }
+  if (safeEarned <= remainingCap) {
+    return {
+      grantedXp: safeEarned,
+      capped: false,
+      remainingCap: remainingCap - safeEarned,
+    };
+  }
+  return { grantedXp: remainingCap, capped: true, remainingCap: 0 };
+}
+
+/**
+ * 단일 진입점 — 이벤트와 오늘 이미 획득한 XP 를 받아 최종 지급치 + 애정도 반환.
+ * 애정도는 일일 캡 영향을 받지 않음 (정서적 보상은 계속 누적).
+ */
+export interface GrantResult {
+  xp: DailyCapResult;
+  affection: number;
+  event: XpEvent;
+}
+
+export function computeGrant(
+  event: XpEvent,
+  alreadyEarnedToday: number,
+  cap: number = DAILY_XP_CAP,
+): GrantResult {
+  const earned = computeXpForEvent(event);
+  const xp = applyDailyXpCap(earned, alreadyEarnedToday, cap);
+  // 애정도는 일일 XP 캡의 영향을 받지 않는다 — 정서적 보상은 계속 누적.
+  const affection = computeAffectionForEvent(event);
+  return { xp, affection, event };
+}

--- a/packages/backend/test/xpRules.test.ts
+++ b/packages/backend/test/xpRules.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DAILY_XP_CAP,
+  applyDailyXpCap,
+  computeAffectionForEvent,
+  computeGrant,
+  computeXpForEvent,
+  isXpEvent,
+} from '../src/lib/xpRules';
+
+describe('computeXpForEvent', () => {
+  it('alarm_completed=30, alarm_snoozed=5, alarm_dismissed=0', () => {
+    expect(computeXpForEvent('alarm_completed')).toBe(30);
+    expect(computeXpForEvent('alarm_snoozed')).toBe(5);
+    expect(computeXpForEvent('alarm_dismissed')).toBe(0);
+  });
+
+  it('family_alarm_received=10, friend_invited=50', () => {
+    expect(computeXpForEvent('family_alarm_received')).toBe(10);
+    expect(computeXpForEvent('friend_invited')).toBe(50);
+  });
+});
+
+describe('computeAffectionForEvent', () => {
+  it('alarm_completed=2, family_alarm_received=3, friend_invited=5', () => {
+    expect(computeAffectionForEvent('alarm_completed')).toBe(2);
+    expect(computeAffectionForEvent('family_alarm_received')).toBe(3);
+    expect(computeAffectionForEvent('friend_invited')).toBe(5);
+  });
+
+  it('스누즈·강제 종료는 애정도 0', () => {
+    expect(computeAffectionForEvent('alarm_snoozed')).toBe(0);
+    expect(computeAffectionForEvent('alarm_dismissed')).toBe(0);
+  });
+});
+
+describe('isXpEvent', () => {
+  it('정의된 이벤트 이름이면 true', () => {
+    expect(isXpEvent('alarm_completed')).toBe(true);
+    expect(isXpEvent('friend_invited')).toBe(true);
+  });
+
+  it('오타·타입 오염은 false', () => {
+    expect(isXpEvent('alarm_complete')).toBe(false);
+    expect(isXpEvent(42)).toBe(false);
+    expect(isXpEvent(null)).toBe(false);
+    expect(isXpEvent(undefined)).toBe(false);
+  });
+});
+
+describe('applyDailyXpCap', () => {
+  it('여유 내에서는 그대로 지급 + capped=false', () => {
+    expect(applyDailyXpCap(30, 0)).toEqual({
+      grantedXp: 30,
+      capped: false,
+      remainingCap: 170,
+    });
+  });
+
+  it('정확히 캡 도달 → 전부 지급, remainingCap=0, capped=false', () => {
+    expect(applyDailyXpCap(50, 150)).toEqual({
+      grantedXp: 50,
+      capped: false,
+      remainingCap: 0,
+    });
+  });
+
+  it('캡 초과 → 남은 몫만 지급 + capped=true', () => {
+    expect(applyDailyXpCap(30, 190)).toEqual({
+      grantedXp: 10,
+      capped: true,
+      remainingCap: 0,
+    });
+  });
+
+  it('이미 캡 소진 → 0 지급 + capped=true', () => {
+    expect(applyDailyXpCap(30, 200)).toEqual({
+      grantedXp: 0,
+      capped: true,
+      remainingCap: 0,
+    });
+  });
+
+  it('earned=0 → capped=false, grantedXp=0 (캡은 발동 안 함)', () => {
+    expect(applyDailyXpCap(0, 100)).toEqual({
+      grantedXp: 0,
+      capped: false,
+      remainingCap: 100,
+    });
+  });
+
+  it('음수·NaN earned 방어', () => {
+    expect(applyDailyXpCap(-10, 0).grantedXp).toBe(0);
+    expect(applyDailyXpCap(Number.NaN, 0).grantedXp).toBe(0);
+  });
+
+  it('음수 alreadyEarnedToday 는 0 으로 처리', () => {
+    expect(applyDailyXpCap(30, -50)).toEqual({
+      grantedXp: 30,
+      capped: false,
+      remainingCap: 170,
+    });
+  });
+
+  it('custom cap 적용 가능', () => {
+    expect(applyDailyXpCap(60, 0, 50)).toEqual({
+      grantedXp: 50,
+      capped: true,
+      remainingCap: 0,
+    });
+  });
+
+  it('DAILY_XP_CAP 상수는 200', () => {
+    expect(DAILY_XP_CAP).toBe(200);
+  });
+});
+
+describe('computeGrant', () => {
+  it('여유 내 alarm_completed → xp 30 + 애정도 2', () => {
+    const r = computeGrant('alarm_completed', 0);
+    expect(r.event).toBe('alarm_completed');
+    expect(r.xp.grantedXp).toBe(30);
+    expect(r.xp.capped).toBe(false);
+    expect(r.affection).toBe(2);
+  });
+
+  it('캡 초과되어 일부만 지급돼도 애정도는 온전히 유지', () => {
+    const r = computeGrant('alarm_completed', 190);
+    expect(r.xp.grantedXp).toBe(10);
+    expect(r.xp.capped).toBe(true);
+    expect(r.affection).toBe(2);
+  });
+
+  it('강제 종료는 XP·애정도 모두 0', () => {
+    const r = computeGrant('alarm_dismissed', 0);
+    expect(r.xp.grantedXp).toBe(0);
+    expect(r.affection).toBe(0);
+  });
+
+  it('친구 초대 50 XP + 5 애정도', () => {
+    const r = computeGrant('friend_invited', 0);
+    expect(r.xp.grantedXp).toBe(50);
+    expect(r.affection).toBe(5);
+  });
+});


### PR DESCRIPTION
## 개요

- 이슈: #93
- 요약: Phase 7 #41 — 이벤트별 XP·애정도 규칙을 문서로 정의하고 순수 함수로 구현

## 변경 내용

### 문서 (`docs/XP_RULES.md`)
- 이벤트→XP/애정도 매핑표, 설계 근거(정상 완료 30 / 스누즈 5 / 강제 종료 0 / 가족 10+3 / 친구 초대 50+5)
- 일일 캡 200 + 초과/정확히 도달/이미 소진 시나리오 예시
- 애정도는 캡 영향을 받지 않는 근거
- 엣지 케이스 방어 규칙 명시
- #42 범위 안내 (지급 API 설계 방향)

### 순수 함수 (`lib/xpRules.ts`)
- `XpEvent` 유니온 타입 5종
- `DAILY_XP_CAP=200`
- `computeXpForEvent` / `computeAffectionForEvent` — 화이트리스트 조회
- `isXpEvent` — 런타임 가드
- `applyDailyXpCap(earned, already, cap?)` → `{ grantedXp, capped, remainingCap }`
- `computeGrant(event, already, cap?)` — 단일 진입점, XP·애정도 한 번에 계산

### 테스트 (`test/xpRules.test.ts`)
- 매핑 5건 / 가드 2건 / 캡 8건 (정확 도달/초과/음수/NaN/custom cap/상수 검증) / grant 4건

## 검증

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 448 그린 (기존 429 + 신규 19)
- [x] perso.ai / ElevenLabs / PG 실호출 없음

## 리스크 / 팔로업

- #42 에서 `POST /characters/xp` 구현 시 이 함수들을 호출하고, `characters.daily_xp` + `daily_xp_reset_at` (또는 `character_xp_logs`) 를 새로 추가해야 함.
- `alarm_snoozed` 5 XP 가 남용되지 않는지 Phase 10 에서 모니터링 필요.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)