### PR TITLE
feat: original audio alarms (≤30s recording or upload)

### DIFF
--- a/apps/mobile/app/alarm/source-record.tsx
+++ b/apps/mobile/app/alarm/source-record.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Alert,
+  Platform,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Audio } from 'expo-av';
+import { useTranslation } from 'react-i18next';
+import { Spacing, BorderRadius, FontSize, FontFamily } from '../../src/constants/theme';
+import { useTheme, type ThemeColors } from '../../src/hooks/useTheme';
+import { requestMicPermission, startRecording, stopRecording } from '../../src/services/audio';
+import { useAlarmDraftStore } from '../../src/stores/useAlarmDraftStore';
+
+const MAX_DURATION_MS = 30_000;
+
+export default function AlarmSourceRecordScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const setRawAudio = useAlarmDraftStore((s) => s.setRawAudio);
+
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const [recordedUri, setRecordedUri] = useState<string | null>(null);
+  const [durationMs, setDurationMs] = useState(0);
+
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(0);
+
+  useEffect(() => {
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+      if (recording) recording.stopAndUnloadAsync().catch(() => {});
+    };
+  }, [recording]);
+
+  const handleRequestPermission = async () => {
+    const ok = await requestMicPermission();
+    setHasPermission(ok);
+    if (!ok) {
+      Alert.alert(t('voiceRecord.permissionTitle'), t('voiceRecord.permissionDesc'));
+    }
+  };
+
+  const handleStart = async () => {
+    if (hasPermission === null) {
+      const ok = await requestMicPermission();
+      setHasPermission(ok);
+      if (!ok) {
+        Alert.alert(t('voiceRecord.permissionTitle'), t('voiceRecord.permissionDesc'));
+        return;
+      }
+    } else if (!hasPermission) {
+      handleRequestPermission();
+      return;
+    }
+
+    try {
+      const rec = await startRecording(false);
+      setRecording(rec);
+      setIsRecording(true);
+      setRecordedUri(null);
+      setDurationMs(0);
+      startTimeRef.current = Date.now();
+      tickRef.current = setInterval(() => {
+        const elapsed = Date.now() - startTimeRef.current;
+        setDurationMs(elapsed);
+        if (elapsed >= MAX_DURATION_MS) {
+          handleStop(rec, MAX_DURATION_MS);
+        }
+      }, 100);
+    } catch {
+      Alert.alert(t('voiceRecord.errorTitle'), t('voiceRecord.errorStart'));
+    }
+  };
+
+  const handleStop = async (rec?: Audio.Recording, finalMs?: number) => {
+    const target = rec ?? recording;
+    if (!target) return;
+    if (tickRef.current) {
+      clearInterval(tickRef.current);
+      tickRef.current = null;
+    }
+    setIsRecording(false);
+    try {
+      const result = await stopRecording(target);
+      setRecordedUri(result.uri);
+      setDurationMs(finalMs ?? Math.round(result.duration * 1000));
+    } catch {
+      // ignore — keeps current durationMs/recordedUri null state
+    } finally {
+      setRecording(null);
+    }
+  };
+
+  const handleUse = () => {
+    if (!recordedUri) return;
+    setRawAudio({
+      uri: recordedUri,
+      durationMs,
+      origin: 'recording',
+      fileName: `alarm-source-${Date.now()}.${Platform.OS === 'ios' ? 'm4a' : 'm4a'}`,
+      mimeType: 'audio/m4a',
+    });
+    router.back();
+  };
+
+  const handleRetry = () => {
+    setRecordedUri(null);
+    setDurationMs(0);
+  };
+
+  const seconds = Math.min(MAX_DURATION_MS, durationMs) / 1000;
+  const remaining = Math.max(0, MAX_DURATION_MS - durationMs) / 1000;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.intro}>{t('alarmSource.recordIntro')}</Text>
+
+      <View style={styles.timerBox}>
+        <Text style={styles.timer}>
+          {seconds.toFixed(1)}s
+        </Text>
+        <Text style={styles.timerHint}>
+          {isRecording
+            ? t('alarmSource.recordingRemaining', { s: remaining.toFixed(0) })
+            : t('alarmSource.recordMax')}
+        </Text>
+      </View>
+
+      {!recordedUri && (
+        <TouchableOpacity
+          style={[styles.bigButton, isRecording && styles.bigButtonRecording]}
+          onPress={isRecording ? () => handleStop() : handleStart}
+          accessibilityRole="button"
+          accessibilityLabel={isRecording ? t('alarmSource.stop') : t('alarmSource.startRecording')}
+        >
+          <Text style={styles.bigButtonEmoji}>{isRecording ? '⏹' : '🎙️'}</Text>
+          <Text style={styles.bigButtonText}>
+            {isRecording ? t('alarmSource.stop') : t('alarmSource.startRecording')}
+          </Text>
+        </TouchableOpacity>
+      )}
+
+      {recordedUri && (
+        <View style={styles.resultRow}>
+          <TouchableOpacity
+            style={[styles.actionButton, styles.secondaryButton]}
+            onPress={handleRetry}
+            accessibilityRole="button"
+          >
+            <Text style={styles.secondaryText}>{t('alarmSource.retry')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionButton, styles.primaryButton]}
+            onPress={handleUse}
+            accessibilityRole="button"
+          >
+            <Text style={styles.primaryText}>{t('alarmSource.use')}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+      padding: Spacing.lg,
+    },
+    intro: {
+      fontSize: FontSize.md,
+      color: colors.textSecondary,
+      lineHeight: 22,
+      marginBottom: Spacing.xl,
+    },
+    timerBox: {
+      alignItems: 'center',
+      marginBottom: Spacing.xl,
+    },
+    timer: {
+      fontSize: 56,
+      fontFamily: FontFamily.bold,
+      color: colors.text,
+    },
+    timerHint: {
+      fontSize: FontSize.sm,
+      color: colors.textSecondary,
+      marginTop: Spacing.xs,
+    },
+    bigButton: {
+      backgroundColor: colors.primary,
+      borderRadius: BorderRadius.xl,
+      paddingVertical: Spacing.xl,
+      alignItems: 'center',
+    },
+    bigButtonRecording: {
+      backgroundColor: colors.error,
+    },
+    bigButtonEmoji: {
+      fontSize: 56,
+      marginBottom: Spacing.sm,
+    },
+    bigButtonText: {
+      color: colors.textOnPrimary,
+      fontSize: FontSize.lg,
+      fontFamily: FontFamily.bold,
+    },
+    resultRow: {
+      flexDirection: 'row' as const,
+      gap: Spacing.md,
+    },
+    actionButton: {
+      flex: 1,
+      borderRadius: BorderRadius.lg,
+      paddingVertical: Spacing.md + 4,
+      alignItems: 'center',
+    },
+    primaryButton: {
+      backgroundColor: colors.primary,
+    },
+    secondaryButton: {
+      backgroundColor: colors.surfaceVariant,
+    },
+    primaryText: {
+      color: colors.textOnPrimary,
+      fontSize: FontSize.lg,
+      fontFamily: FontFamily.bold,
+    },
+    secondaryText: {
+      color: colors.text,
+      fontSize: FontSize.lg,
+      fontFamily: FontFamily.semibold,
+    },
+  });
+}

