### PR TITLE
[#137] [Phase 10] 웹 formatRepeatDays 순수 함수 추출

### DIFF
--- a/packages/web/src/lib/alarmForm.ts
+++ b/packages/web/src/lib/alarmForm.ts
@@ -15,6 +15,18 @@ export function parseRepeatDays(raw: unknown): number[] {
   return [];
 }
 
+export const DAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+export function formatRepeatDays(raw: unknown): string {
+  const parsed = parseRepeatDays(raw);
+  if (parsed.length === 0) return '한 번만';
+  if (parsed.length === 7) return '매일';
+  const sorted = parsed.slice().sort((a, b) => a - b);
+  if (sorted.length === 5 && sorted[0] === 1 && sorted[4] === 5) return '평일';
+  if (sorted.length === 2 && sorted[0] === 0 && sorted[1] === 6) return '주말';
+  return sorted.map((d) => DAYS[d] ?? String(d)).join(', ');
+}
+
 export type AlarmMode = 'tts' | 'sound-only';
 
 export interface AlarmFormInput {

--- a/packages/web/src/pages/AlarmsPage.tsx
+++ b/packages/web/src/pages/AlarmsPage.tsx
@@ -14,10 +14,8 @@ import type { Alarm, Message, VoiceProfile, PresetCategory } from '../types';
 import { AlarmSkeleton } from '../components/Skeleton';
 import { getApiErrorMessage } from '../types';
 import { VoiceDetailModal } from './VoicesPage';
-import { validateAlarmForm, parseRepeatDays } from '../lib/alarmForm';
+import { validateAlarmForm, parseRepeatDays, formatRepeatDays, DAYS } from '../lib/alarmForm';
 import { buildFamilyAlarmLabel } from '../lib/familyAlarmLabel';
-
-const DAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
 type AlarmFilter = 'all' | 'active' | 'inactive';
 
@@ -92,25 +90,6 @@ export default function AlarmsPage() {
       setShowCreate(false);
     },
   });
-
-  const formatRepeat = (days: number[] | string | null | undefined) => {
-    let parsed: number[] = [];
-    if (Array.isArray(days)) parsed = days.slice();
-    else if (typeof days === 'string' && days.length > 0) {
-      try {
-        const maybe: unknown = JSON.parse(days);
-        if (Array.isArray(maybe)) parsed = maybe.filter((n): n is number => Number.isInteger(n));
-      } catch {
-        parsed = [];
-      }
-    }
-    if (parsed.length === 0) return '한 번만';
-    if (parsed.length === 7) return '매일';
-    const sorted = parsed.slice().sort();
-    if (JSON.stringify(sorted) === JSON.stringify([1, 2, 3, 4, 5])) return '평일';
-    if (JSON.stringify(sorted) === JSON.stringify([0, 6])) return '주말';
-    return sorted.map((d) => DAYS[d]).join(', ');
-  };
 
   const filteredAlarms = (() => {
     if (!alarms) return [];
@@ -249,7 +228,7 @@ export default function AlarmsPage() {
                       ) : null;
                     })()}
                   </div>
-                  <p className="text-sm text-[var(--color-text-secondary)] mt-1">{formatRepeat(alarm.repeat_days)}</p>
+                  <p className="text-sm text-[var(--color-text-secondary)] mt-1">{formatRepeatDays(alarm.repeat_days)}</p>
                   <div className="mt-2">
                     <span
                       className="text-sm text-[var(--color-primary)] font-medium hover:underline cursor-pointer"

--- a/packages/web/test/alarmForm.test.ts
+++ b/packages/web/test/alarmForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildCreatePayload,
+  formatRepeatDays,
   parseRepeatDays,
   validateAlarmForm,
   type AlarmFormInput,
@@ -32,6 +33,30 @@ describe('parseRepeatDays', () => {
   });
   it('비정수 필터링', () => {
     expect(parseRepeatDays([1, '2', 3.5, null, 4])).toEqual([1, 4]);
+  });
+});
+
+describe('formatRepeatDays', () => {
+  it('빈 배열 → 한 번만', () => {
+    expect(formatRepeatDays([])).toBe('한 번만');
+  });
+  it('7개 → 매일', () => {
+    expect(formatRepeatDays([0, 1, 2, 3, 4, 5, 6])).toBe('매일');
+  });
+  it('[1,2,3,4,5] → 평일', () => {
+    expect(formatRepeatDays([1, 2, 3, 4, 5])).toBe('평일');
+  });
+  it('[0,6] → 주말', () => {
+    expect(formatRepeatDays([0, 6])).toBe('주말');
+  });
+  it('개별 요일 표시', () => {
+    expect(formatRepeatDays([1, 3, 5])).toBe('월, 수, 금');
+  });
+  it('문자열 JSON 파싱', () => {
+    expect(formatRepeatDays('[0,6]')).toBe('주말');
+  });
+  it('null → 한 번만', () => {
+    expect(formatRepeatDays(null)).toBe('한 번만');
   });
 });
 


### PR DESCRIPTION
## 개요
- 이슈: #137
- 요약: Phase 10 — AlarmsPage 인라인 formatRepeat를 순수 함수로 추출

## 변경 내용
- `lib/alarmForm.ts`: `formatRepeatDays` + `DAYS` export
- `AlarmsPage.tsx`: 인라인 함수 18줄 제거 → import 사용
- `test/alarmForm.test.ts`: +7건

## 검증
- [x] web 117건 그린 (110→117)
- [x] tsc 0 에러

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**