### PR TITLE
chore: stag 제거, 2인 팀 브랜치 전략 간소화

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,8 @@
 - [ ] test: 테스트
 
 ## Branch
-- [ ] `feature/*` → `develop`
-- [ ] `develop` → `stag` (리뷰 1명 필요)
-- [ ] `stag` → `main` (approve 2명 필요: @Jin1370 @alpaka206)
+- [ ] `feature/*` / `fix/*` → `develop` (CI 통과 시 셀프 머지 가능)
+- [ ] `develop` → `main` (1명 approve 필요: @Jin1370 @alpaka206)
 
 ## Checklist
 - [ ] `npm run lint` 통과

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop, stag, main]
+    branches: [develop, main]
   pull_request:
-    branches: [develop, stag, main]
+    branches: [develop, main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -2,7 +2,7 @@ name: Deploy Web Dashboard (Cloudflare Pages)
 
 on:
   push:
-    branches: [stag, main]
+    branches: [main]
     paths:
       - 'packages/web/**'
       - '.github/workflows/deploy-web.yml'


### PR DESCRIPTION
## Summary
- 3단계(main→stag→develop) → 2단계(main→develop)로 간소화
- CI/Deploy 워크플로우에서 stag 참조 제거
- PR 템플릿 업데이트

## Changes
- CI: `[develop, main]`만 트리거
- Deploy: `[main]`에서만 실행
- PR 템플릿: 2단계 브랜치 가이드로 변경

## Type
- [x] chore: 빌드/CI/의존성

🤖 Generated with [Claude Code](https://claude.com/claude-code)