--- a/apps/mobile/app/alarm/source-upload.tsx
+++ b/apps/mobile/app/alarm/source-upload.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { useRouter } from 'expo-router';
+import * as DocumentPicker from 'expo-document-picker';
+import { Audio } from 'expo-av';
+import { useTranslation } from 'react-i18next';
+import { Spacing, BorderRadius, FontSize, FontFamily } from '../../src/constants/theme';
+import { useTheme, type ThemeColors } from '../../src/hooks/useTheme';
+import { useAlarmDraftStore } from '../../src/stores/useAlarmDraftStore';
+
+const MAX_DURATION_MS = 30_000;
+
+export default function AlarmSourceUploadScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const setRawAudio = useAlarmDraftStore((s) => s.setRawAudio);
+
+  const [picked, setPicked] = useState<DocumentPicker.DocumentPickerAsset | null>(null);
+  const [durationMs, setDurationMs] = useState<number | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  const probeDuration = async (uri: string): Promise<number> => {
+    const { sound, status } = await Audio.Sound.createAsync({ uri }, { shouldPlay: false });
+    try {
+      if (status.isLoaded && typeof status.durationMillis === 'number') {
+        return status.durationMillis;
+      }
+      return 0;
+    } finally {
+      await sound.unloadAsync();
+    }
+  };
+
+  const handlePick = async () => {
+    const result = await DocumentPicker.getDocumentAsync({
+      type: ['audio/*', 'video/*'],
+      copyToCacheDirectory: true,
+    });
+    if (result.canceled || result.assets.length === 0) return;
+    const file = result.assets[0]!;
+    setChecking(true);
+    setPicked(file);
+    setDurationMs(null);
+    try {
+      const ms = await probeDuration(file.uri);
+      setDurationMs(ms);
+      if (ms > MAX_DURATION_MS) {
+        Alert.alert(
+          t('alarmSource.tooLongTitle'),
+          t('alarmSource.tooLongDesc', { sec: Math.round(ms / 1000) }),
+        );
+      }
+    } catch {
+      // length probe failed; allow user to retry but disable Use until known
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleUse = () => {
+    if (!picked || durationMs == null) return;
+    if (durationMs > MAX_DURATION_MS) {
+      Alert.alert(
+        t('alarmSource.tooLongTitle'),
+        t('alarmSource.tooLongDesc', { sec: Math.round(durationMs / 1000) }),
+      );
+      return;
+    }
+    setRawAudio({
+      uri: picked.uri,
+      durationMs,
+      origin: 'upload',
+      fileName: picked.name,
+      mimeType: picked.mimeType ?? 'audio/m4a',
+    });
+    router.back();
+  };
+
+  const overLimit = durationMs != null && durationMs > MAX_DURATION_MS;
+  const useDisabled = !picked || durationMs == null || overLimit || checking;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.intro}>{t('alarmSource.uploadIntro')}</Text>
+
+      <TouchableOpacity
+        style={styles.pickBox}
+        onPress={handlePick}
+        accessibilityRole="button"
+        accessibilityLabel={t('alarmSource.pickFile')}
+      >
+        <Text style={styles.pickEmoji}>📁</Text>
+        <Text style={styles.pickText}>{picked ? picked.name : t('alarmSource.pickFile')}</Text>
+        {durationMs != null && (
+          <Text style={[styles.pickHint, overLimit && styles.pickHintError]}>
+            {(durationMs / 1000).toFixed(1)}s {overLimit ? `(>${MAX_DURATION_MS / 1000}s)` : ''}
+          </Text>
+        )}
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[styles.useButton, useDisabled && styles.disabled]}
+        onPress={handleUse}
+        disabled={useDisabled}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: useDisabled }}
+      >
+        <Text style={styles.useButtonText}>{t('alarmSource.use')}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+      padding: Spacing.lg,
+    },
+    intro: {
+      fontSize: FontSize.md,
+      color: colors.textSecondary,
+      lineHeight: 22,
+      marginBottom: Spacing.lg,
+    },
+    pickBox: {
+      backgroundColor: colors.surface,
+      borderRadius: BorderRadius.lg,
+      padding: Spacing.xl,
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: colors.border,
+      borderStyle: 'dashed',
+      marginBottom: Spacing.lg,
+    },
+    pickEmoji: {
+      fontSize: 48,
+      marginBottom: Spacing.sm,
+    },
+    pickText: {
+      fontSize: FontSize.md,
+      color: colors.text,
+      fontFamily: FontFamily.semibold,
+      textAlign: 'center',
+    },
+    pickHint: {
+      marginTop: Spacing.xs,
+      fontSize: FontSize.sm,
+      color: colors.textSecondary,
+    },
+    pickHintError: {
+      color: colors.error,
+    },
+    useButton: {
+      backgroundColor: colors.primary,
+      borderRadius: BorderRadius.lg,
+      paddingVertical: Spacing.md,
+      alignItems: 'center',
+    },
+    useButtonText: {
+      color: colors.textOnPrimary,
+      fontSize: FontSize.lg,
+      fontFamily: FontFamily.bold,
+    },
+    disabled: {
+      opacity: 0.5,
+    },
+  });
+}

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -464,6 +464,25 @@ export const migrations: Migration[] = [
       `CREATE INDEX IF NOT EXISTS idx_alarms_target_active ON alarms(target_user_id, is_active)`,
     ],
   },
