### PR TITLE
[#119] [Phase 10] rate limit 미들웨어 테스트 4건 추가

### DIFF
--- a/packages/backend/test/rateLimit.test.ts
+++ b/packages/backend/test/rateLimit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { rateLimitMiddleware } from '../src/middleware/rateLimit';
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', rateLimitMiddleware);
+  app.get('/test', (c) => c.json({ ok: true }));
+  return app;
+}
+
+function makeReq(ip = '1.2.3.4') {
+  return new Request('http://localhost/test', {
+    headers: { 'x-forwarded-for': ip },
+  });
+}
+
+describe('rateLimitMiddleware', () => {
+  it('정상 요청은 200 + 헤더 포함', async () => {
+    const app = buildApp();
+    const res = await app.request(makeReq('10.0.0.1'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(res.headers.has('X-RateLimit-Remaining')).toBe(true);
+    expect(res.headers.has('X-RateLimit-Reset')).toBe(true);
+  });
+
+  it('61번째 요청은 429', async () => {
+    const app = buildApp();
+    const ip = '10.0.0.2';
+    for (let i = 0; i < 60; i++) {
+      const res = await app.request(makeReq(ip));
+      expect(res.status).toBe(200);
+    }
+    const res61 = await app.request(makeReq(ip));
+    expect(res61.status).toBe(429);
+    const body = await res61.json();
+    expect(body.error).toContain('Too many');
+    expect(res61.headers.has('Retry-After')).toBe(true);
+  });
+
+  it('다른 IP는 독립 카운트', async () => {
+    const app = buildApp();
+    for (let i = 0; i < 60; i++) {
+      await app.request(makeReq('10.0.0.3'));
+    }
+    const res429 = await app.request(makeReq('10.0.0.3'));
+    expect(res429.status).toBe(429);
+
+    const resOther = await app.request(makeReq('10.0.0.4'));
+    expect(resOther.status).toBe(200);
+  });
+
+  it('Remaining 헤더가 감소', async () => {
+    const app = buildApp();
+    const ip = '10.0.0.5';
+    const res1 = await app.request(makeReq(ip));
+    const rem1 = Number(res1.headers.get('X-RateLimit-Remaining'));
+
+    const res2 = await app.request(makeReq(ip));
+    const rem2 = Number(res2.headers.get('X-RateLimit-Remaining'));
+
+    expect(rem2).toBe(rem1 - 1);
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #119
- 요약: Phase 10 자율 개선 — rate limit 미들웨어 테스트 커버리지 보강

## 변경 내용
- `test/rateLimit.test.ts` 신규 4건 (정상 200+헤더 / 61회 429 / IP 독립 카운트 / Remaining 감소)

## 검증
- [x] backend 472건 그린 (468→472)

## Phase 10 점수
- 가치: 4 / 리스크: 1 / 복구성: 5 / **총점: 8**