### PR TITLE
[#111] 웹 온보딩 튜토리얼 3-스텝 (#50)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -20,6 +20,13 @@ export type {
 } from './tokens';
 
 export { resolveStateView } from './stateView';
+export {
+  ONBOARDING_STEPS,
+  ONBOARDING_STORAGE_KEY,
+  isLastStep,
+  clampStepIndex,
+} from './onboarding';
+export type { OnboardingStep } from './onboarding';
 export type { StateViewVariant, StateViewConfig } from './stateView';
 
 export {

--- a/packages/ui/src/onboarding.ts
+++ b/packages/ui/src/onboarding.ts
@@ -1,0 +1,33 @@
+export interface OnboardingStep {
+  emoji: string;
+  title: string;
+  description: string;
+}
+
+export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  {
+    emoji: '🎙️',
+    title: '누구의 목소리를 듣고 싶나요?',
+    description: '엄마, 아빠, 연인, 친구...\n소중한 사람의 목소리를 등록해보세요.\n짧은 녹음이나 통화 녹음만 있으면 돼요.',
+  },
+  {
+    emoji: '💌',
+    title: '매일 따뜻한 메시지가 찾아와요',
+    description: '"점심 잘 챙겨 먹어"\n"오늘도 고생 많았어"\n그 사람의 목소리로 응원을 받아보세요.',
+  },
+  {
+    emoji: '⏰',
+    title: '소중한 목소리로 하루를 시작하세요',
+    description: '알람부터 퇴근 알림까지,\n하루 종일 소중한 사람의 목소리와 함께.\n지금 바로 시작해볼까요?',
+  },
+] as const;
+
+export const ONBOARDING_STORAGE_KEY = 'voice_alarm_onboarding_completed';
+
+export function isLastStep(index: number): boolean {
+  return index >= ONBOARDING_STEPS.length - 1;
+}
+
+export function clampStepIndex(index: number): number {
+  return Math.max(0, Math.min(index, ONBOARDING_STEPS.length - 1));
+}

--- a/packages/ui/test/onboarding.test.ts
+++ b/packages/ui/test/onboarding.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ONBOARDING_STEPS, isLastStep, clampStepIndex, ONBOARDING_STORAGE_KEY } from '../src/index';
+
+describe('ONBOARDING_STEPS', () => {
+  it('has 3 steps', () => {
+    expect(ONBOARDING_STEPS).toHaveLength(3);
+  });
+
+  it('each step has emoji, title, description', () => {
+    for (const step of ONBOARDING_STEPS) {
+      expect(step.emoji).toBeTruthy();
+      expect(step.title).toBeTruthy();
+      expect(step.description).toBeTruthy();
+    }
+  });
+});
+
+describe('isLastStep', () => {
+  it('returns false for 0', () => {
+    expect(isLastStep(0)).toBe(false);
+  });
+  it('returns true for 2 (last index)', () => {
+    expect(isLastStep(2)).toBe(true);
+  });
+  it('returns true for out of range', () => {
+    expect(isLastStep(10)).toBe(true);
+  });
+});
+
+describe('clampStepIndex', () => {
+  it('clamps negative to 0', () => {
+    expect(clampStepIndex(-1)).toBe(0);
+  });
+  it('clamps over to max', () => {
+    expect(clampStepIndex(100)).toBe(2);
+  });
+  it('passes valid index', () => {
+    expect(clampStepIndex(1)).toBe(1);
+  });
+});
+
+describe('ONBOARDING_STORAGE_KEY', () => {
+  it('is a non-empty string', () => {
+    expect(ONBOARDING_STORAGE_KEY.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, lazy, Suspense } from 'react';
 import LoginPage from './components/LoginPage';
 import ErrorBoundary from './components/ErrorBoundary';
+import OnboardingOverlay from './components/OnboardingOverlay';
 import { useDarkMode } from './hooks/useDarkMode';
 import { useAuth } from './hooks/useAuth';
 
@@ -89,6 +90,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col md:flex-row bg-[var(--color-bg)]">
+      <OnboardingOverlay />
       {/* Sidebar — desktop only */}
       <nav
         aria-label="메인 메뉴"

--- a/packages/web/src/components/OnboardingOverlay.tsx
+++ b/packages/web/src/components/OnboardingOverlay.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import {
+  ONBOARDING_STEPS,
+  ONBOARDING_STORAGE_KEY,
+  isLastStep,
+  clampStepIndex,
+} from '@voice-alarm/ui';
+
+export default function OnboardingOverlay() {
+  const [step, setStep] = useState(0);
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(ONBOARDING_STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const handleNext = useCallback(() => {
+    if (isLastStep(step)) {
+      try {
+        localStorage.setItem(ONBOARDING_STORAGE_KEY, 'true');
+      } catch { /* noop */ }
+      setDismissed(true);
+    } else {
+      setStep((s) => clampStepIndex(s + 1));
+    }
+  }, [step]);
+
+  const handleSkip = useCallback(() => {
+    try {
+      localStorage.setItem(ONBOARDING_STORAGE_KEY, 'true');
+    } catch { /* noop */ }
+    setDismissed(true);
+  }, []);
+
+  if (dismissed) return null;
+
+  const current = ONBOARDING_STEPS[clampStepIndex(step)];
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className="bg-[var(--color-surface)] rounded-2xl p-8 max-w-md w-full text-center shadow-xl">
+        <span className="text-5xl block mb-4">{current.emoji}</span>
+        <h2 className="text-xl font-bold text-[var(--color-text)] mb-3 whitespace-pre-line">
+          {current.title}
+        </h2>
+        <p className="text-sm text-[var(--color-text-secondary)] whitespace-pre-line mb-6 leading-relaxed">
+          {current.description}
+        </p>
+
+        <div className="flex items-center justify-center gap-2 mb-6">
+          {ONBOARDING_STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`w-2 h-2 rounded-full transition-all ${
+                i === step
+                  ? 'bg-[var(--color-primary)] w-6'
+                  : 'bg-[var(--color-border)]'
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="flex gap-3 justify-center">
+          {!isLastStep(step) && (
+            <button
+              onClick={handleSkip}
+              className="px-4 py-2 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+            >
+              건너뛰기
+            </button>
+          )}
+          <button
+            onClick={handleNext}
+            className="px-6 py-2 bg-[var(--color-primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-all"
+          >
+            {isLastStep(step) ? '시작하기' : '다음'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
- 이슈: #111
- 요약: Phase 8 #50 (마지막) — 웹 온보딩 오버레이 + 순수 데이터 함수

## 변경 내용
- `packages/ui/src/onboarding.ts`: `ONBOARDING_STEPS` 3종 + `isLastStep`/`clampStepIndex` + 스토리지 키
- `packages/web/src/components/OnboardingOverlay.tsx`: 모달(z-50), dot indicator, 건너뛰기/다음/시작하기
- `packages/web/src/App.tsx`: `OnboardingOverlay` 추가 (인증 후 표시)
- vitest ui +9건

## 검증
- [x] `npm run typecheck` — 0 에러
- [x] ui 38건 그린

## 리스크 / 팔로업
- **Phase 8 완료.** 다음 Phase 9 (문서화 & 마무리).