### PR TITLE
[#107] 에러 경계(ErrorBoundary) 추가 (#48)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import {
   SNOOZE_ACTION,
 } from '../src/services/notifications';
 import { OfflineBanner } from '../src/components/OfflineBanner';
+import { ErrorBoundary } from '../src/components/ErrorBoundary';
 import { AuthProvider } from '../src/hooks/useAuth';
 import '../src/i18n';
 
@@ -83,6 +84,7 @@ export default function RootLayout() {
   }, []);
 
   return (
+    <ErrorBoundary>
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
@@ -161,5 +163,6 @@ export default function RootLayout() {
         </AuthProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
+    </ErrorBoundary>
   );
 }

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -1,0 +1,96 @@
+import { Component, type ReactNode } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Colors, Spacing, BorderRadius, FontSize } from '../constants/theme';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, errorMessage: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, errorMessage: error.message };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, errorMessage: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container} accessibilityRole="alert">
+          <Text style={styles.emoji}>😵</Text>
+          <Text style={styles.title}>문제가 발생했습니다</Text>
+          <Text style={styles.subtitle}>앱을 다시 시도해 주세요</Text>
+          {this.state.errorMessage && (
+            <Text style={styles.detail} numberOfLines={3}>
+              {this.state.errorMessage}
+            </Text>
+          )}
+          <Pressable
+            onPress={this.handleRetry}
+            style={styles.retryButton}
+            accessibilityRole="button"
+            accessibilityLabel="다시 시도"
+          >
+            <Text style={styles.retryText}>다시 시도</Text>
+          </Pressable>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.xl,
+    backgroundColor: Colors.light.background,
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.lg,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: Spacing.sm,
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    color: Colors.light.textSecondary,
+    marginBottom: Spacing.md,
+    textAlign: 'center',
+  },
+  detail: {
+    fontSize: FontSize.xs,
+    color: Colors.light.textTertiary,
+    marginBottom: Spacing.lg,
+    textAlign: 'center',
+    maxWidth: 280,
+  },
+  retryButton: {
+    backgroundColor: Colors.light.primary,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  retryText: {
+    color: '#FFFFFF',
+    fontSize: FontSize.sm,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/test/errorBoundary.test.ts
+++ b/apps/mobile/test/errorBoundary.test.ts
@@ -1,0 +1,16 @@
+import { ErrorBoundary } from '../src/components/ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('getDerivedStateFromError sets hasError and message', () => {
+    const err = new Error('test crash');
+    const state = ErrorBoundary.getDerivedStateFromError(err);
+    expect(state.hasError).toBe(true);
+    expect(state.errorMessage).toBe('test crash');
+  });
+
+  it('initial state has no error', () => {
+    const instance = new ErrorBoundary({ children: null });
+    expect(instance.state.hasError).toBe(false);
+    expect(instance.state.errorMessage).toBeNull();
+  });
+});

--- a/packages/web/test/errorBoundary.test.ts
+++ b/packages/web/test/errorBoundary.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import ErrorBoundary from '../src/components/ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('getDerivedStateFromError returns hasError true', () => {
+    const state = ErrorBoundary.getDerivedStateFromError();
+    expect(state.hasError).toBe(true);
+  });
+
+  it('initial state has no error', () => {
+    const instance = new ErrorBoundary({ children: null });
+    expect(instance.state.hasError).toBe(false);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #107
- 요약: Phase 8 #48 — 모바일 ErrorBoundary + 웹/모바일 테스트

## 변경 내���
- `apps/mobile/src/components/ErrorBoundary.tsx`: RN ErrorBoundary (에러 이모지 + 메시지 + 다시 시도 버튼, minHeight 44 터치 타겟)
- `apps/mobile/app/_layout.tsx`: ErrorBoundary 최외곽 래핑
- 웹/모바일 ErrorBoundary 순수 로직 테스트 (+4건)
- 백엔드는 기존 `onError` 구조화 핸들러로 충분 — 변경 없음

## 검증
- [x] `npm run typecheck` — 0 에러
- [x] 모바일 129건 / 웹 98건 / ui 23건 그린

## 리스크 / 팔로업
- Sentry 등 외부 에러 추적 서비스 연동은 별도 이슈