### PR TITLE
[#115] [Phase 10] dub.ts 라우트 순서 버그 수정 + 테스트 7건

### DIFF
--- a/packages/backend/src/routes/dub.ts
+++ b/packages/backend/src/routes/dub.ts
@@ -90,6 +90,19 @@ dub.post('/', async (c) => {
   }
 });
 
+dub.get('/jobs', async (c) => {
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+
+  const result = await db.execute({
+    sql: `SELECT id, source_message_id, source_language, target_language, status, progress, result_message_id, error_message, created_at
+          FROM dub_jobs WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`,
+    args: [userId],
+  });
+
+  return c.json({ jobs: result.rows });
+});
+
 dub.get('/:id', async (c) => {
   const userId = c.get('userId');
   const db = getDB(c.env);
@@ -234,19 +247,6 @@ dub.get('/:id', async (c) => {
       500,
     );
   }
-});
-
-dub.get('/jobs', async (c) => {
-  const userId = c.get('userId');
-  const db = getDB(c.env);
-
-  const result = await db.execute({
-    sql: `SELECT id, source_message_id, source_language, target_language, status, progress, result_message_id, error_message, created_at
-          FROM dub_jobs WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`,
-    args: [userId],
-  });
-
-  return c.json({ jobs: result.rows });
 });
 
 export default dub;

--- a/packages/backend/test/dub.test.ts
+++ b/packages/backend/test/dub.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+vi.mock('../src/lib/perso', () => ({
+  PersoClient: vi.fn().mockImplementation(() => ({
+    listLanguages: vi.fn().mockResolvedValue({ result: { languages: [{ code: 'ko', name: 'Korean' }] } }),
+    listSpaces: vi.fn().mockResolvedValue({ result: [{ spaceSeq: 1 }] }),
+  })),
+}));
+
+import dubRoutes from '../src/routes/dub';
+
+function buildApp(userId = 'user-1') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware(userId));
+  app.route('/dub', dubRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+describe('GET /dub/jobs', () => {
+  it('빈 목록 반환', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/jobs'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.jobs).toEqual([]);
+  });
+
+  it('작업 목록 반환', async () => {
+    mockDB.pushResult([
+      { id: 'job-1', source_language: 'ko', target_language: 'en', status: 'ready', progress: 100 },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/jobs'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.jobs).toHaveLength(1);
+  });
+});
+
+describe('GET /dub/:id', () => {
+  it('잘못된 UUID 포맷 → 400', async () => {
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/not-a-uuid'));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain('Invalid');
+  });
+
+  it('존재하지 않는 작업 → 404', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/12345678-1234-1234-1234-123456789012'));
+    expect(res.status).toBe(404);
+  });
+
+  it('완료된 작업(ready) 반환', async () => {
+    mockDB.pushResult([{
+      id: '12345678-1234-1234-1234-123456789012',
+      user_id: 'user-1',
+      status: 'ready',
+      progress: 100,
+      result_message_id: 'msg-1',
+      error_message: null,
+    }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/12345678-1234-1234-1234-123456789012'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('ready');
+    expect(data.progress).toBe(100);
+  });
+
+  it('실패한 작업(failed) 반환', async () => {
+    mockDB.pushResult([{
+      id: '12345678-1234-1234-1234-123456789012',
+      user_id: 'user-1',
+      status: 'failed',
+      progress: 30,
+      error_message: 'Dubbing failed',
+      result_message_id: null,
+    }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/12345678-1234-1234-1234-123456789012'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('failed');
+    expect(data.error_message).toBe('Dubbing failed');
+  });
+
+  it('업로딩 중(uploading) → progress 0', async () => {
+    mockDB.pushResult([{
+      id: '12345678-1234-1234-1234-123456789012',
+      user_id: 'user-1',
+      status: 'uploading',
+      progress: 0,
+      error_message: null,
+      result_message_id: null,
+    }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/dub/12345678-1234-1234-1234-123456789012'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe('uploading');
+    expect(data.progress).toBe(0);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #115
- 요약: Phase 10 자율 개선 — dub.ts 테스트 커버리지 보강 중 라우트 순서 버그 발견·수정

## 변경 내용
- `packages/backend/src/routes/dub.ts`: `GET /jobs` 를 `GET /:id` 앞으로 이동 (순서 버그 수정)
- `packages/backend/test/dub.test.ts`: 신규 7건 (jobs 빈 목록/1건 + :id 400/404/ready/failed/uploading)

## 검증
- [x] backend 464건 그린 (457→464)
- [x] `npm run typecheck` — 0 에러

## Phase 10 점수
- 가치: 4 / 리스크: 1 / 복구성: 5 / **총점: 8**