### PR TITLE
feat: native Google sign-in + auth diagnostics

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -65,7 +65,8 @@
       "expo-document-picker",
       "expo-web-browser",
       "expo-font",
-      "@sentry/react-native"
+      "@sentry/react-native",
+      "@react-native-google-signin/google-signin"
     ],
     "extra": {
       "router": {

--- a/apps/mobile/src/components/LoginButtons.tsx
+++ b/apps/mobile/src/components/LoginButtons.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Spacing, BorderRadius, FontSize, FontFamily } from '../constants/theme';
 import {
-  useGoogleAuth,
+  signInWithGoogle,
   signInWithApple,
   isAppleAuthAvailable,
   saveAuthToken,
@@ -13,7 +13,6 @@ import { useAppStore } from '../stores/useAppStore';
 
 export default function LoginButtons() {
   const { setAuth } = useAppStore();
-  const { request, response, promptAsync } = useGoogleAuth();
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
 
@@ -31,28 +30,15 @@ export default function LoginButtons() {
     }
   }, [setAuth, t]);
 
-  useEffect(() => {
-    if (!response) return;
-
-    if (response.type === 'success') {
-      const idToken = response.params.id_token;
-      if (idToken) {
-        handleLoginSuccess(idToken, 'google');
-      } else {
-        Alert.alert(t('login.error'), t('login.noToken'));
-      }
-    } else if (response.type === 'error') {
-      const msg = response.error?.message || t('login.unknownError');
-      Alert.alert(t('login.error'), msg);
-    }
-    // 'dismiss' (사용자가 취소)는 무시
-    setLoading(false); // eslint-disable-line react-hooks/set-state-in-effect
-  }, [response, handleLoginSuccess, t]);
-
   const handleGoogleLogin = async () => {
     setLoading(true);
     try {
-      await promptAsync();
+      const result = await signInWithGoogle();
+      if (result) {
+        await handleLoginSuccess(result.idToken, 'google');
+      } else {
+        setLoading(false);
+      }
     } catch {
       Alert.alert(t('login.error'), t('login.googleFailed'));
       setLoading(false);
@@ -79,7 +65,7 @@ export default function LoginButtons() {
       <TouchableOpacity
         style={[styles.googleButton, loading && styles.disabledButton]}
         onPress={handleGoogleLogin}
-        disabled={!request || loading}
+        disabled={loading}
         accessibilityRole="button"
         accessibilityLabel={t('login.google')}
       >

--- a/apps/mobile/src/hooks/useAuth.tsx
+++ b/apps/mobile/src/hooks/useAuth.tsx
@@ -125,7 +125,9 @@ export function AuthProvider({ children, apiBase, storage, fetchImpl }: AuthProv
         setIsLoading(false);
       }
     })();
-  }, [store, refresh]);
+    // boot은 마운트 시 1회만 실행. refresh/store 변경에도 재실행 금지.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const login = useCallback(
     async (email: string, password: string): Promise<AuthUser> => {

--- a/apps/mobile/src/services/api/core.ts
+++ b/apps/mobile/src/services/api/core.ts
@@ -92,12 +92,18 @@ export async function request<T>(config: RequestConfig): Promise<T> {
         signal: controller.signal,
       });
 
-      if (res.status === 401) {
-        await AsyncStorage.removeItem('auth_token');
-      }
-
       if (!res.ok) {
         const errData = await res.json().catch(() => null);
+        // eslint-disable-next-line no-console
+        console.log(
+          `[API ${res.status}] ${config.method} ${config.path}`,
+          'hasToken=', !!token,
+          'tokenLen=', token?.length ?? 0,
+          'body=', JSON.stringify(errData),
+        );
+        if (res.status === 401) {
+          await AsyncStorage.removeItem('auth_token');
+        }
         throw new ApiError(res.status, errData);
       }
 

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -1,53 +1,76 @@
-import { useState } from 'react';
-import * as AuthSession from 'expo-auth-session';
-import * as WebBrowser from 'expo-web-browser';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
+import {
+  GoogleSignin,
+  statusCodes,
+  isErrorWithCode,
+} from '@react-native-google-signin/google-signin';
 
