### PR TITLE
[#99] 모바일 캐릭터 화면 + 🌱 탭 등록 (#44)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -11,6 +11,7 @@ function TabIcon({ name, focused }: { name: string; focused: boolean }) {
     alarms: '⏰',
     friends: '👥',
     family: '👨‍👩‍👧',
+    character: '🌱',
     library: '📚',
     settings: '⚙️',
   };
@@ -65,6 +66,13 @@ export default function TabLayout() {
         options={{
           title: t('tab.family'),
           tabBarIcon: ({ focused }) => <TabIcon name="family" focused={focused} />,
+        }}
+      />
+      <Tabs.Screen
+        name="character"
+        options={{
+          title: t('tab.character'),
+          tabBarIcon: ({ focused }) => <TabIcon name="character" focused={focused} />,
         }}
       />
       <Tabs.Screen

--- a/apps/mobile/app/(tabs)/character.tsx
+++ b/apps/mobile/app/(tabs)/character.tsx
@@ -1,0 +1,330 @@
+import { useState, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getCharacterMe,
+  grantCharacterXp,
+} from '../../src/services/api';
+import type { XpEvent } from '../../src/services/api';
+import {
+  formatProgress,
+  pickRandomDialogue,
+  progressBarWidthPct,
+  stageToEmoji,
+  stageToLabel,
+} from '../../src/lib/character';
+import { Colors, Spacing, BorderRadius, FontSize } from '../../src/constants/theme';
+
+const DEV_EVENTS: { event: XpEvent; label: string }[] = [
+  { event: 'alarm_completed', label: '알람 정상 종료 +30 XP' },
+  { event: 'alarm_snoozed', label: '스누즈 +5 XP' },
+  { event: 'family_alarm_received', label: '가족 알람 수신 +10 XP' },
+];
+
+export default function CharacterScreen() {
+  const queryClient = useQueryClient();
+  const [dialogueSeed, setDialogueSeed] = useState(0);
+  const [lastGrantNotice, setLastGrantNotice] = useState<string | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['character-me'],
+    queryFn: getCharacterMe,
+  });
+
+  const grantMutation = useMutation({
+    mutationFn: grantCharacterXp,
+    onSuccess: (res) => {
+      const suffix = res.grant.capped ? ' (일일 캡 도달)' : '';
+      setLastGrantNotice(`+${res.grant.granted_xp} XP · +${res.grant.affection} 애정도${suffix}`);
+      queryClient.invalidateQueries({ queryKey: ['character-me'] });
+    },
+    onError: () => {
+      setLastGrantNotice('XP 지급 실패');
+    },
+  });
+
+  const stage = data?.character.stage ?? 'seed';
+  const dialogue = useMemo(
+    () => pickRandomDialogue(stage, () => ((dialogueSeed * 9301 + 49297) % 233280) / 233280),
+    [stage, dialogueSeed],
+  );
+
+  const handleTap = useCallback(() => {
+    setDialogueSeed((n) => n + 1);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.light.primary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>캐릭터를 불러오지 못했어요.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const { character, progress } = data;
+  const barWidth = progressBarWidthPct(progress);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.headerTitle}>내 캐릭터</Text>
+        <Text style={styles.headerSubtitle}>알람을 잘 들을수록 캐릭터가 자라요.</Text>
+
+        <Pressable
+          onPress={handleTap}
+          style={styles.characterCard}
+          accessibilityRole="button"
+          accessibilityLabel="캐릭터를 탭하면 새 대사가 나와요"
+        >
+          <Text style={styles.emoji}>{stageToEmoji(character.stage)}</Text>
+          <View style={styles.nameRow}>
+            <Text style={styles.characterName}>{character.name}</Text>
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>
+                Lv.{character.level} · {stageToLabel(character.stage)}
+              </Text>
+            </View>
+          </View>
+          <Text style={styles.dialogue}>{dialogue}</Text>
+        </Pressable>
+
+        <View style={styles.section}>
+          <View style={styles.progressHeader}>
+            <Text style={styles.sectionTitle}>성장 진행도</Text>
+            <Text style={styles.progressText}>{formatProgress(progress)}</Text>
+          </View>
+          <View
+            style={styles.progressBarBg}
+            accessibilityRole="progressbar"
+            accessibilityValue={{
+              min: 0,
+              max: 100,
+              now: Math.round(barWidth),
+            }}
+            accessibilityLabel="경험치 진행도"
+          >
+            <View style={[styles.progressBarFill, { width: `${barWidth}%` }]} />
+          </View>
+          <View style={styles.statsRow}>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>총 XP</Text>
+              <Text style={styles.statValue}>{character.xp}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>애정도</Text>
+              <Text style={styles.statValue}>💗 {character.affection}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <Text style={styles.statLabel}>오늘 획득</Text>
+              <Text style={styles.statValue}>{character.daily_xp} / 200</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>테스트용 XP 지급</Text>
+          <Text style={styles.devHint}>
+            실제 앱에서는 알람 종료/가족 알람 수신 시 자동으로 호출돼요.
+          </Text>
+          <View style={styles.devButtonsRow}>
+            {DEV_EVENTS.map((e) => (
+              <Pressable
+                key={e.event}
+                onPress={() => grantMutation.mutate({ event: e.event })}
+                disabled={grantMutation.isPending}
+                style={[styles.devButton, grantMutation.isPending && styles.devButtonDisabled]}
+              >
+                <Text style={styles.devButtonText}>{e.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+          {lastGrantNotice && (
+            <Text style={styles.grantNotice} accessibilityRole="text">
+              {lastGrantNotice}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.light.background,
+  },
+  scrollContent: {
+    padding: Spacing.lg,
+    paddingBottom: Spacing.xxl,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.lg,
+  },
+  errorText: {
+    fontSize: FontSize.md,
+    color: Colors.light.textSecondary,
+    textAlign: 'center',
+  },
+  headerTitle: {
+    fontSize: FontSize.xl,
+    fontWeight: '700',
+    color: Colors.light.primary,
+    marginBottom: Spacing.xs,
+  },
+  headerSubtitle: {
+    fontSize: FontSize.sm,
+    color: Colors.light.textTertiary,
+    marginBottom: Spacing.lg,
+  },
+  characterCard: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    padding: Spacing.xl,
+    alignItems: 'center',
+    marginBottom: Spacing.lg,
+  },
+  emoji: {
+    fontSize: 72,
+    marginBottom: Spacing.md,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.sm,
+  },
+  characterName: {
+    fontSize: FontSize.xl,
+    fontWeight: '700',
+    color: Colors.light.text,
+  },
+  badge: {
+    backgroundColor: `${Colors.light.primary}20`,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.full,
+  },
+  badgeText: {
+    fontSize: FontSize.xs,
+    color: Colors.light.primary,
+    fontWeight: '600',
+  },
+  dialogue: {
+    fontSize: FontSize.sm,
+    color: Colors.light.textSecondary,
+    textAlign: 'center',
+  },
+  section: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1,
+    borderColor: Colors.light.border,
+    padding: Spacing.lg,
+    marginBottom: Spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: FontSize.sm,
+    fontWeight: '600',
+    color: Colors.light.text,
+  },
+  progressHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    marginBottom: Spacing.sm,
+  },
+  progressText: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
+  },
+  progressBarBg: {
+    height: 10,
+    backgroundColor: Colors.light.surfaceVariant,
+    borderRadius: BorderRadius.full,
+    overflow: 'hidden',
+  },
+  progressBarFill: {
+    height: '100%',
+    backgroundColor: Colors.light.primary,
+    borderRadius: BorderRadius.full,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    marginTop: Spacing.md,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statLabel: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
+    marginBottom: 2,
+  },
+  statValue: {
+    fontSize: FontSize.lg,
+    fontWeight: '700',
+    color: Colors.light.text,
+  },
+  devHint: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
+    marginTop: Spacing.xs,
+    marginBottom: Spacing.md,
+  },
+  devButtonsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  devButton: {
+    backgroundColor: `${Colors.light.primary}15`,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.sm,
+  },
+  devButtonDisabled: {
+    opacity: 0.5,
+  },
+  devButtonText: {
+    fontSize: FontSize.xs,
+    color: Colors.light.primary,
+    fontWeight: '600',
+  },
+  grantNotice: {
+    marginTop: Spacing.md,
+    fontSize: FontSize.xs,
+    color: Colors.light.textSecondary,
+  },
+});

