### PR TITLE
[#139] [Phase 10] formatRelativeTime 순수 함수 추출 + 테스트

### DIFF
--- a/packages/web/src/lib/timeFormat.ts
+++ b/packages/web/src/lib/timeFormat.ts
@@ -1,0 +1,11 @@
+export function formatRelativeTime(dateStr: string, now: number = Date.now()): string {
+  const diff = now - new Date(dateStr).getTime();
+  if (diff < 0) return '방금 전';
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return '방금 전';
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}

--- a/packages/web/src/pages/DashboardPage.tsx
+++ b/packages/web/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { getStats, getRecentActivity, getVoiceProfiles } from '../services/api';
 import type { Stats, Activity, WeekTrend } from '../services/api';
 import type { VoiceProfile } from '../types';
 import { VoiceDetailModal } from './VoicesPage';
+import { formatRelativeTime } from '../lib/timeFormat';
 
 interface StatCardProps {
   emoji: string;
@@ -50,17 +51,6 @@ const TYPE_META: Record<Activity['type'], { emoji: string; label: string; page: 
   gift: { emoji: '🎁', label: '선물', page: 'gifts' },
   voice: { emoji: '🎙️', label: '음성', page: 'voices' },
 };
-
-function formatRelativeTime(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return '방금 전';
-  if (mins < 60) return `${mins}분 전`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}시간 전`;
-  const days = Math.floor(hours / 24);
-  return `${days}일 전`;
-}
 
 export default function DashboardPage({ onNavigate }: { onNavigate: (page: string) => void }) {
   const { data: stats, isLoading, isError: statsError, refetch: refetchStats } = useQuery<Stats>({

--- a/packages/web/test/timeFormat.test.ts
+++ b/packages/web/test/timeFormat.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../src/lib/timeFormat';
+
+const NOW = new Date('2026-04-21T18:00:00Z').getTime();
+
+describe('formatRelativeTime', () => {
+  it('30초 전 → 방금 전', () => {
+    const date = new Date(NOW - 30_000).toISOString();
+    expect(formatRelativeTime(date, NOW)).toBe('방금 전');
+  });
+
+  it('5분 전', () => {
+    const date = new Date(NOW - 5 * 60_000).toISOString();
+    expect(formatRelativeTime(date, NOW)).toBe('5분 전');
+  });
+
+  it('2시간 전', () => {
+    const date = new Date(NOW - 2 * 3600_000).toISOString();
+    expect(formatRelativeTime(date, NOW)).toBe('2시간 전');
+  });
+
+  it('3일 전', () => {
+    const date = new Date(NOW - 3 * 86400_000).toISOString();
+    expect(formatRelativeTime(date, NOW)).toBe('3일 전');
+  });
+
+  it('미래 시간 → 방금 전', () => {
+    const date = new Date(NOW + 60_000).toISOString();
+    expect(formatRelativeTime(date, NOW)).toBe('방금 전');
+  });
+});


### PR DESCRIPTION
## 개요
- 이슈: #139
- 요약: Phase 10 — DashboardPage 인라인 함수 추출

## 변경 내용
- `lib/timeFormat.ts`: `formatRelativeTime(dateStr, now?)` + now 주입으로 결정성 확보
- `DashboardPage.tsx`: 인라인 함수 제거 → import
- `test/timeFormat.test.ts`: 5건

## 검증
- [x] web 122건 그린 (117→122)
- [x] tsc 0 에러

## Phase 10 점수
- 가치: 3 / 리스크: 1 / 복구성: 5 / **총점: 7**