### PR TITLE
feat(backend): alarm-only 모드 + 알람 리스트 LEFT JOIN

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,26 @@
+# Cloudflare Workers backend secrets.
+#
+# In production these live in the Cloudflare secret store, set via:
+#   npx wrangler secret put <NAME>
+#
+# This file documents what to set; we don't read a literal `.env` here.
+# (Locally, `wrangler dev` will pick them up if you create a `.dev.vars`.)
+
+# ===== AI providers =====
+PERSO_API_KEY=
+ELEVENLABS_API_KEY=
+
+# ===== Turso DB =====
+TURSO_DATABASE_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=
+
+# ===== Auth =====
+# Web OAuth client ID — used as the audience when verifying Google id tokens.
+GOOGLE_CLIENT_ID=000000000000-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
+# HMAC key for the app's own JWTs (>= 32 chars).
+JWT_SECRET=
+# Server-side pepper appended before bcrypt hashing.
+PASSWORD_PEPPER=
+
+# ===== Push (optional) =====
+FIREBASE_PROJECT_ID=

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -489,6 +489,101 @@ export const migrations: Migration[] = [
       `ALTER TABLE alarms ADD COLUMN raw_audio_duration_ms INTEGER`,
     ],
   },
+  {
+    id: 22,
+    // Make alarms.message_id NULLABLE so the "alarm-only" play mode (just a
+    // buzzer, no TTS or voice clip) can store an alarm row without inventing
+    // a placeholder message. SQLite has no ALTER COLUMN DROP NOT NULL, so we
+    // rebuild the table. NOTE: this version (re)introduced FK constraints
+    // that conflict with the established convention of storing the JWT sub
+    // (Google ID) in `user_id` instead of the users.id PK — superseded by
+    // migration 23, which drops those FKs. Kept here for ledger continuity.
+    name: 'alarms-message-id-nullable',
+    statements: [
+      `PRAGMA foreign_keys=off`,
+      `DROP TABLE IF EXISTS alarms_v2`,
+      `CREATE TABLE alarms_v2 (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES users(id),
+        target_user_id TEXT,
+        message_id TEXT REFERENCES messages(id),
+        time TEXT NOT NULL,
+        repeat_days TEXT DEFAULT '[]',
+        is_active INTEGER DEFAULT 1,
+        snooze_minutes INTEGER DEFAULT 5,
+        mode TEXT NOT NULL DEFAULT 'tts',
+        voice_profile_id TEXT,
+        speaker_id TEXT,
+        vibration_pattern TEXT NOT NULL DEFAULT 'default',
+        wake_mode TEXT NOT NULL DEFAULT 'sound_then_voice',
+        raw_audio_url TEXT,
+        raw_audio_duration_ms INTEGER,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )`,
+      `INSERT INTO alarms_v2 (
+        id, user_id, target_user_id, message_id, time, repeat_days,
+        is_active, snooze_minutes, mode, voice_profile_id, speaker_id,
+        vibration_pattern, wake_mode, raw_audio_url, raw_audio_duration_ms,
+        created_at, updated_at
+      ) SELECT
+        id, user_id, target_user_id, message_id, time, repeat_days,
+        is_active, snooze_minutes, mode, voice_profile_id, speaker_id,
+        vibration_pattern, wake_mode, raw_audio_url, raw_audio_duration_ms,
+        created_at, updated_at
+      FROM alarms`,
+      `DROP TABLE alarms`,
+      `ALTER TABLE alarms_v2 RENAME TO alarms`,
+      `PRAGMA foreign_keys=on`,
+    ],
+  },
+  {
+    id: 23,
+    // Drop the FK constraints (re)added by migration 22. The codebase stores
+    // the Google JWT sub in `alarms.user_id` (rather than the users.id PK)
+    // to match the legacy `WHERE google_id = ?` lookup convention used
+    // across other routes. With the FK enabled, every new alarm fails with
+    // SQLITE_CONSTRAINT: FOREIGN KEY constraint failed because the sub
+    // doesn't match any users.id. Rebuild without FKs; nullability is kept.
+    name: 'alarms-drop-fks',
+    statements: [
+      `PRAGMA foreign_keys=off`,
+      `DROP TABLE IF EXISTS alarms_v3`,
+      `CREATE TABLE alarms_v3 (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        target_user_id TEXT,
+        message_id TEXT,
+        time TEXT NOT NULL,
+        repeat_days TEXT DEFAULT '[]',
+        is_active INTEGER DEFAULT 1,
+        snooze_minutes INTEGER DEFAULT 5,
+        mode TEXT NOT NULL DEFAULT 'tts',
+        voice_profile_id TEXT,
+        speaker_id TEXT,
+        vibration_pattern TEXT NOT NULL DEFAULT 'default',
+        wake_mode TEXT NOT NULL DEFAULT 'sound_then_voice',
+        raw_audio_url TEXT,
+        raw_audio_duration_ms INTEGER,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )`,
+      `INSERT INTO alarms_v3 (
+        id, user_id, target_user_id, message_id, time, repeat_days,
+        is_active, snooze_minutes, mode, voice_profile_id, speaker_id,
+        vibration_pattern, wake_mode, raw_audio_url, raw_audio_duration_ms,
+        created_at, updated_at
+      ) SELECT
+        id, user_id, target_user_id, message_id, time, repeat_days,
+        is_active, snooze_minutes, mode, voice_profile_id, speaker_id,
+        vibration_pattern, wake_mode, raw_audio_url, raw_audio_duration_ms,
+        created_at, updated_at
+      FROM alarms`,
+      `DROP TABLE alarms`,
+      `ALTER TABLE alarms_v3 RENAME TO alarms`,
+      `PRAGMA foreign_keys=on`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -35,13 +35,11 @@ alarmMutation.post('/', async (c) => {
   if (!body.time) {
     return c.json({ error: 'time is required', error_code: 'REQUIRED_FIELDS_MISSING' }, 400);
   }
-  // Either a TTS message OR a raw-audio source must be present.
-  if (!body.message_id && !body.raw_audio_url) {
-    return c.json(
-      { error: 'either message_id or raw_audio_url is required', error_code: 'ALARM_SOURCE_MISSING' },
-      400,
-    );
-  }
+  // Three valid sources for what the alarm plays:
+  //   1. message_id          → TTS / saved voice clip
+  //   2. raw_audio_url       → user-recorded raw audio
+  //   3. neither             → "alarm-only" mode: device default alarm sound
+  // No further check needed; the alarm row stores message_id NULL for case 3.
 
   const fieldError = validateAlarmFields(body);
   if (fieldError) return c.json(fieldError, 400);

--- a/packages/backend/src/routes/alarm-query.ts
+++ b/packages/backend/src/routes/alarm-query.ts
@@ -70,10 +70,14 @@ alarmQuery.get('/', async (c) => {
     whereArgs.push(voiceProfileId);
   }
 
+  // LEFT JOIN messages/voice_profiles so the new "alarm-only" play mode
+  // (message_id NULL, no associated voice clip) still appears in the list.
+  // The voice_profile_id filter naturally excludes those rows by requiring
+  // m to be present.
   const [countRes, result] = await Promise.all([
     db.execute({
       sql: `SELECT COUNT(*) as total FROM alarms a
-            JOIN messages m ON a.message_id = m.id
+            LEFT JOIN messages m ON a.message_id = m.id
             ${whereClause}`,
       args: whereArgs,
     }),
@@ -81,8 +85,8 @@ alarmQuery.get('/', async (c) => {
       sql: `SELECT a.*, m.text as message_text, m.category, vp.name as voice_name,
               creator.email as creator_email, creator.name as creator_name
             FROM alarms a
-            JOIN messages m ON a.message_id = m.id
-            JOIN voice_profiles vp ON m.voice_profile_id = vp.id
+            LEFT JOIN messages m ON a.message_id = m.id
+            LEFT JOIN voice_profiles vp ON m.voice_profile_id = vp.id
             LEFT JOIN users creator ON creator.google_id = a.user_id
             ${whereClause}
             ORDER BY a.time ASC
@@ -109,8 +113,8 @@ alarmQuery.get('/:id', async (c) => {
     sql: `SELECT a.*, m.text as message_text, m.category, vp.name as voice_name,
             creator.email as creator_email, creator.name as creator_name
           FROM alarms a
-          JOIN messages m ON a.message_id = m.id
-          JOIN voice_profiles vp ON m.voice_profile_id = vp.id
+          LEFT JOIN messages m ON a.message_id = m.id
+          LEFT JOIN voice_profiles vp ON m.voice_profile_id = vp.id
           LEFT JOIN users creator ON creator.google_id = a.user_id
           WHERE a.id = ? AND (a.user_id = ? OR a.target_user_id = ?)`,
     args: [id, userId, userId],

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -28,13 +28,14 @@ beforeEach(() => {
 describe('POST /alarms', () => {
   const validBody = { message_id: ID.message, time: '07:30' };
 
-  it('message_id / raw_audio_url 둘 다 누락 시 400 ALARM_SOURCE_MISSING', async () => {
-    // raw-audio alarms relaxed the constraint to "either message_id OR
-    // raw_audio_url is required" — only message_id missing is still allowed
-    // when a raw_audio_url is supplied.
+  it('message_id / raw_audio_url 둘 다 누락 시 alarm-only 모드로 201 (message_id NULL)', async () => {
+    // The "alarm-only" play mode plays just the device's default alarm sound
+    // and stores neither a TTS message nor a raw-audio source. Schema migration
+    // 22 made alarms.message_id nullable so the row stores NULL.
     const res = await buildApp().request(jsonReq('POST', '/alarms', { time: '07:30' }));
-    expect(res.status).toBe(400);
-    expect((await res.json()).error_code).toBe('ALARM_SOURCE_MISSING');
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { alarm: { message_id?: string | null } };
+    expect(body.alarm.message_id ?? null).toBe(null);
   });
 
   it('time 누락 시 400', async () => {

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -490,14 +490,14 @@ describe('DELETE /alarm/:id — 알람 삭제', () => {
 });
 
 describe('error_code 일관성 검증', () => {
-  it('POST — required fields 누락 시 ALARM_SOURCE_MISSING', async () => {
-    // After raw-audio support was added the create endpoint accepts either
-    // message_id or raw_audio_url, so missing message_id alone now returns
-    // ALARM_SOURCE_MISSING (only `time` truly missing yields the legacy code).
+  it('POST — time 누락 시 REQUIRED_FIELDS_MISSING', async () => {
+    // Source-less alarms are now valid ("alarm-only" play mode plays the
+    // device default sound), so the only true required field at create time
+    // is `time`.
     const app = buildApp();
-    const res = await app.request(jsonReq('POST', '/alarm', { time: '07:00' }));
+    const res = await app.request(jsonReq('POST', '/alarm', {}));
     const body = await res.json();
-    expect(body.error_code).toBe('ALARM_SOURCE_MISSING');
+    expect(body.error_code).toBe('REQUIRED_FIELDS_MISSING');
   });
 
   it('POST — 잘못된 mode 시 INVALID_ALARM_MODE', async () => {


### PR DESCRIPTION
## Summary
- 백엔드에서 \"알람만\" 재생 모드(메시지/음성 둘 다 없이 OS 기본 알람음만 울리는 패턴) 지원
- 마이그레이션 22로 `alarms.message_id` NULLABLE, 마이그레이션 23으로 FK 제거 (codebase가 `user_id` 컬럼에 Google JWT sub를 저장하는 기존 컨벤션과 충돌해서)
- 알람 GET 쿼리의 `JOIN messages/voice_profiles`를 `LEFT JOIN`으로 → `message_id` NULL인 alarm-only row도 리스트에 보임

## Migration ops
배포 후 init-db 트리거 필요:
\`\`\`
curl -X POST \"https://voice-alarm-api.voicealarm.workers.dev/api/init-db?fromId=22&toId=22\"
curl -X POST \"https://voice-alarm-api.voicealarm.workers.dev/api/init-db?fromId=23&toId=23\"
\`\`\`
(prod에는 이미 적용 완료)

## Test plan
- [x] migration 22, 23 prod 적용 확인 (`success: true`, ran ledger entry)
- [x] alarm-only POST → 201 + message_id NULL 확인
- [ ] alarm 리스트 GET이 alarm-only row 포함하는지 확인
- [x] 기존 테스트 갱신 (`alarm-mutation.test.ts`, `alarm.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)