--- a/apps/mobile/src/i18n/en.json
+++ b/apps/mobile/src/i18n/en.json
@@ -37,6 +37,7 @@
     "alarms": "Alarms",
     "friends": "Friends",
     "family": "Family",
+    "character": "Character",
     "library": "Library",
     "settings": "Settings"
   },

--- a/apps/mobile/src/i18n/ko.json
+++ b/apps/mobile/src/i18n/ko.json
@@ -37,6 +37,7 @@
     "alarms": "알람",
     "friends": "친구",
     "family": "가족",
+    "character": "내 캐릭터",
     "library": "보관함",
     "settings": "설정"
   },

--- a/apps/mobile/src/lib/character.ts
+++ b/apps/mobile/src/lib/character.ts
@@ -1,0 +1,102 @@
+export type CharacterStage = 'seed' | 'sprout' | 'tree' | 'bloom';
+
+const STAGE_EMOJI: Record<CharacterStage, string> = {
+  seed: '🌱',
+  sprout: '🌿',
+  tree: '🌳',
+  bloom: '🌸',
+};
+
+const STAGE_LABEL: Record<CharacterStage, string> = {
+  seed: '씨앗',
+  sprout: '새싹',
+  tree: '나무',
+  bloom: '꽃',
+};
+
+const DIALOGUES: Record<CharacterStage, readonly string[]> = {
+  seed: [
+    '조용히 자라고 있어요.',
+    '햇살이 필요해요. ☀️',
+    '물 주실래요?',
+    '아직은 작지만, 곧 자랄 거예요.',
+  ],
+  sprout: [
+    '새싹이 돋았어요!',
+    '바람이 기분 좋아요. 🌬️',
+    '오늘도 같이 깨워주세요.',
+    '조금씩 자라고 있어요.',
+  ],
+  tree: [
+    '그늘을 드리워 드릴게요. 🌳',
+    '오늘 알람 잘 들으셨나요?',
+    '나무가 되었어요!',
+    '가족도 같이 깨워봐요.',
+  ],
+  bloom: [
+    '꽃이 피었어요! 🌸',
+    '완전 잘 자랐죠?',
+    '함께 해주셔서 고마워요.',
+    '이 순간이 제일 좋아요.',
+  ],
+};
+
+export interface CharacterPayload {
+  stage?: CharacterStage | string;
+  xp?: number;
+  level?: number;
+}
+
+export interface ProgressPayload {
+  xp_into_level?: number;
+  xp_to_next_level?: number;
+  level_span?: number;
+  progress_ratio?: number;
+}
+
+export function normalizeStage(stage: unknown): CharacterStage {
+  if (stage === 'sprout' || stage === 'tree' || stage === 'bloom') return stage;
+  return 'seed';
+}
+
+export function stageToEmoji(stage: unknown): string {
+  return STAGE_EMOJI[normalizeStage(stage)];
+}
+
+export function stageToLabel(stage: unknown): string {
+  return STAGE_LABEL[normalizeStage(stage)];
+}
+
+export function listDialogues(stage: unknown): readonly string[] {
+  return DIALOGUES[normalizeStage(stage)];
+}
+
+export function pickRandomDialogue(
+  stage: unknown,
+  rng: () => number = Math.random,
+): string {
+  const list = DIALOGUES[normalizeStage(stage)];
+  if (list.length === 0) return '';
+  const safeRng = typeof rng === 'function' ? rng : Math.random;
+  const raw = safeRng();
+  const ratio = Number.isFinite(raw) ? Math.max(0, Math.min(raw, 0.999999)) : 0;
+  const idx = Math.floor(ratio * list.length);
+  return list[idx] ?? list[0];
+}
+
+export function formatProgress(progress: ProgressPayload | null | undefined): string {
+  const into = Math.max(Number(progress?.xp_into_level ?? 0), 0);
+  const span = Math.max(Number(progress?.level_span ?? 0), 0);
+  const ratio =
+    span > 0 && Number.isFinite(Number(progress?.progress_ratio))
+      ? Math.max(0, Math.min(Number(progress?.progress_ratio), 1))
+      : 0;
+  const pct = Math.round(ratio * 100);
+  return `XP ${into} / ${span} (${pct}%)`;
+}
+
+export function progressBarWidthPct(progress: ProgressPayload | null | undefined): number {
+  const ratio = Number(progress?.progress_ratio ?? 0);
+  if (!Number.isFinite(ratio)) return 0;
+  return Math.max(0, Math.min(ratio, 1)) * 100;
+}

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -531,6 +531,67 @@ export interface FamilyAlarmCreateResponse {
   message: { id: string; text: string; category: string };
 }
 
