### PR TITLE
[#129] [Phase 10] health check 엔드포인트 테스트 2건 추가

### DIFF
--- a/packages/backend/test/health.test.ts
+++ b/packages/backend/test/health.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => ({
+    execute: vi.fn().mockResolvedValue({ rows: [{ '1': 1 }] }),
+  }),
+  initDB: vi.fn(),
+}));
+
+import app from '../src/index';
+
+describe('GET / — health check', () => {
+  it('DB 정상 시 ok 반환', async () => {
+    const res = await app.fetch(new Request('http://localhost/'), {
+      TURSO_DATABASE_URL: 'mock',
+      TURSO_AUTH_TOKEN: 'mock',
+    } as never);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.name).toBe('VoiceAlarm API');
+    expect(data.status).toBe('ok');
+    expect(data.db).toBe('ok');
+  });
+
+  it('응답에 version 필드 포함', async () => {
+    const res = await app.fetch(new Request('http://localhost/'), {
+      TURSO_DATABASE_URL: 'mock',
+      TURSO_AUTH_TOKEN: 'mock',
+    } as never);
+    const data = await res.json();
+    expect(data.version).toBe('1.0.0');
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #129
- 요약: Phase 10 자율 개선 — `GET /` health check 테스트

## 변경 내용
- `test/health.test.ts` 2건 (DB ok 시 status=ok / version 필드 검증)

## 검증
- [x] backend 486건 그린 (484→486)

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**