### PR TITLE
feat(backend): XP 지급 API (POST /characters/xp) + 멱등성 로그 (#95)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -338,6 +338,31 @@ export const migrations: Migration[] = [
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_characters_user ON characters(user_id)',
     ],
   },
+  {
+    id: 12,
+    name: 'character-xp-logs',
+    statements: [
+      // 일일 XP 캡 관리: 지급 시점 날짜(YYYY-MM-DD) 와 달라지면 daily_xp 리셋.
+      `ALTER TABLE characters ADD COLUMN daily_xp INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE characters ADD COLUMN daily_xp_reset_at TEXT`,
+      // 지급 이력 + 멱등성 로그. client_nonce 가 있으면 (character_id, client_nonce) 유니크.
+      `CREATE TABLE IF NOT EXISTS character_xp_logs (
+        id TEXT PRIMARY KEY,
+        character_id TEXT NOT NULL REFERENCES characters(id),
+        event TEXT NOT NULL,
+        client_nonce TEXT,
+        granted_xp INTEGER NOT NULL DEFAULT 0,
+        affection_delta INTEGER NOT NULL DEFAULT 0,
+        capped INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now'))
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_character_xp_logs_character ON character_xp_logs(character_id)',
+      'CREATE INDEX IF NOT EXISTS idx_character_xp_logs_created ON character_xp_logs(created_at)',
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_character_xp_logs_nonce
+        ON character_xp_logs(character_id, client_nonce)
+        WHERE client_nonce IS NOT NULL`,
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/character.ts
+++ b/packages/backend/src/routes/character.ts
@@ -7,6 +7,7 @@ import {
   xpThresholdForLevel,
   type CharacterStage,
 } from '../lib/character';
+import { computeGrant, isXpEvent } from '../lib/xpRules';
 
 const character = new Hono<AppEnv>();
 
@@ -18,6 +19,8 @@ interface CharacterRow {
   xp: number;
   affection: number;
   stage: CharacterStage;
+  daily_xp: number;
+  daily_xp_reset_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -42,9 +45,35 @@ function rowToCharacter(row: Record<string, unknown>): CharacterRow {
     xp: Number(row.xp ?? 0),
     affection: Number(row.affection ?? 0),
     stage: (row.stage as CharacterStage) ?? 'seed',
+    daily_xp: Number(row.daily_xp ?? 0),
+    daily_xp_reset_at: (row.daily_xp_reset_at as string | null) ?? null,
     created_at: String(row.created_at ?? ''),
     updated_at: String(row.updated_at ?? ''),
   };
+}
+
+async function loadOrCreateCharacter(
+  db: ReturnType<typeof getDB>,
+  userPk: string,
+): Promise<CharacterRow> {
+  const existing = await db.execute({
+    sql: 'SELECT * FROM characters WHERE user_id = ?',
+    args: [userPk],
+  });
+  if (existing.rows.length > 0) {
+    return rowToCharacter(existing.rows[0] as Record<string, unknown>);
+  }
+  const id = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO characters (id, user_id, name, level, xp, affection, stage)
+          VALUES (?, ?, ?, 1, 0, 0, 'seed')`,
+    args: [id, userPk, '내 캐릭터'],
+  });
+  const created = await db.execute({
+    sql: 'SELECT * FROM characters WHERE id = ?',
+    args: [id],
+  });
+  return rowToCharacter(created.rows[0] as Record<string, unknown>);
 }
 
 function buildProgress(xp: number, level: number) {
@@ -60,6 +89,19 @@ function buildProgress(xp: number, level: number) {
   };
 }
 
+function serializeCharacter(row: CharacterRow) {
+  const level = computeLevelFromXp(row.xp);
+  const stage = computeStageFromLevel(level);
+  return {
+    character: { ...row, level, stage },
+    progress: buildProgress(row.xp, level),
+  };
+}
+
+function todayString(now: Date = new Date()): string {
+  return now.toISOString().split('T')[0];
+}
+
 /**
  * GET /characters/me
  * 현재 사용자의 캐릭터를 반환. 없으면 기본값(level=1, xp=0, stage='seed') 으로 생성.
@@ -71,41 +113,115 @@ character.get('/me', async (c) => {
   const userPk = await resolveUserPk(db, userId);
   if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
 
-  const existing = await db.execute({
-    sql: 'SELECT * FROM characters WHERE user_id = ?',
-    args: [userPk],
-  });
+  const row = await loadOrCreateCharacter(db, userPk);
+  return c.json(serializeCharacter(row));
+});
 
-  let row: CharacterRow;
-  if (existing.rows.length === 0) {
-    const id = crypto.randomUUID();
-    await db.execute({
-      sql: `INSERT INTO characters (id, user_id, name, level, xp, affection, stage)
-            VALUES (?, ?, ?, 1, 0, 0, 'seed')`,
-      args: [id, userPk, '내 캐릭터'],
+/**
+ * POST /characters/xp { event, client_nonce? }
+ * 이벤트별 XP·애정도 지급. client_nonce 가 있으면 멱등 (중복 호출 시 기존 결과 반환).
+ * 날짜가 바뀌면 daily_xp 리셋 후 재산정.
+ */
+character.post('/xp', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const body = await c.req
+    .json<{ event?: unknown; client_nonce?: unknown }>()
+    .catch(() => ({ event: undefined, client_nonce: undefined }));
+
+  if (!isXpEvent(body.event)) {
+    return c.json({ error: '지원하지 않는 event 입니다' }, 400);
+  }
+  const event = body.event;
+  const clientNonce =
+    typeof body.client_nonce === 'string' && body.client_nonce.trim().length > 0
+      ? body.client_nonce.trim()
+      : null;
+
+  const userPk = await resolveUserPk(db, userId);
+  if (!userPk) return c.json({ error: '사용자를 찾을 수 없습니다' }, 404);
+
+  // 멱등성: 동일 client_nonce 로 이미 지급된 로그가 있으면 그대로 재응답.
+  if (clientNonce) {
+    const dup = await db.execute({
+      sql: `SELECT l.* FROM character_xp_logs l
+            JOIN characters c ON c.id = l.character_id
+            WHERE c.user_id = ? AND l.client_nonce = ?
+            LIMIT 1`,
+      args: [userPk, clientNonce],
     });
-    const created = await db.execute({
-      sql: 'SELECT * FROM characters WHERE id = ?',
-      args: [id],
-    });
-    row = rowToCharacter(created.rows[0] as Record<string, unknown>);
-  } else {
-    row = rowToCharacter(existing.rows[0] as Record<string, unknown>);
+    if (dup.rows.length > 0) {
+      const log = dup.rows[0] as Record<string, unknown>;
+      const row = await loadOrCreateCharacter(db, userPk);
+      const serialized = serializeCharacter(row);
+      return c.json({
+        ...serialized,
+        grant: {
+          event: String(log.event),
+          granted_xp: Number(log.granted_xp ?? 0),
+          affection: Number(log.affection_delta ?? 0),
+          capped: Number(log.capped ?? 0) === 1,
+          remaining_cap: 0,
+          duplicated: true,
+        },
+      });
+    }
   }
 
-  // 저장된 값이 헬퍼 결과와 다르면 신뢰할 수 있게 헬퍼 값으로 정규화해 노출.
-  const level = computeLevelFromXp(row.xp);
-  const stage = computeStageFromLevel(level);
-  const progress = buildProgress(row.xp, level);
+  const today = todayString();
+  const current = await loadOrCreateCharacter(db, userPk);
+  const dailyXpBase =
+    current.daily_xp_reset_at === today ? current.daily_xp : 0;
 
-  return c.json({
-    character: {
-      ...row,
-      level,
-      stage,
-    },
-    progress,
+  const grant = computeGrant(event, dailyXpBase);
+  const newXp = current.xp + grant.xp.grantedXp;
+  const newAffection = current.affection + grant.affection;
+  const newDailyXp = dailyXpBase + grant.xp.grantedXp;
+  const newLevel = computeLevelFromXp(newXp);
+  const newStage = computeStageFromLevel(newLevel);
+
+  await db.execute({
+    sql: `UPDATE characters
+          SET xp = ?, affection = ?, level = ?, stage = ?,
+              daily_xp = ?, daily_xp_reset_at = ?,
+              updated_at = datetime('now')
+          WHERE id = ?`,
+    args: [newXp, newAffection, newLevel, newStage, newDailyXp, today, current.id],
   });
+
+  const logId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO character_xp_logs
+          (id, character_id, event, client_nonce, granted_xp, affection_delta, capped)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      logId,
+      current.id,
+      event,
+      clientNonce,
+      grant.xp.grantedXp,
+      grant.affection,
+      grant.xp.capped ? 1 : 0,
+    ],
+  });
+
+  const refreshed = await loadOrCreateCharacter(db, userPk);
+  const serialized = serializeCharacter(refreshed);
+  return c.json(
+    {
+      ...serialized,
+      grant: {
+        event,
+        granted_xp: grant.xp.grantedXp,
+        affection: grant.affection,
+        capped: grant.xp.capped,
+        remaining_cap: grant.xp.remainingCap,
+        duplicated: false,
+      },
+    },
+    201,
+  );
 });
 
 export default character;

--- a/packages/backend/test/character.xp.test.ts
+++ b/packages/backend/test/character.xp.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import characterRoutes from '../src/routes/character';
+
+function buildApp(userId = 'google-1') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware(userId));
+  app.route('/characters', characterRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+const TODAY = new Date().toISOString().split('T')[0];
+
+function baseCharacter(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'char-1',
+    user_id: 'user-pk-1',
+    name: '내 캐릭터',
+    level: 1,
+    xp: 0,
+    affection: 0,
+    stage: 'seed',
+    daily_xp: 0,
+    daily_xp_reset_at: null,
+    created_at: '',
+    updated_at: '',
+    ...over,
+  };
+}
+
+describe('POST /characters/xp', () => {
+  it('event 검증 실패 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'unknown_event' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('event');
+  });
+
+  it('사용자 없음 → 404', async () => {
+    mockDB.pushResult([]); // resolveUserPk
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_completed' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('여유 내 alarm_completed → 201, XP +30, affection +2', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([baseCharacter()]); // loadOrCreateCharacter — existing
+    mockDB.pushResult([], 1); // UPDATE characters
+    mockDB.pushResult([], 1); // INSERT character_xp_logs
+    mockDB.pushResult([baseCharacter({ xp: 30, affection: 2, daily_xp: 30 })]); // refreshed
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_completed' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.grant.event).toBe('alarm_completed');
+    expect(body.grant.granted_xp).toBe(30);
+    expect(body.grant.affection).toBe(2);
+    expect(body.grant.capped).toBe(false);
+    expect(body.grant.duplicated).toBe(false);
+    expect(body.character.xp).toBe(30);
+    expect(body.character.level).toBe(1); // threshold(2)=100 → still 1
+    expect(body.character.stage).toBe('seed');
+  });
+
+  it('일일 캡 초과 → 남은 몫만 지급, capped=true', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([
+      baseCharacter({
+        xp: 190,
+        affection: 10,
+        daily_xp: 190,
+        daily_xp_reset_at: TODAY,
+      }),
+    ]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([
+      baseCharacter({
+        xp: 200,
+        affection: 12, // 애정도는 캡과 무관하게 +2
+        daily_xp: 200,
+        daily_xp_reset_at: TODAY,
+      }),
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_completed' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.grant.granted_xp).toBe(10);
+    expect(body.grant.capped).toBe(true);
+    expect(body.grant.affection).toBe(2);
+    expect(body.character.xp).toBe(200);
+  });
+
+  it('날짜 바뀌면 daily_xp 리셋 후 재지급', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([
+      baseCharacter({
+        xp: 200,
+        daily_xp: 200, // 어제 캡 소진
+        daily_xp_reset_at: '2000-01-01',
+      }),
+    ]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([
+      baseCharacter({
+        xp: 230,
+        daily_xp: 30,
+        daily_xp_reset_at: TODAY,
+      }),
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_completed' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.grant.granted_xp).toBe(30);
+    expect(body.grant.capped).toBe(false);
+    expect(body.character.xp).toBe(230);
+    // UPDATE 에 today 바인딩 확인
+    const updateCall = mockDB.calls.find((c) => c.sql.startsWith('UPDATE characters'));
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args).toContain(TODAY);
+  });
+
+  it('client_nonce 중복 → 기존 로그 재응답, UPDATE/INSERT 호출 안 함', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([
+      {
+        id: 'log-1',
+        character_id: 'char-1',
+        event: 'alarm_completed',
+        client_nonce: 'nonce-abc',
+        granted_xp: 30,
+        affection_delta: 2,
+        capped: 0,
+        created_at: '2026-04-21',
+      },
+    ]); // duplicate lookup
+    mockDB.pushResult([baseCharacter({ xp: 30, affection: 2, daily_xp: 30 })]); // load for response
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', {
+        event: 'alarm_completed',
+        client_nonce: 'nonce-abc',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grant.duplicated).toBe(true);
+    expect(body.grant.granted_xp).toBe(30);
+    expect(body.grant.affection).toBe(2);
+    // UPDATE / INSERT 로그 호출이 없어야 함
+    expect(mockDB.calls.some((c) => c.sql.startsWith('UPDATE characters'))).toBe(false);
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO character_xp_logs'))).toBe(
+      false,
+    );
+  });
+
+  it('캐릭터 없으면 자동 생성 후 지급', async () => {
+    mockDB.pushResult([{ id: 'user-pk-2' }]); // resolveUserPk
+    // loadOrCreateCharacter (첫 호출) — 없음 → INSERT → SELECT
+    mockDB.pushResult([]); // SELECT characters
+    mockDB.pushResult([], 1); // INSERT characters
+    mockDB.pushResult([baseCharacter({ id: 'char-new', user_id: 'user-pk-2' })]); // SELECT after insert
+    mockDB.pushResult([], 1); // UPDATE characters
+    mockDB.pushResult([], 1); // INSERT log
+    mockDB.pushResult([
+      baseCharacter({
+        id: 'char-new',
+        user_id: 'user-pk-2',
+        xp: 30,
+        affection: 2,
+        daily_xp: 30,
+      }),
+    ]); // refreshed
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_completed' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.character.id).toBe('char-new');
+    expect(body.grant.granted_xp).toBe(30);
+  });
+
+  it('alarm_dismissed → XP 0, affection 0 이어도 로그는 남음', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([baseCharacter()]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([baseCharacter()]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/characters/xp', { event: 'alarm_dismissed' }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.grant.granted_xp).toBe(0);
+    expect(body.grant.affection).toBe(0);
+
+    const logInsert = mockDB.calls.find((c) =>
+      c.sql.includes('INSERT INTO character_xp_logs'),
+    );
+    expect(logInsert).toBeDefined();
+  });
+});

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -171,6 +171,22 @@ describe('migrations', () => {
     expect(all).toContain('idx_characters_user');
   });
 
+  it('마이그레이션 #12 에서 character_xp_logs 테이블 + daily_xp 컬럼 추가', () => {
+    const m = migrations.find((x) => x.id === 12);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('ALTER TABLE characters ADD COLUMN daily_xp');
+    expect(all).toContain('ALTER TABLE characters ADD COLUMN daily_xp_reset_at');
+    expect(all).toContain('CREATE TABLE IF NOT EXISTS character_xp_logs');
+    expect(all).toContain('character_id TEXT NOT NULL REFERENCES characters(id)');
+    expect(all).toContain('client_nonce TEXT');
+    expect(all).toContain('granted_xp INTEGER NOT NULL DEFAULT 0');
+    expect(all).toContain('affection_delta INTEGER NOT NULL DEFAULT 0');
+    expect(all).toContain('idx_character_xp_logs_character');
+    expect(all).toContain('idx_character_xp_logs_nonce');
+    expect(all).toContain('WHERE client_nonce IS NOT NULL');
+  });
+
   it('마이그레이션 #6 에서 기본 플랜 3종(free / plus_personal / family) 을 시드한다', () => {
     const m = migrations.find((x) => x.id === 6);
     expect(m).toBeDefined();


### PR DESCRIPTION
## 개요

- 이슈: #95
- 요약: Phase 7 #42 — 알람 정상 종료·가족 알람 수신 등 이벤트에 대해 서버가 XP/애정도를 지급하는 API

## 변경 내용

### 마이그레이션 #12 (`character-xp-logs`)
- `characters.daily_xp INTEGER NOT NULL DEFAULT 0`
- `characters.daily_xp_reset_at TEXT` (YYYY-MM-DD)
- `character_xp_logs` 테이블 (id, character_id FK, event, client_nonce, granted_xp, affection_delta, capped, created_at)
- `(character_id, client_nonce)` 유니크 partial index — **client_nonce IS NOT NULL** 일 때만 적용

### `POST /api/characters/xp`
- 요청 `{ event, client_nonce? }`
- `isXpEvent` 화이트리스트 검증 → 400
- 사용자 PK 없음 → 404
- `client_nonce` 가 있고 기존 로그에 동일 값이 있으면 기존 결과 재응답(`duplicated=true`, 200)
- `daily_xp_reset_at !== today` 면 `daily_xp=0` 으로 리셋 후 베이스 계산
- `computeGrant(event, dailyXpBase)` (#93 헬퍼) → granted_xp / affection / capped
- `characters` UPDATE + `character_xp_logs` INSERT
- 응답 201 `{ character, progress, grant: { event, granted_xp, affection, capped, remaining_cap, duplicated } }`

### 테스트 (`character.xp.test.ts`)
- 8건: 400(unknown event) / 404(user missing) / 정상(완료) / 캡 초과 / 날짜 리셋 / 멱등 중복 / 자동 생성 / dismissed 0 지급 로그

## 검증

- [x] `npx tsc --noEmit` 통과 (백엔드)
- [x] `npx vitest run` 457 그린 (기존 448 + 신규 9)
- [x] perso.ai / ElevenLabs / PG 실호출 없음

## 리스크 / 팔로업

- DB 트랜잭션은 libsql 웹 클라이언트에서 수동 BEGIN/COMMIT 지원이 제한되어 UPDATE→INSERT 를 순차 실행 — 둘 사이에 장애가 나면 로그 없이 XP 만 올라갈 여지. 실제로는 `INSERT or ROLLBACK` 패턴 or Cloudflare Durable Object 경로 고려 필요(후속 이슈).
- 친구 초대(`friend_invited`) 이벤트는 아직 호출부가 없음 — #32 플로우에서 연결할지는 별도 이슈.
- `daily_xp_reset_at` 는 서버 UTC 기준 날짜 — 사용자 타임존 보정은 Phase 10 개선 후보.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)