### PR TITLE
[#131] [Phase 10] getApiErrorMessage 테스트 6건 추가

### DIFF
--- a/packages/web/test/apiErrorMessage.test.ts
+++ b/packages/web/test/apiErrorMessage.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getApiErrorMessage } from '../src/types';
+
+describe('getApiErrorMessage', () => {
+  it('axios 형태 에러에서 메시지 추출', () => {
+    const err = { response: { data: { error: '잘못된 요청' } } };
+    expect(getApiErrorMessage(err, '기본')).toBe('잘못된 요청');
+  });
+
+  it('response.data.error 가 없으면 fallback', () => {
+    const err = { response: { data: {} } };
+    expect(getApiErrorMessage(err, '기본 에러')).toBe('기본 에러');
+  });
+
+  it('response 가 없으면 fallback', () => {
+    expect(getApiErrorMessage({}, '폴백')).toBe('폴백');
+  });
+
+  it('null 이면 fallback', () => {
+    expect(getApiErrorMessage(null, '폴백')).toBe('폴백');
+  });
+
+  it('undefined 이면 fallback', () => {
+    expect(getApiErrorMessage(undefined, '폴백')).toBe('폴백');
+  });
+
+  it('Error 객체면 fallback (response 없음)', () => {
+    expect(getApiErrorMessage(new Error('boom'), '에러 발생')).toBe('에러 발생');
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #131
- 요약: Phase 10 자율 개선 — 웹 에러 메시지 추출 유틸 테스트

## 변경 내용
- `test/apiErrorMessage.test.ts` 6건

## 검증
- [x] web 104건 그린 (98→104)

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**