### PR TITLE
fix: flaky alarmCountdown test timing

### DIFF
--- a/apps/mobile/test/alarmCountdown.test.ts
+++ b/apps/mobile/test/alarmCountdown.test.ts
@@ -198,7 +198,7 @@ describe('getNearestFireMs', () => {
     ];
     const nearest = getNearestFireMs(alarms);
     const expected = getNextFireMs(alarms[1]!);
-    expect(nearest).toBe(expected);
+    expect(Math.abs(nearest! - expected!)).toBeLessThanOrEqual(50);
   });
 
   it('single active alarm returns its fire ms', () => {
@@ -207,6 +207,6 @@ describe('getNearestFireMs', () => {
     const alarm = makeAlarm({ time: `${String(h).padStart(2, '0')}:30` });
     const nearest = getNearestFireMs([alarm]);
     const expected = getNextFireMs(alarm);
-    expect(nearest).toBe(expected);
+    expect(Math.abs(nearest! - expected!)).toBeLessThanOrEqual(50);
   });
 });


### PR DESCRIPTION
## Summary
- `getNearestFireMs`와 `getNextFireMs`를 별도 시점에 호출하면 ms 차이 발생 → CI flaky test
- strict `toBe` → `toBeLessThanOrEqual(50)` 허용 오차로 변경 (기존 동일 파일의 다른 테스트와 패턴 통일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)