+// ===== Character API =====
+
+export type CharacterStage = 'seed' | 'sprout' | 'tree' | 'bloom';
+
+export type XpEvent =
+  | 'alarm_completed'
+  | 'alarm_snoozed'
+  | 'alarm_dismissed'
+  | 'family_alarm_received'
+  | 'friend_invited';
+
+export interface CharacterPayload {
+  id: string;
+  user_id: string;
+  name: string;
+  level: number;
+  xp: number;
+  affection: number;
+  stage: CharacterStage;
+  daily_xp: number;
+  daily_xp_reset_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CharacterProgress {
+  xp_into_level: number;
+  xp_to_next_level: number;
+  level_span: number;
+  progress_ratio: number;
+}
+
+export interface CharacterResponse {
+  character: CharacterPayload;
+  progress: CharacterProgress;
+}
+
+export interface CharacterGrantResponse extends CharacterResponse {
+  grant: {
+    event: XpEvent;
+    granted_xp: number;
+    affection: number;
+    capped: boolean;
+    remaining_cap: number;
+    duplicated: boolean;
+  };
+}
+
+export async function getCharacterMe(): Promise<CharacterResponse> {
+  return get<CharacterResponse>('/characters/me');
+}
+
+export async function grantCharacterXp(payload: {
+  event: XpEvent;
+  client_nonce?: string;
+}): Promise<CharacterGrantResponse> {
+  return post<CharacterGrantResponse>('/characters/xp', payload);
+}
+
+// ===== Family Group / Family Alarm API =====
+
 export async function getFamilyGroupCurrent() {
   return get<FamilyGroupCurrent>('/family/groups/current');
 }

--- a/apps/mobile/test/character.test.ts
+++ b/apps/mobile/test/character.test.ts
@@ -1,0 +1,101 @@
+import {
+  normalizeStage,
+  stageToEmoji,
+  stageToLabel,
+  listDialogues,
+  pickRandomDialogue,
+  formatProgress,
+  progressBarWidthPct,
+} from '../src/lib/character';
+
+describe('normalizeStage', () => {
+  it('returns seed for unknown values', () => {
+    expect(normalizeStage(undefined)).toBe('seed');
+    expect(normalizeStage(null)).toBe('seed');
+    expect(normalizeStage('')).toBe('seed');
+    expect(normalizeStage('invalid')).toBe('seed');
+    expect(normalizeStage(42)).toBe('seed');
+  });
+
+  it('passes through valid stages', () => {
+    expect(normalizeStage('seed')).toBe('seed');
+    expect(normalizeStage('sprout')).toBe('sprout');
+    expect(normalizeStage('tree')).toBe('tree');
+    expect(normalizeStage('bloom')).toBe('bloom');
+  });
+});
+
+describe('stageToEmoji / stageToLabel', () => {
+  it('maps seed', () => {
+    expect(stageToEmoji('seed')).toBe('🌱');
+    expect(stageToLabel('seed')).toBe('씨앗');
+  });
+  it('maps bloom', () => {
+    expect(stageToEmoji('bloom')).toBe('🌸');
+    expect(stageToLabel('bloom')).toBe('꽃');
+  });
+  it('falls back to seed for unknown', () => {
+    expect(stageToEmoji('xyz')).toBe('🌱');
+    expect(stageToLabel(null)).toBe('씨앗');
+  });
+});
+
+describe('listDialogues', () => {
+  it('returns 4 dialogues per stage', () => {
+    for (const s of ['seed', 'sprout', 'tree', 'bloom'] as const) {
+      expect(listDialogues(s)).toHaveLength(4);
+    }
+  });
+});
+
+describe('pickRandomDialogue', () => {
+  it('uses deterministic rng', () => {
+    const a = pickRandomDialogue('seed', () => 0);
+    const b = pickRandomDialogue('seed', () => 0);
+    expect(a).toBe(b);
+  });
+  it('different rng values give different dialogues', () => {
+    const a = pickRandomDialogue('seed', () => 0);
+    const b = pickRandomDialogue('seed', () => 0.75);
+    expect(a).not.toBe(b);
+  });
+  it('clamps NaN rng to 0', () => {
+    const result = pickRandomDialogue('tree', () => NaN);
+    expect(result).toBe(listDialogues('tree')[0]);
+  });
+  it('clamps negative rng', () => {
+    const result = pickRandomDialogue('bloom', () => -1);
+    expect(result).toBe(listDialogues('bloom')[0]);
+  });
+});
+
+describe('formatProgress', () => {
+  it('formats normal progress', () => {
+    expect(formatProgress({ xp_into_level: 50, level_span: 100, progress_ratio: 0.5 })).toBe('XP 50 / 100 (50%)');
+  });
+  it('handles null', () => {
+    expect(formatProgress(null)).toBe('XP 0 / 0 (0%)');
+  });
+  it('handles undefined', () => {
+    expect(formatProgress(undefined)).toBe('XP 0 / 0 (0%)');
+  });
+  it('clamps negative xp_into_level', () => {
+    expect(formatProgress({ xp_into_level: -10, level_span: 100, progress_ratio: 0 })).toBe('XP 0 / 100 (0%)');
+  });
+});
+
+describe('progressBarWidthPct', () => {
+  it('returns percentage', () => {
+    expect(progressBarWidthPct({ progress_ratio: 0.75 })).toBe(75);
+  });
+  it('clamps to 0-100', () => {
+    expect(progressBarWidthPct({ progress_ratio: 1.5 })).toBe(100);
+    expect(progressBarWidthPct({ progress_ratio: -0.5 })).toBe(0);
+  });
+  it('returns 0 for NaN', () => {
+    expect(progressBarWidthPct({ progress_ratio: NaN } as never)).toBe(0);
+  });
+  it('returns 0 for null', () => {
+    expect(progressBarWidthPct(null)).toBe(0);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #99
- 요약: Phase 7 #44 — 웹 캐릭터 화면과 동일 계약의 모바일(React Native) 캐릭터 탭 구현

## 변경 내용
- `apps/mobile/src/lib/character.ts` 순수 함수 이식 (normalizeStage, stageToEmoji, stageToLabel, listDialogues, pickRandomDialogue, formatProgress, progressBarWidthPct)
- `apps/mobile/src/services/api.ts`에 Character API 타입 + `getCharacterMe`/`grantCharacterXp` 추가
- `apps/mobile/app/(tabs)/character.tsx` 신규 — 이모지 아바타, Lv·라벨 뱃지, 탭→대사 전환, XP 게이지 바(accessibilityRole=progressbar), 총 XP/애정도/오늘 획득 3-column, 개발용 XP 지급 버튼 3종
- `(tabs)/_layout.tsx`에 🌱 탭 등록
- i18n ko/en에 `tab.character` 추가
- jest 18건 신규

## 검증
- [x] `npm test` — 모바일 121건 그린 (103→121)
- [x] `npm run typecheck` — 0 에러

## 리스크 / 팔로업
- 개발용 XP 지급 버튼이 항상 노출됨 — Phase 8에서 `__DEV__` 기반 숨김 처리
- 이모지 기반 아바타는 MVP — 커스텀 일러스트는 Phase 10 후보