### PR TITLE
[#121] [Phase 10] 개발용 XP 지급 버튼 DEV 모드 전용 제한

### DIFF
--- a/apps/mobile/app/(tabs)/character.tsx
+++ b/apps/mobile/app/(tabs)/character.tsx
@@ -166,6 +166,7 @@ export default function CharacterScreen() {
           </View>
         </View>
 
+        {__DEV__ && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>테스트용 XP 지급</Text>
           <Text style={styles.devHint}>
@@ -189,6 +190,7 @@ export default function CharacterScreen() {
             </Text>
           )}
         </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/packages/web/src/pages/CharacterPage.tsx
+++ b/packages/web/src/pages/CharacterPage.tsx
@@ -149,6 +149,7 @@ export default function CharacterPage() {
         </div>
       </section>
 
+      {import.meta.env.DEV && (
       <section className="mt-6 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-6">
         <h2 className="text-sm font-semibold mb-3 text-[var(--color-text)]">테스트용 XP 지급</h2>
         <p className="text-xs text-[var(--color-text-tertiary)] mb-3">
@@ -172,6 +173,7 @@ export default function CharacterPage() {
           </p>
         )}
       </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 개요
- 이슈: #121
- 요약: Phase 10 자율 개선 — 프로덕션에서 XP 테스트 버튼 비노출

## 변경 내용
- `packages/web/src/pages/CharacterPage.tsx`: `import.meta.env.DEV` 가드
- `apps/mobile/app/(tabs)/character.tsx`: `__DEV__` 가드

## 검증
- [x] `npm run typecheck` — 0 에러

## Phase 10 점수
- 가치: 4 / 리스크: 1 / 복구성: 5 / **총점: 8**