### PR TITLE
[#117] [Phase 10] UUID 검증 유틸 추출 — 7개 라우트 중복 제거

### DIFF
--- a/packages/backend/src/lib/validate.ts
+++ b/packages/backend/src/lib/validate.ts
@@ -1,0 +1,5 @@
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidUUID(value: string): boolean {
+  return UUID_RE.test(value);
+}

--- a/packages/backend/src/routes/alarm.ts
+++ b/packages/backend/src/routes/alarm.ts
@@ -2,8 +2,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { selectFiringAlarms, type ScheduledAlarm } from '../lib/scheduler';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 const ALARM_MODES = ['sound-only', 'tts'] as const;
 type AlarmMode = (typeof ALARM_MODES)[number];
 

--- a/packages/backend/src/routes/dub.ts
+++ b/packages/backend/src/routes/dub.ts
@@ -2,8 +2,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { PersoClient } from '../lib/perso';
 import { getDB } from '../lib/db';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 
 const dub = new Hono<AppEnv>();
 

--- a/packages/backend/src/routes/friend.ts
+++ b/packages/backend/src/routes/friend.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 
 const friend = new Hono<AppEnv>();
 

--- a/packages/backend/src/routes/gift.ts
+++ b/packages/backend/src/routes/gift.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 
 const gift = new Hono<AppEnv>();
 

--- a/packages/backend/src/routes/library.ts
+++ b/packages/backend/src/routes/library.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 const library = new Hono<AppEnv>();

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -2,8 +2,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { ElevenLabsClient } from '../lib/elevenlabs';
 import { getDB } from '../lib/db';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { UUID_RE } from '../lib/validate';
 
 const tts = new Hono<AppEnv>();
 

--- a/packages/backend/src/routes/voice.ts
+++ b/packages/backend/src/routes/voice.ts
@@ -4,9 +4,9 @@ import { ElevenLabsClient } from '../lib/elevenlabs';
 import { getDB } from '../lib/db';
 import { getSharedInMemoryVoiceStorage, MockVoiceProvider } from '@voice-alarm/voice';
 
-const voice = new Hono<AppEnv>();
+import { UUID_RE } from '../lib/validate';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const voice = new Hono<AppEnv>();
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MiB
 const MAX_SPEAKERS = 3;
 

--- a/packages/backend/test/validate.test.ts
+++ b/packages/backend/test/validate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { UUID_RE, isValidUUID } from '../src/lib/validate';
+
+describe('UUID_RE', () => {
+  it('matches valid UUIDs', () => {
+    expect(UUID_RE.test('12345678-1234-1234-1234-123456789012')).toBe(true);
+    expect(UUID_RE.test('ABCDEF12-3456-7890-ABCD-EF1234567890')).toBe(true);
+  });
+  it('rejects invalid formats', () => {
+    expect(UUID_RE.test('not-a-uuid')).toBe(false);
+    expect(UUID_RE.test('')).toBe(false);
+    expect(UUID_RE.test('12345678123412341234123456789012')).toBe(false);
+  });
+});
+
+describe('isValidUUID', () => {
+  it('returns true for valid', () => {
+    expect(isValidUUID('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(true);
+  });
+  it('returns false for invalid', () => {
+    expect(isValidUUID('jobs')).toBe(false);
+    expect(isValidUUID('123')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #117
- 요약: Phase 10 자율 개선 — 7개 라우트의 중복 UUID_RE 정규식을 공용 유틸로 추출

## 변경 내용
- `src/lib/validate.ts`: `UUID_RE` + `isValidUUID` 신규
- 7개 라우트(alarm/dub/friend/gift/library/tts/voice): 로컬 `UUID_RE` 제거 → import
- `test/validate.test.ts`: 4건

## 검증
- [x] backend 468건 그린 (464→468)
- [x] `npm run typecheck` — 0 에러

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**