-WebBrowser.maybeCompleteAuthSession();
+const GOOGLE_IOS_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID ?? '';
+const GOOGLE_WEB_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID ?? '';
 
-// ============================
-// Google Cloud Console에서 OAuth 2.0 Client ID를 생성하세요:
-// 1. https://console.cloud.google.com/apis/credentials
-// 2. "Create Credentials" → "OAuth client ID"
-// 3. Application type: "Web application"
-// 4. Authorized redirect URIs에 추가:
-//    - Expo Go: https://auth.expo.io/@your-username/voice-alarm
-//    - 프로덕션: voicealarm://redirect
-// 5. 생성된 Client ID를 아래에 입력
-// ============================
-const GOOGLE_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? '';
+let googleConfigured = false;
 
-// ===== Google 로그인 =====
-
-export function useGoogleAuth() {
-  const redirectUri = AuthSession.makeRedirectUri({
-    scheme: 'voicealarm',
-    path: 'redirect',
+function ensureGoogleConfigured() {
+  if (googleConfigured) return;
+  GoogleSignin.configure({
+    webClientId: GOOGLE_WEB_CLIENT_ID,
+    iosClientId: GOOGLE_IOS_CLIENT_ID || undefined,
+    scopes: ['profile', 'email'],
+    offlineAccess: false,
   });
+  googleConfigured = true;
+}
 
+export type GoogleSignInResult = {
+  idToken: string;
+  user: { id: string; email: string | null; name: string | null; photo: string | null };
+} | null;
 
-  const [nonce] = useState(
-    () => Math.random().toString(36).substring(2) + Date.now().toString(36),
-  );
+export async function signInWithGoogle(): Promise<GoogleSignInResult> {
+  ensureGoogleConfigured();
+  try {
+    await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+    // 캐시된 계정으로 자동 로그인되지 않도록 먼저 세션 정리 →
+    // 매번 시스템 계정 선택 다이얼로그가 뜬다.
+    try {
+      await GoogleSignin.signOut();
+    } catch {
+      // 로그인된 적 없으면 무시
+    }
+    const result = await GoogleSignin.signIn();
 
-  const [request, response, promptAsync] = AuthSession.useAuthRequest(
-    {
-      clientId: GOOGLE_CLIENT_ID,
-      scopes: ['openid', 'profile', 'email'],
-      responseType: 'id_token',
-      usePKCE: false,
-      extraParams: { nonce },
-      redirectUri,
-    },
-    {
-      authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
-      tokenEndpoint: 'https://oauth2.googleapis.com/token',
-    },
-  );
+    if (result.type !== 'success') return null;
 
-  return { request, response, promptAsync, redirectUri };
+    const { idToken, user } = result.data;
+    if (!idToken) return null;
+
+    return {
+      idToken,
+      user: {
+        id: user.id,
+        email: user.email ?? null,
+        name: user.name ?? null,
+        photo: user.photo ?? null,
+      },
+    };
+  } catch (err: unknown) {
+    if (isErrorWithCode(err)) {
+      if (err.code === statusCodes.SIGN_IN_CANCELLED) return null;
+      if (err.code === statusCodes.IN_PROGRESS) return null;
+    }
+    throw err;
+  }
+}
+
+export async function signOutGoogle(): Promise<void> {
+  ensureGoogleConfigured();
+  try {
+    await GoogleSignin.signOut();
+  } catch {
+    // ignore — sign-out failure shouldn't block local cleanup
+  }
 }
 
 // ===== Apple 로그인 (iOS only) =====
@@ -111,6 +134,7 @@ export async function getAuthProvider(): Promise<'google' | 'apple' | null> {
 }
 
 export async function signOut() {
+  await signOutGoogle();
   await AsyncStorage.removeItem('auth_token');
   await AsyncStorage.removeItem('auth_provider');
   await AsyncStorage.removeItem('user_id');

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -45,7 +45,7 @@ export function configureNotificationChannels(t: TFunction): void {
       name: t('settings.channelAlarms'),
       description: t('settings.channelAlarmsDesc'),
       importance: Notifications.AndroidImportance.MAX,
-      sound: 'default',
+      sound: 'default_alarm',
       vibrationPattern: [0, 500, 250, 500],
       enableLights: true,
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
@@ -56,7 +56,7 @@ export function configureNotificationChannels(t: TFunction): void {
       name: t('settings.channelNotes'),
       description: t('settings.channelNotesDesc'),
       importance: Notifications.AndroidImportance.HIGH,
-      sound: 'default',
+      sound: 'default_alarm',
       vibrationPattern: [0, 250, 200, 250],
       enableLights: true,
     });
@@ -65,7 +65,7 @@ export function configureNotificationChannels(t: TFunction): void {
       name: t('settings.channelReminders'),
       description: t('settings.channelRemindersDesc'),
       importance: Notifications.AndroidImportance.DEFAULT,
-      sound: 'default',
+      sound: 'default_alarm',
     });
 
     Notifications.setNotificationChannelAsync(NotificationChannel.SYSTEM, {
@@ -117,7 +117,7 @@ export async function syncAlarmNotifications(alarms: Alarm[]): Promise<void> {
     const content: Notifications.NotificationContentInput = {
       title,
       body,
-      sound: 'default',
+      sound: 'default_alarm',
       categoryIdentifier: ALARM_CATEGORY,
       data: notificationData,
       ...(Platform.OS === 'android' && { channelId: NotificationChannel.ALARMS }),
@@ -160,7 +160,7 @@ export async function scheduleSnoozeNotification(
     content: {
       title,
       body,
-      sound: 'default',
+      sound: 'default_alarm',
       categoryIdentifier: ALARM_CATEGORY,
       data,
       ...(Platform.OS === 'android' && { channelId: NotificationChannel.ALARMS }),

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -71,6 +71,8 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
           : message.includes('format')
             ? 'AUTH_MALFORMED_TOKEN'
             : 'AUTH_VERIFICATION_FAILED';
+    // eslint-disable-next-line no-console
+    console.log('[AUTH 401]', code, '|', message, '| GOOGLE_CLIENT_ID set:', !!c.env.GOOGLE_CLIENT_ID);
     return c.json({ error: message, error_code: code }, 401);
   }
 }


### PR DESCRIPTION
## Summary
- Switches Google login from \`expo-auth-session\` (Custom Tab browser flow) to **\`@react-native-google-signin/google-signin\`** (system account picker) for the more familiar Instagram/Discord-style UX.
- Forces \`signOut()\` before every \`signIn()\` so users can pick a different account each time.
- \`app.json\` registers the native config plugin (**requires EAS rebuild**).
- \`LoginButtons\` drops the \`response\`/\`promptAsync\` hook pattern in favor of an imperative call.
- Top-level \`signOut()\` also revokes the Google session.

### Side fixes bundled
- Notifications channel sound \`'default'\` → \`'default_alarm'\` so the custom WAV registered in \`app.json\` plugins actually plays.
- AuthProvider's boot useEffect deps reduced to \`[]\` (the refresh ref guard wasn't enough when token state changed during boot).
- API client logs body + token presence on non-2xx responses; backend auth middleware logs resolved \`error_code\` + \`GOOGLE_CLIENT_ID\` presence — both gated by structured prefixes for grep.

## Test plan
- [ ] EAS rebuild with new plugin
- [ ] Tap 'Continue with Google' → system dialog (no browser tab opens)
- [ ] Sign out → tap again → dialog reappears letting user pick a different account
- [ ] Backend tail shows \`[AUTH 401]\` line when token rejected (audience mismatch / expired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)