### PR TITLE
[#103] 공용 디자인 토큰 패키지 @voice-alarm/ui (#46)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,6 +3154,10 @@
       "resolved": "packages/shared",
       "link": true
     },
+    "node_modules/@voice-alarm/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
     "node_modules/@voice-alarm/voice": {
       "resolved": "packages/voice",
       "link": true
@@ -6295,6 +6299,14 @@
       "dependencies": {
         "zod": "^3.23.8"
       },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.4"
+      }
+    },
+    "packages/ui": {
+      "name": "@voice-alarm/ui",
+      "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^4.1.4"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@voice-alarm/ui",
+  "version": "0.1.0",
+  "description": "Shared design tokens for voice_alarm monorepo (colors, typography, spacing)",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
+  },
+  "private": true
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,20 @@
+export {
+  ColorPalette,
+  LightColors,
+  DarkColors,
+  Spacing,
+  BorderRadius,
+  FontSize,
+  FontWeight,
+  FontFamily,
+  getColors,
+} from './tokens';
+
+export type {
+  ColorPaletteKey,
+  SemanticColorKey,
+  SpacingKey,
+  BorderRadiusKey,
+  FontSizeKey,
+  FontWeightKey,
+} from './tokens';

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,0 +1,120 @@
+export const ColorPalette = {
+  coral: '#FF7F6B',
+  coralLight: '#FFB4A8',
+  coralDark: '#E05A47',
+  peach: '#FFCBA4',
+  pinkAccent: '#FF6B8A',
+  white: '#FFFFFF',
+  warmBg: '#FFF5F3',
+  warmSurface: '#FFF0ED',
+  warmBorder: '#F2E8E5',
+  darkBg: '#1A1A2E',
+  darkSurface: '#232340',
+  darkSurfaceAlt: '#2D2D4A',
+  darkBorder: '#3A3A55',
+  text: '#2D2D2D',
+  textSecondary: '#6B7280',
+  textTertiary: '#9CA3AF',
+  darkText: '#E8E8F0',
+  darkTextSecondary: '#A0A0B8',
+  darkTextTertiary: '#6B6B82',
+  success: '#34C759',
+  warning: '#FF9500',
+  error: '#FF3B30',
+  darkSuccess: '#30D158',
+  darkWarning: '#FF9F0A',
+  darkError: '#FF453A',
+} as const;
+
+export type ColorPaletteKey = keyof typeof ColorPalette;
+
+export const LightColors = {
+  primary: ColorPalette.coral,
+  primaryLight: ColorPalette.coralLight,
+  primaryDark: ColorPalette.coralDark,
+  secondary: ColorPalette.peach,
+  accent: ColorPalette.pinkAccent,
+  background: ColorPalette.warmBg,
+  surface: ColorPalette.white,
+  surfaceVariant: ColorPalette.warmSurface,
+  text: ColorPalette.text,
+  textSecondary: ColorPalette.textSecondary,
+  textTertiary: ColorPalette.textTertiary,
+  border: ColorPalette.warmBorder,
+  success: ColorPalette.success,
+  warning: ColorPalette.warning,
+  error: ColorPalette.error,
+  shadow: 'rgba(255, 127, 107, 0.15)',
+} as const;
+
+export const DarkColors = {
+  primary: '#FF8F7D',
+  primaryLight: '#FFAA99',
+  primaryDark: '#E06A58',
+  secondary: '#FFD4B3',
+  accent: '#FF7B96',
+  background: ColorPalette.darkBg,
+  surface: ColorPalette.darkSurface,
+  surfaceVariant: ColorPalette.darkSurfaceAlt,
+  text: ColorPalette.darkText,
+  textSecondary: '#8E8E93',
+  textTertiary: ColorPalette.darkTextTertiary,
+  border: ColorPalette.darkBorder,
+  success: ColorPalette.darkSuccess,
+  warning: ColorPalette.darkWarning,
+  error: ColorPalette.darkError,
+  shadow: 'rgba(0, 0, 0, 0.3)',
+} as const;
+
+export type SemanticColorKey = keyof typeof LightColors;
+
+export const Spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  xxl: 48,
+} as const;
+
+export type SpacingKey = keyof typeof Spacing;
+
+export const BorderRadius = {
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  full: 9999,
+} as const;
+
+export type BorderRadiusKey = keyof typeof BorderRadius;
+
+export const FontSize = {
+  xs: 11,
+  sm: 13,
+  md: 15,
+  lg: 17,
+  xl: 20,
+  xxl: 28,
+  hero: 34,
+} as const;
+
+export type FontSizeKey = keyof typeof FontSize;
+
+export const FontWeight = {
+  normal: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+} as const;
+
+export type FontWeightKey = keyof typeof FontWeight;
+
+export const FontFamily = {
+  system: "-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+  mono: "ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace",
+} as const;
+
+export function getColors(mode: 'light' | 'dark') {
+  return mode === 'dark' ? DarkColors : LightColors;
+}

