### PR TITLE
chore: develop → main 동기화 (dependabot + flaky test fix)

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -48,7 +48,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^30.0.0",
         "@types/react": "~19.2.14",
-        "babel-preset-expo": "^54.0.10",
+        "babel-preset-expo": "^55.0.18",
         "jest": "^29.7.0",
         "jest-expo": "^55.0.16",
         "typescript": "~5.9.2"
@@ -5185,12 +5185,12 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-      "integrity": "sha512-wTt7POavLFypLcPW/uC5v8y+mtQKDJiyGLzYCjqr9tx0Qc3vCXcDKk1iCFIj/++Iy5CWhhTflEa7VvVPNWeCfw==",
-      "dev": true,
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.18.tgz",
+      "integrity": "sha512-zmDwKxCFBTe4e/jQXuITRUZlbl8HTZOhsUlwcHGjwEUB0lKQfRdaSYXZckQ+jMOBC34MrOl3Cs7/6F6vNbj5Pw==",
       "license": "MIT",
       "dependencies": {
+        "@babel/generator": "^7.20.5",
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-proposal-export-default-from": "^7.24.7",
@@ -5206,10 +5206,10 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.5",
+        "@react-native/babel-preset": "0.83.6",
         "babel-plugin-react-compiler": "^1.0.0",
         "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.29.1",
+        "babel-plugin-syntax-hermes-parser": "^0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "debug": "^4.3.4",
         "resolve-from": "^5.0.0"
@@ -5217,6 +5217,7 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
+        "expo-widgets": "^55.0.14",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -5225,28 +5226,29 @@
         },
         "expo": {
           "optional": true
+        },
+        "expo-widgets": {
+          "optional": true
         }
       }
     },
     "node_modules/babel-preset-expo/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.5.tgz",
-      "integrity": "sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==",
-      "dev": true,
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.6.tgz",
+      "integrity": "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.81.5"
+        "@react-native/codegen": "0.83.6"
       },
       "engines": {
         "node": ">= 20.19.4"
       }
     },
     "node_modules/babel-preset-expo/node_modules/@react-native/babel-preset": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.5.tgz",
-      "integrity": "sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==",
-      "dev": true,
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.83.6.tgz",
+      "integrity": "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -5290,8 +5292,8 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.81.5",
-        "babel-plugin-syntax-hermes-parser": "0.29.1",
+        "@react-native/babel-plugin-codegen": "0.83.6",
+        "babel-plugin-syntax-hermes-parser": "0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
@@ -5302,27 +5304,34 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/babel-preset-expo/node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.32.0"
+      }
+    },
     "node_modules/babel-preset-expo/node_modules/@react-native/babel-preset/node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/babel-preset-expo/node_modules/@react-native/codegen": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.5.tgz",
-      "integrity": "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==",
-      "dev": true,
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.6.tgz",
+      "integrity": "sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.29.1",
+        "hermes-parser": "0.32.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
@@ -5335,20 +5344,33 @@
       }
     },
     "node_modules/babel-preset-expo/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
-      "integrity": "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==",
-      "dev": true,
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.29.1"
+        "hermes-parser": "0.32.1"
+      }
+    },
+    "node_modules/babel-preset-expo/node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
+      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
+      "license": "MIT"
+    },
+    "node_modules/babel-preset-expo/node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.1"
       }
     },
     "node_modules/babel-preset-expo/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5360,7 +5382,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5378,27 +5399,24 @@
       }
     },
     "node_modules/babel-preset-expo/node_modules/hermes-estree": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
-      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
-      "dev": true,
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
       "license": "MIT"
     },
     "node_modules/babel-preset-expo/node_modules/hermes-parser": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
-      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
-      "dev": true,
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.29.1"
+        "hermes-estree": "0.32.0"
       }
     },
     "node_modules/babel-preset-expo/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7666,211 +7684,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/expo/node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.6.tgz",
