### PR TITLE
[#135] [Phase 10] 웹 parseRepeatDays 추출 + 인라인 JSON.parse 제거

### DIFF
--- a/packages/web/src/lib/alarmForm.ts
+++ b/packages/web/src/lib/alarmForm.ts
@@ -1,3 +1,20 @@
+export function parseRepeatDays(raw: unknown): number[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((n): n is number => Number.isInteger(n));
+  }
+  if (typeof raw === 'string' && raw.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((n): n is number => Number.isInteger(n));
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
 export type AlarmMode = 'tts' | 'sound-only';
 
 export interface AlarmFormInput {

--- a/packages/web/src/pages/AlarmsPage.tsx
+++ b/packages/web/src/pages/AlarmsPage.tsx
@@ -14,7 +14,7 @@ import type { Alarm, Message, VoiceProfile, PresetCategory } from '../types';
 import { AlarmSkeleton } from '../components/Skeleton';
 import { getApiErrorMessage } from '../types';
 import { VoiceDetailModal } from './VoicesPage';
-import { validateAlarmForm } from '../lib/alarmForm';
+import { validateAlarmForm, parseRepeatDays } from '../lib/alarmForm';
 import { buildFamilyAlarmLabel } from '../lib/familyAlarmLabel';
 
 const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
@@ -638,16 +638,7 @@ function AlarmEditInline({
   isPending: boolean;
   error: string | null;
 }) {
-  const initialRepeat: number[] = Array.isArray(alarm.repeat_days)
-    ? alarm.repeat_days.slice()
-    : (() => {
-        try {
-          const parsed: unknown = JSON.parse(String(alarm.repeat_days ?? '[]'));
-          return Array.isArray(parsed) ? parsed.filter((n): n is number => Number.isInteger(n)) : [];
-        } catch {
-          return [];
-        }
-      })();
+  const initialRepeat: number[] = parseRepeatDays(alarm.repeat_days);
   const [time, setTime] = useState(alarm.time);
   const [repeatDays, setRepeatDays] = useState<number[]>(initialRepeat);
   const [selectedMessageId, setSelectedMessageId] = useState(alarm.message_id);

--- a/packages/web/test/alarmForm.test.ts
+++ b/packages/web/test/alarmForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildCreatePayload,
+  parseRepeatDays,
   validateAlarmForm,
   type AlarmFormInput,
 } from '../src/lib/alarmForm';
@@ -11,6 +12,28 @@ const baseInput: AlarmFormInput = {
   repeatDays: [],
   mode: 'tts',
 };
+
+describe('parseRepeatDays', () => {
+  it('배열은 정수만 필터', () => {
+    expect(parseRepeatDays([0, 1, 6])).toEqual([0, 1, 6]);
+  });
+  it('문자열 JSON 파싱', () => {
+    expect(parseRepeatDays('[1,3,5]')).toEqual([1, 3, 5]);
+  });
+  it('빈 문자열 → 빈 배열', () => {
+    expect(parseRepeatDays('')).toEqual([]);
+  });
+  it('잘못된 JSON → 빈 배열', () => {
+    expect(parseRepeatDays('{bad')).toEqual([]);
+  });
+  it('null/undefined → 빈 배열', () => {
+    expect(parseRepeatDays(null)).toEqual([]);
+    expect(parseRepeatDays(undefined)).toEqual([]);
+  });
+  it('비정수 필터링', () => {
+    expect(parseRepeatDays([1, '2', 3.5, null, 4])).toEqual([1, 4]);
+  });
+});
 
 describe('buildCreatePayload', () => {
   it('기본 TTS 모드 — voice_profile_id/speaker_id 제외', () => {


### PR DESCRIPTION
## 개요
- 이슈: #135
- 요약: Phase 10 — AlarmsPage의 인라인 JSON.parse를 순수 함수로 교체

## 변경 내용
- `lib/alarmForm.ts`: `parseRepeatDays` 추가 (모바일과 동일 계약)
- `AlarmsPage.tsx`: 10줄 IIFE → 1줄 함수 호출
- `test/alarmForm.test.ts`: +6건

## 검증
- [x] web 110건 그린 (104→110)
- [x] tsc 0 에러

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**