+  {
+    id: 20,
+    // Cleanup orphaned `alarms_new` left behind by a half-applied earlier
+    // attempt at the table-recreation migration. No-op on fresh DBs.
+    name: 'alarm-raw-audio-cleanup',
+    statements: [
+      'DROP TABLE IF EXISTS alarms_new',
+    ],
+  },
+  {
+    id: 21,
+    // Add raw_audio columns directly via ALTER. Keeps `message_id` NOT NULL —
+    // raw-audio alarms get a placeholder message row in alarm-mutation.
+    name: 'alarm-raw-audio-columns',
+    statements: [
+      `ALTER TABLE alarms ADD COLUMN raw_audio_url TEXT`,
+      `ALTER TABLE alarms ADD COLUMN raw_audio_duration_ms INTEGER`,
+    ],
+  },
 ];
 
 export async function runMigrations(db: Client): Promise<string[]> {

--- a/packages/backend/src/routes/alarm-helpers.ts
+++ b/packages/backend/src/routes/alarm-helpers.ts
@@ -19,6 +19,8 @@ export type AlarmRow = Record<string, unknown> & {
   creator_email?: unknown;
   creator_name?: unknown;
   category?: unknown;
+  raw_audio_url?: unknown;
+  raw_audio_duration_ms?: unknown;
 };
 
 export function normalizeAlarmRow(row: AlarmRow, viewerUserId?: string | null) {
@@ -65,6 +67,11 @@ export function normalizeAlarmRow(row: AlarmRow, viewerUserId?: string | null) {
     wake_mode: wakeMode,
     voice_profile_id: (row.voice_profile_id ?? null) as string | null,
     speaker_id: (row.speaker_id ?? null) as string | null,
+    raw_audio_url: (row.raw_audio_url ?? null) as string | null,
+    raw_audio_duration_ms:
+      typeof row.raw_audio_duration_ms === 'number'
+        ? row.raw_audio_duration_ms
+        : null,
     sender_user_id: senderUserId,
     sender_name: senderName,
     sender_email: senderEmail,
@@ -84,11 +91,11 @@ export function validateAlarmFields(body: {
   time?: string;
   repeat_days?: number[];
   snooze_minutes?: number;
-  message_id?: string;
+  message_id?: string | null;
   is_active?: boolean;
   target_user_id?: string;
 }): FieldError | null {
-  if (body.message_id !== undefined && !UUID_RE.test(body.message_id)) {
+  if (body.message_id != null && !UUID_RE.test(body.message_id)) {
     return { error: 'Invalid message_id format', error_code: 'INVALID_MESSAGE_ID' };
   }
 

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -18,7 +18,7 @@ alarmMutation.post('/', async (c) => {
   const db = getDB(c.env);
 
   const body = await c.req.json<{
-    message_id: string;
+    message_id?: string;
     time: string;
     repeat_days?: number[];
     snooze_minutes?: number;
@@ -28,10 +28,19 @@ alarmMutation.post('/', async (c) => {
     wake_mode?: string;
     voice_profile_id?: string;
     speaker_id?: string;
+    raw_audio_url?: string;
+    raw_audio_duration_ms?: number;
   }>();
 
-  if (!body.message_id || !body.time) {
-    return c.json({ error: 'message_id and time are required', error_code: 'REQUIRED_FIELDS_MISSING' }, 400);
+  if (!body.time) {
+    return c.json({ error: 'time is required', error_code: 'REQUIRED_FIELDS_MISSING' }, 400);
+  }
+  // Either a TTS message OR a raw-audio source must be present.
+  if (!body.message_id && !body.raw_audio_url) {
+    return c.json(
+      { error: 'either message_id or raw_audio_url is required', error_code: 'ALARM_SOURCE_MISSING' },
+      400,
+    );
   }
 
   const fieldError = validateAlarmFields(body);
@@ -66,12 +75,45 @@ alarmMutation.post('/', async (c) => {
     }
   }
 
-  const msg = await db.execute({
-    sql: 'SELECT id FROM messages WHERE id = ? AND user_id = ?',
-    args: [body.message_id, userId],
-  });
-  if (msg.rows.length === 0) {
-    return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);
+  // Raw-audio alarms have no real TTS message but the schema still requires
+  // message_id (NOT NULL). Insert a "raw" placeholder message that points at
+  // the same audio URL so the alarm row is satisfied. We attach it to the
+  // user's first voice profile because messages.voice_profile_id is NOT NULL.
+  let resolvedMessageId: string | null = body.message_id ?? null;
+  if (!resolvedMessageId && body.raw_audio_url) {
+    const firstVoice = await db.execute({
+      sql: 'SELECT id FROM voice_profiles WHERE user_id = ? LIMIT 1',
+      args: [userId],
+    });
+    if (firstVoice.rows.length === 0) {
+      return c.json(
+        {
+          error: 'A voice profile is required to create a raw-audio alarm.',
+          error_code: 'VOICE_PROFILE_REQUIRED',
+        },
+        400,
+      );
+    }
+    const placeholderMsgId = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+            VALUES (?, ?, ?, '', ?, 'raw')`,
+      args: [
+        placeholderMsgId,
+        userId,
+        firstVoice.rows[0]!.id as string,
+        body.raw_audio_url,
+      ],
+    });
+    resolvedMessageId = placeholderMsgId;
+  } else if (resolvedMessageId) {
+    const msg = await db.execute({
+      sql: 'SELECT id FROM messages WHERE id = ? AND user_id = ?',
+      args: [resolvedMessageId, userId],
+    });
+    if (msg.rows.length === 0) {
+      return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);
+    }
   }
 
   const alarmId = crypto.randomUUID();
@@ -81,13 +123,14 @@ alarmMutation.post('/', async (c) => {
   await db.execute({
     sql: `INSERT INTO alarms
             (id, user_id, target_user_id, message_id, time, repeat_days, snooze_minutes,
-             mode, vibration_pattern, wake_mode, voice_profile_id, speaker_id)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             mode, vibration_pattern, wake_mode, voice_profile_id, speaker_id,
+             raw_audio_url, raw_audio_duration_ms)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       alarmId,
       userId,
       body.target_user_id ?? null,
-      body.message_id,
+      resolvedMessageId,
       body.time,
       JSON.stringify(body.repeat_days ?? []),
       body.snooze_minutes ?? 5,
@@ -96,6 +139,8 @@ alarmMutation.post('/', async (c) => {
       wakeMode,
       body.voice_profile_id ?? null,
       body.speaker_id ?? null,
+      body.raw_audio_url ?? null,
+      body.raw_audio_duration_ms ?? null,
     ],
   });
 
@@ -128,12 +173,14 @@ alarmMutation.patch('/:id', async (c) => {
     repeat_days?: number[];
     is_active?: boolean;
     snooze_minutes?: number;
-    message_id?: string;
+    message_id?: string | null;
     mode?: string;
     vibration_pattern?: string;
     wake_mode?: string;
     voice_profile_id?: string | null;
     speaker_id?: string | null;
+    raw_audio_url?: string | null;
+    raw_audio_duration_ms?: number | null;
   }>();
 
   const fieldError = validateAlarmFields(body);
@@ -189,6 +236,14 @@ alarmMutation.patch('/:id', async (c) => {
   if (body.speaker_id !== undefined) {
     updates.push('speaker_id = ?');
     args.push(body.speaker_id);
+  }
+  if (body.raw_audio_url !== undefined) {
+    updates.push('raw_audio_url = ?');
+    args.push(body.raw_audio_url);
+  }
+  if (body.raw_audio_duration_ms !== undefined) {
+    updates.push('raw_audio_duration_ms = ?');
+    args.push(body.raw_audio_duration_ms);
   }
 
   if (updates.length === 0) {

--- a/packages/backend/src/routes/alarm-source.ts
+++ b/packages/backend/src/routes/alarm-source.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { getFormFile } from '../lib/db-types';
+
+/**
+ * Upload a short raw audio clip (≤30s) to be played directly when an alarm
+ * fires. Stores the clip in R2 under `raw-alarms/{userId}/{uuid}` and returns
+ * the public/signed URL caller should attach to the alarm payload.
+ *
+ * Body: multipart/form-data
+ *   - audio: File (audio/* or video/* — caller should crop video → audio first
+ *            for now; auto-crop is a follow-up step)
+ *   - durationMs: integer, must be ≤ MAX_DURATION_MS
+ */
+const alarmSource = new Hono<AppEnv>();
+
+const MAX_DURATION_MS = 30_000;
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MiB cap for a 30s clip
+
+alarmSource.post('/source', async (c) => {
+  const userId = c.get('userId');
+  const bucket = c.env.VOICE_BUCKET;
+  if (!bucket) {
+    return c.json(
+      { error: 'voice storage not configured', error_code: 'STORAGE_UNAVAILABLE' },
+      503,
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json(
+      { error: 'multipart/form-data body required', error_code: 'MULTIPART_BODY_REQUIRED' },
+      400,
+    );
+  }
+
+  const audioFile = getFormFile(formData, 'audio');
+  if (!audioFile || typeof audioFile === 'string') {
+    return c.json({ error: 'audio file is required', error_code: 'AUDIO_FILE_REQUIRED' }, 400);
+  }
+
+  const mimeType = audioFile.type || 'application/octet-stream';
+  if (!mimeType.startsWith('audio/') && !mimeType.startsWith('video/')) {
+    return c.json(
+      { error: 'audio/* or video/* MIME type required', error_code: 'INVALID_MIME_TYPE' },
+      415,
+    );
+  }
+
+  const durationRaw = formData.get('durationMs');
+  const durationMs =
+    typeof durationRaw === 'string' ? Number.parseInt(durationRaw, 10) : NaN;
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    return c.json(
+      { error: 'durationMs must be a positive integer', error_code: 'INVALID_DURATION' },
+      400,
+    );
+  }
+  if (durationMs > MAX_DURATION_MS) {
+    return c.json(
+      {
+        error: `clip exceeds ${MAX_DURATION_MS / 1000}s (got ${Math.round(durationMs / 1000)}s)`,
+        error_code: 'CLIP_TOO_LONG',
+      },
+      400,
+    );
+  }
+
+  const buffer = await audioFile.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    return c.json({ error: 'audio file is empty', error_code: 'AUDIO_FILE_EMPTY' }, 400);
+  }
+  if (buffer.byteLength > MAX_BYTES) {
+    return c.json(
+      {
+        error: `clip exceeds ${MAX_BYTES} bytes (got ${buffer.byteLength})`,
+        error_code: 'CLIP_TOO_LARGE',
+      },
+      413,
+    );
+  }
+
+  const id = crypto.randomUUID();
+  const objectKey = `raw-alarms/${userId}/${id}`;
+  await bucket.put(objectKey, buffer, {
+    httpMetadata: { contentType: mimeType },
+    customMetadata: {
+      userId,
+      durationMs: String(durationMs),
+      originalName: audioFile.name?.slice(0, 200) ?? '',
+    },
+  });
+
+  // Return a relative URL the alarm-fire client can resolve against the
+  // public bucket / signed-URL endpoint. Storing the bare object key keeps
+  // the DB row stable across bucket renames.
+  return c.json(
+    {
+      object_key: objectKey,
+      raw_audio_url: `r2://${objectKey}`,
+      duration_ms: durationMs,
+      mime_type: mimeType,
+    },
+    201,
+  );
+});
+
+export default alarmSource;

--- a/packages/backend/src/routes/alarm.ts
+++ b/packages/backend/src/routes/alarm.ts
@@ -2,10 +2,12 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import alarmQuery from './alarm-query';
 import alarmMutation from './alarm-mutation';
+import alarmSource from './alarm-source';
 
 const alarm = new Hono<AppEnv>();
 
 alarm.route('/', alarmQuery);
 alarm.route('/', alarmMutation);
+alarm.route('/', alarmSource);
 
 export default alarm;


### PR DESCRIPTION
## Summary
Lets users attach a **30-second user-recorded or user-uploaded clip** as the alarm sound, instead of (or in addition to) a TTS message.

### Backend
- **Migration 20**: cleanup orphaned \`alarms_new\` from an earlier failed table-recreation attempt (DROP IF EXISTS, no-op on fresh DBs).
- **Migration 21**: \`ALTER TABLE alarms ADD COLUMN raw_audio_url TEXT, raw_audio_duration_ms INTEGER\`.
- **POST /api/alarm/source**: multipart upload (audio/* or video/*), ≤30s, ≤5 MiB. Stores at \`raw-alarms/{userId}/{uuid}\` in R2 (\`VOICE_BUCKET\`). Returns \`raw_audio_url\` + \`object_key\` + \`duration_ms\`.
- **POST/PATCH /api/alarm**: accepts \`message_id\` OR \`raw_audio_url\` (one required). For raw alarms it auto-creates a placeholder \`'raw'\`-category message attached to the user's first voice profile so the existing \`message_id NOT NULL\` constraint is satisfied without a schema-breaking change. Returns \`VOICE_PROFILE_REQUIRED\` 400 if user has no voice profile.
- \`normalizeAlarmRow\` surfaces \`raw_audio_url\` + \`raw_audio_duration_ms\` in API responses.

### Frontend
- **/alarm/source-record**: tap-to-record with auto-stop at 30s. Retry / Use buttons.
- **/alarm/source-upload**: file picker (audio/* + video/*) with \`expo-av\` Sound duration probe → rejects clips >30s with an alert.

## Followups (not in this PR)
- Alarm trigger logic to actually play the raw audio when the notification fires (currently the row is saved but \`syncAlarmNotifications\` still uses the default sound).
- Auto-crop for >30s files (today: alert + reject).

## Test plan
- [ ] Wrangler deploy applies migrations 20+21 cleanly
- [ ] \`POST /api/alarm/source\` with a 5s WAV returns 201 + \`raw_audio_url: r2://raw-alarms/...\`
- [ ] Object visible in \`wrangler r2 object list voice-alarm-voices --prefix raw-alarms/\`
- [ ] \`POST /api/alarm\` with \`raw_audio_url\` + no \`message_id\` succeeds (placeholder message auto-created)
- [ ] \`POST /api/alarm\` with neither returns 400 \`ALARM_SOURCE_MISSING\`
- [ ] User without voice profile → \`VOICE_PROFILE_REQUIRED\` on raw upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)