-      "integrity": "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.83.6"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      }
-    },
-    "node_modules/expo/node_modules/@react-native/babel-preset": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.83.6.tgz",
-      "integrity": "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-computed-properties": "^7.24.7",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-function-name": "^7.25.1",
-        "@babel/plugin-transform-literals": "^7.25.2",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-numeric-separator": "^7.24.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.25.2",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-        "@babel/plugin-transform-regenerator": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
-        "@babel/plugin-transform-spread": "^7.24.7",
-        "@babel/plugin-transform-sticky-regex": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.83.6",
-        "babel-plugin-syntax-hermes-parser": "0.32.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-parser": "0.32.0"
-      }
-    },
-    "node_modules/expo/node_modules/@react-native/codegen": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.6.tgz",
-      "integrity": "sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/parser": "^7.25.3",
-        "glob": "^7.1.1",
-        "hermes-parser": "0.32.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@react-native/codegen/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
-      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-parser": "0.32.1"
-      }
-    },
-    "node_modules/expo/node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
-      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
-      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.32.1"
-      }
-    },
-    "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "55.0.18",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.18.tgz",
-      "integrity": "sha512-zmDwKxCFBTe4e/jQXuITRUZlbl8HTZOhsUlwcHGjwEUB0lKQfRdaSYXZckQ+jMOBC34MrOl3Cs7/6F6vNbj5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^7.20.5",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.83.6",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.32.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "expo-widgets": "^55.0.14",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        },
-        "expo-widgets": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/expo/node_modules/expo-constants": {
       "version": "55.0.15",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
@@ -7906,33 +7719,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/hermes-estree": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
-      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.32.0"
-      }
-    },
-    "node_modules/expo/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/expo/node_modules/react-refresh": {
@@ -12794,7 +12580,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.96.2",
         "expo": "~55.0.17",
         "expo-apple-authentication": "~8.0.8",
-        "expo-auth-session": "~7.0.10",
+        "expo-auth-session": "~55.0.15",
         "expo-av": "^16.0.8",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
@@ -6878,9 +6878,9 @@
       }
     },
     "node_modules/expo-application": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
-      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.14.tgz",
+      "integrity": "sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -6929,20 +6929,80 @@
       }
     },
     "node_modules/expo-auth-session": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-7.0.10.tgz",
-      "integrity": "sha512-XDnKkudvhHSKkZfJ+KkodM+anQcrxB71i+h0kKabdLa5YDXTQ81aC38KRc3TMqmnBDHAu0NpfbzEVd9WDFY3Qg==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-55.0.15.tgz",
+      "integrity": "sha512-RPnoLs6+FY2MMWnV0cqz4uNzi2b1dwjqE6vv7Izb5vWI2RCFUnBSMy1fgXp4BSWaFm0VZzeMl6UjsgVh2QFe0g==",
       "license": "MIT",
       "dependencies": {
-        "expo-application": "~7.0.8",
-        "expo-constants": "~18.0.11",
-        "expo-crypto": "~15.0.8",
-        "expo-linking": "~8.0.10",
-        "expo-web-browser": "~15.0.10",
+        "expo-application": "~55.0.14",
+        "expo-constants": "~55.0.15",
+        "expo-crypto": "~55.0.14",
+        "expo-linking": "~55.0.14",
+        "expo-web-browser": "~55.0.14",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/@expo/env": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.1.tgz",
+      "integrity": "sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "getenv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/expo-constants": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.15.tgz",
+      "integrity": "sha512-w394fcZLJjeKN+9ZnJzL/HiarE1nwZFDa+3S9frevh6Ur+MAAs9QDrcXhDrV8T3xqRzzYaqsP6Z8TFZ4efWN1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/env": "~2.1.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/expo-crypto": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-55.0.14.tgz",
+      "integrity": "sha512-TfAADBGZNNv9OOmdKFJCz54wDj87ufxtzQNSY+Roycpm8e5tuCnDIL7EjqUOmNTGH99Jj8ftPGFt4KGG2Ii2fg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/expo-linking": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.14.tgz",
+      "integrity": "sha512-ZSqOvJyEquf04M5/ZpQo2diK9QRnNrzgqZo7p8gzxaPPHxP6IyUJnmcd12qT+dTxnRTVmUpxFQVHHWbvwPNIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-constants": "~55.0.15",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session/node_modules/expo-web-browser": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-55.0.14.tgz",
+      "integrity": "sha512-bTDkBSQBnrlnYcM7Aak72AOvJuvdgA3M8p//Lazrm0Nfa77T9cRXzQ6KhLrB08V39n1+00d1dvuTWznJslkmdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -7168,15 +7228,6 @@
       },
       "engines": {
         "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/expo-application": {
-      "version": "55.0.14",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.14.tgz",
-      "integrity": "sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-notifications/node_modules/expo-constants": {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~55.0.10",
         "@react-native-async-storage/async-storage": "3.0.2",
-        "@react-native-community/netinfo": "^11.4.1",
+        "@react-native-community/netinfo": "^12.0.1",
         "@sentry/react-native": "~7.2.0",
         "@tanstack/react-query": "^5.96.2",
         "expo": "~55.0.17",
@@ -3443,11 +3443,12 @@
       }
     },
     "node_modules/@react-native-community/netinfo": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
-      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
       "license": "MIT",
       "peerDependencies": {
+        "react": "*",
         "react-native": ">=0.59"
       }
     },

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -40,7 +40,7 @@
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.7.0",
-        "react-native-screens": "~4.16.0",
+        "react-native-screens": "~4.24.0",
         "react-native-web": "^0.21.0",
         "zustand": "^5.0.12"
       },