--- a/packages/ui/test/tokens.test.ts
+++ b/packages/ui/test/tokens.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ColorPalette,
+  LightColors,
+  DarkColors,
+  Spacing,
+  BorderRadius,
+  FontSize,
+  FontWeight,
+  getColors,
+} from '../src/index';
+
+describe('ColorPalette', () => {
+  it('contains hex color values', () => {
+    for (const [key, val] of Object.entries(ColorPalette)) {
+      expect(val).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+});
+
+describe('LightColors / DarkColors', () => {
+  it('have matching semantic keys', () => {
+    const lightKeys = Object.keys(LightColors).sort();
+    const darkKeys = Object.keys(DarkColors).sort();
+    expect(lightKeys).toEqual(darkKeys);
+  });
+
+  it('primary is coral in light mode', () => {
+    expect(LightColors.primary).toBe('#FF7F6B');
+  });
+
+  it('background differs between modes', () => {
+    expect(LightColors.background).not.toBe(DarkColors.background);
+  });
+});
+
+describe('getColors', () => {
+  it('returns light colors for light mode', () => {
+    expect(getColors('light')).toBe(LightColors);
+  });
+  it('returns dark colors for dark mode', () => {
+    expect(getColors('dark')).toBe(DarkColors);
+  });
+});
+
+describe('Spacing', () => {
+  it('values are ascending', () => {
+    expect(Spacing.xs).toBeLessThan(Spacing.sm);
+    expect(Spacing.sm).toBeLessThan(Spacing.md);
+    expect(Spacing.md).toBeLessThan(Spacing.lg);
+    expect(Spacing.lg).toBeLessThan(Spacing.xl);
+    expect(Spacing.xl).toBeLessThan(Spacing.xxl);
+  });
+});
+
+describe('BorderRadius', () => {
+  it('full is 9999', () => {
+    expect(BorderRadius.full).toBe(9999);
+  });
+});
+
+describe('FontSize', () => {
+  it('xs < sm < md < lg', () => {
+    expect(FontSize.xs).toBeLessThan(FontSize.sm);
+    expect(FontSize.sm).toBeLessThan(FontSize.md);
+    expect(FontSize.md).toBeLessThan(FontSize.lg);
+  });
+});
+
+describe('FontWeight', () => {
+  it('bold is 700', () => {
+    expect(FontWeight.bold).toBe('700');
+  });
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## 개요
- 이슈: #103
- 요약: Phase 8 #46 — `packages/ui` 워크스페이스 신규, 웹/모바일 공용 디자인 토큰

## 변경 내용
- `packages/ui` 워크스페이스 생성 (`@voice-alarm/ui`)
- `tokens.ts`: ColorPalette(19색), LightColors/DarkColors(16 시맨틱 키), Spacing(6단계), BorderRadius(5단계), FontSize(7단계), FontWeight(4단계), FontFamily, `getColors(mode)` 헬퍼
- vitest 10건 (색상 hex 검증, 라이트/다크 키 일치, spacing 오름차순 등)

## 검증
- [x] `npm run typecheck` — 5 패키지 (shared, ui, voice, web, mobile) 0 에러
- [x] `npm test` — ui 10건 + 기존 전체 통과

## 리스크 / 팔로업
- 웹/모바일의 기존 하드코딩 색상을 `@voice-alarm/ui` import로 교체하는 것은 후속 이슈