### PR TITLE
feat(mobile): 진짜 알람 시계 동작 + alarm-only 모드

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -48,7 +48,13 @@
         "android.permission.RECEIVE_BOOT_COMPLETED",
         "android.permission.WAKE_LOCK",
         "android.permission.READ_EXTERNAL_STORAGE",
-        "android.permission.MODIFY_AUDIO_SETTINGS"
+        "android.permission.MODIFY_AUDIO_SETTINGS",
+        "android.permission.FOREGROUND_SERVICE",
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
+        "android.permission.SYSTEM_ALERT_WINDOW",
+        "android.permission.USE_FULL_SCREEN_INTENT",
+        "android.permission.TURN_SCREEN_ON",
+        "android.permission.DISABLE_KEYGUARD"
       ]
     },
     "plugins": [

--- a/apps/mobile/app/(tabs)/alarms.tsx
+++ b/apps/mobile/app/(tabs)/alarms.tsx
@@ -24,9 +24,12 @@ import { playAudio } from '../../src/services/audio';
 import { useAppStore } from '../../src/stores/useAppStore';
 import { DAY_KEYS } from '../../src/constants/presets';
 import { ErrorView } from '../../src/components/QueryStateView';
+import { AppIcon } from '../../src/components/AppIcon';
 import { useNetworkStatus } from '../../src/hooks/useNetworkStatus';
 import { cacheAlarms, getCachedAlarms } from '../../src/services/offlineCache';
 import { syncAlarmNotifications } from '../../src/services/notifications';
+import { setMonitoredAlarms } from '../../src/services/alarmRinger';
+import { syncNotifeeAlarms } from '../../src/services/notifeeAlarms';
 import type { Alarm } from '../../src/types';
 import { getApiErrorMessage } from '../../src/lib/apiErrors';
 import {
@@ -118,10 +121,19 @@ function AlarmsScreen() {
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (alarms && alarms.length > 0) {
+    // Sync the offline cache + OS notifications whenever the live list
+    // changes — including the empty case (last alarm deleted), so stale
+    // cached rows don't stick around and the OS cancels old schedules.
+    if (alarms) {
       cacheAlarms(alarms);
       setCachedAlarms(alarms);
       syncAlarmNotifications(alarms);
+      // iOS: foreground keep-alive ticker (Alarmy-style background audio).
+      setMonitoredAlarms(alarms);
+      // Android: notifee schedules an exact-time, full-screen-intent
+      // alarm so the ringing screen pops over the lock screen even if
+      // the OS killed our process.
+      void syncNotifeeAlarms(alarms);
     }
   }, [alarms]);
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -161,7 +173,13 @@ function AlarmsScreen() {
 
   const deleteMutation = useMutation({
     mutationFn: deleteAlarm,
-    onSuccess: () => {
+    onSuccess: (_data, deletedId) => {
+      // Drop the row from the cached query data immediately so the list
+      // updates without waiting for the background refetch — invalidate
+      // alone doesn't guarantee instant UI sync.
+      queryClient.setQueryData<Alarm[] | undefined>(['alarms'], (prev) =>
+        prev ? prev.filter((a) => a.id !== deletedId) : prev,
+      );
       queryClient.invalidateQueries({ queryKey: ['alarms'] });
       resyncNotifications();
     },
@@ -282,7 +300,9 @@ function AlarmsScreen() {
         <ErrorView onRetry={refetch} />
       ) : filteredAlarms?.length === 0 ? (
         <View style={styles.emptyState}>
-          <Text style={styles.emptyEmoji}>⏰</Text>
+          <View style={{ marginBottom: 12 }}>
+            <AppIcon name="alarm" size={56} />
+          </View>
           <Text style={styles.emptyTitle}>{t('alarms.emptyTitle')}</Text>
           <Text style={styles.emptyDesc}>{t('alarms.emptyDesc')}</Text>
           <TouchableOpacity

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -29,7 +29,21 @@ import {
 import { OfflineBanner } from '../src/components/OfflineBanner';
 import { ErrorBoundary } from '../src/components/ErrorBoundary';
 import { AuthProvider } from '../src/hooks/useAuth';
+import { startAlarmKeepAlive } from '../src/services/alarmRinger';
+import {
+  configureNotifeeAlarmChannel,
+} from '../src/services/notifeeAlarms';
+import notifee, { EventType } from '@notifee/react-native';
 import '../src/i18n';
+
+// Module-scope registration — required by notifee so the JS runtime can
+// receive the event even when the app was killed and woken by the
+// alarm fire. The actual ringing UI is shown after the app reaches
+// foreground; this just acknowledges the event.
+notifee.onBackgroundEvent(async () => {
+  // No-op — the press/full-screen-intent will bring the app foreground
+  // and `onForegroundEvent` (registered below) handles routing.
+});
 
 initSentry();
 SplashScreen.preventAutoHideAsync();
@@ -116,6 +130,48 @@ export default function RootLayout() {
     ensureAudioDir().then(() => cleanupAudioCache());
     checkForOTAUpdate(t);
     configureNotificationChannels(t);
+    void configureNotifeeAlarmChannel();
+    // Start the Alarmy-style background-audio keep-alive. It only actually
+    // plays once an active alarm exists (setMonitoredAlarms toggles it).
+    void startAlarmKeepAlive();
+
+    // If the app was launched from a notifee full-screen-intent (cold
+    // start while ringing), jump straight to the ringing screen.
+    void notifee
+      .getInitialNotification()
+      .then((initial: Awaited<ReturnType<typeof notifee.getInitialNotification>>) => {
+        const data = initial?.notification?.data as
+          | Record<string, unknown>
+          | undefined;
+        if (data?.alarmId) {
+          router.push({
+            pathname: '/alarm/ringing',
+            params: {
+              alarmId: String(data.alarmId),
+              text: String(data.text ?? ''),
+              voiceName: String(data.voiceName ?? ''),
+            },
+          });
+        }
+      });
+
+    // notifee fullScreenIntent / press → /alarm/ringing
+    const fgUnsub = notifee.onForegroundEvent(({ type, detail }) => {
+      if (
+        (type === EventType.PRESS || type === EventType.DELIVERED) &&
+        detail.notification?.data?.alarmId
+      ) {
+        const data = detail.notification.data as Record<string, unknown>;
+        router.push({
+          pathname: '/alarm/ringing',
+          params: {
+            alarmId: String(data.alarmId),
+            text: String(data.text ?? ''),
+            voiceName: String(data.voiceName ?? ''),
+          },
+        });
+      }
+    });
 
     if (Platform.OS !== 'web') {
       requestNotificationPermissions().then((granted) => {
@@ -140,6 +196,21 @@ export default function RootLayout() {
           return;
         }
 
+        // The default tap (no action button) on an alarm notification
+        // launches the full-screen ringing screen — that's where the
+        // looping alarm sound, vibration and the "알람 끄기" button live.
+        if (data?.alarmId) {
+          router.push({
+            pathname: '/alarm/ringing',
+            params: {
+              alarmId: String(data.alarmId),
+              text: String(data.text || ''),
+              voiceName: String(data.voiceName || ''),
+            },
+          });
+          return;
+        }
+
         if (data?.messageId) {
           router.push({
             pathname: '/player',
@@ -156,6 +227,7 @@ export default function RootLayout() {
 
     return () => {
       responseListener.current?.remove();
+      fgUnsub();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -236,6 +308,15 @@ export default function RootLayout() {
             <Stack.Screen
               name="alarm/vibration"
               options={{ headerShown: true, title: t('alarmCreate.vibrationScreen') }}
+            />
+            <Stack.Screen
+              name="alarm/ringing"
+              options={{
+                headerShown: false,
+                gestureEnabled: false,
+                animation: 'fade',
+                presentation: 'fullScreenModal',
+              }}
             />
             <Stack.Screen
               name="message/[id]"

--- a/apps/mobile/app/alarm/create.tsx
+++ b/apps/mobile/app/alarm/create.tsx
@@ -322,7 +322,6 @@ export default function CreateAlarmScreen() {
               : m === 'voice_only'
                 ? 'alarmCreate.modeVoiceOnly'
                 : 'alarmCreate.modeAlarmVoice';
-          const icon = m === 'alarm_only' ? '🔔' : m === 'voice_only' ? '🗣️' : '🔔🗣️';
           const selected = playMode === m;
           return (
             <TouchableOpacity
@@ -334,7 +333,7 @@ export default function CreateAlarmScreen() {
               accessibilityLabel={t(labelKey)}
             >
               <Text style={[formStyles.modeText, selected && formStyles.modeTextActive]}>
-                {icon} {t(labelKey)}
+                {t(labelKey)}
               </Text>
             </TouchableOpacity>
           );
@@ -417,35 +416,39 @@ export default function CreateAlarmScreen() {
         </>
       )}
 
-      {/* 원본 음성 (선택사항) */}
-      <Text style={formStyles.sectionTitle} accessibilityRole="header">{t('alarmSource.section')}</Text>
-      <Text style={localStyles.sourceHint}>{t('alarmSource.sectionHint')}</Text>
-      {rawAudio ? (
-        <View style={localStyles.sourceCurrent}>
-          <Text style={localStyles.sourceCurrentLabel}>
-            {t('alarmSource.currentLabel')} · {rawAudio.fileName} ({(rawAudio.durationMs / 1000).toFixed(1)}s)
-          </Text>
-          <TouchableOpacity onPress={() => setRawAudio(null)} accessibilityRole="button">
-            <Text style={localStyles.sourceRemove}>{t('alarmSource.remove')}</Text>
-          </TouchableOpacity>
-        </View>
-      ) : (
-        <View style={localStyles.sourceRow}>
-          <TouchableOpacity
-            style={localStyles.sourceCard}
-            onPress={() => router.push('/alarm/source-record')}
-            accessibilityRole="button"
-          >
-            <Text style={localStyles.sourceCardText}>{t('alarmSource.recordCard')}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={localStyles.sourceCard}
-            onPress={() => router.push('/alarm/source-upload')}
-            accessibilityRole="button"
-          >
-            <Text style={localStyles.sourceCardText}>{t('alarmSource.uploadCard')}</Text>
-          </TouchableOpacity>
-        </View>
+      {/* 원본 음성 (선택사항) — 음성을 사용하는 모드일 때만 */}
+      {requiresVoice && (
+        <>
+          <Text style={formStyles.sectionTitle} accessibilityRole="header">{t('alarmSource.section')}</Text>
+          <Text style={localStyles.sourceHint}>{t('alarmSource.sectionHint')}</Text>
+          {rawAudio ? (
+            <View style={localStyles.sourceCurrent}>
+              <Text style={localStyles.sourceCurrentLabel}>
+                {t('alarmSource.currentLabel')} · {rawAudio.fileName} ({(rawAudio.durationMs / 1000).toFixed(1)}s)
+              </Text>
+              <TouchableOpacity onPress={() => setRawAudio(null)} accessibilityRole="button">
+                <Text style={localStyles.sourceRemove}>{t('alarmSource.remove')}</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <View style={localStyles.sourceRow}>
+              <TouchableOpacity
+                style={localStyles.sourceCard}
+                onPress={() => router.push('/alarm/source-record')}
+                accessibilityRole="button"
+              >
+                <Text style={localStyles.sourceCardText}>{t('alarmSource.recordCard')}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={localStyles.sourceCard}
+                onPress={() => router.push('/alarm/source-upload')}
+                accessibilityRole="button"
+              >
+                <Text style={localStyles.sourceCardText}>{t('alarmSource.uploadCard')}</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </>
       )}
 
       {/* 다시 울림 / 진동 — 갤럭시 스타일 sub-screen으로 이동 */}

--- a/apps/mobile/app/alarm/edit.tsx
+++ b/apps/mobile/app/alarm/edit.tsx
@@ -309,7 +309,6 @@ export default function EditAlarmScreen() {
               : m === 'voice_only'
                 ? 'alarmCreate.modeVoiceOnly'
                 : 'alarmCreate.modeAlarmVoice';
-          const icon = m === 'alarm_only' ? '🔔' : m === 'voice_only' ? '🗣️' : '🔔🗣️';
           const selected = playMode === m;
           return (
             <TouchableOpacity
@@ -321,7 +320,7 @@ export default function EditAlarmScreen() {
               accessibilityLabel={t(labelKey)}
             >
               <Text style={[formStyles.modeText, selected && formStyles.modeTextActive]}>
-                {icon} {t(labelKey)}
+                {t(labelKey)}
               </Text>
             </TouchableOpacity>
           );
@@ -404,35 +403,39 @@ export default function EditAlarmScreen() {
         </>
       )}
 
-      {/* 원본 음성 (선택사항) */}
-      <Text style={formStyles.sectionTitle} accessibilityRole="header">{t('alarmSource.section')}</Text>
-      <Text style={localStyles.sourceHint}>{t('alarmSource.sectionHint')}</Text>
-      {rawAudio ? (
-        <View style={localStyles.sourceCurrent}>
-          <Text style={localStyles.sourceCurrentLabel}>
-            {t('alarmSource.currentLabel')} · {rawAudio.fileName} ({(rawAudio.durationMs / 1000).toFixed(1)}s)
-          </Text>
-          <TouchableOpacity onPress={() => setRawAudio(null)} accessibilityRole="button">
-            <Text style={localStyles.sourceRemove}>{t('alarmSource.remove')}</Text>
-          </TouchableOpacity>
-        </View>
-      ) : (
-        <View style={localStyles.sourceRow}>
-          <TouchableOpacity
-            style={localStyles.sourceCard}
-            onPress={() => router.push('/alarm/source-record')}
-            accessibilityRole="button"
-          >
-            <Text style={localStyles.sourceCardText}>{t('alarmSource.recordCard')}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={localStyles.sourceCard}
-            onPress={() => router.push('/alarm/source-upload')}
-            accessibilityRole="button"
-          >
-            <Text style={localStyles.sourceCardText}>{t('alarmSource.uploadCard')}</Text>
-          </TouchableOpacity>
-        </View>
+      {/* 원본 음성 (선택사항) — 음성을 사용하는 모드일 때만 */}
+      {requiresVoice && (
+        <>
+          <Text style={formStyles.sectionTitle} accessibilityRole="header">{t('alarmSource.section')}</Text>
+          <Text style={localStyles.sourceHint}>{t('alarmSource.sectionHint')}</Text>
+          {rawAudio ? (
+            <View style={localStyles.sourceCurrent}>
+              <Text style={localStyles.sourceCurrentLabel}>
+                {t('alarmSource.currentLabel')} · {rawAudio.fileName} ({(rawAudio.durationMs / 1000).toFixed(1)}s)
+              </Text>
+              <TouchableOpacity onPress={() => setRawAudio(null)} accessibilityRole="button">
+                <Text style={localStyles.sourceRemove}>{t('alarmSource.remove')}</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <View style={localStyles.sourceRow}>
+              <TouchableOpacity
+                style={localStyles.sourceCard}
+                onPress={() => router.push('/alarm/source-record')}
+                accessibilityRole="button"
+              >
+                <Text style={localStyles.sourceCardText}>{t('alarmSource.recordCard')}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={localStyles.sourceCard}
+                onPress={() => router.push('/alarm/source-upload')}
+                accessibilityRole="button"
+              >
+                <Text style={localStyles.sourceCardText}>{t('alarmSource.uploadCard')}</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </>
       )}
 
       {/* 다시 울림 / 진동 — sub-screen */}

--- a/apps/mobile/app/alarm/ringing.tsx
+++ b/apps/mobile/app/alarm/ringing.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Vibration,
+  Platform,
+  StatusBar,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Audio } from 'expo-av';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../src/hooks/useTheme';
+import { Spacing, FontFamily } from '../../src/constants/theme';
+import { AppIcon } from '../../src/components/AppIcon';
+import { clearFiringState } from '../../src/services/alarmRinger';
+
+const VIBRATION_PATTERN = [0, 800, 400, 800, 400];
+const KOREAN_WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+function formatHHmm(d: Date): string {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  const wd = KOREAN_WEEKDAYS[d.getDay()];
+  return `${y}.${mo}.${da} ${wd}`;
+}
+
+export default function AlarmRingingScreen() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    alarmId?: string;
+    text?: string;
+    voiceName?: string;
+  }>();
+
+  const soundRef = useRef<Audio.Sound | null>(null);
+  const stoppedRef = useRef(false);
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function start() {
+      try {
+        await Audio.setAudioModeAsync({
+          allowsRecordingIOS: false,
+          staysActiveInBackground: false,
+          playsInSilentModeIOS: true,
+          shouldDuckAndroid: false,
+          playThroughEarpieceAndroid: false,
+        });
+        const { sound } = await Audio.Sound.createAsync(
+          require('../../assets/sounds/default_alarm.wav'),
+          { isLooping: true, volume: 1.0, shouldPlay: true },
+        );
+        if (cancelled || stoppedRef.current) {
+          await sound.unloadAsync();
+          return;
+        }
+        soundRef.current = sound;
+      } catch {
+        // ignore — vibration still fires below
+      }
+      Vibration.vibrate(VIBRATION_PATTERN, true);
+    }
+    void start();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const stopAlarm = async () => {
+    stoppedRef.current = true;
+    Vibration.cancel();
+    const s = soundRef.current;
+    soundRef.current = null;
+    if (s) {
+      try {
+        await s.stopAsync();
+        await s.unloadAsync();
+      } catch {
+        // already disposed
+      }
+    }
+    if (params.alarmId) clearFiringState(String(params.alarmId));
+    if (router.canGoBack()) router.back();
+    else router.replace('/');
+  };
+
+  useEffect(() => {
+    return () => {
+      // safety: stop sound + vibration if the user backs out via the OS
+      Vibration.cancel();
+      const s = soundRef.current;
+      soundRef.current = null;
+      if (s) {
+        s.stopAsync().catch(() => {});
+        s.unloadAsync().catch(() => {});
+      }
+    };
+  }, []);
+
+  return (
+    <View style={[styles.root, { backgroundColor: colors.primary }]}>
+      <StatusBar barStyle="light-content" />
+      <View style={styles.top}>
+        <Text style={styles.timeText}>{formatHHmm(now)}</Text>
+        <Text style={styles.dateText}>{formatDate(now)}</Text>
+      </View>
+
+      <View style={styles.middle}>
+        <View style={styles.bellWrap}>
+          <AppIcon name="alarm" size={120} color="#FFFFFF" duotoneColor="#FFFFFF" />
+        </View>
+        {params.voiceName ? (
+          <Text style={styles.voiceName}>{params.voiceName}</Text>
+        ) : null}
+        {params.text ? (
+          <Text style={styles.message} numberOfLines={3}>
+            "{params.text}"
+          </Text>
+        ) : (
+          <Text style={styles.message}>{t('alarmRinging.title') || '알람'}</Text>
+        )}
+      </View>
+
+      <View style={styles.bottom}>
+        <TouchableOpacity
+          style={styles.dismissButton}
+          onPress={stopAlarm}
+          accessibilityRole="button"
+          accessibilityLabel={t('alarmRinging.dismiss') || '알람 끄기'}
+        >
+          <Text style={styles.dismissText}>
+            {t('alarmRinging.dismiss') || '알람 끄기'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingTop: Platform.OS === 'ios' ? 60 : 40,
+    paddingBottom: 40,
+    paddingHorizontal: Spacing.lg,
+    justifyContent: 'space-between',
+  },
+  top: {
+    alignItems: 'center',
+  },
+  timeText: {
+    fontSize: 80,
+    fontFamily: FontFamily.bold,
+    color: '#FFFFFF',
+    letterSpacing: 1,
+  },
+  dateText: {
+    fontSize: 16,
+    fontFamily: FontFamily.regular,
+    color: '#FFFFFF',
+    opacity: 0.85,
+    marginTop: 4,
+  },
+  middle: {
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  bellWrap: {
+    marginBottom: Spacing.md,
+  },
+  voiceName: {
+    fontSize: 22,
+    fontFamily: FontFamily.semibold,
+    color: '#FFFFFF',
+  },
+  message: {
+    fontSize: 18,
+    fontFamily: FontFamily.regular,
+    color: '#FFFFFF',
+    textAlign: 'center',
+    paddingHorizontal: Spacing.lg,
+  },
+  bottom: {
+    alignItems: 'center',
+  },
+  dismissButton: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 999,
+    paddingVertical: 18,
+    paddingHorizontal: 56,
+    minWidth: 220,
+    alignItems: 'center',
+  },
+  dismissText: {
+    fontSize: 18,
+    fontFamily: FontFamily.bold,
+    color: '#000000',
+  },
+});

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~55.0.10",
+        "@notifee/react-native": "^9.1.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.5.2",
         "@react-native-google-signin/google-signin": "^16.1.2",
@@ -3727,6 +3728,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@notifee/react-native": {
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@notifee/react-native/-/react-native-9.1.8.tgz",
+      "integrity": "sha512-Az/dueoPerJsbbjRxu8a558wKY+gONUrfoy3Hs++5OqbeMsR0dYe6P+4oN6twrLFyzAhEA1tEoZRvQTFDRmvQg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/@poppinss/colors": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~55.0.10",
+    "@notifee/react-native": "^9.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-google-signin/google-signin": "^16.1.2",

--- a/apps/mobile/src/components/WheelTimePicker.tsx
+++ b/apps/mobile/src/components/WheelTimePicker.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   ScrollView,
   Platform,
+  Pressable,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from 'react-native';
@@ -200,10 +201,12 @@ function Column({
     }
   };
 
-  // For small (non-loop) columns, render only labels. For loop columns,
-  // we render the entire repeated list — render volume is bounded (200 × 12
-  // or 200 × 60) and `removeClippedSubviews` is intentionally false because
-  // it kills wheel rendering on Android.
+  // Short non-loop columns (e.g. AM/PM with only two options) don't need a
+  // wheel — scrolling there is meaningless and the overscroll bubbles up to
+  // the parent ScrollView, making the whole screen jiggle. Render those as
+  // a tap-only stack; long loop columns keep the wheel behavior.
+  const isStaticList = !loop && items.length <= VISIBLE_ROWS;
+
   return (
     <ScrollView
       ref={scrollRef}
@@ -218,7 +221,8 @@ function Column({
       }}
       onMomentumScrollEnd={handleEnd}
       onScrollEndDrag={handleEnd}
-      bounces={!loop}
+      scrollEnabled={!isStaticList}
+      bounces={false}
       overScrollMode="never"
       nestedScrollEnabled
       removeClippedSubviews={false}
@@ -228,21 +232,36 @@ function Column({
         const distance = Math.abs(idx - selectedIndex);
         const opacity =
           distance === 0 ? 1 : distance === 1 ? 0.55 : distance === 2 ? 0.25 : 0.12;
+        const content = (
+          <Text
+            style={[
+              styles.itemText,
+              isSelected ? styles.itemTextSelected : null,
+              {
+                opacity,
+                textAlign: align,
+                width: '100%',
+              },
+            ]}
+          >
+            {label}
+          </Text>
+        );
+        if (isStaticList) {
+          return (
+            <Pressable
+              key={`${label}-${idx}`}
+              style={styles.item}
+              onPress={() => onSelect(idx)}
+              accessibilityRole="button"
+            >
+              {content}
+            </Pressable>
+          );
+        }
         return (
           <View key={`${label}-${idx}`} style={styles.item}>
-            <Text
-              style={[
-                styles.itemText,
-                isSelected ? styles.itemTextSelected : null,
-                {
-                  opacity,
-                  textAlign: align,
-                  width: '100%',
-                },
-              ]}
-            >
-              {label}
-            </Text>
+            {content}
           </View>
         );
       })}

--- a/apps/mobile/src/lib/alarmForm.ts
+++ b/apps/mobile/src/lib/alarmForm.ts
@@ -15,7 +15,10 @@ export interface AlarmFormInput {
 }
 
 export interface AlarmCreatePayload {
-  message_id: string;
+  // Optional because the "alarm-only" play mode (just a buzzer, no TTS or
+  // voice clip) sends no message_id at all. The backend resolves what to
+  // store on the alarm row.
+  message_id?: string;
   time: string;
   repeat_days: number[];
   mode: AlarmMode;
@@ -32,9 +35,6 @@ export type ValidationResult =
   | { ok: false; error: string };
 
 export function validateAlarmForm(input: AlarmFormInput, t: TFunction): ValidationResult {
-  if (!input.messageId) {
-    return { ok: false, error: t('alarmValidation.messageRequired') };
-  }
   if (!/^\d{2}:\d{2}$/.test(input.time)) {
     return { ok: false, error: t('alarmValidation.invalidTime') };
   }
@@ -49,11 +49,11 @@ export function validateAlarmForm(input: AlarmFormInput, t: TFunction): Validati
 
 export function buildCreatePayload(input: AlarmFormInput): AlarmCreatePayload {
   const payload: AlarmCreatePayload = {
-    message_id: input.messageId ?? '',
     time: input.time,
     repeat_days: Array.isArray(input.repeatDays) ? input.repeatDays : [],
     mode: input.mode,
   };
+  if (input.messageId) payload.message_id = input.messageId;
   if (input.vibrationPattern) payload.vibration_pattern = input.vibrationPattern;
   if (input.wakeMode) payload.wake_mode = input.wakeMode;
   if (input.voiceProfileId) payload.voice_profile_id = input.voiceProfileId;

--- a/apps/mobile/src/services/alarmRinger.ts
+++ b/apps/mobile/src/services/alarmRinger.ts
@@ -1,0 +1,142 @@
+/**
+ * Alarmy-style alarm clock keep-alive.
+ *
+ * iOS blocks general background scheduling but allows apps that declare
+ * `UIBackgroundModes: ["audio"]` to keep running audio in the background.
+ * We exploit that: the moment any alarm is active we start playing a
+ * (near-)silent looping clip so the OS keeps our JS runtime alive. A 5s
+ * timer ticks against the active-alarm list, and when an alarm's HH:mm
+ * matches "now" we navigate to the full-screen ringing screen which takes
+ * over with the loud alarm sound + sustained vibration.
+ *
+ * Android works the same way — we set `staysActiveInBackground` on the
+ * audio session and Android keeps the audio service running. expo-
+ * notifications schedules are still registered as a backup for the case
+ * where the OS decides to kill us anyway (force-stop, low-memory).
+ */
+import { Audio, InterruptionModeAndroid, InterruptionModeIOS } from 'expo-av';
+import { Platform } from 'react-native';
+import { router } from 'expo-router';
+import type { Alarm } from '../types';
+import { parseRepeatDays } from '../lib/alarmForm';
+
+const SILENT_LOOP = require('../../assets/sounds/default_alarm.wav');
+
+let keepAliveSound: Audio.Sound | null = null;
+let tickInterval: ReturnType<typeof setInterval> | null = null;
+let activeAlarms: Alarm[] = [];
+const recentlyFired = new Map<string, number>();
+const FIRE_COOLDOWN_MS = 60_000;
+const TICK_MS = 5_000;
+let starting = false;
+
+function shouldFireNow(alarm: Alarm, now: Date): boolean {
+  if (!alarm.is_active) return false;
+  const [hStr, mStr] = alarm.time.split(':');
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (Number.isNaN(h) || Number.isNaN(m)) return false;
+  const days = parseRepeatDays(alarm.repeat_days);
+  if (days.length > 0 && !days.includes(now.getDay())) return false;
+  return now.getHours() === h && now.getMinutes() === m;
+}
+
+function tick() {
+  const now = new Date();
+  for (const alarm of activeAlarms) {
+    if (!shouldFireNow(alarm, now)) continue;
+    const last = recentlyFired.get(alarm.id) ?? 0;
+    if (now.getTime() - last < FIRE_COOLDOWN_MS) continue;
+    recentlyFired.set(alarm.id, now.getTime());
+    fireAlarm(alarm);
+    break;
+  }
+}
+
+function fireAlarm(alarm: Alarm) {
+  try {
+    router.push({
+      pathname: '/alarm/ringing',
+      params: {
+        alarmId: alarm.id,
+        text: alarm.message_text ?? '',
+        voiceName: alarm.voice_name ?? '',
+      },
+    });
+  } catch {
+    // router not ready (cold boot edge case) — the OS notification will
+    // fire as a fallback and tapping it lands on the same screen.
+  }
+}
+
+export async function startAlarmKeepAlive(): Promise<void> {
+  if (Platform.OS === 'web') return;
+  if (keepAliveSound || starting) return;
+  starting = true;
+  try {
+    await Audio.setAudioModeAsync({
+      allowsRecordingIOS: false,
+      staysActiveInBackground: true,
+      playsInSilentModeIOS: true,
+      shouldDuckAndroid: true,
+      interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+      interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
+    });
+    const { sound } = await Audio.Sound.createAsync(SILENT_LOOP, {
+      isLooping: true,
+      // Inaudible but non-zero — iOS revokes the background audio
+      // privilege if the audio is *truly* silent (volume 0) for too long.
+      volume: 0.001,
+      shouldPlay: true,
+    });
+    keepAliveSound = sound;
+    if (!tickInterval) tickInterval = setInterval(tick, TICK_MS);
+  } catch {
+    keepAliveSound = null;
+  } finally {
+    starting = false;
+  }
+}
+
+export async function stopAlarmKeepAlive(): Promise<void> {
+  if (tickInterval) {
+    clearInterval(tickInterval);
+    tickInterval = null;
+  }
+  const s = keepAliveSound;
+  keepAliveSound = null;
+  if (s) {
+    try {
+      await s.stopAsync();
+    } catch {
+      // already stopped
+    }
+    try {
+      await s.unloadAsync();
+    } catch {
+      // already unloaded
+    }
+  }
+}
+
+/**
+ * Update the set of active alarms the ticker watches. Pause the silent
+ * loop entirely if there's nothing to fire — saves battery and avoids
+ * keeping the audio session active for no reason.
+ */
+export function setMonitoredAlarms(alarms: Alarm[]): void {
+  activeAlarms = alarms.filter((a) => a.is_active);
+  if (activeAlarms.length === 0) {
+    void stopAlarmKeepAlive();
+  } else {
+    void startAlarmKeepAlive();
+  }
+}
+
+/** Called when the ringing screen unmounts so the next-day fire can occur. */
+export function clearFiringState(alarmId: string): void {
+  // Keep cooldown so a single ringing event doesn't re-trigger the same
+  // minute, but allow re-fire after the cooldown for the next occurrence.
+  // (Set to "now - cooldown + 5s" so the next minute can refire if needed.)
+  recentlyFired.set(alarmId, Date.now() - (FIRE_COOLDOWN_MS - 5_000));
+}

--- a/apps/mobile/src/services/notifeeAlarms.ts
+++ b/apps/mobile/src/services/notifeeAlarms.ts
@@ -1,0 +1,123 @@
+/**
+ * Android-only "true alarm clock" scheduling via @notifee/react-native.
+ *
+ * Why notifee instead of expo-notifications:
+ *   - `trigger.alarmManager.allowWhileIdle: true` survives Doze mode
+ *     (the OS kicking your app to sleep on idle phones), which the
+ *     stock expo-notifications scheduler does NOT.
+ *   - `fullScreenAction` lets the OS launch our ringing activity
+ *     *over* the lock screen automatically when the alarm fires —
+ *     the part you can't reproduce with expo-notifications alone.
+ *   - `loopSound + ongoing + autoCancel:false` makes the notification
+ *     behave like the system Clock app's alarm: the buzzer keeps
+ *     playing until the user dismisses it from the ringing screen.
+ *
+ * iOS stays on the Alarmy-style background-audio trick in
+ * `alarmRinger.ts` — Apple doesn't expose AlarmManager-equivalent APIs.
+ */
+import { Platform } from 'react-native';
+import notifee, {
+  AndroidCategory,
+  AndroidImportance,
+  AndroidVisibility,
+  TriggerType,
+  type TimestampTrigger,
+} from '@notifee/react-native';
+import type { Alarm } from '../types';
+import { parseRepeatDays } from '../lib/alarmForm';
+
+const ALARM_CHANNEL_ID = 'alarm-ringing';
+
+function nextOccurrencesMs(alarm: Alarm, daysAhead = 7): number[] {
+  const [hStr, mStr] = alarm.time.split(':');
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (Number.isNaN(h) || Number.isNaN(m)) return [];
+  const days = parseRepeatDays(alarm.repeat_days);
+  const now = new Date();
+  const out: number[] = [];
+
+  for (let offset = 0; offset <= daysAhead; offset++) {
+    const target = new Date(now);
+    target.setDate(target.getDate() + offset);
+    target.setHours(h, m, 0, 0);
+    if (target.getTime() <= now.getTime()) continue;
+    if (days.length === 0 || days.includes(target.getDay())) {
+      out.push(target.getTime());
+      if (days.length === 0) break; // one-shot: just the next one
+    }
+  }
+  return out;
+}
+
+export async function configureNotifeeAlarmChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await notifee.createChannel({
+    id: ALARM_CHANNEL_ID,
+    name: '알람',
+    description: '알람 시계 — 잠금화면 위에 풀스크린으로 표시됩니다.',
+    importance: AndroidImportance.HIGH,
+    sound: 'default_alarm',
+    vibration: true,
+    vibrationPattern: [300, 800, 300, 800, 300, 800],
+    bypassDnd: true,
+    visibility: AndroidVisibility.PUBLIC,
+  });
+}
+
+export async function syncNotifeeAlarms(alarms: Alarm[]): Promise<void> {
+  if (Platform.OS !== 'android') return;
+
+  // Cancel all of *our* previously-scheduled triggers; we recreate them
+  // from the current list of active alarms below.
+  const ids = await notifee.getTriggerNotificationIds();
+  for (const id of ids) {
+    if (id.startsWith('alarm:')) await notifee.cancelTriggerNotification(id);
+  }
+
+  const active = alarms.filter((a) => a.is_active);
+  if (active.length === 0) return;
+
+  for (const alarm of active) {
+    const occurrences = nextOccurrencesMs(alarm, 7);
+    for (const ts of occurrences) {
+      const trigger: TimestampTrigger = {
+        type: TriggerType.TIMESTAMP,
+        timestamp: ts,
+        alarmManager: {
+          allowWhileIdle: true,
+        },
+      };
+      await notifee.createTriggerNotification(
+        {
+          id: `alarm:${alarm.id}:${ts}`,
+          title: alarm.voice_name ? `🗣️ ${alarm.voice_name}` : '⏰ 알람',
+          body: alarm.message_text || '알람 시간이에요',
+          data: {
+            alarmId: alarm.id,
+            text: alarm.message_text ?? '',
+            voiceName: alarm.voice_name ?? '',
+          },
+          android: {
+            channelId: ALARM_CHANNEL_ID,
+            category: AndroidCategory.ALARM,
+            importance: AndroidImportance.HIGH,
+            visibility: AndroidVisibility.PUBLIC,
+            sound: 'default_alarm',
+            loopSound: true,
+            ongoing: true,
+            autoCancel: false,
+            // Tapping the notification (or the OS auto-launching the
+            // full-screen intent) opens our app, after which our
+            // foreground/background event handler routes to /alarm/ringing.
+            pressAction: { id: 'default', launchActivity: 'default' },
+            fullScreenAction: { id: 'default', launchActivity: 'default' },
+          },
+        },
+        trigger,
+      );
+    }
+  }
+}
+
+export const NOTIFEE_ALARM_CHANNEL_ID = ALARM_CHANNEL_ID;

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -46,10 +46,13 @@ export function configureNotificationChannels(t: TFunction): void {
       description: t('settings.channelAlarmsDesc'),
       importance: Notifications.AndroidImportance.MAX,
       sound: 'default_alarm',
-      vibrationPattern: [0, 500, 250, 500],
+      // Long, repeating buzz pattern (sleep through me if you can).
+      vibrationPattern: [0, 1000, 500, 1000, 500, 1000, 500, 1000],
       enableLights: true,
+      enableVibrate: true,
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
       bypassDnd: true,
+      showBadge: true,
     });
 
     Notifications.setNotificationChannelAsync(NotificationChannel.NOTES, {
@@ -118,6 +121,10 @@ export async function syncAlarmNotifications(alarms: Alarm[]): Promise<void> {
       title,
       body,
       sound: 'default_alarm',
+      priority: Notifications.AndroidNotificationPriority.MAX,
+      vibrate: [0, 1000, 500, 1000, 500, 1000, 500, 1000],
+      sticky: true,
+      autoDismiss: false,
       categoryIdentifier: ALARM_CATEGORY,
       data: notificationData,
       ...(Platform.OS === 'android' && { channelId: NotificationChannel.ALARMS }),


### PR DESCRIPTION
## Summary
OS notification 한 번 띄우고 끝나던 동작을 시스템 Clock 앱처럼 잠금화면 위에 풀스크린으로 뜨고 사용자가 끄기 전엔 멈추지 않는 진짜 알람 클록으로 재구성. 동시에 \"알람만\" 재생 모드(메시지/음성 없이 OS 기본 알람음만)를 클라 측에서 지원.

## Changes
- `@notifee/react-native` 도입 — Android `alarmManager.allowWhileIdle` (Doze 우회) + `fullScreenAction` (잠금화면 위 풀스크린 액티비티 자동 띄움)
- `alarmRinger.ts` — iOS Alarmy 트릭 (background-audio 무음 keep-alive + 5초 tick HH:mm 매칭)
- `app/alarm/ringing.tsx` — 풀스크린 알람 화면 (사운드 무한 루프 + 무한 진동 + 끄기 버튼)
- `_layout.tsx` notifee `onForegroundEvent` / `onBackgroundEvent` / `getInitialNotification` 라우팅
- `WheelTimePicker` AM/PM 흔들림 (짧은 컬럼 scroll 비활성 + tap-only)
- `alarmForm.ts` messageId 검증 제거 + payload에서 빈 값 제외
- `app.json` Android 알람 권한 추가

## Build prereq
\`\`\`
cd apps/mobile
npm install
npx expo prebuild --platform android --clean
cd android && ./gradlew assembleDebug
\`\`\`

## Test plan
- [ ] alarm-only 알람 만들기 → 저장 성공
- [ ] 알람 시간 도달 시 잠금화면 위에 풀스크린 ringing 화면 자동 표시 (Android)
- [ ] iOS: 폰 잠금 풀고 들어오면 ringing 화면, 알람음 + 진동 재생
- [ ] 끄기 버튼 → 사운드/진동 정지 + 화면 닫힘
- [ ] AM/PM 휠 위아래로 당겨도 화면 흔들리지 않음
- [ ] 알람 삭제 시 리스트 즉시 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)