@@ -12320,13 +12320,12 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
-      "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.24.0.tgz",
+      "integrity": "sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
-        "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -14,7 +14,7 @@
         "@sentry/react-native": "~7.2.0",
         "@tanstack/react-query": "^5.96.2",
         "expo": "~55.0.17",
-        "expo-apple-authentication": "~8.0.8",
+        "expo-apple-authentication": "~55.0.13",
         "expo-auth-session": "~7.0.10",
         "expo-av": "^16.0.8",
         "expo-clipboard": "~8.0.8",
@@ -6868,9 +6868,9 @@
       }
     },
     "node_modules/expo-apple-authentication": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
-      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-55.0.13.tgz",
+      "integrity": "sha512-Qvh3DmhXqhtWOe7BC9e7UVApR3XS1qE7+68tVLqb3KI/sET7QV9KT5JgOJogWmmCJVxA/kaot0M136yvW1pdWA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,7 +24,7 @@
     "@sentry/react-native": "~7.2.0",
     "@tanstack/react-query": "^5.96.2",
     "expo": "~55.0.17",
-    "expo-apple-authentication": "~8.0.8",
+    "expo-apple-authentication": "~55.0.13",
     "expo-auth-session": "~7.0.10",
     "expo-av": "^16.0.8",
     "expo-clipboard": "~8.0.8",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,7 +25,7 @@
     "@tanstack/react-query": "^5.96.2",
     "expo": "~55.0.17",
     "expo-apple-authentication": "~8.0.8",
-    "expo-auth-session": "~7.0.10",
+    "expo-auth-session": "~55.0.15",
     "expo-av": "^16.0.8",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -50,7 +50,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.7.0",
-    "react-native-screens": "~4.16.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "^0.21.0",
     "zustand": "^5.0.12"
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -58,7 +58,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.2.14",
-    "babel-preset-expo": "^54.0.10",
+    "babel-preset-expo": "^55.0.18",
     "jest": "^29.7.0",
     "jest-expo": "^55.0.16",
     "typescript": "~5.9.2"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~55.0.10",
     "@react-native-async-storage/async-storage": "3.0.2",
-    "@react-native-community/netinfo": "^11.4.1",
+    "@react-native-community/netinfo": "^12.0.1",
     "@sentry/react-native": "~7.2.0",
     "@tanstack/react-query": "^5.96.2",
     "expo": "~55.0.17",

--- a/apps/mobile/test/alarmCountdown.test.ts
+++ b/apps/mobile/test/alarmCountdown.test.ts
@@ -198,7 +198,7 @@ describe('getNearestFireMs', () => {
     ];
     const nearest = getNearestFireMs(alarms);
     const expected = getNextFireMs(alarms[1]!);
-    expect(nearest).toBe(expected);
+    expect(Math.abs(nearest! - expected!)).toBeLessThanOrEqual(50);
   });
 
   it('single active alarm returns its fire ms', () => {
@@ -207,6 +207,6 @@ describe('getNearestFireMs', () => {
     const alarm = makeAlarm({ time: `${String(h).padStart(2, '0')}:30` });
     const nearest = getNearestFireMs([alarm]);
     const expected = getNextFireMs(alarm);
-    expect(nearest).toBe(expected);
+    expect(Math.abs(nearest! - expected!)).toBeLessThanOrEqual(50);
   });
 });


### PR DESCRIPTION
## Summary
develop에 누적된 변경사항을 main에 동기화합니다.

- **dependabot 의존성 업데이트**: expo-auth-session, expo-apple-authentication, react-native-screens, @react-native-community/netinfo, babel-preset-expo
- **flaky test 수정**: alarmCountdown 테스트 타이밍 허용 오차 적용

## Test plan
- [ ] CI 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)