### PR TITLE
[#125] [Phase 10] cache 미들웨어 테스트 4건 추가

### DIFF
--- a/packages/backend/test/cache.test.ts
+++ b/packages/backend/test/cache.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { publicCache, privateCache, noStore } from '../src/middleware/cache';
+
+function buildApp(mw: Parameters<typeof Hono.prototype.use>[1], status = 200) {
+  const app = new Hono();
+  app.use('*', mw);
+  app.get('/ok', (c) => c.json({ ok: true }, status as 200));
+  return app;
+}
+
+function req() {
+  return new Request('http://localhost/ok');
+}
+
+describe('publicCache', () => {
+  it('200 응답에 Cache-Control public 설정', async () => {
+    const app = buildApp(publicCache);
+    const res = await app.request(req());
+    expect(res.headers.get('Cache-Control')).toContain('public');
+    expect(res.headers.get('Cache-Control')).toContain('max-age=3600');
+    expect(res.headers.get('Vary')).toBeNull();
+  });
+});
+
+describe('privateCache', () => {
+  it('200 응답에 Cache-Control private + Vary: Authorization', async () => {
+    const app = buildApp(privateCache);
+    const res = await app.request(req());
+    expect(res.headers.get('Cache-Control')).toContain('private');
+    expect(res.headers.get('Vary')).toBe('Authorization');
+  });
+});
+
+describe('noStore', () => {
+  it('200 응답에 Cache-Control no-store', async () => {
+    const app = buildApp(noStore);
+    const res = await app.request(req());
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+});
+
+describe('에러 응답 시 캐시 헤더 미설정', () => {
+  it('500 응답에는 Cache-Control 미설정', async () => {
+    const app = new Hono();
+    app.use('*', publicCache);
+    app.get('/ok', (c) => c.json({ error: 'fail' }, 500));
+    const res = await app.request(req());
+    expect(res.headers.get('Cache-Control')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #125
- 요약: Phase 10 자율 개선 — cache 미들웨어 테스트

## 변경 내용
- `test/cache.test.ts` 4건 (publicCache / privateCache+Vary / noStore / 500 미설정)

## 검증
- [x] backend 481건 그린 (477→481)

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**