### PR TITLE
[#101] 성장 단계 전환 애니메이션 (#45)

### DIFF
--- a/apps/mobile/app/(tabs)/character.tsx
+++ b/apps/mobile/app/(tabs)/character.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   ScrollView,
   ActivityIndicator,
+  Animated,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -18,6 +19,7 @@ import {
   formatProgress,
   pickRandomDialogue,
   progressBarWidthPct,
+  shouldShowStageTransition,
   stageToEmoji,
   stageToLabel,
 } from '../../src/lib/character';
@@ -52,6 +54,25 @@ export default function CharacterScreen() {
   });
 
   const stage = data?.character.stage ?? 'seed';
+  const prevStageRef = useRef(stage);
+  const emojiScale = useRef(new Animated.Value(1)).current;
+  const emojiOpacity = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (shouldShowStageTransition(prevStageRef.current, stage)) {
+      emojiScale.setValue(0.3);
+      emojiOpacity.setValue(0);
+      Animated.sequence([
+        Animated.parallel([
+          Animated.spring(emojiScale, { toValue: 1.2, useNativeDriver: true, speed: 12 }),
+          Animated.timing(emojiOpacity, { toValue: 1, duration: 200, useNativeDriver: true }),
+        ]),
+        Animated.spring(emojiScale, { toValue: 1, useNativeDriver: true, speed: 14 }),
+      ]).start();
+    }
+    prevStageRef.current = stage;
+  }, [stage, emojiScale, emojiOpacity]);
+
   const dialogue = useMemo(
     () => pickRandomDialogue(stage, () => ((dialogueSeed * 9301 + 49297) % 233280) / 233280),
     [stage, dialogueSeed],
@@ -96,7 +117,11 @@ export default function CharacterScreen() {
           accessibilityRole="button"
           accessibilityLabel="캐릭터를 탭하면 새 대사가 나와요"
         >
-          <Text style={styles.emoji}>{stageToEmoji(character.stage)}</Text>
+          <Animated.Text
+            style={[styles.emoji, { transform: [{ scale: emojiScale }], opacity: emojiOpacity }]}
+          >
+            {stageToEmoji(character.stage)}
+          </Animated.Text>
           <View style={styles.nameRow}>
             <Text style={styles.characterName}>{character.name}</Text>
             <View style={styles.badge}>

--- a/apps/mobile/src/lib/character.ts
+++ b/apps/mobile/src/lib/character.ts
@@ -95,6 +95,19 @@ export function formatProgress(progress: ProgressPayload | null | undefined): st
   return `XP ${into} / ${span} (${pct}%)`;
 }
 
+const STAGE_ORDER: CharacterStage[] = ['seed', 'sprout', 'tree', 'bloom'];
+
+export function stageIndex(stage: unknown): number {
+  return STAGE_ORDER.indexOf(normalizeStage(stage));
+}
+
+export function shouldShowStageTransition(prev: unknown, next: unknown): boolean {
+  if (prev == null || next == null) return false;
+  const p = normalizeStage(prev);
+  const n = normalizeStage(next);
+  return p !== n;
+}
+
 export function progressBarWidthPct(progress: ProgressPayload | null | undefined): number {
   const ratio = Number(progress?.progress_ratio ?? 0);
   if (!Number.isFinite(ratio)) return 0;

--- a/apps/mobile/test/character.test.ts
+++ b/apps/mobile/test/character.test.ts
@@ -2,6 +2,8 @@ import {
   normalizeStage,
   stageToEmoji,
   stageToLabel,
+  stageIndex,
+  shouldShowStageTransition,
   listDialogues,
   pickRandomDialogue,
   formatProgress,
@@ -37,6 +39,33 @@ describe('stageToEmoji / stageToLabel', () => {
   it('falls back to seed for unknown', () => {
     expect(stageToEmoji('xyz')).toBe('🌱');
     expect(stageToLabel(null)).toBe('씨앗');
+  });
+});
+
+describe('stageIndex', () => {
+  it('returns correct order', () => {
+    expect(stageIndex('seed')).toBe(0);
+    expect(stageIndex('sprout')).toBe(1);
+    expect(stageIndex('tree')).toBe(2);
+    expect(stageIndex('bloom')).toBe(3);
+  });
+  it('returns 0 for unknown (normalized to seed)', () => {
+    expect(stageIndex('nope')).toBe(0);
+  });
+});
+
+describe('shouldShowStageTransition', () => {
+  it('returns true for different stages', () => {
+    expect(shouldShowStageTransition('seed', 'sprout')).toBe(true);
+  });
+  it('returns false for same stage', () => {
+    expect(shouldShowStageTransition('tree', 'tree')).toBe(false);
+  });
+  it('returns false when prev is null', () => {
+    expect(shouldShowStageTransition(null, 'seed')).toBe(false);
+  });
+  it('returns false when next is null', () => {
+    expect(shouldShowStageTransition('seed', null)).toBe(false);
   });
 });
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -60,3 +60,18 @@ body {
   white-space: nowrap;
   border-width: 0;
 }
+
+@keyframes stage-pop {
+  0% {
+    transform: scale(0.3);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/packages/web/src/lib/character.ts
+++ b/packages/web/src/lib/character.ts
@@ -103,6 +103,19 @@ export function formatProgress(progress: ProgressPayload | null | undefined): st
   return `XP ${into} / ${span} (${pct}%)`;
 }
 
+const STAGE_ORDER: CharacterStage[] = ['seed', 'sprout', 'tree', 'bloom'];
+
+export function stageIndex(stage: unknown): number {
+  return STAGE_ORDER.indexOf(normalizeStage(stage));
+}
+
+export function shouldShowStageTransition(prev: unknown, next: unknown): boolean {
+  if (prev == null || next == null) return false;
+  const p = normalizeStage(prev);
+  const n = normalizeStage(next);
+  return p !== n;
+}
+
 export function progressBarWidthPct(progress: ProgressPayload | null | undefined): number {
   const ratio = Number(progress?.progress_ratio ?? 0);
   if (!Number.isFinite(ratio)) return 0;

--- a/packages/web/src/pages/CharacterPage.tsx
+++ b/packages/web/src/pages/CharacterPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getCharacterMe, grantCharacterXp } from '../services/api';
 import type { XpEvent } from '../services/api';
@@ -6,6 +6,7 @@ import {
   formatProgress,
   pickRandomDialogue,
   progressBarWidthPct,
+  shouldShowStageTransition,
   stageToEmoji,
   stageToLabel,
 } from '../lib/character';
@@ -40,6 +41,19 @@ export default function CharacterPage() {
   });
 
   const stage = data?.character.stage ?? 'seed';
+  const prevStageRef = useRef(stage);
+  const [stageAnimating, setStageAnimating] = useState(false);
+
+  useEffect(() => {
+    if (shouldShowStageTransition(prevStageRef.current, stage)) {
+      setStageAnimating(true);
+      const timer = setTimeout(() => setStageAnimating(false), 600);
+      prevStageRef.current = stage;
+      return () => clearTimeout(timer);
+    }
+    prevStageRef.current = stage;
+  }, [stage]);
+
   const dialogue = useMemo(
     () => pickRandomDialogue(stage, () => ((dialogueSeed * 9301 + 49297) % 233280) / 233280),
     [stage, dialogueSeed],
@@ -86,7 +100,10 @@ export default function CharacterPage() {
         aria-label="캐릭터를 탭하면 새 대사가 나와요"
         className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-8 text-center cursor-pointer hover:bg-[var(--color-surface-alt)] transition-colors"
       >
-        <div className="text-7xl mb-4" aria-hidden="true">
+        <div
+          className={`text-7xl mb-4 transition-all duration-500 ${stageAnimating ? 'scale-125 opacity-0 animate-[stage-pop_0.6s_ease-out_forwards]' : ''}`}
+          aria-hidden="true"
+        >
           {stageToEmoji(character.stage)}
         </div>
         <div className="flex items-center justify-center gap-2 mb-2">

--- a/packages/web/test/character.test.ts
+++ b/packages/web/test/character.test.ts
@@ -5,6 +5,8 @@ import {
   normalizeStage,
   pickRandomDialogue,
   progressBarWidthPct,
+  shouldShowStageTransition,
+  stageIndex,
   stageToEmoji,
   stageToLabel,
 } from '../src/lib/character';
@@ -36,6 +38,32 @@ describe('stageToEmoji / stageToLabel', () => {
   it('라벨 한국어 매핑', () => {
     expect(stageToLabel('seed')).toBe('씨앗');
     expect(stageToLabel('bloom')).toBe('꽃');
+  });
+});
+
+describe('stageIndex', () => {
+  it('올바른 순서 반환', () => {
+    expect(stageIndex('seed')).toBe(0);
+    expect(stageIndex('sprout')).toBe(1);
+    expect(stageIndex('tree')).toBe(2);
+    expect(stageIndex('bloom')).toBe(3);
+  });
+  it('알 수 없는 값은 0 (seed)', () => {
+    expect(stageIndex('nope')).toBe(0);
+  });
+});
+
+describe('shouldShowStageTransition', () => {
+  it('다른 스테이지면 true', () => {
+    expect(shouldShowStageTransition('seed', 'sprout')).toBe(true);
+    expect(shouldShowStageTransition('tree', 'bloom')).toBe(true);
+  });
+  it('같은 스테이지면 false', () => {
+    expect(shouldShowStageTransition('tree', 'tree')).toBe(false);
+  });
+  it('null 이면 false', () => {
+    expect(shouldShowStageTransition(null, 'seed')).toBe(false);
+    expect(shouldShowStageTransition('seed', null)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 개요
- 이슈: #101
- 요약: Phase 7 #45 — seed→sprout→tree→bloom 전환 시 심플한 scale+fade 애니메이션

## 변경 내용
- `packages/web/src/lib/character.ts`: `stageIndex`/`shouldShowStageTransition` 순수 함수 추가
- `packages/web/src/index.css`: `@keyframes stage-pop` 애니메이션 정의
- `packages/web/src/pages/CharacterPage.tsx`: `prevStageRef` + `stageAnimating` 상태로 CSS 전환 트리거
- `apps/mobile/src/lib/character.ts`: 동일 순수 함수 이식
- `apps/mobile/app/(tabs)/character.tsx`: `Animated.spring`/`Animated.timing` 기반 scale+opacity 전환
- 웹 vitest +5건, 모바일 jest +6건

## 검증
- [x] `npm test` — 모바일 127건, 웹 96건 그린
- [x] `npm run typecheck` — 0 에러 (3 패키지)

## 리스크 / 팔로업
- 애니메이션은 XP 지급 후 stage 변경 시에만 트리거 — 최초 로딩 시에는 발생하지 않음
- Lottie/스프라이트 기반 복잡한 전환은 Phase 10 후보