### PR TITLE
feat(mobile): unified voice creation entry + multi-speaker upload

### DIFF
--- a/apps/mobile/app/voice/create.tsx
+++ b/apps/mobile/app/voice/create.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Spacing, BorderRadius, FontSize, FontFamily } from '../../src/constants/theme';
+import { useTheme, type ThemeColors } from '../../src/hooks/useTheme';
+
+/**
+ * Unified entry point for creating a voice profile.
+ * Two paths: live recording, or file upload (with optional diarization for
+ * multi-speaker recordings such as call recordings).
+ */
+export default function CreateVoiceScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.intro}>{t('voiceCreate.intro')}</Text>
+
+      <TouchableOpacity
+        style={styles.card}
+        onPress={() => router.push('/voice/record')}
+        accessibilityRole="button"
+        accessibilityLabel={t('voiceCreate.recordTitle')}
+      >
+        <Text style={styles.cardEmoji}>🎙️</Text>
+        <View style={styles.cardBody}>
+          <Text style={styles.cardTitle}>{t('voiceCreate.recordTitle')}</Text>
+          <Text style={styles.cardDesc}>{t('voiceCreate.recordDesc')}</Text>
+        </View>
+        <Text style={styles.chevron}>›</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.card}
+        onPress={() => router.push('/voice/upload')}
+        accessibilityRole="button"
+        accessibilityLabel={t('voiceCreate.uploadTitle')}
+      >
+        <Text style={styles.cardEmoji}>📁</Text>
+        <View style={styles.cardBody}>
+          <Text style={styles.cardTitle}>{t('voiceCreate.uploadTitle')}</Text>
+          <Text style={styles.cardDesc}>{t('voiceCreate.uploadDesc')}</Text>
+        </View>
+        <Text style={styles.chevron}>›</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    content: {
+      padding: Spacing.lg,
+      gap: Spacing.md,
+    },
+    intro: {
+      fontSize: FontSize.md,
+      color: colors.textSecondary,
+      lineHeight: 22,
+      marginBottom: Spacing.sm,
+    },
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: BorderRadius.lg,
+      padding: Spacing.lg,
+      gap: Spacing.md,
+    },
+    cardEmoji: {
+      fontSize: 36,
+    },
+    cardBody: {
+      flex: 1,
+    },
+    cardTitle: {
+      fontSize: FontSize.lg,
+      fontFamily: FontFamily.bold,
+      color: colors.text,
+      marginBottom: 4,
+    },
+    cardDesc: {
+      fontSize: FontSize.sm,
+      color: colors.textSecondary,
+      lineHeight: 18,
+    },
+    chevron: {
+      fontSize: 28,
+      color: colors.textTertiary,
+    },
+  });
+}

