### PR TITLE
[#109] 공용 StateView 컴포넌트 (#49)

### DIFF
--- a/apps/mobile/src/components/StateView.tsx
+++ b/apps/mobile/src/components/StateView.tsx
@@ -1,0 +1,83 @@
+import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { resolveStateView, type StateViewVariant } from '../lib/stateView';
+import { Colors, Spacing, BorderRadius, FontSize } from '../constants/theme';
+
+interface StateViewProps {
+  variant: StateViewVariant;
+  emoji?: string;
+  title?: string;
+  subtitle?: string;
+  action?: { label: string; onPress: () => void };
+}
+
+export function StateView({ variant, emoji, title, subtitle, action }: StateViewProps) {
+  const cfg = resolveStateView(variant, { emoji, title, subtitle });
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole={variant === 'error' ? 'alert' : 'none'}
+    >
+      {variant === 'loading' ? (
+        <ActivityIndicator size="large" color={Colors.light.primary} style={styles.spinner} />
+      ) : (
+        <Text style={styles.emoji}>{cfg.emoji}</Text>
+      )}
+      <Text style={styles.title}>{cfg.title}</Text>
+      {cfg.subtitle ? (
+        <Text style={styles.subtitle}>{cfg.subtitle}</Text>
+      ) : null}
+      {action && (
+        <Pressable
+          onPress={action.onPress}
+          style={styles.actionButton}
+          accessibilityRole="button"
+        >
+          <Text style={styles.actionText}>{action.label}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 200,
+    padding: Spacing.lg,
+  },
+  spinner: {
+    marginBottom: Spacing.md,
+  },
+  emoji: {
+    fontSize: 40,
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.md,
+    fontWeight: '600',
+    color: Colors.light.text,
+    marginBottom: Spacing.xs,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    color: Colors.light.textSecondary,
+    marginBottom: Spacing.md,
+    textAlign: 'center',
+  },
+  actionButton: {
+    backgroundColor: Colors.light.primary,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  actionText: {
+    color: '#FFFFFF',
+    fontSize: FontSize.sm,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/lib/stateView.ts
+++ b/apps/mobile/src/lib/stateView.ts
@@ -1,0 +1,27 @@
+export type StateViewVariant = 'loading' | 'empty' | 'error';
+
+export interface StateViewConfig {
+  variant: StateViewVariant;
+  emoji: string;
+  title: string;
+  subtitle?: string;
+}
+
+const DEFAULTS: Record<StateViewVariant, { emoji: string; title: string; subtitle: string }> = {
+  loading: { emoji: '⏳', title: '불러오는 중...', subtitle: '' },
+  empty: { emoji: '📭', title: '아직 데이터가 없어요', subtitle: '' },
+  error: { emoji: '😵', title: '문제가 발생했습니다', subtitle: '다시 시도해 주세요' },
+};
+
+export function resolveStateView(
+  variant: StateViewVariant,
+  overrides?: Partial<Pick<StateViewConfig, 'emoji' | 'title' | 'subtitle'>>,
+): StateViewConfig {
+  const defaults = DEFAULTS[variant];
+  return {
+    variant,
+    emoji: overrides?.emoji ?? defaults.emoji,
+    title: overrides?.title ?? defaults.title,
+    subtitle: (overrides?.subtitle ?? defaults.subtitle) || undefined,
+  };
+}

--- a/apps/mobile/test/stateView.test.ts
+++ b/apps/mobile/test/stateView.test.ts
@@ -1,0 +1,33 @@
+import { resolveStateView } from '../src/lib/stateView';
+
+describe('resolveStateView', () => {
+  it('loading defaults', () => {
+    const cfg = resolveStateView('loading');
+    expect(cfg.variant).toBe('loading');
+    expect(cfg.emoji).toBe('⏳');
+    expect(cfg.title).toContain('불러오는');
+  });
+
+  it('empty defaults', () => {
+    const cfg = resolveStateView('empty');
+    expect(cfg.variant).toBe('empty');
+    expect(cfg.emoji).toBe('📭');
+  });
+
+  it('error defaults', () => {
+    const cfg = resolveStateView('error');
+    expect(cfg.variant).toBe('error');
+    expect(cfg.subtitle).toBeDefined();
+  });
+
+  it('overrides title', () => {
+    const cfg = resolveStateView('empty', { title: '알람이 없어요' });
+    expect(cfg.title).toBe('알람이 없어요');
+  });
+
+  it('overrides emoji and subtitle', () => {
+    const cfg = resolveStateView('error', { emoji: '❌', subtitle: '네트워크 확인' });
+    expect(cfg.emoji).toBe('❌');
+    expect(cfg.subtitle).toBe('네트워크 확인');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6327,6 +6327,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.96.2",
+        "@voice-alarm/ui": "^0.1.0",
         "axios": "^1.15.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,9 @@ export type {
   FontWeightKey,
 } from './tokens';
 
+export { resolveStateView } from './stateView';
+export type { StateViewVariant, StateViewConfig } from './stateView';
+
 export {
   MIN_TOUCH_TARGET,
   WCAG_AA_NORMAL,

--- a/packages/ui/src/stateView.ts
+++ b/packages/ui/src/stateView.ts
@@ -1,0 +1,27 @@
+export type StateViewVariant = 'loading' | 'empty' | 'error';
+
+export interface StateViewConfig {
+  variant: StateViewVariant;
+  emoji: string;
+  title: string;
+  subtitle?: string;
+}
+
+const DEFAULTS: Record<StateViewVariant, { emoji: string; title: string; subtitle: string }> = {
+  loading: { emoji: '⏳', title: '불러오는 중...', subtitle: '' },
+  empty: { emoji: '📭', title: '아직 데이터가 없어요', subtitle: '' },
+  error: { emoji: '😵', title: '문제가 발생했습니다', subtitle: '다시 시도해 주세요' },
+};
+
+export function resolveStateView(
+  variant: StateViewVariant,
+  overrides?: Partial<Pick<StateViewConfig, 'emoji' | 'title' | 'subtitle'>>,
+): StateViewConfig {
+  const defaults = DEFAULTS[variant];
+  return {
+    variant,
+    emoji: overrides?.emoji ?? defaults.emoji,
+    title: overrides?.title ?? defaults.title,
+    subtitle: (overrides?.subtitle ?? defaults.subtitle) || undefined,
+  };
+}

--- a/packages/ui/test/stateView.test.ts
+++ b/packages/ui/test/stateView.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStateView } from '../src/index';
+
+describe('resolveStateView', () => {
+  it('loading defaults', () => {
+    const cfg = resolveStateView('loading');
+    expect(cfg.variant).toBe('loading');
+    expect(cfg.emoji).toBe('⏳');
+    expect(cfg.title).toContain('불러오는');
+  });
+
+  it('empty defaults', () => {
+    const cfg = resolveStateView('empty');
+    expect(cfg.variant).toBe('empty');
+    expect(cfg.emoji).toBe('📭');
+  });
+
+  it('error defaults', () => {
+    const cfg = resolveStateView('error');
+    expect(cfg.variant).toBe('error');
+    expect(cfg.title).toContain('문제');
+    expect(cfg.subtitle).toBeDefined();
+  });
+
+  it('overrides title', () => {
+    const cfg = resolveStateView('empty', { title: '알람이 없어요' });
+    expect(cfg.title).toBe('알람이 없어요');
+    expect(cfg.emoji).toBe('📭');
+  });
+
+  it('overrides emoji', () => {
+    const cfg = resolveStateView('loading', { emoji: '🔄' });
+    expect(cfg.emoji).toBe('🔄');
+  });
+
+  it('overrides subtitle', () => {
+    const cfg = resolveStateView('error', { subtitle: '네트워크 확인' });
+    expect(cfg.subtitle).toBe('네트워크 확인');
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.2",
+    "@voice-alarm/ui": "^0.1.0",
     "axios": "^1.15.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/packages/web/src/components/StateView.tsx
+++ b/packages/web/src/components/StateView.tsx
@@ -1,0 +1,39 @@
+import { resolveStateView, type StateViewVariant } from '@voice-alarm/ui';
+
+interface StateViewProps {
+  variant: StateViewVariant;
+  emoji?: string;
+  title?: string;
+  subtitle?: string;
+  action?: { label: string; onClick: () => void };
+}
+
+export default function StateView({ variant, emoji, title, subtitle, action }: StateViewProps) {
+  const cfg = resolveStateView(variant, { emoji, title, subtitle });
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[200px] p-6 text-center"
+      role={variant === 'error' ? 'alert' : 'status'}
+      aria-busy={variant === 'loading'}
+    >
+      {variant === 'loading' ? (
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--color-primary)] mb-4" />
+      ) : (
+        <span className="text-4xl mb-4" aria-hidden="true">{cfg.emoji}</span>
+      )}
+      <h3 className="text-base font-semibold text-[var(--color-text)] mb-1">{cfg.title}</h3>
+      {cfg.subtitle && (
+        <p className="text-sm text-[var(--color-text-secondary)] mb-4">{cfg.subtitle}</p>
+      )}
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-all"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
- 이슈: #109
- 요약: Phase 8 #49 — loading/empty/error 3-in-1 상태 UI 컴포넌트

## 변경 내용
- `packages/ui/src/stateView.ts`: `resolveStateView` 순수 함수 + 기본값 (이모지·제목·부제 3종)
- `packages/web/src/components/StateView.tsx`: 웹 버전 (Tailwind + CSS 변수, spinner/emoji/action 지원)
- `apps/mobile/src/components/StateView.tsx`: RN 버전 (ActivityIndicator, accessibilityRole, minHeight 44)
- `apps/mobile/src/lib/stateView.ts`: 모바일 로컬 순수 함수 (ui 패키지와 동일 계약)
- vitest ui +6건, jest mobile +5건

## 검증
- [x] `npm run typecheck` — 0 에러
- [x] ui 29건 / web 98건 / mobile 134건 그린

## 리스크 / 팔로업
- 기존 화면의 인라인 상태 UI를 `StateView`로 교체하는 것은 후속 이슈