### PR TITLE
[#127] [Phase 10] bodyLimit 미들웨어 테스트 3건 추가

### DIFF
--- a/packages/backend/test/bodyLimit.test.ts
+++ b/packages/backend/test/bodyLimit.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { bodyLimitMiddleware } from '../src/middleware/bodyLimit';
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', bodyLimitMiddleware);
+  app.post('/upload', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('bodyLimitMiddleware', () => {
+  it('Content-Length 미포함 시 통과', async () => {
+    const app = buildApp();
+    const res = await app.request(new Request('http://localhost/upload', { method: 'POST' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('25MB 이하 요청 통과', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/upload', {
+        method: 'POST',
+        headers: { 'Content-Length': String(25 * 1024 * 1024) },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('25MB 초과 시 413', async () => {
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/upload', {
+        method: 'POST',
+        headers: { 'Content-Length': String(25 * 1024 * 1024 + 1) },
+      }),
+    );
+    expect(res.status).toBe(413);
+    const data = await res.json();
+    expect(data.error).toContain('too large');
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #127
- 요약: Phase 10 자율 개선 — bodyLimit 미들웨어 테스트

## 변경 내용
- `test/bodyLimit.test.ts` 3건

## 검증
- [x] backend 484건 그린 (481→484)

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**