--- a/apps/mobile/app/voice/upload.tsx
+++ b/apps/mobile/app/voice/upload.tsx
@@ -28,6 +28,7 @@ export default function UploadScreen() {
   const styles = createStyles(colors);
   const [selectedFile, setSelectedFile] = useState<DocumentPicker.DocumentPickerAsset | null>(null);
   const [name, setName] = useState('');
+  const [speakerCount, setSpeakerCount] = useState<1 | 2 | 3 | 4>(1);
 
   const cloneMutation = useMutation({
     mutationFn: (params: { file: DocumentPicker.DocumentPickerAsset; name: string }) =>
@@ -62,7 +63,25 @@ export default function UploadScreen() {
   };
 
   const handleSubmit = () => {
-    if (!selectedFile || !name.trim()) {
+    if (!selectedFile) {
+      toast.show(t('voiceUpload.inputRequired'));
+      return;
+    }
+    // Multi-speaker file → diarization flow (file is the only thing we can pass
+    // through the router; diarize screen prompts for per-speaker names there).
+    if (speakerCount > 1) {
+      router.push({
+        pathname: '/voice/diarize',
+        params: {
+          uri: selectedFile.uri,
+          fileName: selectedFile.name,
+          mimeType: selectedFile.mimeType ?? 'audio/wav',
+          speakerCount: String(speakerCount),
+        },
+      });
+      return;
+    }
+    if (!name.trim()) {
       toast.show(t('voiceUpload.inputRequired'));
       return;
     }
@@ -96,34 +115,70 @@ export default function UploadScreen() {
           </View>
         )}
 
-        {/* 이름 입력 */}
-        <TextInput
-          style={styles.nameInput}
-          placeholder={t('voiceUpload.namePlaceholder')}
-          value={name}
-          onChangeText={setName}
-          placeholderTextColor={colors.textTertiary}
-          accessibilityLabel={t('voiceUpload.a11yNameInput')}
-        />
+        {/* 화자 수 */}
+        <Text style={styles.sectionLabel}>{t('voiceUpload.speakerCount')}</Text>
+        <View style={styles.speakerRow}>
+          {([1, 2, 3, 4] as const).map((n) => {
+            const selected = speakerCount === n;
+            return (
+              <TouchableOpacity
+                key={n}
+                style={[styles.speakerChip, selected && styles.speakerChipActive]}
+                onPress={() => setSpeakerCount(n)}
+                accessibilityRole="radio"
+                accessibilityState={{ selected }}
+                accessibilityLabel={t('voiceUpload.speakerN', { n })}
+              >
+                <Text style={[styles.speakerChipText, selected && styles.speakerChipTextActive]}>
+                  {n === 1 ? t('voiceUpload.singleSpeaker') : t('voiceUpload.speakerN', { n })}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        {/* 이름 입력 (1인 화자만) */}
+        {speakerCount === 1 && (
+          <TextInput
+            style={styles.nameInput}
+            placeholder={t('voiceUpload.namePlaceholder')}
+            value={name}
+            onChangeText={setName}
+            placeholderTextColor={colors.textTertiary}
+            accessibilityLabel={t('voiceUpload.a11yNameInput')}
+          />
+        )}
 
         {/* 제출 */}
+        {(() => {
+          const submitDisabled =
+            !selectedFile ||
+            (speakerCount === 1 && !name.trim()) ||
+            cloneMutation.isPending;
+          const label =
+            speakerCount === 1
+              ? t('voiceUpload.submit')
+              : t('voiceUpload.submitDiarize');
+          return (
         <TouchableOpacity
           style={[
             styles.submitButton,
-            (!selectedFile || !name.trim() || cloneMutation.isPending) && styles.disabled,
+            submitDisabled && styles.disabled,
           ]}
           onPress={handleSubmit}
-          disabled={!selectedFile || !name.trim() || cloneMutation.isPending}
+          disabled={submitDisabled}
           accessibilityRole="button"
           accessibilityLabel={t('voiceUpload.a11ySubmit')}
-          accessibilityState={{ disabled: !selectedFile || !name.trim() || cloneMutation.isPending }}
+          accessibilityState={{ disabled: submitDisabled }}
         >
           {cloneMutation.isPending ? (
             <ActivityIndicator color={colors.textOnPrimary} />
           ) : (
-            <Text style={styles.submitText}>{t('voiceUpload.submit')}</Text>
+            <Text style={styles.submitText}>{label}</Text>
           )}
         </TouchableOpacity>
+          );
+        })()}
       </View>
       <Toast message={toast.message} opacity={toast.opacity} />
     </View>
@@ -182,6 +237,39 @@ const createStyles = (colors: ThemeColors) => StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     marginBottom: Spacing.md,
+  },
+  sectionLabel: {
+    fontSize: FontSize.sm,
+    fontFamily: FontFamily.semibold,
+    color: colors.textSecondary,
+    marginBottom: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  speakerRow: {
+    flexDirection: 'row' as const,
+    flexWrap: 'wrap' as const,
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  speakerChip: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.full,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  speakerChipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  speakerChipText: {
+    fontSize: FontSize.sm,
+    color: colors.text,
+    fontFamily: FontFamily.semibold,
+  },
+  speakerChipTextActive: {
+    color: colors.textOnPrimary,
   },
   submitButton: {
     backgroundColor: colors.primary,


### PR DESCRIPTION
## Summary
- New \`/voice/create\` is a single entry point with two cards: **Record** vs **Upload**.
- Upload screen gains a **speaker-count chip** (1 / 2 / 3 / 4):
  - 1 speaker → existing clone flow (TTS-ready single voice profile).
  - 2+ speakers → routes to \`/voice/diarize\` with the file pre-attached so the user can split a call recording per speaker.

## Files
- \`apps/mobile/app/voice/create.tsx\` (new)
- \`apps/mobile/app/voice/upload.tsx\`

## Test plan
- [ ] Tap 'Add voice' from any entry point → land on \`/voice/create\`
- [ ] Pick 'Record' → existing record screen opens
- [ ] Pick 'Upload' + 1 speaker → name input appears, submit clones single profile
- [ ] Pick 'Upload' + 2 speakers → diarize screen receives file URI/name/mimeType/speakerCount params

🤖 Generated with [Claude Code](https://claude.com/claude-code)