### PR TITLE
feat(web): 캐릭터 화면 + XP 지급 테스트 (#97)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,6 +12,7 @@ const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const FriendsPage = lazy(() => import('./pages/FriendsPage'));
 const GiftsPage = lazy(() => import('./pages/GiftsPage'));
 const FamilyAlarmsPage = lazy(() => import('./pages/FamilyAlarmsPage'));
+const CharacterPage = lazy(() => import('./pages/CharacterPage'));
 
 type Page =
   | 'dashboard'
@@ -19,6 +20,7 @@ type Page =
   | 'messages'
   | 'alarms'
   | 'family'
+  | 'character'
   | 'friends'
   | 'gifts'
   | 'settings';
@@ -29,6 +31,7 @@ const NAV_ITEMS: { key: Page; label: string; emoji: string }[] = [
   { key: 'messages', label: '메시지', emoji: '💌' },
   { key: 'alarms', label: '알람 설정', emoji: '⏰' },
   { key: 'family', label: '가족 알람', emoji: '🏠' },
+  { key: 'character', label: '내 캐릭터', emoji: '🌱' },
   { key: 'friends', label: '친구', emoji: '👥' },
   { key: 'gifts', label: '선물', emoji: '🎁' },
   { key: 'settings', label: '설정', emoji: '⚙️' },
@@ -71,6 +74,8 @@ export default function App() {
         return <AlarmsPage />;
       case 'family':
         return <FamilyAlarmsPage />;
+      case 'character':
+        return <CharacterPage />;
       case 'friends':
         return <FriendsPage />;
       case 'gifts':

--- a/packages/web/src/lib/character.ts
+++ b/packages/web/src/lib/character.ts
@@ -1,0 +1,110 @@
+export type CharacterStage = 'seed' | 'sprout' | 'tree' | 'bloom';
+
+const STAGE_EMOJI: Record<CharacterStage, string> = {
+  seed: '🌱',
+  sprout: '🌿',
+  tree: '🌳',
+  bloom: '🌸',
+};
+
+const STAGE_LABEL: Record<CharacterStage, string> = {
+  seed: '씨앗',
+  sprout: '새싹',
+  tree: '나무',
+  bloom: '꽃',
+};
+
+const DIALOGUES: Record<CharacterStage, readonly string[]> = {
+  seed: [
+    '조용히 자라고 있어요.',
+    '햇살이 필요해요. ☀️',
+    '물 주실래요?',
+    '아직은 작지만, 곧 자랄 거예요.',
+  ],
+  sprout: [
+    '새싹이 돋았어요!',
+    '바람이 기분 좋아요. 🌬️',
+    '오늘도 같이 깨워주세요.',
+    '조금씩 자라고 있어요.',
+  ],
+  tree: [
+    '그늘을 드리워 드릴게요. 🌳',
+    '오늘 알람 잘 들으셨나요?',
+    '나무가 되었어요!',
+    '가족도 같이 깨워봐요.',
+  ],
+  bloom: [
+    '꽃이 피었어요! 🌸',
+    '완전 잘 자랐죠?',
+    '함께 해주셔서 고마워요.',
+    '이 순간이 제일 좋아요.',
+  ],
+};
+
+export interface CharacterPayload {
+  stage?: CharacterStage | string;
+  xp?: number;
+  level?: number;
+}
+
+export interface ProgressPayload {
+  xp_into_level?: number;
+  xp_to_next_level?: number;
+  level_span?: number;
+  progress_ratio?: number;
+}
+
+export function normalizeStage(stage: unknown): CharacterStage {
+  if (stage === 'sprout' || stage === 'tree' || stage === 'bloom') return stage;
+  return 'seed';
+}
+
+export function stageToEmoji(stage: unknown): string {
+  return STAGE_EMOJI[normalizeStage(stage)];
+}
+
+export function stageToLabel(stage: unknown): string {
+  return STAGE_LABEL[normalizeStage(stage)];
+}
+
+export function listDialogues(stage: unknown): readonly string[] {
+  return DIALOGUES[normalizeStage(stage)];
+}
+
+/**
+ * 스테이지별 대사 랜덤 선택. rng 는 [0,1) 실수를 반환하는 함수(기본 Math.random).
+ * 테스트 결정성을 위해 주입 가능.
+ */
+export function pickRandomDialogue(
+  stage: unknown,
+  rng: () => number = Math.random,
+): string {
+  const list = DIALOGUES[normalizeStage(stage)];
+  if (list.length === 0) return '';
+  const safeRng = typeof rng === 'function' ? rng : Math.random;
+  const raw = safeRng();
+  const ratio = Number.isFinite(raw) ? Math.max(0, Math.min(raw, 0.999999)) : 0;
+  const idx = Math.floor(ratio * list.length);
+  return list[idx] ?? list[0];
+}
+
+/**
+ * 진행률 포맷 — "XP 120 / 400 (30%)"
+ * xp_into_level 이 음수거나 level_span 이 0 이하이면 "0 / 0 (0%)".
+ */
+export function formatProgress(progress: ProgressPayload | null | undefined): string {
+  const into = Math.max(Number(progress?.xp_into_level ?? 0), 0);
+  const span = Math.max(Number(progress?.level_span ?? 0), 0);
+  const ratio =
+    span > 0 && Number.isFinite(Number(progress?.progress_ratio))
+      ? Math.max(0, Math.min(Number(progress?.progress_ratio), 1))
+      : 0;
+  const pct = Math.round(ratio * 100);
+  return `XP ${into} / ${span} (${pct}%)`;
+}
+
+export function progressBarWidthPct(progress: ProgressPayload | null | undefined): number {
+  const ratio = Number(progress?.progress_ratio ?? 0);
+  if (!Number.isFinite(ratio)) return 0;
+  return Math.max(0, Math.min(ratio, 1)) * 100;
+}

--- a/packages/web/src/pages/CharacterPage.tsx
+++ b/packages/web/src/pages/CharacterPage.tsx
@@ -1,0 +1,160 @@
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getCharacterMe, grantCharacterXp } from '../services/api';
+import type { XpEvent } from '../services/api';
+import {
+  formatProgress,
+  pickRandomDialogue,
+  progressBarWidthPct,
+  stageToEmoji,
+  stageToLabel,
+} from '../lib/character';
+import { getApiErrorMessage } from '../types';
+
+const DEV_EVENTS: { event: XpEvent; label: string }[] = [
+  { event: 'alarm_completed', label: '알람 정상 종료 +30 XP' },
+  { event: 'alarm_snoozed', label: '스누즈 +5 XP' },
+  { event: 'family_alarm_received', label: '가족 알람 수신 +10 XP' },
+];
+
+export default function CharacterPage() {
+  const queryClient = useQueryClient();
+  const [dialogueSeed, setDialogueSeed] = useState(0);
+  const [lastGrantNotice, setLastGrantNotice] = useState<string | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['character-me'],
+    queryFn: getCharacterMe,
+  });
+
+  const grantMutation = useMutation({
+    mutationFn: grantCharacterXp,
+    onSuccess: (res) => {
+      const suffix = res.grant.capped ? ' (일일 캡 도달)' : '';
+      setLastGrantNotice(`+${res.grant.granted_xp} XP · +${res.grant.affection} 애정도${suffix}`);
+      queryClient.invalidateQueries({ queryKey: ['character-me'] });
+    },
+    onError: (err) => {
+      setLastGrantNotice(getApiErrorMessage(err, 'XP 지급 실패'));
+    },
+  });
+
+  const stage = data?.character.stage ?? 'seed';
+  const dialogue = useMemo(
+    () => pickRandomDialogue(stage, () => ((dialogueSeed * 9301 + 49297) % 233280) / 233280),
+    [stage, dialogueSeed],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64" role="status" aria-label="캐릭터 불러오는 중">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-primary)]" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-6 text-center text-[var(--color-text-secondary)]">
+        <p>캐릭터를 불러오지 못했어요.</p>
+        <p className="text-sm mt-2 text-red-400">{getApiErrorMessage(error, '알 수 없는 오류')}</p>
+      </div>
+    );
+  }
+
+  const { character, progress } = data;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-[var(--color-primary)]">내 캐릭터</h1>
+        <p className="text-sm text-[var(--color-text-tertiary)] mt-1">
+          알람을 잘 들을수록 캐릭터가 자라요.
+        </p>
+      </header>
+
+      <section
+        onClick={() => setDialogueSeed((n) => n + 1)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setDialogueSeed((n) => n + 1);
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label="캐릭터를 탭하면 새 대사가 나와요"
+        className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-8 text-center cursor-pointer hover:bg-[var(--color-surface-alt)] transition-colors"
+      >
+        <div className="text-7xl mb-4" aria-hidden="true">
+          {stageToEmoji(character.stage)}
+        </div>
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <span className="text-xl font-bold text-[var(--color-text)]">{character.name}</span>
+          <span className="px-2 py-0.5 rounded-full text-xs bg-[var(--color-primary)]/15 text-[var(--color-primary)]">
+            Lv.{character.level} · {stageToLabel(character.stage)}
+          </span>
+        </div>
+        <p className="text-sm text-[var(--color-text-secondary)]">{dialogue}</p>
+      </section>
+
+      <section className="mt-6 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-6">
+        <div className="flex justify-between items-baseline mb-2">
+          <span className="text-sm font-semibold text-[var(--color-text)]">성장 진행도</span>
+          <span className="text-xs text-[var(--color-text-tertiary)]">{formatProgress(progress)}</span>
+        </div>
+        <div
+          className="h-3 bg-[var(--color-surface-alt)] rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={Math.round(progressBarWidthPct(progress))}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="경험치 진행도"
+        >
+          <div
+            className="h-full bg-[var(--color-primary)] transition-all"
+            style={{ width: `${progressBarWidthPct(progress)}%` }}
+          />
+        </div>
+        <div className="mt-4 grid grid-cols-3 gap-3 text-center">
+          <div>
+            <div className="text-xs text-[var(--color-text-tertiary)]">총 XP</div>
+            <div className="text-lg font-bold">{character.xp}</div>
+          </div>
+          <div>
+            <div className="text-xs text-[var(--color-text-tertiary)]">애정도</div>
+            <div className="text-lg font-bold">💗 {character.affection}</div>
+          </div>
+          <div>
+            <div className="text-xs text-[var(--color-text-tertiary)]">오늘 획득</div>
+            <div className="text-lg font-bold">{character.daily_xp} / 200</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-6 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-6">
+        <h2 className="text-sm font-semibold mb-3 text-[var(--color-text)]">테스트용 XP 지급</h2>
+        <p className="text-xs text-[var(--color-text-tertiary)] mb-3">
+          실제 앱에서는 알람 종료/가족 알람 수신 시 자동으로 호출돼요.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {DEV_EVENTS.map((e) => (
+            <button
+              key={e.event}
+              onClick={() => grantMutation.mutate({ event: e.event })}
+              disabled={grantMutation.isPending}
+              className="px-3 py-2 text-xs rounded-lg bg-[var(--color-primary)]/10 text-[var(--color-primary)] hover:bg-[var(--color-primary)]/20 disabled:opacity-50 transition-colors"
+            >
+              {e.label}
+            </button>
+          ))}
+        </div>
+        {lastGrantNotice && (
+          <p className="mt-3 text-xs text-[var(--color-text-secondary)]" role="status">
+            {lastGrantNotice}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/services/api.ts
+++ b/packages/web/src/services/api.ts
@@ -434,4 +434,63 @@ export async function createFamilyAlarmText(
   return data;
 }
 
+export type CharacterStage = 'seed' | 'sprout' | 'tree' | 'bloom';
+
+export type XpEvent =
+  | 'alarm_completed'
+  | 'alarm_snoozed'
+  | 'alarm_dismissed'
+  | 'family_alarm_received'
+  | 'friend_invited';
+
+export interface CharacterPayload {
+  id: string;
+  user_id: string;
+  name: string;
+  level: number;
+  xp: number;
+  affection: number;
+  stage: CharacterStage;
+  daily_xp: number;
+  daily_xp_reset_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CharacterProgress {
+  xp_into_level: number;
+  xp_to_next_level: number;
+  level_span: number;
+  progress_ratio: number;
+}
+
+export interface CharacterResponse {
+  character: CharacterPayload;
+  progress: CharacterProgress;
+}
+
+export interface CharacterGrantResponse extends CharacterResponse {
+  grant: {
+    event: XpEvent;
+    granted_xp: number;
+    affection: number;
+    capped: boolean;
+    remaining_cap: number;
+    duplicated: boolean;
+  };
+}
+
+export async function getCharacterMe(): Promise<CharacterResponse> {
+  const { data } = await api.get<CharacterResponse>('/characters/me');
+  return data;
+}
+
+export async function grantCharacterXp(payload: {
+  event: XpEvent;
+  client_nonce?: string;
+}): Promise<CharacterGrantResponse> {
+  const { data } = await api.post<CharacterGrantResponse>('/characters/xp', payload);
+  return data;
+}
+
 export default api;

--- a/packages/web/test/character.test.ts
+++ b/packages/web/test/character.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatProgress,
+  listDialogues,
+  normalizeStage,
+  pickRandomDialogue,
+  progressBarWidthPct,
+  stageToEmoji,
+  stageToLabel,
+} from '../src/lib/character';
+
+describe('normalizeStage', () => {
+  it('유효한 스테이지는 그대로', () => {
+    expect(normalizeStage('seed')).toBe('seed');
+    expect(normalizeStage('sprout')).toBe('sprout');
+    expect(normalizeStage('tree')).toBe('tree');
+    expect(normalizeStage('bloom')).toBe('bloom');
+  });
+
+  it('알 수 없는 값은 seed 로 폴백', () => {
+    expect(normalizeStage('unknown')).toBe('seed');
+    expect(normalizeStage(null)).toBe('seed');
+    expect(normalizeStage(undefined)).toBe('seed');
+    expect(normalizeStage(42)).toBe('seed');
+  });
+});
+
+describe('stageToEmoji / stageToLabel', () => {
+  it('이모지 매핑', () => {
+    expect(stageToEmoji('seed')).toBe('🌱');
+    expect(stageToEmoji('sprout')).toBe('🌿');
+    expect(stageToEmoji('tree')).toBe('🌳');
+    expect(stageToEmoji('bloom')).toBe('🌸');
+  });
+
+  it('라벨 한국어 매핑', () => {
+    expect(stageToLabel('seed')).toBe('씨앗');
+    expect(stageToLabel('bloom')).toBe('꽃');
+  });
+});
+
+describe('listDialogues', () => {
+  it('스테이지별로 1개 이상의 대사 보유', () => {
+    for (const stage of ['seed', 'sprout', 'tree', 'bloom'] as const) {
+      expect(listDialogues(stage).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('pickRandomDialogue', () => {
+  it('결정성 — rng=0 은 첫 번째 대사', () => {
+    const list = listDialogues('seed');
+    expect(pickRandomDialogue('seed', () => 0)).toBe(list[0]);
+  });
+
+  it('결정성 — rng≈0.999 은 마지막 대사', () => {
+    const list = listDialogues('bloom');
+    expect(pickRandomDialogue('bloom', () => 0.9999)).toBe(list[list.length - 1]);
+  });
+
+  it('NaN rng 방어 → 첫 번째 대사', () => {
+    const list = listDialogues('tree');
+    expect(pickRandomDialogue('tree', () => Number.NaN)).toBe(list[0]);
+  });
+
+  it('알 수 없는 스테이지 → seed 의 대사 중 하나', () => {
+    const seedList = listDialogues('seed');
+    const picked = pickRandomDialogue('weird-stage', () => 0.5);
+    expect(seedList).toContain(picked);
+  });
+});
+
+describe('formatProgress', () => {
+  it('정상 — XP 120 / 400 (30%)', () => {
+    expect(
+      formatProgress({
+        xp_into_level: 120,
+        xp_to_next_level: 280,
+        level_span: 400,
+        progress_ratio: 0.3,
+      }),
+    ).toBe('XP 120 / 400 (30%)');
+  });
+
+  it('100% 도달', () => {
+    expect(
+      formatProgress({ xp_into_level: 100, level_span: 100, progress_ratio: 1 }),
+    ).toBe('XP 100 / 100 (100%)');
+  });
+
+  it('null/undefined → 0 / 0 (0%)', () => {
+    expect(formatProgress(null)).toBe('XP 0 / 0 (0%)');
+    expect(formatProgress(undefined)).toBe('XP 0 / 0 (0%)');
+  });
+
+  it('음수·NaN 방어', () => {
+    expect(
+      formatProgress({
+        xp_into_level: -10,
+        level_span: -5,
+        progress_ratio: Number.NaN,
+      }),
+    ).toBe('XP 0 / 0 (0%)');
+  });
+});
+
+describe('progressBarWidthPct', () => {
+  it('0..1 비율을 0..100 % 로', () => {
+    expect(progressBarWidthPct({ progress_ratio: 0 })).toBe(0);
+    expect(progressBarWidthPct({ progress_ratio: 0.5 })).toBe(50);
+    expect(progressBarWidthPct({ progress_ratio: 1 })).toBe(100);
+  });
+
+  it('범위 밖은 클램프', () => {
+    expect(progressBarWidthPct({ progress_ratio: -1 })).toBe(0);
+    expect(progressBarWidthPct({ progress_ratio: 5 })).toBe(100);
+  });
+});


### PR DESCRIPTION
## 개요

- 이슈: #97
- 요약: Phase 7 #43 — 웹 대시보드에 캐릭터 화면 추가. 레벨·스테이지 뱃지 + XP 게이지 바 + 탭 시 랜덤 대사 + 개발용 XP 지급 버튼

## 변경 내용

### 순수 함수 (`src/lib/character.ts`)
- `normalizeStage` — 미지 값은 seed 로 폴백 (런타임 방어)
- `stageToEmoji` seed🌱 sprout🌿 tree🌳 bloom🌸
- `stageToLabel` 씨앗/새싹/나무/꽃
- `pickRandomDialogue(stage, rng?)` — rng 주입 가능, NaN 방어, 결정성 테스트 가능
- `formatProgress` "XP 120 / 400 (30%)"
- `progressBarWidthPct` 0..100 클램프

### API 확장 (`src/services/api.ts`)
- `XpEvent` / `CharacterPayload` / `CharacterProgress` / `CharacterResponse` / `CharacterGrantResponse` 타입
- `getCharacterMe` / `grantCharacterXp`

### UI (`src/pages/CharacterPage.tsx`)
- 로딩/에러/정상 3 상태
- 캐릭터 이모지 대형 + Lv.N · 스테이지 뱃지
- 클릭·엔터·스페이스로 대사 교체 (dialogueSeed 증가)
- 진행도 섹션: formatProgress + `role=progressbar` + 총 XP / 애정도💗 / 오늘 획득(daily_xp/200) 그리드
- 개발용 이벤트 지급 버튼 3종 (alarm_completed/alarm_snoozed/family_alarm_received)
- grant 응답 메시지 인라인 (capped 표기 포함)

### App 라우팅
- `NAV_ITEMS` 에 `character` 🌱 탭 추가
- `renderPage` switch 에 case 추가

### 테스트
- `test/character.test.ts` 15건 (normalize/이모지/라벨/대사 결정성·NaN·미지 스테이지/포맷 정상·0/null/음수/바 너비 클램프)

## 검증

- [x] `npx tsc --noEmit` 통과 (웹)
- [x] `npx vitest run` 91 그린 (기존 76 + 신규 15)
- [x] perso.ai / ElevenLabs / PG 실호출 없음

## 리스크 / 팔로업

- 대사 랜덤 함수가 컴포넌트 렌더마다 재계산되지만 `useMemo(stage, dialogueSeed)` 로 고정 — 탭 시에만 변경.
- 이모지 기반 아바타라 디자인 시스템 연계(SVG/Lottie) 는 Phase 10 개선.
- 개발용 테스트 버튼은 Phase 8 폴리시에서 숨김 처리 예정 (플래그 or 프로덕션 빌드 가드).
- 모바일 버전(#44) 은 다음 iteration.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)