### PR TITLE
[#105] 접근성 유틸 + 터치 타겟 보강 (#47)

### DIFF
--- a/apps/mobile/app/(tabs)/character.tsx
+++ b/apps/mobile/app/(tabs)/character.tsx
@@ -338,6 +338,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md,
     paddingVertical: Spacing.sm,
     borderRadius: BorderRadius.sm,
+    minHeight: 44,
+    justifyContent: 'center',
   },
   devButtonDisabled: {
     opacity: 0.5,

--- a/packages/ui/src/a11y.ts
+++ b/packages/ui/src/a11y.ts
@@ -1,0 +1,35 @@
+export const MIN_TOUCH_TARGET = 44;
+
+export const WCAG_AA_NORMAL = 4.5;
+export const WCAG_AA_LARGE = 3.0;
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace(/^#/, '');
+  const n = h.length === 3
+    ? [h[0] + h[0], h[1] + h[1], h[2] + h[2]]
+    : [h.slice(0, 2), h.slice(2, 4), h.slice(4, 6)];
+  return [parseInt(n[0], 16), parseInt(n[1], 16), parseInt(n[2], 16)];
+}
+
+function srgbToLinear(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+export function contrastRatio(fg: string, bg: string): number {
+  const l1 = relativeLuminance(fg);
+  const l2 = relativeLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function meetsAA(fg: string, bg: string, isLargeText = false): boolean {
+  const ratio = contrastRatio(fg, bg);
+  return ratio >= (isLargeText ? WCAG_AA_LARGE : WCAG_AA_NORMAL);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,3 +18,12 @@ export type {
   FontSizeKey,
   FontWeightKey,
 } from './tokens';
+
+export {
+  MIN_TOUCH_TARGET,
+  WCAG_AA_NORMAL,
+  WCAG_AA_LARGE,
+  relativeLuminance,
+  contrastRatio,
+  meetsAA,
+} from './a11y';

--- a/packages/ui/test/a11y.test.ts
+++ b/packages/ui/test/a11y.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  contrastRatio,
+  meetsAA,
+  relativeLuminance,
+  MIN_TOUCH_TARGET,
+  WCAG_AA_NORMAL,
+  WCAG_AA_LARGE,
+  LightColors,
+  DarkColors,
+} from '../src/index';
+
+describe('relativeLuminance', () => {
+  it('black is 0', () => {
+    expect(relativeLuminance('#000000')).toBeCloseTo(0, 4);
+  });
+  it('white is 1', () => {
+    expect(relativeLuminance('#FFFFFF')).toBeCloseTo(1, 4);
+  });
+});
+
+describe('contrastRatio', () => {
+  it('black on white is 21:1', () => {
+    expect(contrastRatio('#000000', '#FFFFFF')).toBeCloseTo(21, 0);
+  });
+  it('same color is 1:1', () => {
+    expect(contrastRatio('#FF7F6B', '#FF7F6B')).toBeCloseTo(1, 2);
+  });
+  it('order does not matter', () => {
+    const a = contrastRatio('#2D2D2D', '#FFF5F3');
+    const b = contrastRatio('#FFF5F3', '#2D2D2D');
+    expect(a).toBeCloseTo(b, 4);
+  });
+});
+
+describe('meetsAA', () => {
+  it('black on white passes normal text', () => {
+    expect(meetsAA('#000000', '#FFFFFF')).toBe(true);
+  });
+  it('light gray on white fails normal text', () => {
+    expect(meetsAA('#CCCCCC', '#FFFFFF')).toBe(false);
+  });
+  it('isLargeText uses lower threshold', () => {
+    expect(meetsAA('#777777', '#FFFFFF', true)).toBe(true);
+    expect(meetsAA('#777777', '#FFFFFF', false)).toBe(false);
+  });
+});
+
+describe('constants', () => {
+  it('MIN_TOUCH_TARGET is 44', () => {
+    expect(MIN_TOUCH_TARGET).toBe(44);
+  });
+  it('WCAG_AA thresholds', () => {
+    expect(WCAG_AA_NORMAL).toBe(4.5);
+    expect(WCAG_AA_LARGE).toBe(3.0);
+  });
+});
+
+describe('design token color contrast audit', () => {
+  it('light mode: primary text on background meets AA for large text', () => {
+    expect(meetsAA(LightColors.text, LightColors.background)).toBe(true);
+  });
+  it('light mode: primary on surface — coral on white has low contrast (known, decorative use)', () => {
+    const ratio = contrastRatio(LightColors.primary, LightColors.surface);
+    expect(ratio).toBeGreaterThan(2);
+    expect(ratio).toBeLessThan(WCAG_AA_LARGE);
+  });
+  it('dark mode: text on background meets AA', () => {
+    expect(meetsAA(DarkColors.text, DarkColors.background)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #105
- 요약: Phase 8 #47 — WCAG 2.1 AA 색 대비 유틸 + 모바일 터치 타겟 44px 보강

## 변경 내용
- `packages/ui/src/a11y.ts`: `relativeLuminance`, `contrastRatio`, `meetsAA`, `MIN_TOUCH_TARGET=44`, `WCAG_AA_NORMAL=4.5`, `WCAG_AA_LARGE=3.0`
- `packages/ui/src/index.ts`: a11y 함수 re-export
- `packages/ui/test/a11y.test.ts`: 13건 (luminance 2, ratio 3, meetsAA 3, constants 2, token audit 3)
- `apps/mobile/app/(tabs)/character.tsx`: devButton에 `minHeight: 44` 추가

## 검증
- [x] `npm run typecheck` — 0 에러
- [x] vitest ui 23건 / web 96건 / mobile 127건 그린

## 리스크 / 팔로업
- coral(#FF7F6B) on white는 AA 미달(2.7:1) — 장식용/대형 텍스트에만 사용, 필수 텍스트에는 text 색상 사용
- 모든 모바일 버튼/탭에 44px 보강은 Phase 10 리팩토링으로