### PR TITLE
음성 등록과 구독 UI 개선

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
     implementation("com.google.android.gms:play-services-auth:21.2.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     implementation("com.squareup.retrofit2:converter-gson:2.11.0")

--- a/apps/android-native/app/src/main/AndroidManifest.xml
+++ b/apps/android-native/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/MainActivity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.voicealarm.nativeapp
 
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,6 +8,7 @@ import androidx.activity.compose.setContent
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContent {
             VoiceAlarmTheme {
                 VoiceAlarmApp()

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/VoiceAlarmApplication.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/VoiceAlarmApplication.kt
@@ -4,11 +4,17 @@ import android.app.Application
 import android.util.Log
 import com.voicealarm.nativeapp.alarm.NotificationChannels
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
+import com.voicealarm.nativeapp.network.AuthSessionStore
+import com.voicealarm.nativeapp.sync.RemoteAlarmSyncScheduler
 
 class VoiceAlarmApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         NotificationChannels.ensure(this)
+        RemoteAlarmSyncScheduler.ensurePeriodic(this)
+        if (AuthSessionStore(this).read() != null) {
+            RemoteAlarmSyncScheduler.runOnce(this)
+        }
         Log.i(TAG, "Voice Alarm native application started")
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/BootCompletedReceiver.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/BootCompletedReceiver.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.voicealarm.nativeapp.alarm.AlarmContract.ACTION_DEBUG_RESTORE_ALARMS
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.data.AlarmAppContainer
+import com.voicealarm.nativeapp.sync.RemoteAlarmSyncScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -23,6 +24,8 @@ class BootCompletedReceiver : BroadcastReceiver() {
         if (!isRestoreAction) return
 
         Log.i(TAG, "Restore receiver invoked action=$action")
+        RemoteAlarmSyncScheduler.ensurePeriodic(context)
+        RemoteAlarmSyncScheduler.runOnce(context)
         val pendingResult = goAsync()
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             runCatching {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAppContainer.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAppContainer.kt
@@ -13,6 +13,7 @@ object AlarmAppContainer {
                 alarmDao = AlarmDatabase.getInstance(context).alarmDao(),
                 characterEventDao = AlarmDatabase.getInstance(context).characterEventDao(),
                 alarmScheduler = AlarmScheduler(context.applicationContext),
+                alarmAudioStore = AlarmAudioStore(context.applicationContext),
             ).also { repository = it }
         }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -76,6 +76,8 @@ class AlarmAudioStore(
             ?: throw IllegalArgumentException("오디오 길이를 확인할 수 없는 파일은 사용할 수 없어요.")
         val displayName = readDisplayName(sourceUri) ?: "voice_${System.currentTimeMillis()}"
         val extension = extensionFor(sourceUri, displayName)
+        val trackMimeType = audioTrackMime(sourceUri)
+        val trimAsMp3 = extension == "mp3" || isMp3Mime(trackMimeType)
         val resolvedStartMillis = startMillis.coerceIn(0L, (durationMillis - maxDurationMillis).coerceAtLeast(0L))
         val cacheKey = audioCacheKeyForSource(
             sourceUri = sourceUri.toString(),
@@ -96,8 +98,15 @@ class AlarmAudioStore(
             )
         }
         val target = if (resolvedStartMillis > 0 || durationMillis > maxDurationMillis) {
-            File(audioDir, "${safeCacheKey(cacheKey)}.m4a").also {
-                trimToMaxDuration(sourceUri, it, maxDurationMillis, resolvedStartMillis)
+            val trimExtension = if (trimAsMp3) "mp3" else "m4a"
+            File(audioDir, "${safeCacheKey(cacheKey)}.$trimExtension").also {
+                trimToMaxDuration(
+                    sourceUri = sourceUri,
+                    target = it,
+                    maxDurationMillis = maxDurationMillis,
+                    startMillis = resolvedStartMillis,
+                    forceMp3 = trimAsMp3,
+                )
             }
         } else {
             File(audioDir, "${safeCacheKey(cacheKey)}.$extension").also { file ->
@@ -204,7 +213,12 @@ class AlarmAudioStore(
         target: File,
         maxDurationMillis: Long,
         startMillis: Long = 0L,
+        forceMp3: Boolean = false,
     ) {
+        if (forceMp3 || isMp3Mime(audioTrackMime(sourceUri))) {
+            trimMp3Frames(sourceUri, target, maxDurationMillis, startMillis)
+            return
+        }
         runCatching {
             val extractor = MediaExtractor()
             val muxer = MediaMuxer(target.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
@@ -258,6 +272,74 @@ class AlarmAudioStore(
             throw IllegalArgumentException("${maxDurationMillis / 1000}초 초과 파일을 자동으로 자르지 못했어요. m4a/aac/mp4 형식으로 다시 선택해 주세요.", error)
         }.getOrThrow()
     }
+
+    private fun trimMp3Frames(
+        sourceUri: Uri,
+        target: File,
+        maxDurationMillis: Long,
+        startMillis: Long,
+    ) {
+        runCatching {
+            val extractor = MediaExtractor()
+            try {
+                extractor.setDataSource(context, sourceUri, null)
+                val trackIndex = (0 until extractor.trackCount).firstOrNull { index ->
+                    extractor.getTrackFormat(index)
+                        .getString(MediaFormat.KEY_MIME)
+                        ?.startsWith("audio/") == true
+                } ?: error("No audio track found.")
+                extractor.selectTrack(trackIndex)
+                val inputFormat = extractor.getTrackFormat(trackIndex)
+                val maxInputSize = if (inputFormat.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+                    inputFormat.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE)
+                } else {
+                    256 * 1024
+                }.coerceAtLeast(64 * 1024)
+                val buffer = ByteBuffer.allocate(maxInputSize)
+                val startUs = startMillis * 1_000
+                val endUs = startUs + maxDurationMillis * 1_000
+                if (startUs > 0) {
+                    extractor.seekTo(startUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                }
+
+                target.outputStream().use { output ->
+                    while (true) {
+                        val sampleTimeUs = extractor.sampleTime
+                        if (sampleTimeUs < 0 || sampleTimeUs > endUs) break
+                        buffer.clear()
+                        val sampleSize = extractor.readSampleData(buffer, 0)
+                        if (sampleSize < 0) break
+                        output.write(buffer.array(), 0, sampleSize)
+                        extractor.advance()
+                    }
+                }
+            } finally {
+                extractor.release()
+            }
+        }.onFailure { error ->
+            target.delete()
+            Log.e(TAG, "Failed to trim selected mp3 voice audio uri=$sourceUri", error)
+            throw IllegalArgumentException("MP3 구간을 저장하지 못했어요. 다른 파일을 선택해 주세요.", error)
+        }.getOrThrow()
+    }
+
+    private fun audioTrackMime(uri: Uri): String? {
+        val extractor = MediaExtractor()
+        return runCatching {
+            extractor.setDataSource(context, uri, null)
+            (0 until extractor.trackCount).firstNotNullOfOrNull { index ->
+                extractor.getTrackFormat(index)
+                    .getString(MediaFormat.KEY_MIME)
+                    ?.takeIf { it.startsWith("audio/") }
+            }
+        }.getOrNull().also {
+            extractor.release()
+        }
+    }
+
+    private fun isMp3Mime(mimeType: String?): Boolean =
+        mimeType.equals("audio/mpeg", ignoreCase = true) ||
+            mimeType.equals("audio/mp3", ignoreCase = true)
 
     private fun codecBufferFlags(sampleFlags: Int): Int {
         var flags = 0

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
@@ -14,6 +14,9 @@ interface AlarmDao {
     @Query("SELECT * FROM alarms WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): AlarmEntity?
 
+    @Query("SELECT * FROM alarms WHERE remoteAlarmId = :remoteAlarmId LIMIT 1")
+    suspend fun getByRemoteAlarmId(remoteAlarmId: String): AlarmEntity?
+
     @Query(
         """
         SELECT * FROM alarms

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDatabase.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [AlarmEntity::class, CharacterEventEntity::class],
-    version = 6,
+    version = 7,
     exportSchema = false,
 )
 abstract class AlarmDatabase : RoomDatabase() {
@@ -26,7 +26,14 @@ abstract class AlarmDatabase : RoomDatabase() {
                     context.applicationContext,
                     AlarmDatabase::class.java,
                     "voice-alarm.db",
-                ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6).build()
+                ).addMigrations(
+                    MIGRATION_1_2,
+                    MIGRATION_2_3,
+                    MIGRATION_3_4,
+                    MIGRATION_4_5,
+                    MIGRATION_5_6,
+                    MIGRATION_6_7,
+                ).build()
                     .also { instance = it }
             }
 
@@ -88,6 +95,13 @@ abstract class AlarmDatabase : RoomDatabase() {
         private val MIGRATION_5_6 = object : Migration(5, 6) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE alarms ADD COLUMN audioCacheKey TEXT")
+            }
+        }
+
+        private val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE alarms ADD COLUMN snoozeRepeatLimit INTEGER NOT NULL DEFAULT ${SnoozeRepeatLimits.THREE}")
+                db.execSQL("ALTER TABLE alarms ADD COLUMN snoozeCount INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
@@ -14,6 +14,8 @@ data class AlarmEntity(
     val holidayOff: Boolean,
     val snoozeEnabled: Boolean,
     val snoozeMinutes: Int,
+    val snoozeRepeatLimit: Int,
+    val snoozeCount: Int,
     val vibrationPattern: String,
     val playMode: String,
     val defaultAlarmSoundId: String,
@@ -67,6 +69,14 @@ object AlarmPlayModes {
     val all = listOf(ALARM_ONLY, VOICE_ONLY, ALARM_VOICE)
 }
 
+object SnoozeRepeatLimits {
+    const val THREE = 3
+    const val FIVE = 5
+    const val FOREVER = 0
+
+    val all = listOf(THREE, FIVE, FOREVER)
+}
+
 object VoiceSources {
     const val LOCAL_AUDIO = "local_audio"
     const val TTS_PROFILE = "tts_profile"
@@ -87,6 +97,7 @@ data class AlarmDraft(
     val holidayOff: Boolean = false,
     val snoozeEnabled: Boolean = true,
     val snoozeMinutes: Int,
+    val snoozeRepeatLimit: Int = SnoozeRepeatLimits.THREE,
     val vibrationPattern: String,
     val playMode: String,
     val defaultAlarmSoundId: String = DefaultAlarmSounds.BUNDLED_DEFAULT,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
@@ -93,6 +93,8 @@ data class AlarmDraft(
     val label: String,
     val hour: Int,
     val minute: Int,
+    val targetUserId: String? = null,
+    val targetUserName: String? = null,
     val repeatDaysMask: Int,
     val holidayOff: Boolean = false,
     val snoozeEnabled: Boolean = true,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -42,6 +42,8 @@ class AlarmRepository(
             holidayOff = false,
             snoozeEnabled = true,
             snoozeMinutes = 5,
+            snoozeRepeatLimit = SnoozeRepeatLimits.THREE,
+            snoozeCount = 0,
             vibrationPattern = VibrationPatterns.DEFAULT,
             playMode = AlarmPlayModes.ALARM_ONLY,
             defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,
@@ -90,6 +92,8 @@ class AlarmRepository(
             holidayOff = draft.holidayOff,
             snoozeEnabled = draft.snoozeEnabled,
             snoozeMinutes = draft.snoozeMinutes,
+            snoozeRepeatLimit = draft.snoozeRepeatLimit,
+            snoozeCount = 0,
             vibrationPattern = draft.vibrationPattern,
             playMode = draft.playMode,
             defaultAlarmSoundId = draft.defaultAlarmSoundId,
@@ -140,6 +144,8 @@ class AlarmRepository(
             holidayOff = draft.holidayOff,
             snoozeEnabled = draft.snoozeEnabled,
             snoozeMinutes = draft.snoozeMinutes,
+            snoozeRepeatLimit = draft.snoozeRepeatLimit,
+            snoozeCount = 0,
             vibrationPattern = draft.vibrationPattern,
             playMode = draft.playMode,
             defaultAlarmSoundId = draft.defaultAlarmSoundId,
@@ -181,6 +187,7 @@ class AlarmRepository(
                     nowMillis = now,
                 ),
                 enabled = true,
+                snoozeCount = 0,
                 state = AlarmStates.SCHEDULED,
                 syncState = current.nextLocalSyncState(),
                 updatedAtMillis = now,
@@ -273,6 +280,7 @@ class AlarmRepository(
             val next = current.copy(
                 fireAtMillis = nextFireAt,
                 enabled = true,
+                snoozeCount = 0,
                 state = AlarmStates.SCHEDULED,
                 updatedAtMillis = now,
             )
@@ -305,11 +313,19 @@ class AlarmRepository(
             Log.i(TAG, "Snooze ignored because it is disabled id=$alarmId")
             return null
         }
+        if (
+            current.snoozeRepeatLimit != SnoozeRepeatLimits.FOREVER &&
+            current.snoozeCount >= current.snoozeRepeatLimit
+        ) {
+            Log.i(TAG, "Snooze ignored because repeat limit reached id=$alarmId")
+            return null
+        }
 
         val now = System.currentTimeMillis()
         val next = current.copy(
             fireAtMillis = now + current.snoozeMinutes * 60_000L,
             enabled = true,
+            snoozeCount = current.snoozeCount + 1,
             state = AlarmStates.SNOOZED,
             updatedAtMillis = now,
         )
@@ -382,6 +398,7 @@ class AlarmRepository(
         require(draft.minute in 0..59) { "Minute must be between 0 and 59." }
         require(draft.repeatDaysMask in 0..0x7f) { "Repeat days mask must only use Sunday through Saturday bits." }
         require(draft.snoozeMinutes in 1..30) { "Snooze must be between 1 and 30 minutes." }
+        require(draft.snoozeRepeatLimit in SnoozeRepeatLimits.all) { "Unknown snooze repeat limit." }
         require(draft.vibrationPattern in VibrationPatterns.all) { "Unknown vibration pattern." }
         require(draft.playMode in AlarmPlayModes.all) { "Unknown play mode." }
         require(draft.voiceSource in VoiceSources.all) { "Unknown voice source." }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -11,9 +11,15 @@ class AlarmRepository(
     private val alarmDao: AlarmDao,
     private val characterEventDao: CharacterEventDao,
     private val alarmScheduler: AlarmScheduler,
+    private val alarmAudioStore: AlarmAudioStore,
 ) {
     private val characterEvents = CharacterEventRepository(characterEventDao)
     private val alarmSyncService = AlarmSyncService(alarmDao)
+    private val remoteAlarmPullSyncService = RemoteAlarmPullSyncService(
+        alarmDao = alarmDao,
+        alarmScheduler = alarmScheduler,
+        alarmAudioStore = alarmAudioStore,
+    )
     private val characterEventSyncService = CharacterEventSyncService(characterEventDao)
 
     fun observeAlarms(): Flow<List<AlarmEntity>> = alarmDao.observeAlarms()
@@ -389,6 +395,9 @@ class AlarmRepository(
 
     suspend fun syncWithBackend(api: VoiceAlarmApi, token: String): AlarmSyncResult =
         alarmSyncService.syncWithBackend(api, token)
+
+    suspend fun pullReceivedAlarms(api: VoiceAlarmApi, token: String): RemoteAlarmPullResult =
+        remoteAlarmPullSyncService.pullReceivedAlarms(api, token)
 
     suspend fun syncCharacterEvents(api: VoiceAlarmApi, token: String): CharacterEventSyncResult =
         characterEventSyncService.sync(api, token)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
@@ -1,0 +1,161 @@
+package com.voicealarm.nativeapp.data
+
+import android.util.Base64
+import android.util.Log
+import com.voicealarm.nativeapp.alarm.AlarmScheduler
+import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
+import com.voicealarm.nativeapp.network.RemoteAlarm
+import com.voicealarm.nativeapp.network.VoiceAlarmApi
+import com.voicealarm.nativeapp.network.VoiceAlarmApiClient
+import java.util.UUID
+
+data class RemoteAlarmPullResult(
+    val total: Int,
+    val imported: Int,
+    val updated: Int,
+    val skipped: Int,
+    val failed: Int,
+)
+
+internal class RemoteAlarmPullSyncService(
+    private val alarmDao: AlarmDao,
+    private val alarmScheduler: AlarmScheduler,
+    private val alarmAudioStore: AlarmAudioStore,
+) {
+    suspend fun pullReceivedAlarms(api: VoiceAlarmApi, token: String): RemoteAlarmPullResult {
+        val authorization = VoiceAlarmApiClient.bearer(token)
+        val remoteAlarms = api.listAlarms(authorization).alarms
+            .filter { it.isReceivedFamilyAlarm }
+
+        var imported = 0
+        var updated = 0
+        var skipped = 0
+        var failed = 0
+
+        remoteAlarms.forEach { remote ->
+            runCatching {
+                val existing = alarmDao.getByRemoteAlarmId(remote.id)
+                val local = buildLocalAlarm(
+                    api = api,
+                    authorization = authorization,
+                    remote = remote,
+                    existing = existing,
+                ) ?: run {
+                    skipped += 1
+                    return@runCatching
+                }
+
+                if (existing != null) {
+                    alarmScheduler.cancel(existing.id)
+                }
+                if (local.enabled) {
+                    alarmScheduler.schedule(local)
+                }
+                alarmDao.upsert(local)
+                if (existing == null) imported += 1 else updated += 1
+            }.onFailure { error ->
+                failed += 1
+                Log.e(TAG, "Failed to pull received alarm remoteId=${remote.id}", error)
+            }
+        }
+
+        Log.i(
+            TAG,
+            "Remote alarm pull complete total=${remoteAlarms.size} imported=$imported updated=$updated skipped=$skipped failed=$failed",
+        )
+        return RemoteAlarmPullResult(
+            total = remoteAlarms.size,
+            imported = imported,
+            updated = updated,
+            skipped = skipped,
+            failed = failed,
+        )
+    }
+
+    private suspend fun buildLocalAlarm(
+        api: VoiceAlarmApi,
+        authorization: String,
+        remote: RemoteAlarm,
+        existing: AlarmEntity?,
+    ): AlarmEntity? {
+        val time = parseTime(remote.time) ?: return null
+        val repeatMask = repeatDaysToMask(remote.repeatDays.orEmpty())
+        val now = System.currentTimeMillis()
+        val enabled = remote.isActive != false
+
+        val cachedAudio = remote.messageId
+            ?.takeIf { it.isNotBlank() }
+            ?.let { messageId ->
+                val audio = api.getTtsMessageAudio(authorization, messageId)
+                alarmAudioStore.cacheGeneratedAudio(
+                    bytes = Base64.decode(audio.audioBase64, Base64.DEFAULT),
+                    format = audio.audioFormat,
+                    rawAudioUri = audio.audioUrl,
+                    cacheKey = "remote-message-$messageId",
+                    messageId = messageId,
+                )
+            }
+
+        val fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
+            hour = time.first,
+            minute = time.second,
+            repeatDaysMask = repeatMask,
+            holidayOff = false,
+            nowMillis = now,
+        )
+        val playMode = when {
+            cachedAudio == null -> AlarmPlayModes.ALARM_ONLY
+            remote.wakeMode == "voice_only" -> AlarmPlayModes.VOICE_ONLY
+            else -> AlarmPlayModes.ALARM_VOICE
+        }
+        val label = remote.messageText
+            ?.takeIf { it.isNotBlank() }
+            ?: remote.senderName?.takeIf { it.isNotBlank() }?.let { "$it 알람" }
+            ?: "상대방 알람"
+
+        return AlarmEntity(
+            id = existing?.id ?: UUID.randomUUID().toString(),
+            label = label,
+            hour = time.first,
+            minute = time.second,
+            fireAtMillis = fireAtMillis,
+            repeatDaysMask = repeatMask,
+            holidayOff = false,
+            snoozeEnabled = true,
+            snoozeMinutes = remote.snoozeMinutes ?: 5,
+            snoozeRepeatLimit = existing?.snoozeRepeatLimit ?: SnoozeRepeatLimits.THREE,
+            snoozeCount = 0,
+            vibrationPattern = remote.vibrationPattern ?: VibrationPatterns.DEFAULT,
+            playMode = playMode,
+            defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,
+            localAudioUri = cachedAudio?.localAudioUri,
+            audioCacheKey = cachedAudio?.cacheKey,
+            rawAudioUri = cachedAudio?.rawAudioUri ?: remote.rawAudioUrl ?: remote.messageAudioUrl,
+            voiceSource = if (cachedAudio == null) VoiceSources.LOCAL_AUDIO else VoiceSources.SERVER_TTS,
+            voiceProfileId = remote.voiceProfileId,
+            voiceText = remote.messageText,
+            voiceCategory = remote.category,
+            voiceLanguage = null,
+            ttsMessageId = remote.messageId,
+            remoteAlarmId = remote.id,
+            lastSyncedAtMillis = now,
+            syncState = AlarmSyncStates.SYNCED,
+            enabled = enabled,
+            state = if (enabled) AlarmStates.SCHEDULED else AlarmStates.DISABLED,
+            createdAtMillis = existing?.createdAtMillis ?: now,
+            updatedAtMillis = now,
+        )
+    }
+
+    private fun parseTime(value: String?): Pair<Int, Int>? {
+        val parts = value?.split(':') ?: return null
+        if (parts.size < 2) return null
+        val hour = parts[0].toIntOrNull() ?: return null
+        val minute = parts[1].toIntOrNull() ?: return null
+        if (hour !in 0..23 || minute !in 0..59) return null
+        return hour to minute
+    }
+
+    private fun repeatDaysToMask(days: List<Int>): Int =
+        days.filter { it in 0..6 }.fold(0) { mask, day -> mask or (1 shl day) }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
@@ -1,5 +1,6 @@
 package com.voicealarm.nativeapp.network
 
+import com.google.gson.annotations.SerializedName
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -32,12 +33,19 @@ data class RegisterRequest(
     val name: String,
 )
 
+data class GoogleLoginRequest(
+    @SerializedName("id_token") val idToken: String,
+)
+
 interface AuthApi {
     @POST("auth/register")
     suspend fun register(@Body request: RegisterRequest): AuthTokenResponse
 
     @POST("auth/login")
     suspend fun login(@Body request: LoginRequest): AuthTokenResponse
+
+    @POST("auth/google")
+    suspend fun loginGoogle(@Body request: GoogleLoginRequest): AuthTokenResponse
 
     @GET("auth/me")
     suspend fun me(@Header("Authorization") authorization: String): AuthMeResponse

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthSessionStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthSessionStore.kt
@@ -1,6 +1,8 @@
 package com.voicealarm.nativeapp.network
 
 import android.content.Context
+import java.util.Base64
+import org.json.JSONObject
 
 data class AuthSession(
     val token: String,
@@ -14,9 +16,14 @@ class AuthSessionStore(context: Context) {
     fun read(): AuthSession? {
         val token = prefs.getString(KEY_TOKEN, null)?.takeIf { it.isNotBlank() } ?: return null
         val userId = prefs.getString(KEY_USER_ID, null)?.takeIf { it.isNotBlank() } ?: return null
+        val provider = prefs.getString(KEY_PROVIDER, PROVIDER_APP) ?: PROVIDER_APP
+        if (provider == PROVIDER_GOOGLE && !isAppIssuedJwt(token)) {
+            clear()
+            return null
+        }
         return AuthSession(
             token = token,
-            provider = prefs.getString(KEY_PROVIDER, PROVIDER_APP) ?: PROVIDER_APP,
+            provider = provider,
             user = AuthUser(
                 id = userId,
                 email = prefs.getString(KEY_EMAIL, "") ?: "",
@@ -33,7 +40,14 @@ class AuthSessionStore(context: Context) {
             user = response.user,
         )
 
-    fun saveGoogleSession(
+    fun saveGoogleSession(response: AuthTokenResponse): AuthSession =
+        save(
+            token = response.token,
+            provider = PROVIDER_GOOGLE,
+            user = response.user,
+        )
+
+    fun saveLegacyGoogleSession(
         idToken: String,
         id: String,
         email: String,
@@ -66,9 +80,20 @@ class AuthSessionStore(context: Context) {
         return AuthSession(token = token, provider = provider, user = user)
     }
 
+    private fun isAppIssuedJwt(token: String): Boolean =
+        runCatching {
+            val payload = token.split('.').getOrNull(1)?.let { part ->
+                val padding = (4 - part.length % 4) % 4
+                part + "=".repeat(padding)
+            } ?: return@runCatching false
+            val decoded = String(Base64.getUrlDecoder().decode(payload), Charsets.UTF_8)
+            JSONObject(decoded).optString("iss") == APP_JWT_ISSUER
+        }.getOrDefault(false)
+
     companion object {
         const val PROVIDER_APP = "app"
         const val PROVIDER_GOOGLE = "google"
+        private const val APP_JWT_ISSUER = "voice-alarm"
 
         private const val PREFS_NAME = "voice_alarm_auth"
         private const val KEY_TOKEN = "token"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
@@ -37,6 +37,7 @@ data class VoucherListResponse(
 data class VoucherItem(
     val id: String,
     val code: String,
+    @SerializedName("plan_key") val planKey: String? = null,
     @SerializedName("plan_name") val planName: String,
     @SerializedName("plan_type") val planType: String,
     val status: String,
@@ -45,12 +46,13 @@ data class VoucherItem(
 
 data class CheckoutRequest(
     @SerializedName("plan_key") val planKey: String,
+    val gift: Boolean = false,
 )
 
 data class CheckoutResponse(
     val success: Boolean,
     @SerializedName("checkout_stub") val checkoutStub: Boolean = false,
-    val subscription: BillingSubscription,
+    val subscription: BillingSubscription?,
     val plan: BillingPlan,
     val voucher: CheckoutVoucher? = null,
 )

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
@@ -50,6 +50,25 @@ data class FamilyInvite(
     @SerializedName("web_url") val webUrl: String? = null,
 )
 
+data class FamilyVoiceAlarmRequest(
+    @SerializedName("recipient_user_id") val recipientUserId: String,
+    @SerializedName("wake_at") val wakeAt: String,
+    @SerializedName("voice_upload_id") val voiceUploadId: String,
+    val label: String? = null,
+    @SerializedName("repeat_days") val repeatDays: List<Int> = emptyList(),
+)
+
+data class FamilyVoiceAlarmResponse(
+    val alarm: FamilyVoiceAlarm,
+)
+
+data class FamilyVoiceAlarm(
+    val id: String,
+    @SerializedName("recipient_user_id") val recipientUserId: String? = null,
+    @SerializedName("wake_at") val wakeAt: String? = null,
+    val mode: String? = null,
+)
+
 interface FamilyApi {
     @GET("family/groups/current")
     suspend fun getFamilyGroup(@Header("Authorization") authorization: String): FamilyGroupCurrentResponse
@@ -76,4 +95,10 @@ interface FamilyApi {
         @Path("code") code: String,
         @Body request: Map<String, String> = emptyMap(),
     )
+
+    @POST("family/alarms/voice")
+    suspend fun createFamilyVoiceAlarm(
+        @Header("Authorization") authorization: String,
+        @Body request: FamilyVoiceAlarmRequest,
+    ): FamilyVoiceAlarmResponse
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmApi.kt
@@ -31,9 +31,18 @@ data class RemoteAlarm(
     @SerializedName("wake_mode") val wakeMode: String? = null,
     @SerializedName("voice_profile_id") val voiceProfileId: String? = null,
     @SerializedName("speaker_id") val speakerId: String? = null,
+    @SerializedName("message_id") val messageId: String? = null,
+    @SerializedName("message_text") val messageText: String? = null,
+    val category: String? = null,
     @SerializedName("raw_audio_url") val rawAudioUrl: String? = null,
+    @SerializedName("message_audio_url") val messageAudioUrl: String? = null,
     @SerializedName("raw_audio_duration_ms") val rawAudioDurationMs: Long? = null,
     @SerializedName("target_user_id") val targetUserId: String? = null,
+    @SerializedName("sender_user_id") val senderUserId: String? = null,
+    @SerializedName("sender_name") val senderName: String? = null,
+    @SerializedName("sender_email") val senderEmail: String? = null,
+    @SerializedName("is_family_alarm") val isFamilyAlarm: Boolean = false,
+    @SerializedName("is_received_family_alarm") val isReceivedFamilyAlarm: Boolean = false,
 )
 
 data class RemoteAlarmWriteRequest(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmApi.kt
@@ -33,6 +33,7 @@ data class RemoteAlarm(
     @SerializedName("speaker_id") val speakerId: String? = null,
     @SerializedName("raw_audio_url") val rawAudioUrl: String? = null,
     @SerializedName("raw_audio_duration_ms") val rawAudioDurationMs: Long? = null,
+    @SerializedName("target_user_id") val targetUserId: String? = null,
 )
 
 data class RemoteAlarmWriteRequest(
@@ -47,6 +48,7 @@ data class RemoteAlarmWriteRequest(
     @SerializedName("voice_profile_id") val voiceProfileId: String? = null,
     @SerializedName("raw_audio_url") val rawAudioUrl: String? = null,
     @SerializedName("raw_audio_duration_ms") val rawAudioDurationMs: Long? = null,
+    @SerializedName("target_user_id") val targetUserId: String? = null,
 )
 
 interface RemoteAlarmApi {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmMapper.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/RemoteAlarmMapper.kt
@@ -24,13 +24,14 @@ object RemoteAlarmMapper {
             voiceProfileId = alarm.voiceProfileId.takeIf { alarm.voiceSource != VoiceSources.LOCAL_AUDIO },
             rawAudioUrl = rawAudioUrl,
             rawAudioDurationMs = null,
+            targetUserId = null,
         )
     }
 
     fun repeatMaskToDays(mask: Int): List<Int> =
         (0..6).filter { day -> mask and (1 shl day) != 0 }
 
-    private fun isRemoteAudioUrl(value: String): Boolean =
+    fun isRemoteAudioUrl(value: String): Boolean =
         value.startsWith("https://", ignoreCase = true) ||
             value.startsWith("http://", ignoreCase = true) ||
             value.startsWith("r2://", ignoreCase = true)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
@@ -51,7 +51,8 @@ data class VoiceSpeakerSegment(
 )
 
 data class VoiceProfileUpdateRequest(
-    val name: String,
+    val name: String? = null,
+    @SerializedName("is_shared") val isShared: Boolean? = null,
 )
 
 data class VoiceProfile(
@@ -59,6 +60,7 @@ data class VoiceProfile(
     val name: String,
     val status: String? = null,
     @SerializedName("created_at") val createdAt: String? = null,
+    @SerializedName("is_shared") val isShared: Boolean? = null,
 )
 
 data class FamilyVoiceProfile(
@@ -68,6 +70,7 @@ data class FamilyVoiceProfile(
     @SerializedName("created_at") val createdAt: String? = null,
     @SerializedName("user_id") val userId: String? = null,
     @SerializedName("owner_name") val ownerName: String? = null,
+    @SerializedName("is_shared") val isShared: Boolean? = null,
 )
 
 data class FamilyVoiceProfileListResponse(
@@ -84,6 +87,7 @@ interface VoiceProfileApi {
         @Header("Authorization") authorization: String,
         @Part audio: MultipartBody.Part,
         @Part("name") name: RequestBody,
+        @Part("isShared") isShared: RequestBody,
     ): VoiceProfileResponse
 
     @Multipart

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ringing/RingingActivity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ringing/RingingActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.sp
 import com.voicealarm.nativeapp.alarm.AlarmContract.EXTRA_ALARM_ID
 import com.voicealarm.nativeapp.alarm.RingingService
 import com.voicealarm.nativeapp.data.AlarmAppContainer
+import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -58,7 +59,13 @@ class RingingActivity : ComponentActivity() {
             LaunchedEffect(currentAlarmId) {
                 snoozeEnabled = currentAlarmId?.let { id ->
                     withContext(Dispatchers.IO) {
-                        AlarmAppContainer.repository(applicationContext).getAlarm(id)?.snoozeEnabled
+                        AlarmAppContainer.repository(applicationContext).getAlarm(id)?.let { alarm ->
+                            alarm.snoozeEnabled &&
+                                (
+                                    alarm.snoozeRepeatLimit == SnoozeRepeatLimits.FOREVER ||
+                                        alarm.snoozeCount < alarm.snoozeRepeatLimit
+                                    )
+                        }
                     }
                 } ?: true
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncScheduler.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncScheduler.kt
@@ -1,0 +1,47 @@
+package com.voicealarm.nativeapp.sync
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+object RemoteAlarmSyncScheduler {
+    private const val PERIODIC_WORK_NAME = "remote_alarm_periodic_sync"
+    private const val ONE_TIME_WORK_NAME = "remote_alarm_immediate_sync"
+
+    private val networkConstraints = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.CONNECTED)
+        .build()
+
+    fun ensurePeriodic(context: Context) {
+        val request = PeriodicWorkRequestBuilder<RemoteAlarmSyncWorker>(
+            15,
+            TimeUnit.MINUTES,
+        )
+            .setConstraints(networkConstraints)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+            PERIODIC_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request,
+        )
+    }
+
+    fun runOnce(context: Context) {
+        val request = OneTimeWorkRequestBuilder<RemoteAlarmSyncWorker>()
+            .setConstraints(networkConstraints)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+            ONE_TIME_WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncWorker.kt
@@ -1,0 +1,36 @@
+package com.voicealarm.nativeapp.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
+import com.voicealarm.nativeapp.data.AlarmAppContainer
+import com.voicealarm.nativeapp.network.AuthSessionStore
+import com.voicealarm.nativeapp.network.VoiceAlarmApiClient
+
+class RemoteAlarmSyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val session = AuthSessionStore(applicationContext).read() ?: return Result.success()
+        return runCatching {
+            val api = VoiceAlarmApiClient.create()
+            val result = AlarmAppContainer.repository(applicationContext)
+                .pullReceivedAlarms(api, session.token)
+            Log.i(
+                TAG,
+                "Remote alarm worker complete total=${result.total} imported=${result.imported} updated=${result.updated} failed=${result.failed}",
+            )
+            if (result.failed > 0 && result.imported == 0 && result.updated == 0) {
+                Result.retry()
+            } else {
+                Result.success()
+            }
+        }.getOrElse { error ->
+            Log.e(TAG, "Remote alarm worker failed", error)
+            Result.retry()
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -168,6 +168,7 @@ internal fun AlarmListScreen(
                     item {
                         VoiceProfileManagementPanel(
                             voiceProfiles = voiceProfiles,
+                            familyVoices = familyVoices,
                             voiceProfileBusy = voiceProfileBusy,
                             subscriptionResponse = subscriptionResponse,
                             familyGroup = familyGroup,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -61,6 +61,7 @@ internal fun AlarmListScreen(
     onCreateVoiceProfiles: (List<Triple<String, CachedAlarmAudio, Boolean>>) -> Unit,
     onSeparateVoiceSpeakers: suspend (CachedAlarmAudio) -> List<VoiceSpeakerSegment>,
     onRenameVoiceProfile: (String, String) -> Unit,
+    onShareVoiceProfile: (String, Boolean) -> Unit,
     onDeleteVoiceProfile: (String) -> Unit,
     onRefreshSocial: () -> Unit,
     onCreateFamilyInvite: () -> Unit,
@@ -74,6 +75,7 @@ internal fun AlarmListScreen(
     onMarkNoteRead: (String) -> Unit,
     onCheckoutPlan: (String, Boolean) -> Unit,
     onCreateAlarm: () -> Unit,
+    onCreateFamilyAlarm: () -> Unit,
     onToggleEnabled: (String, Boolean) -> Unit,
     onEditAlarm: (AlarmEntity) -> Unit,
     onDeleteAlarm: (String) -> Unit,
@@ -87,6 +89,9 @@ internal fun AlarmListScreen(
     val nextAlarm = remember(alarms) {
         alarms.filter { it.enabled }.minByOrNull { it.fireAtMillis }
     }
+    val canCreateFamilyAlarm = authSession != null &&
+        hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup) &&
+        familyAlarmRecipients(familyGroup, authSession).isNotEmpty()
 
     LazyColumn(
         modifier = Modifier
@@ -128,6 +133,8 @@ internal fun AlarmListScreen(
                     QuickStartGrid(
                         onRecordVoice = { onSelectTab(NativeTab.Voices) },
                         onAddAlarm = onCreateAlarm,
+                        canCreateFamilyAlarm = canCreateFamilyAlarm,
+                        onAddFamilyAlarm = onCreateFamilyAlarm,
                     )
                 }
                 if (authSession == null) {
@@ -168,6 +175,7 @@ internal fun AlarmListScreen(
                             onCreateVoiceProfiles = onCreateVoiceProfiles,
                             onSeparateVoiceSpeakers = onSeparateVoiceSpeakers,
                             onRenameVoiceProfile = onRenameVoiceProfile,
+                            onShareVoiceProfile = onShareVoiceProfile,
                             onDeleteVoiceProfile = onDeleteVoiceProfile,
                         )
                     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -281,7 +281,7 @@ internal fun AlarmListScreen(
                 item {
                     ScreenHeader(
                         title = "캐릭터",
-                        subtitle = "알람을 끄고 다시 울릴 때마다 캐릭터가 자라요.",
+                        subtitle = "알람을 제대로 끄면 캐릭터가 성장해요!",
                     )
                 }
                 if (authSession == null) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -52,8 +52,6 @@ internal fun AlarmListScreen(
     vouchers: List<VoucherItem>,
     noteBusy: Boolean,
     receivedNotes: List<ReceivedNote>,
-    message: String?,
-    onClearMessage: () -> Unit,
     onLogin: (String, String) -> Unit,
     onRegister: (String, String, String) -> Unit,
     onGoogleSignIn: () -> Unit,
@@ -126,9 +124,6 @@ internal fun AlarmListScreen(
                         onClick = { onSelectTab(NativeTab.Growth) },
                     )
                 }
-                if (message != null) {
-                    item { StatusChip(message = message, onClearMessage = onClearMessage) }
-                }
                 item {
                     QuickStartGrid(
                         onRecordVoice = { onSelectTab(NativeTab.Voices) },
@@ -183,9 +178,6 @@ internal fun AlarmListScreen(
                 item { AlarmsHeader(onCreateAlarm = onCreateAlarm) }
                 if (nextAlarm != null) {
                     item { CountdownBanner(nextAlarm = nextAlarm) }
-                }
-                if (message != null) {
-                    item { StatusChip(message = message, onClearMessage = onClearMessage) }
                 }
                 if (sortedAlarms.isEmpty()) {
                     item { EmptyAlarmCard(onCreateAlarm = onCreateAlarm) }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -59,8 +59,8 @@ internal fun AlarmListScreen(
     onGoogleSignIn: () -> Unit,
     onSyncNow: () -> Unit,
     onLogout: () -> Unit,
-    onCreateVoiceProfile: (String, CachedAlarmAudio) -> Unit,
-    onCreateVoiceProfiles: (List<Pair<String, CachedAlarmAudio>>) -> Unit,
+    onCreateVoiceProfile: (String, CachedAlarmAudio, Boolean) -> Unit,
+    onCreateVoiceProfiles: (List<Triple<String, CachedAlarmAudio, Boolean>>) -> Unit,
     onSeparateVoiceSpeakers: suspend (CachedAlarmAudio) -> List<VoiceSpeakerSegment>,
     onRenameVoiceProfile: (String, String) -> Unit,
     onDeleteVoiceProfile: (String) -> Unit,
@@ -167,6 +167,8 @@ internal fun AlarmListScreen(
                         VoiceProfileManagementPanel(
                             voiceProfiles = voiceProfiles,
                             voiceProfileBusy = voiceProfileBusy,
+                            subscriptionResponse = subscriptionResponse,
+                            familyGroup = familyGroup,
                             onCreateVoiceProfile = onCreateVoiceProfile,
                             onCreateVoiceProfiles = onCreateVoiceProfiles,
                             onSeparateVoiceSpeakers = onSeparateVoiceSpeakers,
@@ -202,8 +204,8 @@ internal fun AlarmListScreen(
             NativeTab.People -> {
                 item {
                     ScreenHeader(
-                        title = "커플/가족 연결",
-                        subtitle = "초대 코드로 연결하고, 공유 허용된 음성만 알람에 사용할 수 있어요.",
+                        title = "코드 등록",
+                        subtitle = "초대 코드 및 이용권을 등록하세요.",
                     )
                 }
                 if (authSession == null) {
@@ -233,6 +235,7 @@ internal fun AlarmListScreen(
                             onCreateFamilyInvite = onCreateFamilyInvite,
                             onAcceptFamilyInvite = onAcceptFamilyInvite,
                             onRevokeFamilyInvite = onRevokeFamilyInvite,
+                            onRegisterCode = onRegisterCode,
                             onOpenBilling = { onSelectTab(NativeTab.Billing) },
                         )
                     }
@@ -243,7 +246,7 @@ internal fun AlarmListScreen(
                 item {
                     ScreenHeader(
                         title = "음성 메시지",
-                        subtitle = "커플/가족 플랜에서 연결된 사람에게 메시지를 보내고 받은 메시지를 확인해요.",
+                        subtitle = "소중한 사람들에게 응원의 메시지를 보내봐요.",
                     )
                 }
                 if (authSession == null) {
@@ -324,8 +327,8 @@ internal fun AlarmListScreen(
             NativeTab.Billing -> {
                 item {
                     ScreenHeader(
-                        title = "구독/이용권",
-                        subtitle = "플랜을 확인하고 이용권 코드를 등록해요.",
+                        title = "구독",
+                        subtitle = "플랜을 확인하고 구매해요.",
                     )
                 }
                 if (authSession == null) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -74,7 +74,7 @@ internal fun AlarmListScreen(
     onRefreshNotes: () -> Unit,
     onSendNote: (String, String) -> Unit,
     onMarkNoteRead: (String) -> Unit,
-    onCheckoutPlan: (String) -> Unit,
+    onCheckoutPlan: (String, Boolean) -> Unit,
     onCreateAlarm: () -> Unit,
     onToggleEnabled: (String, Boolean) -> Unit,
     onEditAlarm: (AlarmEntity) -> Unit,
@@ -106,18 +106,6 @@ internal fun AlarmListScreen(
                         onSelectTab = onSelectTab,
                         onSyncNow = onSyncNow,
                         onLogout = onLogout,
-                    )
-                }
-                item {
-                    NextAlarmHeroCard(
-                        nextAlarm = nextAlarm,
-                        onClick = {
-                            if (nextAlarm == null) {
-                                onCreateAlarm()
-                            } else {
-                                onEditAlarm(nextAlarm)
-                            }
-                        },
                     )
                 }
                 item {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -109,6 +109,18 @@ internal fun AlarmListScreen(
                     )
                 }
                 item {
+                    NextAlarmHeroCard(
+                        nextAlarm = nextAlarm,
+                        onClick = {
+                            if (nextAlarm == null) {
+                                onCreateAlarm()
+                            } else {
+                                onEditAlarm(nextAlarm)
+                            }
+                        },
+                    )
+                }
+                item {
                     CharacterMiniCard(
                         characterResponse = characterResponse,
                         onClick = { onSelectTab(NativeTab.Growth) },

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -79,6 +79,10 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     LaunchedEffect(selectedTab, authSession?.token) {
         if (authSession == null) return@LaunchedEffect
         when (selectedTab) {
+            NativeTab.Voices -> {
+                viewModel.preloadVoiceProfiles()
+                viewModel.preloadSocial()
+            }
             NativeTab.People -> viewModel.refreshSocial()
             NativeTab.Messages -> {
                 viewModel.refreshSocial()
@@ -265,6 +269,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 familyGroup = familyGroup,
                 familyAlarmMode = current.familyTargetMode,
                 voiceProfiles = voiceProfiles,
+                familyVoices = familyVoices,
                 voiceProfileBusy = voiceProfileBusy,
                 onCancel = ::goBackInApp,
                 onGenerateTts = viewModel::generateTtsAudio,
@@ -280,6 +285,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 familyGroup = familyGroup,
                 familyAlarmMode = false,
                 voiceProfiles = voiceProfiles,
+                familyVoices = familyVoices,
                 voiceProfileBusy = voiceProfileBusy,
                 onCancel = ::goBackInApp,
                 onGenerateTts = viewModel::generateTtsAudio,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -69,7 +69,11 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     LaunchedEffect(authSession?.token) {
-        if (authSession != null) viewModel.preloadVoiceProfiles()
+        if (authSession != null) {
+            viewModel.preloadVoiceProfiles()
+            viewModel.preloadSocial()
+            viewModel.preloadCharacterAndBilling()
+        }
     }
 
     LaunchedEffect(selectedTab, authSession?.token) {
@@ -234,6 +238,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onCreateVoiceProfiles = viewModel::createVoiceProfiles,
                 onSeparateVoiceSpeakers = viewModel::separateVoiceSpeakers,
                 onRenameVoiceProfile = viewModel::renameVoiceProfile,
+                onShareVoiceProfile = viewModel::setVoiceProfileShared,
                 onDeleteVoiceProfile = viewModel::deleteVoiceProfile,
                 onRefreshSocial = viewModel::refreshSocial,
                 onCreateFamilyInvite = viewModel::createFamilyInvite,
@@ -246,16 +251,19 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onSendNote = viewModel::sendNote,
                 onMarkNoteRead = viewModel::markNoteRead,
                 onCheckoutPlan = viewModel::checkoutPlan,
-                onCreateAlarm = { screen = AlarmScreen.Create },
+                onCreateAlarm = { screen = AlarmScreen.Create() },
+                onCreateFamilyAlarm = { screen = AlarmScreen.Create(familyTargetMode = true) },
                 onToggleEnabled = viewModel::setAlarmEnabled,
                 onEditAlarm = { screen = AlarmScreen.Edit(it) },
                 onDeleteAlarm = viewModel::deleteAlarm,
             )
 
-            AlarmScreen.Create -> AlarmEditorScreen(
+            is AlarmScreen.Create -> AlarmEditorScreen(
                 contentPadding = padding,
                 alarm = null,
                 authSession = authSession,
+                familyGroup = familyGroup,
+                familyAlarmMode = current.familyTargetMode,
                 voiceProfiles = voiceProfiles,
                 voiceProfileBusy = voiceProfileBusy,
                 onCancel = ::goBackInApp,
@@ -269,6 +277,8 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 contentPadding = padding,
                 alarm = current.alarm,
                 authSession = authSession,
+                familyGroup = familyGroup,
+                familyAlarmMode = false,
                 voiceProfiles = voiceProfiles,
                 voiceProfileBusy = voiceProfileBusy,
                 onCancel = ::goBackInApp,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -13,6 +13,8 @@ import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -58,6 +60,13 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     var selectedTab by remember { mutableStateOf(NativeTab.Home) }
     var tabBackStack by remember { mutableStateOf<List<NativeTab>>(emptyList()) }
     var planGateMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(message) {
+        val currentMessage = message ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(currentMessage)
+        viewModel.clearMessage()
+    }
 
     LaunchedEffect(authSession?.token) {
         if (authSession != null) viewModel.preloadVoiceProfiles()
@@ -183,6 +192,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         bottomBar = {
             if (screen is AlarmScreen.List) {
                 VoiceAlarmBottomBar(
@@ -215,8 +225,6 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 vouchers = vouchers,
                 noteBusy = noteBusy,
                 receivedNotes = receivedNotes,
-                message = message,
-                onClearMessage = viewModel::clearMessage,
                 onLogin = viewModel::login,
                 onRegister = viewModel::register,
                 onGoogleSignIn = ::launchGoogleSignIn,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -121,6 +121,14 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
 
     fun navigateToTab(tab: NativeTab) {
         if (selectedTab == tab) return
+        if (
+            tab == NativeTab.Messages &&
+            authSession != null &&
+            !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
+        ) {
+            viewModel.message = "커플/가족 플랜만 사용할 수 있어요"
+            return
+        }
         tabBackStack = tabBackStack + selectedTab
         selectedTab = tab
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -11,7 +11,10 @@ import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -54,6 +57,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     var screen by remember { mutableStateOf<AlarmScreen>(AlarmScreen.List) }
     var selectedTab by remember { mutableStateOf(NativeTab.Home) }
     var tabBackStack by remember { mutableStateOf<List<NativeTab>>(emptyList()) }
+    var planGateMessage by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(authSession?.token) {
         if (authSession != null) viewModel.preloadVoiceProfiles()
@@ -126,7 +130,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             authSession != null &&
             !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
         ) {
-            viewModel.message = "커플/가족 플랜만 사용할 수 있어요"
+            planGateMessage = "메시지는 커플/가족 플랜에서 사용할 수 있어요. 초대 코드나 이용권을 등록하거나 플랜을 구매해 주세요."
             return
         }
         tabBackStack = tabBackStack + selectedTab
@@ -149,6 +153,34 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         enabled = screen !is AlarmScreen.List || tabBackStack.isNotEmpty(),
         onBack = ::goBackInApp,
     )
+
+    planGateMessage?.let { gateMessage ->
+        AlertDialog(
+            onDismissRequest = { planGateMessage = null },
+            title = { Text("플랜 안내") },
+            text = { Text(gateMessage) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        planGateMessage = null
+                        navigateToTab(NativeTab.Billing)
+                    },
+                ) {
+                    Text("구독 보기")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        planGateMessage = null
+                        navigateToTab(NativeTab.People)
+                    },
+                ) {
+                    Text("코드 등록")
+                }
+            },
+        )
+    }
 
     Scaffold(
         bottomBar = {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -65,6 +66,14 @@ internal fun VoiceAlarmBottomBar(
                 selectedTab = selectedTab,
                 icon = Icons.Outlined.Alarm,
                 label = "알람",
+                onSelectTab = onSelectTab,
+                modifier = Modifier.weight(1f),
+            )
+            VoiceAlarmTabItem(
+                tab = NativeTab.Messages,
+                selectedTab = selectedTab,
+                icon = Icons.Outlined.Message,
+                label = "메시지",
                 onSelectTab = onSelectTab,
                 modifier = Modifier.weight(1f),
             )

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -40,6 +41,7 @@ internal fun VoiceAlarmBottomBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .height(76.dp)
                 .padding(horizontal = 6.dp, vertical = 6.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -1,5 +1,6 @@
 package com.voicealarm.nativeapp
 
+import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -12,11 +13,9 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -30,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,10 +45,11 @@ internal fun SubscriptionPanel(
     vouchers: List<VoucherItem>,
     onRefresh: () -> Unit,
     onRegisterCode: (String) -> Unit,
-    onCheckoutPlan: (String) -> Unit,
+    onCheckoutPlan: (String, Boolean) -> Unit,
 ) {
-    var checkoutTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
+    var checkoutTarget by remember { mutableStateOf<CheckoutSelection?>(null) }
     val currentPlan = subscriptionResponse?.plan
+    val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val options = remember {
         listOf(
@@ -82,6 +83,15 @@ internal fun SubscriptionPanel(
             ),
         )
     }
+    fun shareVoucher(voucher: VoucherItem) {
+        val shareText = "Voice Alarm ${voucher.planName} 이용권 코드: ${voucher.code}"
+        clipboard.setText(AnnotatedString(voucher.code))
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, shareText)
+        }
+        context.startActivity(Intent.createChooser(sendIntent, "이용권 코드 공유"))
+    }
 
     OutlinedCard {
         Column(
@@ -100,46 +110,45 @@ internal fun SubscriptionPanel(
                 } else {
                     currentPlan?.key == option.key
                 }
+                val voucherForPlan = vouchers.firstOrNull { voucher ->
+                    voucher.status in listOf("issued", "active", "pending") &&
+                        (voucher.planKey == option.key || voucher.planName.contains(option.name))
+                }
                 SubscriptionPlanCard(
                     option = option,
                     isCurrent = isCurrent,
                     busy = billingBusy,
-                    onPurchase = { checkoutTarget = option },
-                    onGift = { checkoutTarget = option },
+                    voucher = voucherForPlan,
+                    onPurchase = { checkoutTarget = CheckoutSelection(option = option, gift = false) },
+                    onGift = { checkoutTarget = CheckoutSelection(option = option, gift = true) },
+                    onShareVoucher = { voucher -> shareVoucher(voucher) },
                 )
-            }
-
-            if (vouchers.isNotEmpty()) {
-                HorizontalDivider()
-                Text("초대 코드", fontWeight = FontWeight.SemiBold)
-                vouchers.take(6).forEach { voucher ->
-                    CompactActionRow(
-                        title = voucher.code,
-                        subtitle = "${voucher.planName} · ${voucherStatusLabel(voucher.status)}",
-                        actionLabel = "복사하기",
-                        enabled = true,
-                        onAction = { clipboard.setText(AnnotatedString(voucher.code)) },
-                    )
-                }
             }
         }
     }
 
-    checkoutTarget?.let { target ->
+    checkoutTarget?.let { selection ->
+        val target = selection.option
         AlertDialog(
             onDismissRequest = { checkoutTarget = null },
-            title = { Text("${target.name} 플랜 구매") },
+            title = { Text(if (selection.gift) "${target.name} 플랜 선물하기" else "${target.name} 플랜 구매") },
             text = {
-                Text("구매를 진행할까요? 구매 후 초대 코드를 복사할 수 있어요.")
+                Text(
+                    if (selection.gift) {
+                        "내 구독을 변경하지 않고 다른 사람이 등록할 수 있는 이용권 코드를 만들어요."
+                    } else {
+                        "구매를 진행할까요? 구매 후 공유하기로 코드를 보낼 수 있어요."
+                    },
+                )
             },
             confirmButton = {
                 TextButton(
                     onClick = {
                         checkoutTarget = null
-                        onCheckoutPlan(target.key)
+                        onCheckoutPlan(target.key, selection.gift)
                     },
                 ) {
-                    Text("구매")
+                    Text(if (selection.gift) "결제" else "구매")
                 }
             },
             dismissButton = {
@@ -156,8 +165,10 @@ internal fun SubscriptionPlanCard(
     option: SubscriptionPlanOption,
     isCurrent: Boolean,
     busy: Boolean,
+    voucher: VoucherItem?,
     onPurchase: () -> Unit,
     onGift: () -> Unit,
+    onShareVoucher: (VoucherItem) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -201,6 +212,40 @@ internal fun SubscriptionPlanCard(
             }
             if (option.key != "free") {
                 if (option.key == "plus_personal") {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Button(
+                                onClick = onPurchase,
+                                enabled = !busy && !isCurrent,
+                                modifier = Modifier.weight(1f),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text("구매")
+                            }
+                            OutlinedButton(
+                                onClick = onGift,
+                                enabled = !busy,
+                                modifier = Modifier.weight(1f),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text("선물하기")
+                            }
+                        }
+                        if (voucher != null) {
+                            OutlinedButton(
+                                onClick = { onShareVoucher(voucher) },
+                                enabled = !busy,
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text("공유하기")
+                            }
+                        }
+                    }
+                } else {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -213,29 +258,27 @@ internal fun SubscriptionPlanCard(
                         ) {
                             Text("구매")
                         }
-                        OutlinedButton(
-                            onClick = onGift,
-                            enabled = !busy,
-                            modifier = Modifier.weight(1f),
-                            shape = RoundedCornerShape(14.dp),
-                        ) {
-                            Text("선물하기")
+                        if (voucher != null) {
+                            OutlinedButton(
+                                onClick = { onShareVoucher(voucher) },
+                                enabled = !busy,
+                                modifier = Modifier.weight(1f),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text("공유하기")
+                            }
                         }
-                    }
-                } else {
-                    Button(
-                        onClick = onPurchase,
-                        enabled = !busy && !isCurrent,
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
-                    ) {
-                        Text("구매")
                     }
                 }
             }
         }
     }
 }
+
+private data class CheckoutSelection(
+    val option: SubscriptionPlanOption,
+    val gift: Boolean,
+)
 
 @Composable
 internal fun CharacterBillingPanel(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
@@ -328,60 +329,66 @@ internal fun CharacterBillingPanel(
     onSyncEvents: () -> Unit,
     onRegisterCode: (String) -> Unit,
 ) {
-    val pendingEvents = characterEvents.count { it.state != "synced" }
-
     OutlinedCard {
         Column(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            PanelHeader(
-                title = "성장",
-                actionLabel = if (characterBusy || billingBusy) "불러오는 중" else "새로고침",
-                enabled = !characterBusy && !billingBusy,
-                onAction = onRefresh,
+            Text(
+                text = "성장",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
             )
 
             if (characterResponse == null) {
                 MutedText("캐릭터 정보를 아직 불러오지 않았어요.")
             } else {
                 val character = characterResponse.character
-                Text(
-                    text = "${stageEmoji(character.stage)} ${character.name}",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                MutedText(
-                    "레벨 ${character.level} - ${stageLabel(character.stage)} - XP ${character.xp} - 애정도 ${character.affection}",
-                )
+                val progress = characterResponse.progress
+                val progressRatio = progress.progressRatio.toFloat().coerceIn(0f, 1f)
+                val levelSpan = progress.levelSpan.coerceAtLeast(1)
+                val xpIntoLevel = progress.xpIntoLevel.coerceIn(0, levelSpan)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stageEmoji(character.stage),
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                    Text(
+                        text = "LV.${character.level}",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "XP",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = "$xpIntoLevel/$levelSpan",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    LinearProgressIndicator(
+                        progress = { progressRatio },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    MutedText("누적 XP ${character.xp}")
+                }
                 MutedText(
                     "연속 ${characterResponse.streak.current}일 - 최장 ${characterResponse.streak.longest}일",
                 )
-                MutedText(
-                    "진행도 ${characterResponse.progress.xpIntoLevel}/${characterResponse.progress.levelSpan}",
-                )
             }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Button(
-                    onClick = onSyncEvents,
-                    enabled = pendingEvents > 0 && !characterBusy,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Text("XP 동기화")
-                }
-                OutlinedButton(
-                    onClick = onRefresh,
-                    enabled = !characterBusy && !billingBusy,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Text("대기 ${pendingEvents}개")
-                }
-            }
-            MutedText("구독은 홈 오른쪽 위 프로필 메뉴에서 관리해요.")
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -1,11 +1,14 @@
 package com.voicealarm.nativeapp
 
 import android.content.Intent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -13,7 +16,6 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
@@ -28,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -379,17 +382,39 @@ internal fun CharacterBillingPanel(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
-                    LinearProgressIndicator(
-                        progress = { progressRatio },
+                    CharacterXpBar(
+                        progress = progressRatio,
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    MutedText("누적 XP ${character.xp}")
+                    MutedText("다음 레벨까지 ${progress.xpToNextLevel} XP")
                 }
                 MutedText(
                     "연속 ${characterResponse.streak.current}일 - 최장 ${characterResponse.streak.longest}일",
                 )
             }
         }
+    }
+}
+
+@Composable
+internal fun CharacterXpBar(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(999.dp)
+    Box(
+        modifier = modifier
+            .height(8.dp)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .height(8.dp)
+                .clip(shape)
+                .background(MaterialTheme.colorScheme.primary),
+        )
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.CharacterEventEntity
@@ -45,9 +47,9 @@ internal fun SubscriptionPanel(
     onRegisterCode: (String) -> Unit,
     onCheckoutPlan: (String) -> Unit,
 ) {
-    var code by remember { mutableStateOf("") }
     var checkoutTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
     val currentPlan = subscriptionResponse?.plan
+    val clipboard = LocalClipboardManager.current
     val options = remember {
         listOf(
             SubscriptionPlanOption(
@@ -65,10 +67,17 @@ internal fun SubscriptionPanel(
                 features = listOf("AI 음성 프로필 2개", "TTS 알람", "캐릭터/스트릭"),
             ),
             SubscriptionPlanOption(
+                key = "couple",
+                name = "커플",
+                price = "월 7,900원",
+                description = "두 사람이 음성과 메시지를 공유",
+                features = listOf("초대 코드", "공유 음성", "메시지", "최대 2명"),
+            ),
+            SubscriptionPlanOption(
                 key = "family",
-                name = "커플/가족",
+                name = "가족",
                 price = "월 9,900원",
-                description = "연결된 사람과 음성을 공유",
+                description = "가족과 음성, 메시지를 공유",
                 features = listOf("초대 코드", "공유 음성", "메시지", "최대 6명"),
             ),
         )
@@ -79,19 +88,11 @@ internal fun SubscriptionPanel(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            PanelHeader(
-                title = "구독",
-                actionLabel = if (billingBusy) "불러오는 중" else "새로고침",
-                enabled = !billingBusy,
-                onAction = onRefresh,
+            Text(
+                text = "구독",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
             )
-
-            Text("현재 플랜", fontWeight = FontWeight.SemiBold)
-            if (currentPlan == null) {
-                MutedText("무료 플랜 또는 활성 구독 없음")
-            } else {
-                MutedText("${currentPlan.name} - ${planTypeLabel(currentPlan.planType)} - 최대 ${currentPlan.maxMembers}명")
-            }
 
             options.forEach { option ->
                 val isCurrent = if (option.key == "free") {
@@ -103,41 +104,22 @@ internal fun SubscriptionPanel(
                     option = option,
                     isCurrent = isCurrent,
                     busy = billingBusy,
-                    onCheckout = { checkoutTarget = option },
+                    onPurchase = { checkoutTarget = option },
+                    onGift = { checkoutTarget = option },
                 )
             }
 
-            HorizontalDivider()
-
-            Text("이용권 코드 등록", fontWeight = FontWeight.SemiBold)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedTextField(
-                    value = code,
-                    onValueChange = { code = it.uppercase().take(18) },
-                    label = { Text("VA-XXXX-XXXX-XXXX") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                Button(
-                    onClick = {
-                        onRegisterCode(code)
-                        code = ""
-                    },
-                    enabled = code.isNotBlank() && !billingBusy,
-                ) {
-                    Text("등록")
-                }
-            }
-
-            Text("발급된 이용권", fontWeight = FontWeight.SemiBold)
-            if (vouchers.isEmpty()) {
-                MutedText("발급된 이용권이 없어요.")
-            } else {
+            if (vouchers.isNotEmpty()) {
+                HorizontalDivider()
+                Text("초대 코드", fontWeight = FontWeight.SemiBold)
                 vouchers.take(6).forEach { voucher ->
-                    MutedText("${voucher.code} - ${voucher.planName} - ${voucherStatusLabel(voucher.status)}")
+                    CompactActionRow(
+                        title = voucher.code,
+                        subtitle = "${voucher.planName} · ${voucherStatusLabel(voucher.status)}",
+                        actionLabel = "복사하기",
+                        enabled = true,
+                        onAction = { clipboard.setText(AnnotatedString(voucher.code)) },
+                    )
                 }
             }
         }
@@ -146,9 +128,9 @@ internal fun SubscriptionPanel(
     checkoutTarget?.let { target ->
         AlertDialog(
             onDismissRequest = { checkoutTarget = null },
-            title = { Text("${target.name} 플랜 변경") },
+            title = { Text("${target.name} 플랜 구매") },
             text = {
-                Text("선택한 플랜으로 변경할까요? 적용 후 선물용 이용권 코드가 발급됩니다.")
+                Text("구매를 진행할까요? 구매 후 초대 코드를 복사할 수 있어요.")
             },
             confirmButton = {
                 TextButton(
@@ -157,7 +139,7 @@ internal fun SubscriptionPanel(
                         onCheckoutPlan(target.key)
                     },
                 ) {
-                    Text("적용")
+                    Text("구매")
                 }
             },
             dismissButton = {
@@ -174,7 +156,8 @@ internal fun SubscriptionPlanCard(
     option: SubscriptionPlanOption,
     isCurrent: Boolean,
     busy: Boolean,
-    onCheckout: () -> Unit,
+    onPurchase: () -> Unit,
+    onGift: () -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -216,14 +199,38 @@ internal fun SubscriptionPlanCard(
             option.features.forEach { feature ->
                 MutedText("• $feature")
             }
-            if (!isCurrent && option.key != "free") {
-                Button(
-                    onClick = onCheckout,
-                    enabled = !busy,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(14.dp),
-                ) {
-                    Text("${option.name} 적용")
+            if (option.key != "free") {
+                if (option.key == "plus_personal") {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Button(
+                            onClick = onPurchase,
+                            enabled = !busy && !isCurrent,
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(14.dp),
+                        ) {
+                            Text("구매")
+                        }
+                        OutlinedButton(
+                            onClick = onGift,
+                            enabled = !busy,
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(14.dp),
+                        ) {
+                            Text("선물하기")
+                        }
+                    }
+                } else {
+                    Button(
+                        onClick = onPurchase,
+                        enabled = !busy && !isCurrent,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text("구매")
+                    }
                 }
             }
         }
@@ -295,7 +302,7 @@ internal fun CharacterBillingPanel(
                     Text("대기 ${pendingEvents}개")
                 }
             }
-            MutedText("구독과 이용권 코드는 홈 오른쪽 위 프로필 메뉴의 구독/이용권에서 관리해요.")
+            MutedText("구독은 홈 오른쪽 위 프로필 메뉴에서 관리해요.")
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -48,6 +48,7 @@ internal fun SubscriptionPanel(
     onCheckoutPlan: (String, Boolean) -> Unit,
 ) {
     var checkoutTarget by remember { mutableStateOf<CheckoutSelection?>(null) }
+    var shareTarget by remember { mutableStateOf<List<VoucherItem>>(emptyList()) }
     val currentPlan = subscriptionResponse?.plan
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
@@ -92,6 +93,13 @@ internal fun SubscriptionPanel(
         }
         context.startActivity(Intent.createChooser(sendIntent, "이용권 코드 공유"))
     }
+    fun openVoucherShare(vouchersForPlan: List<VoucherItem>) {
+        if (vouchersForPlan.size == 1) {
+            shareVoucher(vouchersForPlan.first())
+        } else if (vouchersForPlan.isNotEmpty()) {
+            shareTarget = vouchersForPlan
+        }
+    }
 
     OutlinedCard {
         Column(
@@ -110,7 +118,7 @@ internal fun SubscriptionPanel(
                 } else {
                     currentPlan?.key == option.key
                 }
-                val voucherForPlan = vouchers.firstOrNull { voucher ->
+                val vouchersForPlan = vouchers.filter { voucher ->
                     voucher.status in listOf("issued", "active", "pending") &&
                         (voucher.planKey == option.key || voucher.planName.contains(option.name))
                 }
@@ -118,10 +126,10 @@ internal fun SubscriptionPanel(
                     option = option,
                     isCurrent = isCurrent,
                     busy = billingBusy,
-                    voucher = voucherForPlan,
+                    vouchers = vouchersForPlan,
                     onPurchase = { checkoutTarget = CheckoutSelection(option = option, gift = false) },
                     onGift = { checkoutTarget = CheckoutSelection(option = option, gift = true) },
-                    onShareVoucher = { voucher -> shareVoucher(voucher) },
+                    onShareVouchers = { selectedVouchers -> openVoucherShare(selectedVouchers) },
                 )
             }
         }
@@ -158,6 +166,34 @@ internal fun SubscriptionPanel(
             },
         )
     }
+
+    if (shareTarget.isNotEmpty()) {
+        AlertDialog(
+            onDismissRequest = { shareTarget = emptyList() },
+            title = { Text("공유할 코드 선택") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    shareTarget.forEach { voucher ->
+                        CompactActionRow(
+                            title = voucher.code,
+                            subtitle = "${voucher.planName} · ${voucherStatusLabel(voucher.status)}",
+                            actionLabel = "공유",
+                            enabled = true,
+                            onAction = {
+                                shareTarget = emptyList()
+                                shareVoucher(voucher)
+                            },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { shareTarget = emptyList() }) {
+                    Text("닫기")
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -165,10 +201,10 @@ internal fun SubscriptionPlanCard(
     option: SubscriptionPlanOption,
     isCurrent: Boolean,
     busy: Boolean,
-    voucher: VoucherItem?,
+    vouchers: List<VoucherItem>,
     onPurchase: () -> Unit,
     onGift: () -> Unit,
-    onShareVoucher: (VoucherItem) -> Unit,
+    onShareVouchers: (List<VoucherItem>) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(14.dp),
@@ -234,9 +270,9 @@ internal fun SubscriptionPlanCard(
                                 Text("선물하기")
                             }
                         }
-                        if (voucher != null) {
+                        if (vouchers.isNotEmpty()) {
                             OutlinedButton(
-                                onClick = { onShareVoucher(voucher) },
+                                onClick = { onShareVouchers(vouchers) },
                                 enabled = !busy,
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = RoundedCornerShape(14.dp),
@@ -258,9 +294,9 @@ internal fun SubscriptionPlanCard(
                         ) {
                             Text("구매")
                         }
-                        if (voucher != null) {
+                        if (vouchers.isNotEmpty()) {
                             OutlinedButton(
-                                onClick = { onShareVoucher(voucher) },
+                                onClick = { onShareVouchers(vouchers) },
                                 enabled = !busy,
                                 modifier = Modifier.weight(1f),
                                 shape = RoundedCornerShape(14.dp),

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/ControlsAndPermissions.kt
@@ -58,11 +58,13 @@ internal fun VoiceAlarmSwitch(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     val isDark = androidx.compose.foundation.isSystemInDarkTheme()
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
+        enabled = enabled,
         modifier = modifier,
         colors = SwitchDefaults.colors(
             checkedThumbColor = MaterialTheme.colorScheme.onPrimary,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/ControlsAndPermissions.kt
@@ -260,9 +260,13 @@ internal fun AlarmRow(
                 }
                 Text(
                     text = listOf(
-                        repeatLabel(alarm.repeatDaysMask),
+                        alarm.repeatDaysMask.takeIf { it != 0 }?.let(::repeatLabel),
                         if (alarm.holidayOff) "공휴일 끔" else null,
-                        if (alarm.snoozeEnabled) "다시 울림 ${alarm.snoozeMinutes}분" else "다시 울림 꺼짐",
+                        snoozeListLabel(
+                            enabled = alarm.snoozeEnabled,
+                            minutes = alarm.snoozeMinutes,
+                            repeatLimit = alarm.snoozeRepeatLimit,
+                        ),
                         vibrationLabel(alarm.vibrationPattern),
                         playModeLabel(alarm.playMode),
                     ).filterNotNull().joinToString(" · "),

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/VoiceInputControls.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/VoiceInputControls.kt
@@ -1,0 +1,328 @@
+package com.voicealarm.nativeapp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.UploadFile
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToLong
+
+internal enum class VoiceCaptureMode {
+    Record,
+    File,
+}
+
+internal fun audioTimeLabel(millis: Long): String {
+    val totalSeconds = (millis / 1000).coerceAtLeast(0L)
+    return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
+}
+
+@Composable
+internal fun VoiceCaptureModeSelector(
+    selected: VoiceCaptureMode,
+    onSelect: (VoiceCaptureMode) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        VoiceInputModeButton(
+            label = "녹음",
+            selected = selected == VoiceCaptureMode.Record,
+            enabled = enabled,
+            onClick = { onSelect(VoiceCaptureMode.Record) },
+            modifier = Modifier.weight(1f),
+        )
+        VoiceInputModeButton(
+            label = "파일",
+            selected = selected == VoiceCaptureMode.File,
+            enabled = enabled,
+            onClick = { onSelect(VoiceCaptureMode.File) },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+internal fun VoiceInputModeButton(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    if (selected) {
+        Button(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = modifier,
+            shape = RoundedCornerShape(999.dp),
+        ) {
+            Text(label)
+        }
+    } else {
+        OutlinedButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = modifier,
+            shape = RoundedCornerShape(999.dp),
+        ) {
+            Text(label)
+        }
+    }
+}
+
+@Composable
+internal fun VoiceRecordControls(
+    isRecording: Boolean,
+    elapsedMillis: Long,
+    maxDurationMillis: Long,
+    levels: List<Float>,
+    enabled: Boolean,
+    notice: String,
+    onRecordClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        MutedText(notice)
+        Button(
+            onClick = onRecordClick,
+            enabled = enabled,
+            modifier = Modifier.size(92.dp),
+            shape = CircleShape,
+            contentPadding = ButtonDefaults.ContentPadding,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (isRecording) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+            ),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Mic,
+                contentDescription = if (isRecording) "녹음 종료" else "녹음",
+                modifier = Modifier.size(34.dp),
+            )
+        }
+        Text(
+            text = "${audioTimeLabel(elapsedMillis)} / ${audioTimeLabel(maxDurationMillis)}",
+            style = MaterialTheme.typography.titleMedium,
+            color = if (isRecording) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            fontWeight = FontWeight.SemiBold,
+        )
+        VoiceLevelBars(levels = levels, active = isRecording)
+        RecordingProgressBar(
+            progress = (elapsedMillis.toFloat() / maxDurationMillis.toFloat()).coerceIn(0f, 1f),
+            active = isRecording,
+        )
+    }
+}
+
+@Composable
+internal fun VoiceFileControls(
+    durationMillis: Long?,
+    cropStartMillis: Long,
+    cropEndMillis: Long,
+    minDurationMillis: Long,
+    maxDurationMillis: Long,
+    enabled: Boolean,
+    uploadLabel: String,
+    notice: String,
+    onPickFile: () -> Unit,
+    onCropChange: (Long, Long) -> Unit,
+    onPreviewCrop: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        MutedText(notice)
+        Button(
+            onClick = onPickFile,
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Icon(Icons.Outlined.UploadFile, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(uploadLabel)
+        }
+        durationMillis?.let { duration ->
+            AudioCropRangeSelector(
+                durationMillis = duration,
+                cropStartMillis = cropStartMillis,
+                cropEndMillis = cropEndMillis,
+                minDurationMillis = minDurationMillis,
+                maxDurationMillis = maxDurationMillis,
+                onCropChange = onCropChange,
+                onPreviewCrop = onPreviewCrop,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun AudioCropRangeSelector(
+    durationMillis: Long,
+    cropStartMillis: Long,
+    cropEndMillis: Long,
+    minDurationMillis: Long,
+    maxDurationMillis: Long,
+    onCropChange: (Long, Long) -> Unit,
+    onPreviewCrop: () -> Unit,
+) {
+    val safeDuration = durationMillis.coerceAtLeast(1L)
+    val safeStart = cropStartMillis.coerceIn(0L, safeDuration)
+    val safeEnd = cropEndMillis.coerceIn(safeStart, safeDuration)
+    val selectedDuration = (safeEnd - safeStart).coerceAtLeast(0L)
+    val waveform = remember(safeDuration) {
+        List(40) { index ->
+            0.18f + ((index * 17) % 31) / 40f
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(
+                    text = "${audioTimeLabel(safeStart)} - ${audioTimeLabel(safeEnd)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                MutedText("선택 ${audioTimeLabel(selectedDuration)} / 전체 ${audioTimeLabel(safeDuration)}")
+            }
+            OutlinedButton(onClick = onPreviewCrop, enabled = selectedDuration > 0L) {
+                Icon(Icons.Outlined.PlayArrow, contentDescription = null)
+                Spacer(Modifier.width(6.dp))
+                Text("듣기")
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(54.dp)
+                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(10.dp))
+                .padding(horizontal = 8.dp, vertical = 7.dp),
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            waveform.forEachIndexed { index, level ->
+                val point = safeDuration * index / waveform.lastIndex.coerceAtLeast(1)
+                val selected = point in safeStart..safeEnd
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height((12 + level * 34).dp)
+                        .background(
+                            if (selected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outline
+                            },
+                            RoundedCornerShape(999.dp),
+                        ),
+                )
+            }
+        }
+        RangeSlider(
+            value = safeStart.toFloat()..safeEnd.toFloat(),
+            onValueChange = { range ->
+                val nextStart = range.start.roundToLong().coerceIn(0L, safeDuration)
+                val maxEndByStart = (nextStart + maxDurationMillis).coerceAtMost(safeDuration)
+                val minEndByStart = (nextStart + minDurationMillis).coerceAtMost(safeDuration)
+                val nextEnd = range.endInclusive.roundToLong()
+                    .coerceIn(minEndByStart, maxEndByStart)
+                    .coerceAtLeast(nextStart)
+                onCropChange(nextStart, nextEnd)
+            },
+            valueRange = 0f..safeDuration.toFloat(),
+        )
+    }
+}
+
+@Composable
+internal fun VoiceLevelBars(
+    levels: List<Float>,
+    active: Boolean,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        levels.forEachIndexed { index, level ->
+            val resolvedLevel = if (active) level else 0.1f + (index % 4) * 0.04f
+            Box(
+                modifier = Modifier
+                    .width(4.dp)
+                    .height((10 + resolvedLevel * 34).dp)
+                    .background(
+                        if (active) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.outlineVariant
+                        },
+                        RoundedCornerShape(999.dp),
+                    ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecordingProgressBar(
+    progress: Float,
+    active: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(6.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(999.dp)),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress)
+                .height(6.dp)
+                .background(
+                    if (active) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    RoundedCornerShape(999.dp),
+                ),
+        )
+    }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/VoiceInputControls.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/components/VoiceInputControls.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 import kotlin.math.roundToLong
 
 internal enum class VoiceCaptureMode {
@@ -263,12 +264,32 @@ internal fun AudioCropRangeSelector(
         RangeSlider(
             value = safeStart.toFloat()..safeEnd.toFloat(),
             onValueChange = { range ->
-                val nextStart = range.start.roundToLong().coerceIn(0L, safeDuration)
-                val maxEndByStart = (nextStart + maxDurationMillis).coerceAtMost(safeDuration)
-                val minEndByStart = (nextStart + minDurationMillis).coerceAtMost(safeDuration)
-                val nextEnd = range.endInclusive.roundToLong()
-                    .coerceIn(minEndByStart, maxEndByStart)
-                    .coerceAtLeast(nextStart)
+                val rawStart = range.start.roundToLong().coerceIn(0L, safeDuration)
+                val rawEnd = range.endInclusive.roundToLong().coerceIn(0L, safeDuration)
+                val movingEnd = abs(rawEnd - safeEnd) >= abs(rawStart - safeStart)
+                var nextStart = rawStart.coerceAtMost(rawEnd)
+                var nextEnd = rawEnd.coerceAtLeast(nextStart)
+                val selected = nextEnd - nextStart
+                if (selected > maxDurationMillis) {
+                    if (movingEnd) {
+                        nextStart = (nextEnd - maxDurationMillis).coerceAtLeast(0L)
+                    } else {
+                        nextEnd = (nextStart + maxDurationMillis).coerceAtMost(safeDuration)
+                    }
+                }
+                if (nextEnd - nextStart < minDurationMillis) {
+                    if (movingEnd) {
+                        nextStart = (nextEnd - minDurationMillis).coerceAtLeast(0L)
+                        if (nextEnd - nextStart < minDurationMillis) {
+                            nextEnd = (nextStart + minDurationMillis).coerceAtMost(safeDuration)
+                        }
+                    } else {
+                        nextEnd = (nextStart + minDurationMillis).coerceAtMost(safeDuration)
+                        if (nextEnd - nextStart < minDurationMillis) {
+                            nextStart = (nextEnd - minDurationMillis).coerceAtLeast(0L)
+                        }
+                    }
+                }
                 onCropChange(nextStart, nextEnd)
             },
             valueRange = 0f..safeDuration.toFloat(),

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -3,6 +3,7 @@ package com.voicealarm.nativeapp
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.MediaPlayer
 import android.net.Uri
 import android.util.Base64
 import android.util.Log
@@ -73,6 +74,14 @@ internal fun AlarmEditorScreen(
     var audioMessage by remember { mutableStateOf<String?>(null) }
     var isRecording by remember { mutableStateOf(false) }
     var isSaving by remember { mutableStateOf(false) }
+    var localInputMode by remember { mutableStateOf(VoiceCaptureMode.Record) }
+    var recordingElapsedMillis by remember { mutableStateOf(0L) }
+    var recordingLevels by remember { mutableStateOf(List(18) { 0.08f }) }
+    var selectedFileUri by remember { mutableStateOf<Uri?>(null) }
+    var selectedFileDurationMillis by remember { mutableStateOf<Long?>(null) }
+    var cropStartMillis by remember { mutableStateOf(0L) }
+    var cropEndMillis by remember { mutableStateOf(AlarmAudioLimits.MAX_DURATION_MILLIS) }
+    var mediaPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
 
     fun applyCachedAudio(audio: CachedAlarmAudio) {
         editor.setCachedAudio(audio)
@@ -80,15 +89,55 @@ internal fun AlarmEditorScreen(
         audioMessage = "음성 오디오가 준비됐어요$seconds"
     }
 
-    fun cacheSelectedAudio(uri: Uri) {
+    fun prepareSelectedAudio(uri: Uri) {
         scope.launch {
             runCatching {
-                withContext(Dispatchers.IO) { audioStore.cacheFromUri(uri) }
-            }.onSuccess(::applyCachedAudio)
+                withContext(Dispatchers.IO) { audioStore.readDurationMillis(uri) }
+                    ?: throw IllegalArgumentException("오디오 길이를 확인할 수 없는 파일은 사용할 수 없어요.")
+            }.onSuccess { durationMillis ->
+                selectedFileUri = uri
+                selectedFileDurationMillis = durationMillis
+                cropStartMillis = 0L
+                cropEndMillis = durationMillis.coerceAtMost(AlarmAudioLimits.MAX_DURATION_MILLIS)
+                editor.clearAudio()
+                audioMessage = null
+            }
                 .onFailure { error ->
                     Log.e(TAG, "Failed to cache selected audio", error)
                     audioMessage = userFacingError(error, "선택한 오디오를 사용할 수 없어요")
                 }
+        }
+    }
+
+    suspend fun cacheSelectedCrop(): CachedAlarmAudio {
+        val uri = selectedFileUri ?: throw IllegalStateException("파일을 선택해 주세요")
+        val cropDurationMillis = (cropEndMillis - cropStartMillis).coerceIn(1_000L, AlarmAudioLimits.MAX_DURATION_MILLIS)
+        return withContext(Dispatchers.IO) {
+            audioStore.cacheFromUri(
+                sourceUri = uri,
+                maxDurationMillis = cropDurationMillis,
+                startMillis = cropStartMillis,
+            )
+        }
+    }
+
+    fun playSelectedCrop() {
+        scope.launch {
+            runCatching {
+                cacheSelectedCrop()
+            }.onSuccess { audio ->
+                mediaPlayer?.release()
+                mediaPlayer = MediaPlayer.create(context, Uri.parse(audio.localAudioUri))?.apply {
+                    setOnCompletionListener {
+                        it.release()
+                        if (mediaPlayer === it) mediaPlayer = null
+                    }
+                    start()
+                }
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to play cropped alarm audio", error)
+                audioMessage = userFacingError(error, "선택한 구간을 재생하지 못했어요")
+            }
         }
     }
 
@@ -98,6 +147,9 @@ internal fun AlarmEditorScreen(
                 withContext(Dispatchers.IO) { recorder.stop() }
             }.onSuccess { audio ->
                 isRecording = false
+                recordingElapsedMillis = audio.durationMillis ?: recordingElapsedMillis
+                selectedFileUri = null
+                selectedFileDurationMillis = null
                 applyCachedAudio(audio)
             }.onFailure { error ->
                 isRecording = false
@@ -109,8 +161,10 @@ internal fun AlarmEditorScreen(
 
     fun startRecording() {
         runCatching {
-            recorder.start()
+            recorder.start(maxDurationMillis = AlarmAudioLimits.MAX_DURATION_MILLIS)
             isRecording = true
+            recordingElapsedMillis = 0L
+            recordingLevels = List(18) { 0.08f }
             audioMessage = "녹음 중..."
         }.onFailure { error ->
             Log.e(TAG, "Failed to start recording", error)
@@ -126,6 +180,22 @@ internal fun AlarmEditorScreen(
             return
         }
         if (editor.voiceSource == VoiceSources.LOCAL_AUDIO) {
+            if (selectedFileUri != null) {
+                scope.launch {
+                    isSaving = true
+                    runCatching {
+                        cacheSelectedCrop()
+                    }.onSuccess { audio ->
+                        applyCachedAudio(audio)
+                        onSave(editor.toDraft())
+                    }.onFailure { error ->
+                        Log.e(TAG, "Failed to cache cropped local alarm audio", error)
+                        audioMessage = userFacingError(error, "선택한 구간을 저장하지 못했어요")
+                    }
+                    isSaving = false
+                }
+                return
+            }
             if (editor.localAudioUri.isNullOrBlank()) {
                 audioMessage = "음성 오디오를 녹음하거나 파일로 선택해 주세요"
                 return
@@ -143,7 +213,7 @@ internal fun AlarmEditorScreen(
             audioMessage = "사용할 음성 프로필을 선택해 주세요"
             return
         }
-        val text = editor.ttsTextForSave()
+        val text = editor.localizedTtsTextForSave()
         if (text.isBlank()) {
             audioMessage = "읽어줄 문구를 입력하거나 랜덤 문구를 켜 주세요"
             return
@@ -218,7 +288,7 @@ internal fun AlarmEditorScreen(
     }
 
     val pickAudioLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        if (uri != null) cacheSelectedAudio(uri)
+        if (uri != null) prepareSelectedAudio(uri)
     }
     val recordPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
         if (granted) {
@@ -230,14 +300,25 @@ internal fun AlarmEditorScreen(
 
     LaunchedEffect(isRecording) {
         if (isRecording) {
-            delay(AlarmAudioLimits.MAX_DURATION_MILLIS)
-            if (isRecording) stopRecording()
+            val startedAt = System.currentTimeMillis()
+            while (isRecording) {
+                recordingElapsedMillis = (System.currentTimeMillis() - startedAt)
+                    .coerceAtMost(AlarmAudioLimits.MAX_DURATION_MILLIS)
+                val level = (recorder.maxAmplitude().toFloat() / 32767f).coerceIn(0.06f, 1f)
+                recordingLevels = recordingLevels.drop(1) + level
+                if (recordingElapsedMillis >= AlarmAudioLimits.MAX_DURATION_MILLIS) {
+                    stopRecording()
+                    break
+                }
+                delay(250)
+            }
         }
     }
 
     DisposableEffect(Unit) {
         onDispose {
             if (recorder.isRecording) recorder.cancel()
+            mediaPlayer?.release()
         }
     }
 
@@ -320,7 +401,16 @@ internal fun AlarmEditorScreen(
                         voiceProfiles = voiceProfiles,
                         voiceProfileBusy = voiceProfileBusy,
                         audioMessage = audioMessage,
+                        localInputMode = localInputMode,
                         isRecording = isRecording,
+                        recordingElapsedMillis = recordingElapsedMillis,
+                        recordingLevels = recordingLevels,
+                        selectedFileDurationMillis = selectedFileDurationMillis,
+                        cropStartMillis = cropStartMillis,
+                        cropEndMillis = cropEndMillis,
+                        onLocalInputModeChange = {
+                            if (!isRecording) localInputMode = it
+                        },
                         onPick = { pickAudioLauncher.launch("audio/*") },
                         onRecord = {
                             if (isRecording) {
@@ -333,8 +423,16 @@ internal fun AlarmEditorScreen(
                                 recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
                             }
                         },
+                        onCropChange = { start, end ->
+                            cropStartMillis = start
+                            cropEndMillis = end
+                            editor.clearAudio()
+                        },
+                        onPreviewCrop = { playSelectedCrop() },
                         onClear = {
                             editor.clearAudio()
+                            selectedFileUri = null
+                            selectedFileDurationMillis = null
                             audioMessage = "음성 오디오를 지웠어요"
                         },
                     )
@@ -347,9 +445,11 @@ internal fun AlarmEditorScreen(
                 AlarmSettingsCard(
                     snoozeEnabled = editor.snoozeEnabled,
                     snoozeMinutes = editor.snoozeMinutes,
+                    snoozeRepeatLimit = editor.snoozeRepeatLimit,
                     vibrationPattern = editor.vibrationPattern,
                     onSnoozeEnabledChange = { editor.snoozeEnabled = it },
                     onSnoozeMinutesChange = { editor.snoozeMinutes = it },
+                    onSnoozeRepeatLimitChange = { editor.snoozeRepeatLimit = it },
                     onVibrationEnabledChange = {
                         editor.vibrationPattern = if (it) VibrationPatterns.DEFAULT else VibrationPatterns.NONE
                     },

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -85,8 +85,7 @@ internal fun AlarmEditorScreen(
 
     fun applyCachedAudio(audio: CachedAlarmAudio) {
         editor.setCachedAudio(audio)
-        val seconds = audio.durationMillis?.let { " (${it / 1000}s)" } ?: ""
-        audioMessage = "음성 오디오가 준비됐어요$seconds"
+        audioMessage = null
     }
 
     fun prepareSelectedAudio(uri: Uri) {
@@ -138,6 +137,25 @@ internal fun AlarmEditorScreen(
                 Log.e(TAG, "Failed to play cropped alarm audio", error)
                 audioMessage = userFacingError(error, "선택한 구간을 재생하지 못했어요")
             }
+        }
+    }
+
+    fun playCachedAudio() {
+        val audioUri = editor.localAudioUri ?: return
+        runCatching {
+            mediaPlayer?.release()
+            val player = MediaPlayer.create(context, Uri.parse(audioUri))
+                ?: throw IllegalStateException("음성을 재생할 수 없어요")
+            mediaPlayer = player.apply {
+                setOnCompletionListener {
+                    it.release()
+                    if (mediaPlayer === it) mediaPlayer = null
+                }
+                start()
+            }
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to play cached alarm audio", error)
+            audioMessage = userFacingError(error, "음성을 재생하지 못했어요")
         }
     }
 
@@ -408,8 +426,21 @@ internal fun AlarmEditorScreen(
                         selectedFileDurationMillis = selectedFileDurationMillis,
                         cropStartMillis = cropStartMillis,
                         cropEndMillis = cropEndMillis,
-                        onLocalInputModeChange = {
-                            if (!isRecording) localInputMode = it
+                        onLocalInputModeChange = { mode ->
+                            if (!isRecording && mode != localInputMode) {
+                                mediaPlayer?.release()
+                                mediaPlayer = null
+                                if (mode == VoiceCaptureMode.File) {
+                                    editor.clearAudio()
+                                } else {
+                                    selectedFileUri = null
+                                    selectedFileDurationMillis = null
+                                    cropStartMillis = 0L
+                                    cropEndMillis = AlarmAudioLimits.MAX_DURATION_MILLIS
+                                }
+                                audioMessage = null
+                                localInputMode = mode
+                            }
                         },
                         onPick = { pickAudioLauncher.launch("audio/*") },
                         onRecord = {
@@ -429,6 +460,7 @@ internal fun AlarmEditorScreen(
                             editor.clearAudio()
                         },
                         onPreviewCrop = { playSelectedCrop() },
+                        onPreviewAudio = { playCachedAudio() },
                         onClear = {
                             editor.clearAudio()
                             selectedFileUri = null

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -50,6 +50,7 @@ import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyGroupMember
+import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.TtsGenerateRequest
 import com.voicealarm.nativeapp.network.TtsGenerateResponse
 import com.voicealarm.nativeapp.network.VoiceProfile
@@ -66,6 +67,7 @@ internal fun AlarmEditorScreen(
     familyGroup: FamilyGroupCurrentResponse?,
     familyAlarmMode: Boolean,
     voiceProfiles: List<VoiceProfile>,
+    familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
     onCancel: () -> Unit,
     onGenerateTts: suspend (TtsGenerateRequest) -> TtsGenerateResponse,
@@ -462,6 +464,7 @@ internal fun AlarmEditorScreen(
                     VoiceAudioCard(
                         editor = editor,
                         voiceProfiles = voiceProfiles,
+                        familyVoices = familyVoices,
                         voiceProfileBusy = voiceProfileBusy,
                         audioMessage = audioMessage,
                         localInputMode = localInputMode,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -43,6 +43,7 @@ import com.voicealarm.nativeapp.data.AlarmAudioStore
 import com.voicealarm.nativeapp.data.AlarmDraft
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.AlarmPlayModes
+import com.voicealarm.nativeapp.data.AlarmTimeCalculator
 import com.voicealarm.nativeapp.data.AlarmVoiceRecorder
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VibrationPatterns
@@ -227,6 +228,18 @@ internal fun AlarmEditorScreen(
 
     fun saveEditor() {
         if (isSaving) return
+        if (familyAlarmMode) {
+            val fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
+                hour = editor.hour,
+                minute = editor.minute,
+                repeatDaysMask = editor.repeatDaysMask,
+                holidayOff = editor.holidayOff,
+            )
+            if (fireAtMillis - System.currentTimeMillis() < FAMILY_ALARM_MIN_LEAD_MILLIS) {
+                audioMessage = "상대방 알람은 최소 30분 이후로 설정해 주세요."
+                return
+            }
+        }
         if (editor.playMode == AlarmPlayModes.ALARM_ONLY) {
             editor.clearAudio()
             submitDraft(editor.toDraft())
@@ -590,6 +603,8 @@ internal fun FamilyAlarmTargetCard(
         }
     }
 }
+
+private const val FAMILY_ALARM_MIN_LEAD_MILLIS = 30 * 60 * 1_000L
 
 internal fun familyMemberLabel(member: FamilyGroupMember): String =
     member.name?.takeIf { it.isNotBlank() }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -46,6 +48,8 @@ import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.AuthSession
+import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
+import com.voicealarm.nativeapp.network.FamilyGroupMember
 import com.voicealarm.nativeapp.network.TtsGenerateRequest
 import com.voicealarm.nativeapp.network.TtsGenerateResponse
 import com.voicealarm.nativeapp.network.VoiceProfile
@@ -59,6 +63,8 @@ internal fun AlarmEditorScreen(
     contentPadding: PaddingValues,
     alarm: AlarmEntity?,
     authSession: AuthSession?,
+    familyGroup: FamilyGroupCurrentResponse?,
+    familyAlarmMode: Boolean,
     voiceProfiles: List<VoiceProfile>,
     voiceProfileBusy: Boolean,
     onCancel: () -> Unit,
@@ -82,6 +88,15 @@ internal fun AlarmEditorScreen(
     var cropStartMillis by remember { mutableStateOf(0L) }
     var cropEndMillis by remember { mutableStateOf(AlarmAudioLimits.MAX_DURATION_MILLIS) }
     var mediaPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
+    val familyRecipients = remember(familyGroup, authSession?.user?.id, authSession?.user?.email) {
+        familyAlarmRecipients(familyGroup, authSession)
+    }
+    var selectedFamilyRecipientId by remember(familyAlarmMode, familyRecipients) {
+        mutableStateOf(if (familyAlarmMode) familyRecipients.firstOrNull()?.userId else null)
+    }
+
+    fun selectedFamilyRecipient(): FamilyGroupMember? =
+        familyRecipients.firstOrNull { it.userId == selectedFamilyRecipientId }
 
     fun applyCachedAudio(audio: CachedAlarmAudio) {
         editor.setCachedAudio(audio)
@@ -159,6 +174,24 @@ internal fun AlarmEditorScreen(
         }
     }
 
+    fun submitDraft(draft: AlarmDraft) {
+        if (!familyAlarmMode) {
+            onSave(draft)
+            return
+        }
+        val recipient = selectedFamilyRecipient()
+        if (recipient == null) {
+            audioMessage = "알람을 받을 사람을 선택해 주세요"
+            return
+        }
+        onSave(
+            draft.copy(
+                targetUserId = recipient.userId,
+                targetUserName = familyMemberLabel(recipient),
+            ),
+        )
+    }
+
     fun stopRecording() {
         scope.launch {
             runCatching {
@@ -194,7 +227,7 @@ internal fun AlarmEditorScreen(
         if (isSaving) return
         if (editor.playMode == AlarmPlayModes.ALARM_ONLY) {
             editor.clearAudio()
-            onSave(editor.toDraft())
+            submitDraft(editor.toDraft())
             return
         }
         if (editor.voiceSource == VoiceSources.LOCAL_AUDIO) {
@@ -205,7 +238,7 @@ internal fun AlarmEditorScreen(
                         cacheSelectedCrop()
                     }.onSuccess { audio ->
                         applyCachedAudio(audio)
-                        onSave(editor.toDraft())
+                        submitDraft(editor.toDraft())
                     }.onFailure { error ->
                         Log.e(TAG, "Failed to cache cropped local alarm audio", error)
                         audioMessage = userFacingError(error, "선택한 구간을 저장하지 못했어요")
@@ -218,7 +251,7 @@ internal fun AlarmEditorScreen(
                 audioMessage = "음성 오디오를 녹음하거나 파일로 선택해 주세요"
                 return
             }
-            onSave(editor.toDraft())
+            submitDraft(editor.toDraft())
             return
         }
         if (authSession == null) {
@@ -237,7 +270,7 @@ internal fun AlarmEditorScreen(
             return
         }
         if (editor.hasFreshTtsAudio(profileId, text)) {
-            onSave(editor.toDraft())
+            submitDraft(editor.toDraft())
             return
         }
         val localTtsCacheKey = AlarmAudioStore.ttsCacheKey(
@@ -255,7 +288,7 @@ internal fun AlarmEditorScreen(
                 rawAudioUri = cached.rawAudioUri,
             )
             audioMessage = "기존 음성 캐시를 사용했어요"
-            onSave(editor.toDraft())
+            submitDraft(editor.toDraft())
             return
         }
 
@@ -296,7 +329,7 @@ internal fun AlarmEditorScreen(
                     rawAudioUri = rawAudioUri,
                 )
                 audioMessage = "생성한 음성을 로컬에 저장했어요"
-                onSave(editor.toDraft())
+                submitDraft(editor.toDraft())
             }.onFailure { error ->
                 Log.e(TAG, "Failed to generate TTS alarm audio", error)
                 audioMessage = userFacingError(error, "음성 생성에 실패했어요")
@@ -370,6 +403,18 @@ internal fun AlarmEditorScreen(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
+            }
+        }
+
+        if (familyAlarmMode) {
+            item {
+                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                    FamilyAlarmTargetCard(
+                        recipients = familyRecipients,
+                        selectedRecipientId = selectedFamilyRecipientId,
+                        onSelectRecipient = { selectedFamilyRecipientId = it },
+                    )
+                }
             }
         }
 
@@ -512,3 +557,38 @@ internal fun EditorSectionTitle(title: String) {
         color = MaterialTheme.colorScheme.onBackground,
     )
 }
+
+@Composable
+internal fun FamilyAlarmTargetCard(
+    recipients: List<FamilyGroupMember>,
+    selectedRecipientId: String?,
+    onSelectRecipient: (String) -> Unit,
+) {
+    Card(
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text("받는 사람", fontWeight = FontWeight.SemiBold)
+            if (recipients.isEmpty()) {
+                MutedText("연결된 상대가 없어요. 코드 등록에서 먼저 연결해 주세요.")
+            } else {
+                ChipGrid(
+                    options = recipients.map { it.userId to familyMemberLabel(it) },
+                    selected = selectedRecipientId.orEmpty(),
+                    onSelect = onSelectRecipient,
+                )
+                MutedText("선택한 상대에게 알람을 설정해요.")
+            }
+        }
+    }
+}
+
+internal fun familyMemberLabel(member: FamilyGroupMember): String =
+    member.name?.takeIf { it.isNotBlank() }
+        ?: member.email?.takeIf { it.isNotBlank() }
+        ?: "멤버"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorState.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorState.kt
@@ -10,6 +10,7 @@ import com.voicealarm.nativeapp.data.AlarmDraft
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.AlarmPlayModes
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
+import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.TtsMessage
@@ -55,6 +56,7 @@ internal class AlarmEditorState(
     holidayOff: Boolean,
     snoozeEnabled: Boolean,
     snoozeMinutes: Int,
+    snoozeRepeatLimit: Int,
     vibrationPattern: String,
     playMode: String,
     localAudioUri: String?,
@@ -75,6 +77,7 @@ internal class AlarmEditorState(
     var holidayOff by mutableStateOf(holidayOff)
     var snoozeEnabled by mutableStateOf(snoozeEnabled)
     var snoozeMinutes by mutableIntStateOf(snoozeMinutes)
+    var snoozeRepeatLimit by mutableIntStateOf(snoozeRepeatLimit)
     var vibrationPattern by mutableStateOf(vibrationPattern)
     var playMode by mutableStateOf(playMode)
     var localAudioUri by mutableStateOf(localAudioUri)
@@ -108,6 +111,7 @@ internal class AlarmEditorState(
             holidayOff = holidayOff,
             snoozeEnabled = snoozeEnabled,
             snoozeMinutes = snoozeMinutes,
+            snoozeRepeatLimit = snoozeRepeatLimit,
             vibrationPattern = vibrationPattern,
             playMode = playMode,
             localAudioUri = if (alarmOnly) null else localAudioUri,
@@ -147,6 +151,9 @@ internal class AlarmEditorState(
         } else {
             voiceText.trim()
         }
+
+    fun localizedTtsTextForSave(): String =
+        translateAlarmTextIfNeeded(ttsTextForSave(), voiceCategory, voiceLanguage)
 
     fun hasFreshTtsAudio(profileId: String, text: String): Boolean =
         !localAudioUri.isNullOrBlank() && (
@@ -215,6 +222,7 @@ internal class AlarmEditorState(
                 holidayOff = alarm?.holidayOff ?: false,
                 snoozeEnabled = alarm?.snoozeEnabled ?: true,
                 snoozeMinutes = alarm?.snoozeMinutes ?: 5,
+                snoozeRepeatLimit = alarm?.snoozeRepeatLimit ?: SnoozeRepeatLimits.THREE,
                 vibrationPattern = alarm?.vibrationPattern ?: VibrationPatterns.DEFAULT,
                 playMode = alarm?.playMode ?: AlarmPlayModes.ALARM_ONLY,
                 localAudioUri = alarm?.localAudioUri,
@@ -263,4 +271,24 @@ internal fun randomTtsPrompt(category: String, language: String): String {
         else -> ko
     }
     return pool.random()
+}
+
+private fun translateAlarmTextIfNeeded(text: String, category: String, language: String): String {
+    if (language == "ko" || text.none { it in '\uAC00'..'\uD7A3' }) return text
+    return when (language) {
+        "en" -> when {
+            text.contains("점심") -> "It is lunch time. Take a short break and recharge."
+            text.contains("약") -> "It is time to take your medicine with water."
+            text.contains("공부") || text.contains("영어") -> "It is study time. Start with one small step."
+            text.contains("자") || text.contains("잠") || text.contains("쉬") -> "It is time to wind down and get some rest."
+            text.contains("일어나") || text.contains("기상") || text.contains("아침") -> "Good morning. It is time to wake up."
+            else -> randomTtsPrompt(category, "en")
+        }
+        "ja" -> when {
+            text.contains("공부") || text.contains("영어") -> "勉強する時間です。短く始めましょう。"
+            text.contains("자") || text.contains("잠") || text.contains("쉬") -> "そろそろ休む時間です。ゆっくり眠りましょう。"
+            else -> randomTtsPrompt(category, "ja")
+        }
+        else -> text
+    }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.AlarmAudioLimits
 import com.voicealarm.nativeapp.data.AlarmPlayModes
+import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.VoiceProfile
@@ -67,13 +68,30 @@ internal fun ChipGrid(
     }
 }
 
+private val SnoozeIntervals = listOf(3, 5, 10, 15, 30)
+
+private fun snoozeRepeatLabel(limit: Int): String = when (limit) {
+    SnoozeRepeatLimits.THREE -> "3회"
+    SnoozeRepeatLimits.FIVE -> "5회"
+    SnoozeRepeatLimits.FOREVER -> "계속 반복"
+    else -> "${limit}회"
+}
+
+private fun nextSnoozeInterval(current: Int): Int =
+    SnoozeIntervals.firstOrNull { it > current } ?: SnoozeIntervals.last()
+
+private fun previousSnoozeInterval(current: Int): Int =
+    SnoozeIntervals.lastOrNull { it < current } ?: SnoozeIntervals.first()
+
 @Composable
 internal fun AlarmSettingsCard(
     snoozeEnabled: Boolean,
     snoozeMinutes: Int,
+    snoozeRepeatLimit: Int,
     vibrationPattern: String,
     onSnoozeEnabledChange: (Boolean) -> Unit,
     onSnoozeMinutesChange: (Int) -> Unit,
+    onSnoozeRepeatLimitChange: (Int) -> Unit,
     onVibrationEnabledChange: (Boolean) -> Unit,
     onVibrationSelect: (String) -> Unit,
 ) {
@@ -96,7 +114,7 @@ internal fun AlarmSettingsCard(
                 ) {
                     Column(modifier = Modifier.padding(vertical = 4.dp)) {
                         Text("다시 울림", fontWeight = FontWeight.SemiBold)
-                        MutedText(if (snoozeEnabled) "${snoozeMinutes}분" else "꺼짐")
+                        MutedText(if (snoozeEnabled) "${snoozeMinutes}분 · ${snoozeRepeatLabel(snoozeRepeatLimit)}" else "꺼짐")
                     }
                 }
                 VoiceAlarmSwitch(
@@ -153,8 +171,22 @@ internal fun AlarmSettingsCard(
                     StepperField(
                         label = "간격",
                         valueLabel = "${snoozeMinutes}분",
-                        onDecrease = { onSnoozeMinutesChange((snoozeMinutes - 1).coerceAtLeast(1)) },
-                        onIncrease = { onSnoozeMinutesChange((snoozeMinutes + 1).coerceAtMost(30)) },
+                        onDecrease = {
+                            onSnoozeMinutesChange(previousSnoozeInterval(snoozeMinutes))
+                        },
+                        onIncrease = {
+                            onSnoozeMinutesChange(nextSnoozeInterval(snoozeMinutes))
+                        },
+                    )
+                    Text("반복", fontWeight = FontWeight.SemiBold)
+                    OptionChips(
+                        options = listOf(
+                            SnoozeRepeatLimits.THREE.toString() to "3회",
+                            SnoozeRepeatLimits.FIVE.toString() to "5회",
+                            SnoozeRepeatLimits.FOREVER.toString() to "계속 반복",
+                        ),
+                        selected = snoozeRepeatLimit.toString(),
+                        onSelect = { onSnoozeRepeatLimitChange(it.toInt()) },
                     )
                 }
             },

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
@@ -70,13 +70,6 @@ internal fun ChipGrid(
 
 private val SnoozeIntervals = listOf(3, 5, 10, 15, 30)
 
-private fun snoozeRepeatLabel(limit: Int): String = when (limit) {
-    SnoozeRepeatLimits.THREE -> "3회"
-    SnoozeRepeatLimits.FIVE -> "5회"
-    SnoozeRepeatLimits.FOREVER -> "계속 반복"
-    else -> "${limit}회"
-}
-
 private fun nextSnoozeInterval(current: Int): Int =
     SnoozeIntervals.firstOrNull { it > current } ?: SnoozeIntervals.last()
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
@@ -44,12 +44,14 @@ import com.voicealarm.nativeapp.data.AlarmAudioLimits
 import com.voicealarm.nativeapp.data.AlarmPlayModes
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.data.VoiceSources
+import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.VoiceProfile
 
 @Composable
 internal fun VoiceAudioCard(
     editor: AlarmEditorState,
     voiceProfiles: List<VoiceProfile>,
+    familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
     audioMessage: String?,
     localInputMode: VoiceCaptureMode,
@@ -115,25 +117,32 @@ internal fun VoiceAudioCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 val readyProfiles = voiceProfiles.filter { it.status == null || it.status == "ready" }
-                LaunchedEffect(visibleVoiceSource, readyProfiles) {
+                val readyFamilyVoices = familyVoices.filter {
+                    (it.status == null || it.status == "ready") && it.isShared != false
+                }
+                val profileOptions = readyProfiles.map { it.id to it.name } +
+                    readyFamilyVoices.map { profile ->
+                        profile.id to sharedVoiceLabel(profile)
+                    }
+                LaunchedEffect(visibleVoiceSource, profileOptions) {
                     if (
                         visibleVoiceSource == VoiceSources.TTS_PROFILE &&
                         editor.voiceProfileId.isNullOrBlank() &&
-                        readyProfiles.isNotEmpty()
+                        profileOptions.isNotEmpty()
                     ) {
-                        editor.voiceProfileId = readyProfiles.first().id
+                        editor.voiceProfileId = profileOptions.first().first
                     }
                 }
                 Text("음성 프로필", fontWeight = FontWeight.SemiBold)
                 if (voiceProfileBusy) {
                     MutedText("음성 프로필을 불러오는 중이에요.")
-                } else if (voiceProfiles.isEmpty()) {
-                    MutedText("사용 가능한 음성 프로필이 없어요. 프로필을 만들면 자동으로 표시됩니다.")
-                } else if (readyProfiles.isEmpty()) {
+                } else if (voiceProfiles.isEmpty() && readyFamilyVoices.isEmpty()) {
+                    MutedText("사용 가능한 음성 프로필이 없어요. 프로필을 만들거나 공유받으면 자동으로 표시됩니다.")
+                } else if (profileOptions.isEmpty()) {
                     MutedText("준비 완료된 음성 프로필이 아직 없어요.")
                 } else {
                     ChipGrid(
-                        options = readyProfiles.map { it.id to it.name },
+                        options = profileOptions,
                         selected = editor.voiceProfileId ?: "",
                         onSelect = {
                             editor.voiceProfileId = it
@@ -261,5 +270,14 @@ internal fun VoiceAudioCard(
                 )
             }
         }
+    }
+}
+
+private fun sharedVoiceLabel(profile: FamilyVoiceProfile): String {
+    val owner = profile.ownerName?.takeIf { it.isNotBlank() }
+    return if (owner == null) {
+        "${profile.name} · 공유"
+    } else {
+        "${profile.name} · $owner"
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
@@ -64,6 +64,7 @@ internal fun VoiceAudioCard(
     onRecord: () -> Unit,
     onCropChange: (Long, Long) -> Unit,
     onPreviewCrop: () -> Unit,
+    onPreviewAudio: () -> Unit,
     onClear: () -> Unit,
 ) {
     val visibleVoiceSource = if (editor.voiceSource == VoiceSources.SERVER_TTS) {
@@ -224,8 +225,16 @@ internal fun VoiceAudioCard(
                     )
                 }
                 if (editor.localAudioUri != null) {
-                    OutlinedButton(onClick = onClear, modifier = Modifier.fillMaxWidth()) {
-                        Text("음성 지우기")
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        OutlinedButton(onClick = onPreviewAudio, modifier = Modifier.weight(1f)) {
+                            Text("들어보기")
+                        }
+                        OutlinedButton(onClick = onClear, modifier = Modifier.weight(1f)) {
+                            Text("지우기")
+                        }
                     }
                 }
                 if (

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
@@ -52,9 +52,18 @@ internal fun VoiceAudioCard(
     voiceProfiles: List<VoiceProfile>,
     voiceProfileBusy: Boolean,
     audioMessage: String?,
+    localInputMode: VoiceCaptureMode,
     isRecording: Boolean,
+    recordingElapsedMillis: Long,
+    recordingLevels: List<Float>,
+    selectedFileDurationMillis: Long?,
+    cropStartMillis: Long,
+    cropEndMillis: Long,
+    onLocalInputModeChange: (VoiceCaptureMode) -> Unit,
     onPick: () -> Unit,
     onRecord: () -> Unit,
+    onCropChange: (Long, Long) -> Unit,
+    onPreviewCrop: () -> Unit,
     onClear: () -> Unit,
 ) {
     val visibleVoiceSource = if (editor.voiceSource == VoiceSources.SERVER_TTS) {
@@ -161,16 +170,18 @@ internal fun VoiceAudioCard(
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
-                Text("카테고리", fontWeight = FontWeight.SemiBold)
-                ChipGrid(
-                    options = TtsCategories,
-                    selected = editor.voiceCategory,
-                    onSelect = {
-                        editor.voiceCategory = it
-                        editor.clearTtsMeta()
-                        if (editor.voiceRandomPrompt) editor.voiceText = ""
-                    },
-                )
+                if (editor.voiceRandomPrompt) {
+                    Text("카테고리", fontWeight = FontWeight.SemiBold)
+                    ChipGrid(
+                        options = TtsCategories,
+                        selected = editor.voiceCategory,
+                        onSelect = {
+                            editor.voiceCategory = it
+                            editor.clearTtsMeta()
+                            editor.voiceText = ""
+                        },
+                    )
+                }
                 Text("언어", fontWeight = FontWeight.SemiBold)
                 ChipGrid(
                     options = TtsLanguages,
@@ -181,42 +192,53 @@ internal fun VoiceAudioCard(
                         if (editor.voiceRandomPrompt) editor.voiceText = ""
                     },
                 )
-                if (editor.localAudioUri != null) {
-                    MutedText("저장된 음성: ${audioFileLabel(editor.localAudioUri ?: "")}")
-                }
             } else {
-                Text(
-                    text = editor.localAudioUri?.let(::audioFileLabel) ?: "선택된 음성 오디오가 없어요",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                VoiceCaptureModeSelector(
+                    selected = localInputMode,
+                    enabled = !isRecording,
+                    onSelect = onLocalInputModeChange,
                 )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    OutlinedButton(
-                        onClick = onPick,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text("파일 선택")
-                    }
-                    Button(
-                        onClick = onRecord,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(if (isRecording) "녹음 종료" else "녹음")
-                    }
+                if (localInputMode == VoiceCaptureMode.Record) {
+                    VoiceRecordControls(
+                        isRecording = isRecording,
+                        elapsedMillis = recordingElapsedMillis,
+                        maxDurationMillis = AlarmAudioLimits.MAX_DURATION_MILLIS,
+                        levels = recordingLevels,
+                        enabled = true,
+                        notice = "녹음은 최대 ${AlarmAudioLimits.MAX_DURATION_MILLIS / 1000}초까지 저장돼요.",
+                        onRecordClick = onRecord,
+                    )
+                } else {
+                    VoiceFileControls(
+                        durationMillis = selectedFileDurationMillis,
+                        cropStartMillis = cropStartMillis,
+                        cropEndMillis = cropEndMillis,
+                        minDurationMillis = 1_000L,
+                        maxDurationMillis = AlarmAudioLimits.MAX_DURATION_MILLIS,
+                        enabled = !isRecording,
+                        uploadLabel = "파일 업로드",
+                        notice = "원하는 시작과 끝을 고르세요. 최대 ${AlarmAudioLimits.MAX_DURATION_MILLIS / 1000}초까지 알람에 저장돼요.",
+                        onPickFile = onPick,
+                        onCropChange = onCropChange,
+                        onPreviewCrop = onPreviewCrop,
+                    )
                 }
                 if (editor.localAudioUri != null) {
                     OutlinedButton(onClick = onClear, modifier = Modifier.fillMaxWidth()) {
                         Text("음성 지우기")
                     }
                 }
-                Text(
-                    text = "최대 ${AlarmAudioLimits.MAX_DURATION_MILLIS / 1000}초까지 사용할 수 있고, 긴 파일은 30초로 자릅니다.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                if (
+                    editor.localAudioUri == null &&
+                    selectedFileDurationMillis == null &&
+                    !isRecording
+                ) {
+                    Text(
+                        text = "녹음하거나 파일을 업로드해 주세요.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
             if (audioMessage != null) {
                 Text(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeCards.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeCards.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.People
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -181,6 +182,8 @@ internal fun NextAlarmHeroCard(
 internal fun QuickStartGrid(
     onRecordVoice: () -> Unit,
     onAddAlarm: () -> Unit,
+    canCreateFamilyAlarm: Boolean,
+    onAddFamilyAlarm: () -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -200,6 +203,14 @@ internal fun QuickStartGrid(
                 icon = Icons.Outlined.Alarm,
                 onClick = onAddAlarm,
                 modifier = Modifier.weight(1f),
+            )
+        }
+        if (canCreateFamilyAlarm) {
+            HomeActionCard(
+                label = "상대방 알람 맞춰주기",
+                icon = Icons.Outlined.People,
+                onClick = onAddFamilyAlarm,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -13,12 +13,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
-import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.People
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -43,24 +41,6 @@ import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.CharacterResponse
-
-@Composable
-internal fun StatusChip(
-    message: String,
-    onClearMessage: () -> Unit,
-) {
-    AssistChip(
-        onClick = onClearMessage,
-        label = { Text(message) },
-        leadingIcon = {
-            Icon(
-                imageVector = Icons.Outlined.CheckCircle,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-            )
-        },
-    )
-}
 
 @Composable
 internal fun HomeHeader(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -152,7 +152,7 @@ internal fun ProfileMenu(
                 onClick = { expanded = false },
             )
             HorizontalDivider()
-            ProfileMenuItem("커플/가족 연결") {
+            ProfileMenuItem("코드 등록") {
                 expanded = false
                 onSelectTab(NativeTab.People)
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -164,7 +164,7 @@ internal fun ProfileMenu(
                 expanded = false
                 onSelectTab(NativeTab.Growth)
             }
-            ProfileMenuItem("구독/이용권") {
+            ProfileMenuItem("구독") {
                 expanded = false
                 onSelectTab(NativeTab.Billing)
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
@@ -39,6 +39,7 @@ import com.voicealarm.nativeapp.network.VoiceAlarmApiClient
 import com.voicealarm.nativeapp.network.VoiceProfile
 import com.voicealarm.nativeapp.network.VoiceProfileUpdateRequest
 import com.voicealarm.nativeapp.network.VoucherItem
+import com.voicealarm.nativeapp.sync.RemoteAlarmSyncScheduler
 import java.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -120,6 +121,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         internal set
 
     init {
+        RemoteAlarmSyncScheduler.ensurePeriodic(application)
+        if (authSession != null) {
+            RemoteAlarmSyncScheduler.runOnce(application)
+        }
         viewModelScope.launch {
             runCatching {
                 repository.reschedulePendingAlarms()

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
@@ -15,8 +15,10 @@ import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.data.AlarmAppContainer
 import com.voicealarm.nativeapp.data.AlarmDraft
 import com.voicealarm.nativeapp.data.AlarmEntity
+import com.voicealarm.nativeapp.data.AlarmPlayModes
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.CharacterEventEntity
+import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.AuthTokenResponse
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.AuthSessionStore
@@ -30,6 +32,8 @@ import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.LoginRequest
 import com.voicealarm.nativeapp.network.ReceivedNote
 import com.voicealarm.nativeapp.network.RegisterRequest
+import com.voicealarm.nativeapp.network.RemoteAlarmMapper
+import com.voicealarm.nativeapp.network.RemoteAlarmWriteRequest
 import com.voicealarm.nativeapp.network.SendNoteRequest
 import com.voicealarm.nativeapp.network.TtsGenerateRequest
 import com.voicealarm.nativeapp.network.TtsGenerateResponse
@@ -54,6 +58,10 @@ import androidx.compose.runtime.setValue
 
 internal fun MainViewModel.createAlarm(draft: AlarmDraft, onDone: () -> Unit) {
     viewModelScope.launch {
+        if (!draft.targetUserId.isNullOrBlank()) {
+            createFamilyTargetAlarm(draft, onDone)
+            return@launch
+        }
         runCatching {
             repository.createAlarm(draft)
         }.onSuccess { alarm ->
@@ -64,6 +72,65 @@ internal fun MainViewModel.createAlarm(draft: AlarmDraft, onDone: () -> Unit) {
             message = userFacingError(error, "알람 저장에 실패했어요")
         }
     }
+}
+
+private suspend fun MainViewModel.createFamilyTargetAlarm(draft: AlarmDraft, onDone: () -> Unit) {
+    val session = authSession
+    if (session == null) {
+        message = "상대방 알람을 설정하려면 먼저 로그인해 주세요"
+        return
+    }
+    if (!hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)) {
+        message = "상대방 알람은 커플/가족 플랜에서 사용할 수 있어요"
+        return
+    }
+    if (
+        draft.playMode != AlarmPlayModes.ALARM_ONLY &&
+        draft.ttsMessageId == null &&
+        draft.rawAudioUri?.let(RemoteAlarmMapper::isRemoteAudioUrl) != true
+    ) {
+        message = "상대방 알람은 알람만 또는 음성 프로필로 만든 음성만 보낼 수 있어요"
+        return
+    }
+
+    runCatching {
+        withContext(Dispatchers.IO) {
+            api.createAlarm(
+                authorization = VoiceAlarmApiClient.bearer(session.token),
+                request = draft.toRemoteAlarmWriteRequest(),
+            ).alarm
+        }
+    }.onSuccess {
+        val target = draft.targetUserName?.takeIf { it.isNotBlank() } ?: "상대방"
+        message = "${target}에게 알람을 설정했어요"
+        onDone()
+    }.onFailure { error ->
+        Log.e(TAG, "Failed to create family target alarm target=${draft.targetUserId}", error)
+        message = userFacingError(error, "상대방 알람 설정에 실패했어요")
+    }
+}
+
+private fun AlarmDraft.toRemoteAlarmWriteRequest(): RemoteAlarmWriteRequest {
+    val rawAudioUrl = rawAudioUri?.takeIf(RemoteAlarmMapper::isRemoteAudioUrl)
+        ?.takeUnless { ttsMessageId != null }
+    val hasRemoteVoice = ttsMessageId != null || rawAudioUrl != null
+    return RemoteAlarmWriteRequest(
+        time = "%02d:%02d".format(hour, minute),
+        repeatDays = RemoteAlarmMapper.repeatMaskToDays(repeatDaysMask),
+        snoozeMinutes = snoozeMinutes,
+        mode = if (hasRemoteVoice) "tts" else "sound-only",
+        vibrationPattern = vibrationPattern,
+        wakeMode = when (playMode) {
+            AlarmPlayModes.VOICE_ONLY -> "voice_only"
+            else -> "sound_then_voice"
+        },
+        isActive = true,
+        messageId = ttsMessageId,
+        voiceProfileId = voiceProfileId.takeIf { voiceSource != VoiceSources.LOCAL_AUDIO },
+        rawAudioUrl = rawAudioUrl,
+        rawAudioDurationMs = null,
+        targetUserId = targetUserId,
+    )
 }
 
 internal fun MainViewModel.updateAlarm(alarmId: String, draft: AlarmDraft, onDone: () -> Unit) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
@@ -28,6 +28,7 @@ import com.voicealarm.nativeapp.network.CheckoutRequest
 import com.voicealarm.nativeapp.network.CodeRegisterRequest
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyInvite
+import com.voicealarm.nativeapp.network.FamilyVoiceAlarmRequest
 import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.LoginRequest
 import com.voicealarm.nativeapp.network.ReceivedNote
@@ -84,21 +85,32 @@ private suspend fun MainViewModel.createFamilyTargetAlarm(draft: AlarmDraft, onD
         message = "상대방 알람은 커플/가족 플랜에서 사용할 수 있어요"
         return
     }
-    if (
-        draft.playMode != AlarmPlayModes.ALARM_ONLY &&
-        draft.ttsMessageId == null &&
-        draft.rawAudioUri?.let(RemoteAlarmMapper::isRemoteAudioUrl) != true
-    ) {
-        message = "상대방 알람은 알람만 또는 음성 프로필로 만든 음성만 보낼 수 있어요"
-        return
-    }
-
     runCatching {
         withContext(Dispatchers.IO) {
-            api.createAlarm(
-                authorization = VoiceAlarmApiClient.bearer(session.token),
-                request = draft.toRemoteAlarmWriteRequest(),
-            ).alarm
+            if (draft.shouldUploadLocalVoiceForFamilyAlarm()) {
+                val localAudio = draft.toCachedLocalAudio()
+                val upload = api.uploadVoiceAudio(
+                    authorization = VoiceAlarmApiClient.bearer(session.token),
+                    audio = voiceUploadPart(localAudio),
+                    durationMs = (localAudio.durationMillis ?: 0L).toString().toRequestBody("text/plain".toMediaType()),
+                    originalName = localAudio.displayName.toRequestBody("text/plain".toMediaType()),
+                ).upload
+                api.createFamilyVoiceAlarm(
+                    authorization = VoiceAlarmApiClient.bearer(session.token),
+                    request = FamilyVoiceAlarmRequest(
+                        recipientUserId = requireNotNull(draft.targetUserId),
+                        wakeAt = "%02d:%02d".format(draft.hour, draft.minute),
+                        voiceUploadId = upload.id,
+                        label = draft.label.ifBlank { "가족이 보낸 음성" },
+                        repeatDays = RemoteAlarmMapper.repeatMaskToDays(draft.repeatDaysMask),
+                    ),
+                ).alarm
+            } else {
+                api.createAlarm(
+                    authorization = VoiceAlarmApiClient.bearer(session.token),
+                    request = draft.toRemoteAlarmWriteRequest(),
+                ).alarm
+            }
         }
     }.onSuccess {
         val target = draft.targetUserName?.takeIf { it.isNotBlank() } ?: "상대방"
@@ -109,6 +121,21 @@ private suspend fun MainViewModel.createFamilyTargetAlarm(draft: AlarmDraft, onD
         message = userFacingError(error, "상대방 알람 설정에 실패했어요")
     }
 }
+
+private fun AlarmDraft.shouldUploadLocalVoiceForFamilyAlarm(): Boolean =
+    playMode != AlarmPlayModes.ALARM_ONLY &&
+        voiceSource == VoiceSources.LOCAL_AUDIO &&
+        !localAudioUri.isNullOrBlank() &&
+        rawAudioUri?.let(RemoteAlarmMapper::isRemoteAudioUrl) != true
+
+private fun AlarmDraft.toCachedLocalAudio(): CachedAlarmAudio =
+    CachedAlarmAudio(
+        localAudioUri = requireNotNull(localAudioUri),
+        rawAudioUri = rawAudioUri,
+        displayName = localAudioUri?.let(::audioFileLabel) ?: "family_alarm_voice",
+        durationMillis = null,
+        cacheKey = audioCacheKey,
+    )
 
 private fun AlarmDraft.toRemoteAlarmWriteRequest(): RemoteAlarmWriteRequest {
     val rawAudioUrl = rawAudioUri?.takeIf(RemoteAlarmMapper::isRemoteAudioUrl)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -40,6 +40,7 @@ import com.voicealarm.nativeapp.network.VoiceAlarmApiClient
 import com.voicealarm.nativeapp.network.VoiceProfile
 import com.voicealarm.nativeapp.network.VoiceProfileUpdateRequest
 import com.voicealarm.nativeapp.network.VoucherItem
+import com.voicealarm.nativeapp.sync.RemoteAlarmSyncScheduler
 import java.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -61,6 +62,8 @@ internal fun MainViewModel.login(email: String, password: String) {
             api.login(LoginRequest(email = email.trim(), password = password))
         }.onSuccess { response ->
             authSession = authSessionStore.saveAppSession(response)
+            RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
+            RemoteAlarmSyncScheduler.runOnce(getApplication())
             message = "${response.user.email} 계정으로 로그인했어요"
         }.onFailure { error ->
             Log.e(TAG, "Email login failed", error)
@@ -77,6 +80,8 @@ internal fun MainViewModel.register(email: String, password: String, name: Strin
             api.register(RegisterRequest(email = email.trim(), password = password, name = name.trim()))
         }.onSuccess { response ->
             authSession = authSessionStore.saveAppSession(response)
+            RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
+            RemoteAlarmSyncScheduler.runOnce(getApplication())
             message = "${response.user.email} 계정을 만들었어요"
         }.onFailure { error ->
             Log.e(TAG, "Email registration failed", error)
@@ -93,6 +98,8 @@ internal fun MainViewModel.finishGoogleLogin(idToken: String, id: String, email:
             api.loginGoogle(GoogleLoginRequest(idToken = idToken))
         }.onSuccess { response ->
             authSession = authSessionStore.saveGoogleSession(response)
+            RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
+            RemoteAlarmSyncScheduler.runOnce(getApplication())
             message = null
         }.onFailure { error ->
             if ((error as? HttpException)?.code() == 404) {
@@ -102,6 +109,8 @@ internal fun MainViewModel.finishGoogleLogin(idToken: String, id: String, email:
                     email = email,
                     name = name,
                 )
+                RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
+                RemoteAlarmSyncScheduler.runOnce(getApplication())
                 message = null
             } else {
                 Log.e(TAG, "Google token exchange failed", error)
@@ -127,9 +136,11 @@ internal fun MainViewModel.syncNow() {
     viewModelScope.launch {
         syncBusy = true
         runCatching {
-            repository.syncWithBackend(api, session.token)
-        }.onSuccess { result ->
-            message = "동기화 완료: 생성 ${result.created}개, 수정 ${result.updated}개, 실패 ${result.failed}개"
+            val push = repository.syncWithBackend(api, session.token)
+            val pull = repository.pullReceivedAlarms(api, session.token)
+            push to pull
+        }.onSuccess { (push, pull) ->
+            message = "동기화 완료: 생성 ${push.created}개, 수정 ${push.updated}개, 수신 ${pull.imported + pull.updated}개, 실패 ${push.failed + pull.failed}개"
         }.onFailure { error ->
             Log.e(TAG, "Backend sync failed", error)
             message = userFacingError(error, "동기화에 실패했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -91,7 +91,7 @@ internal fun MainViewModel.finishGoogleLogin(idToken: String, id: String, email:
         email = email,
         name = name,
     )
-    message = "Google 계정으로 로그인했어요"
+    message = null
 }
 
 internal fun MainViewModel.logout() {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -27,6 +27,7 @@ import com.voicealarm.nativeapp.network.CodeRegisterRequest
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyInvite
 import com.voicealarm.nativeapp.network.FamilyVoiceProfile
+import com.voicealarm.nativeapp.network.GoogleLoginRequest
 import com.voicealarm.nativeapp.network.LoginRequest
 import com.voicealarm.nativeapp.network.ReceivedNote
 import com.voicealarm.nativeapp.network.RegisterRequest
@@ -50,6 +51,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import retrofit2.HttpException
 
 
 internal fun MainViewModel.login(email: String, password: String) {
@@ -85,13 +87,29 @@ internal fun MainViewModel.register(email: String, password: String, name: Strin
 }
 
 internal fun MainViewModel.finishGoogleLogin(idToken: String, id: String, email: String, name: String) {
-    authSession = authSessionStore.saveGoogleSession(
-        idToken = idToken,
-        id = id,
-        email = email,
-        name = name,
-    )
-    message = null
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.loginGoogle(GoogleLoginRequest(idToken = idToken))
+        }.onSuccess { response ->
+            authSession = authSessionStore.saveGoogleSession(response)
+            message = null
+        }.onFailure { error ->
+            if ((error as? HttpException)?.code() == 404) {
+                authSession = authSessionStore.saveLegacyGoogleSession(
+                    idToken = idToken,
+                    id = id,
+                    email = email,
+                    name = name,
+                )
+                message = null
+            } else {
+                Log.e(TAG, "Google token exchange failed", error)
+                message = userFacingError(error, "Google 로그인 세션을 서버에 연결하지 못했어요")
+            }
+        }
+        authBusy = false
+    }
 }
 
 internal fun MainViewModel.logout() {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -53,6 +53,15 @@ import androidx.compose.runtime.setValue
 
 
 internal fun MainViewModel.refreshCharacterAndBilling() {
+    refreshCharacterAndBillingData(showMessage = true)
+}
+
+internal fun MainViewModel.preloadCharacterAndBilling() {
+    if (authSession == null || characterBusy || billingBusy) return
+    refreshCharacterAndBillingData(showMessage = false)
+}
+
+private fun MainViewModel.refreshCharacterAndBillingData(showMessage: Boolean) {
     val authorization = bearerOrMessage("성장 정보를 불러오려면 먼저 로그인해 주세요") ?: return
     viewModelScope.launch {
         characterBusy = true
@@ -67,10 +76,10 @@ internal fun MainViewModel.refreshCharacterAndBilling() {
             characterResponse = snapshot.character
             subscriptionResponse = snapshot.subscription
             vouchers = snapshot.vouchers
-            message = "캐릭터와 플랜 정보를 불러왔어요"
+            if (showMessage) message = "캐릭터와 플랜 정보를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to load character or billing", error)
-            message = userFacingError(error, "성장 정보를 불러오지 못했어요")
+            if (showMessage) message = userFacingError(error, "성장 정보를 불러오지 못했어요")
         }
         characterBusy = false
         billingBusy = false

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -188,7 +188,7 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
         runCatching {
             api.checkoutPlan(authorization, CheckoutRequest(planKey = planKey, gift = gift))
         }.onSuccess { response ->
-            response.subscription?.let { subscription ->
+            if (!gift) response.subscription?.let { subscription ->
                 subscriptionResponse = BillingSubscriptionResponse(
                     subscription = subscription,
                     plan = response.plan,
@@ -212,8 +212,10 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
             } else {
                 "${response.plan.name} 플랜을 적용했어요"
             }
-            refreshAppSession()
-            refreshSocial()
+            if (!gift) {
+                refreshAppSession()
+                refreshSocial()
+            }
         }.onFailure { error ->
             Log.e(TAG, "Failed to checkout plan key=$planKey gift=$gift", error)
             message = userFacingError(error, "구매에 실패했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -181,22 +181,25 @@ internal fun MainViewModel.markNoteRead(noteId: String) {
     }
 }
 
-internal fun MainViewModel.checkoutPlan(planKey: String) {
+internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) {
     val authorization = bearerOrMessage("구독을 변경하려면 먼저 로그인해 주세요") ?: return
     viewModelScope.launch {
         billingBusy = true
         runCatching {
-            api.checkoutPlan(authorization, CheckoutRequest(planKey = planKey))
+            api.checkoutPlan(authorization, CheckoutRequest(planKey = planKey, gift = gift))
         }.onSuccess { response ->
-            subscriptionResponse = BillingSubscriptionResponse(
-                subscription = response.subscription,
-                plan = response.plan,
-            )
+            response.subscription?.let { subscription ->
+                subscriptionResponse = BillingSubscriptionResponse(
+                    subscription = subscription,
+                    plan = response.plan,
+                )
+            }
             response.voucher?.let { voucher ->
                 vouchers = listOf(
                     VoucherItem(
                         id = voucher.id,
                         code = voucher.code,
+                        planKey = response.plan.key,
                         planName = response.plan.name,
                         planType = response.plan.planType,
                         status = "issued",
@@ -204,12 +207,16 @@ internal fun MainViewModel.checkoutPlan(planKey: String) {
                     ),
                 ) + vouchers
             }
-            message = "${response.plan.name} 플랜을 적용했어요"
+            message = if (gift) {
+                "${response.plan.name} 이용권을 만들었어요"
+            } else {
+                "${response.plan.name} 플랜을 적용했어요"
+            }
             refreshAppSession()
             refreshSocial()
         }.onFailure { error ->
-            Log.e(TAG, "Failed to checkout plan key=$planKey", error)
-            message = userFacingError(error, "구독 변경에 실패했어요")
+            Log.e(TAG, "Failed to checkout plan key=$planKey gift=$gift", error)
+            message = userFacingError(error, "구매에 실패했어요")
         }
         billingBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelMessageActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelMessageActions.kt
@@ -66,17 +66,19 @@ internal fun MainViewModel.clearMessage() {
 
 internal fun MainViewModel.refreshAppSession() {
     val session = authSession ?: return
-    if (session.provider != AuthSessionStore.PROVIDER_APP) return
     viewModelScope.launch {
         runCatching {
             api.me(VoiceAlarmApiClient.bearer(session.token)).user
         }.onSuccess { user ->
-            authSession = authSessionStore.saveAppSession(
-                AuthTokenResponse(
-                    token = session.token,
-                    user = user,
-                ),
+            val response = AuthTokenResponse(
+                token = session.token,
+                user = user,
             )
+            authSession = if (session.provider == AuthSessionStore.PROVIDER_GOOGLE) {
+                authSessionStore.saveGoogleSession(response)
+            } else {
+                authSessionStore.saveAppSession(response)
+            }
         }.onFailure { error ->
             Log.w(TAG, "Auth refresh failed", error)
         }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
@@ -59,7 +59,13 @@ internal fun MainViewModel.refreshSocial() {
         runCatching {
             val group = api.getFamilyGroup(authorization)
             val invites = api.listFamilyInvites(authorization).invites
-            val sharedVoices = api.listFamilyVoiceProfiles(authorization).profiles
+            val sharedVoices = runCatching {
+                api.listFamilyVoiceProfiles(authorization).profiles
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to refresh family voice profiles", error)
+            }.getOrElse {
+                familyVoices
+            }
             SocialSnapshot(
                 familyGroup = group,
                 familyInvites = invites,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
@@ -53,6 +53,15 @@ import androidx.compose.runtime.setValue
 
 
 internal fun MainViewModel.refreshSocial() {
+    refreshSocialData(showMessage = true)
+}
+
+internal fun MainViewModel.preloadSocial() {
+    if (authSession == null || socialBusy) return
+    refreshSocialData(showMessage = false)
+}
+
+private fun MainViewModel.refreshSocialData(showMessage: Boolean) {
     val authorization = bearerOrMessage("커플/가족 정보를 불러오려면 먼저 로그인해 주세요") ?: return
     viewModelScope.launch {
         socialBusy = true
@@ -75,10 +84,10 @@ internal fun MainViewModel.refreshSocial() {
             familyGroup = snapshot.familyGroup
             familyInvites = snapshot.familyInvites
             familyVoices = snapshot.familyVoices
-            message = "커플/가족 정보를 불러왔어요"
+            if (showMessage) message = "커플/가족 정보를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to refresh social data", error)
-            message = userFacingError(error, "커플/가족 정보를 불러오지 못했어요")
+            if (showMessage) message = userFacingError(error, "커플/가족 정보를 불러오지 못했어요")
         }
         socialBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -175,12 +175,52 @@ internal fun MainViewModel.renameVoiceProfile(profileId: String, name: String) {
             }
         }.onSuccess { profile ->
             voiceProfiles = voiceProfiles.map {
-                if (it.id == profile.id) it.copy(name = profile.name) else it
+                if (it.id == profile.id) it.copy(name = profile.name, isShared = profile.isShared ?: it.isShared) else it
             }
             message = "음성 프로필 이름을 바꿨어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to rename voice profile id=$profileId", error)
             message = userFacingError(error, "음성 프로필 이름 변경에 실패했어요")
+        }
+        voiceProfileBusy = false
+    }
+}
+
+internal fun MainViewModel.setVoiceProfileShared(profileId: String, shared: Boolean) {
+    val session = authSession
+    if (session == null) {
+        message = "음성 프로필을 공유하려면 먼저 로그인해 주세요"
+        return
+    }
+    if (!hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)) {
+        message = "음성 공유는 커플/가족 플랜에서 사용할 수 있어요"
+        return
+    }
+
+    viewModelScope.launch {
+        if (voiceProfileBusy) return@launch
+        voiceProfileBusy = true
+        runCatching {
+            withContext(Dispatchers.IO) {
+                api.updateVoiceProfile(
+                    authorization = VoiceAlarmApiClient.bearer(session.token),
+                    id = profileId,
+                    request = VoiceProfileUpdateRequest(isShared = shared),
+                ).profile
+            }
+        }.onSuccess { profile ->
+            voiceProfiles = voiceProfiles.map {
+                if (it.id == profile.id) it.copy(isShared = profile.isShared ?: shared) else it
+            }
+            runCatching {
+                api.listFamilyVoiceProfiles(VoiceAlarmApiClient.bearer(session.token)).profiles
+            }.onSuccess { profiles ->
+                familyVoices = profiles
+            }
+            message = if (shared) "음성 프로필을 공유했어요" else "음성 프로필 공유를 껐어요"
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to update voice profile sharing id=$profileId shared=$shared", error)
+            message = userFacingError(error, "음성 프로필 공유 설정에 실패했어요")
         }
         voiceProfileBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -84,17 +84,17 @@ internal fun MainViewModel.fetchVoiceProfiles(showMessage: Boolean) {
     }
 }
 
-internal fun MainViewModel.createVoiceProfile(name: String, audio: CachedAlarmAudio) {
-    createVoiceProfiles(listOf(name to audio))
+internal fun MainViewModel.createVoiceProfile(name: String, audio: CachedAlarmAudio, shared: Boolean) {
+    createVoiceProfiles(listOf(Triple(name, audio, shared)))
 }
 
-internal fun MainViewModel.createVoiceProfiles(items: List<Pair<String, CachedAlarmAudio>>) {
+internal fun MainViewModel.createVoiceProfiles(items: List<Triple<String, CachedAlarmAudio, Boolean>>) {
     val session = authSession
     if (session == null) {
         message = "음성 프로필을 만들려면 먼저 로그인해 주세요"
         return
     }
-    val drafts = items.map { (name, audio) -> name.trim() to audio }
+    val drafts = items.map { (name, audio, shared) -> Triple(name.trim(), audio, shared) }
     if (drafts.isEmpty() || drafts.any { it.first.isBlank() }) {
         message = "음성 프로필 이름을 입력해 주세요"
         return
@@ -109,11 +109,12 @@ internal fun MainViewModel.createVoiceProfiles(items: List<Pair<String, CachedAl
         voiceProfileBusy = true
         runCatching {
             withContext(Dispatchers.IO) {
-                drafts.map { (name, audio) ->
+                drafts.map { (name, audio, shared) ->
                     api.createVoiceClone(
                         authorization = VoiceAlarmApiClient.bearer(session.token),
                         audio = voiceUploadPart(audio),
                         name = name.toRequestBody("text/plain".toMediaType()),
+                        isShared = shared.toString().toRequestBody("text/plain".toMediaType()),
                     ).profile
                 }
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
@@ -33,7 +33,7 @@ internal data class SubscriptionPlanOption(
 
 internal sealed interface AlarmScreen {
     data object List : AlarmScreen
-    data object Create : AlarmScreen
+    data class Create(val familyTargetMode: Boolean = false) : AlarmScreen
     data class Edit(val alarm: AlarmEntity) : AlarmScreen
 }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -1,5 +1,7 @@
 package com.voicealarm.nativeapp
 
+import android.media.MediaPlayer
+import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,12 +12,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
@@ -24,6 +30,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
@@ -31,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -52,37 +60,23 @@ internal fun FamilyConnectionPanel(
     onCreateFamilyInvite: () -> Unit,
     onAcceptFamilyInvite: (String) -> Unit,
     onRevokeFamilyInvite: (String) -> Unit,
+    onRegisterCode: (String) -> Unit,
     onOpenBilling: () -> Unit,
 ) {
     var inviteCode by remember { mutableStateOf("") }
-    val group = familyGroup
-    val isGroupReady = group?.group != null
-    val plan = subscriptionResponse?.plan
+    var voucherCode by remember { mutableStateOf("") }
 
     OutlinedCard {
         Column(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            PanelHeader(
-                title = "커플/가족",
-                actionLabel = if (socialBusy) "불러오는 중" else "새로고침",
-                enabled = !socialBusy,
-                onAction = onRefreshSocial,
+            Text(
+                text = "코드 등록",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
             )
-
-            Text("현재 플랜", fontWeight = FontWeight.SemiBold)
-            if (plan == null) {
-                MutedText("무료 플랜 또는 활성 구독이 없어요.")
-            } else {
-                MutedText("${plan.name} - ${planTypeLabel(plan.planType)} - 최대 ${plan.maxMembers}명")
-            }
-            OutlinedButton(
-                onClick = onOpenBilling,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text("구독/이용권 관리")
-            }
+            MutedText("초대 코드 및 이용권을 등록하세요.")
 
             Text("초대 코드 등록", fontWeight = FontWeight.SemiBold)
             Row(
@@ -91,8 +85,8 @@ internal fun FamilyConnectionPanel(
             ) {
                 OutlinedTextField(
                     value = inviteCode,
-                    onValueChange = { inviteCode = it },
-                    label = { Text("초대 코드") },
+                    onValueChange = { inviteCode = it.filter(Char::isDigit).take(6) },
+                    placeholder = { Text("123456") },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.weight(1f),
@@ -108,44 +102,28 @@ internal fun FamilyConnectionPanel(
                 }
             }
 
-            Text("연결된 멤버", fontWeight = FontWeight.SemiBold)
-            if (!isGroupReady) {
-                MutedText("아직 연결된 커플/가족 그룹이 없어요. 초대 코드를 등록하거나 구독 후 코드를 발급하세요.")
-            } else {
-                MutedText("${roleLabel(group.role)} - ${group.members.size}/${group.group.maxMembers}명")
-                group.members.forEach { member ->
-                    MutedText("${member.name ?: member.email ?: member.userId} (${roleLabel(member.role)})")
-                }
-            }
-
-            OutlinedButton(
-                onClick = onCreateFamilyInvite,
-                enabled = !socialBusy,
+            Text("이용권 등록", fontWeight = FontWeight.SemiBold)
+            Row(
                 modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Text("초대 코드 만들기")
-            }
-
-            familyInvites.take(3).forEach { invite ->
-                CompactActionRow(
-                    title = invite.code,
-                    subtitle = "${inviteStatusLabel(invite.status)} - 만료 ${invite.expiresAt ?: "알 수 없음"}",
-                    actionLabel = "취소",
-                    enabled = invite.status == "pending" && !socialBusy,
-                    onAction = { onRevokeFamilyInvite(invite.code) },
+                OutlinedTextField(
+                    value = voucherCode,
+                    onValueChange = { voucherCode = it.uppercase().take(18) },
+                    placeholder = { Text("VA-XXXX-XXXX-XXXX") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
                 )
-            }
-
-            Text("공유 음성", fontWeight = FontWeight.SemiBold)
-            if (familyVoices.isEmpty()) {
-                MutedText("공유된 음성이 아직 없어요.")
-            } else {
-                familyVoices.forEach { voice ->
-                    MutedText("${voice.name} - ${voice.ownerName ?: "가족"} (${voiceStatusLabel(voice.status)})")
+                Button(
+                    onClick = {
+                        onRegisterCode(voucherCode)
+                        voucherCode = ""
+                    },
+                    enabled = voucherCode.isNotBlank() && !socialBusy,
+                ) {
+                    Text("등록")
                 }
             }
-
-            MutedText("커플/가족 연결 안에서 허용된 음성만 공유됩니다.")
         }
     }
 }
@@ -163,6 +141,7 @@ internal fun VoiceMessagePanel(
     onOpenFamily: () -> Unit,
     onOpenBilling: () -> Unit,
 ) {
+    val context = LocalContext.current
     val isAvailable = hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
     val recipients = remember(familyGroup, authSession.user.id, authSession.user.email) {
         familyGroup?.members.orEmpty().filterNot { member ->
@@ -171,18 +150,33 @@ internal fun VoiceMessagePanel(
     }
     var selectedRecipientId by remember(recipients) { mutableStateOf(recipients.firstOrNull()?.userId) }
     var text by remember { mutableStateOf("") }
+    var notePlayer by remember { mutableStateOf<MediaPlayer?>(null) }
+
+    fun playNoteAudio(url: String?) {
+        val audioUrl = url?.takeIf { it.startsWith("http") || it.startsWith("file:") || it.startsWith("content:") }
+            ?: return
+        notePlayer?.release()
+        notePlayer = MediaPlayer.create(context, Uri.parse(audioUrl))?.apply {
+            setOnCompletionListener {
+                it.release()
+                if (notePlayer === it) notePlayer = null
+            }
+            start()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            notePlayer?.release()
+        }
+    }
 
     OutlinedCard {
         Column(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            PanelHeader(
-                title = "메시지",
-                actionLabel = if (noteBusy) "불러오는 중" else "새로고침",
-                enabled = !noteBusy,
-                onAction = onRefresh,
-            )
+            Text("소중한 사람들에게 응원의 메시지를 보내봐요.")
 
             if (!isAvailable) {
                 MutedText("음성 메시지는 커플/가족 플랜에서만 사용할 수 있어요.")
@@ -262,16 +256,31 @@ internal fun VoiceMessagePanel(
             ) {
                 Text("메시지 보내기")
             }
-            MutedText("보낸 메시지는 상대의 메시지함에 표시돼요. 음성 파일이 첨부된 메시지는 목록에서 확인할 수 있어요.")
+            MutedText("보낸 메시지는 상대의 메시지함에 표시돼요.")
 
             HorizontalDivider()
 
-            Text("받은 메시지", fontWeight = FontWeight.SemiBold)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("음성 메시지", fontWeight = FontWeight.SemiBold)
+                IconButton(onClick = onRefresh, enabled = !noteBusy) {
+                    Icon(Icons.Outlined.Refresh, contentDescription = "새로고침")
+                }
+            }
             if (receivedNotes.isEmpty()) {
                 MutedText("아직 받은 메시지가 없어요.")
             } else {
                 receivedNotes.take(8).forEach { note ->
-                    NoteRow(note = note, onClick = { onMarkNoteRead(note.id) })
+                    NoteRow(
+                        note = note,
+                        onClick = {
+                            playNoteAudio(note.audioUrl)
+                            onMarkNoteRead(note.id)
+                        },
+                    )
                 }
             }
         }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -87,9 +87,9 @@ internal fun FamilyConnectionPanel(
                         inviteCode = value
                             .uppercase()
                             .filter { it.isLetterOrDigit() || it == '-' }
-                            .take(10)
+                            .take(18)
                     },
-                    placeholder = { Text("INV-123456") },
+                    placeholder = { Text("INV-XXXX-XXXX-XXXX") },
                     singleLine = true,
                     modifier = Modifier.weight(1f),
                 )

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Refresh
@@ -40,7 +39,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
@@ -78,17 +76,21 @@ internal fun FamilyConnectionPanel(
             )
             MutedText("초대 코드 및 이용권을 등록하세요.")
 
-            Text("초대 코드 등록", fontWeight = FontWeight.SemiBold)
+            Text("초대권 코드 등록", fontWeight = FontWeight.SemiBold)
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 OutlinedTextField(
                     value = inviteCode,
-                    onValueChange = { inviteCode = it.filter(Char::isDigit).take(6) },
-                    placeholder = { Text("123456") },
+                    onValueChange = { value ->
+                        inviteCode = value
+                            .uppercase()
+                            .filter { it.isLetterOrDigit() || it == '-' }
+                            .take(10)
+                    },
+                    placeholder = { Text("INV-123456") },
                     singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.weight(1f),
                 )
                 Button(
@@ -199,13 +201,7 @@ internal fun VoiceMessagePanel(
 
             Text("받는 사람", fontWeight = FontWeight.SemiBold)
             if (recipients.isEmpty()) {
-                MutedText("같은 커플/가족 그룹에 보낼 사람이 없어요.")
-                OutlinedButton(
-                    onClick = onOpenFamily,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text("초대 코드 관리")
-                }
+                MutedText("연결된 상대가 아직 없어요. 코드 등록에서 초대권을 공유하거나 등록하면 여기에 표시돼요.")
             } else {
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -164,7 +164,7 @@ internal fun planTypeLabel(type: String?): String = when (type) {
 }
 
 internal fun voucherStatusLabel(status: String?): String = when (status) {
-    "active" -> "사용 가능"
+    "active", "issued" -> "사용 가능"
     "pending" -> "대기 중"
     "redeemed", "used" -> "사용됨"
     "expired" -> "만료됨"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -15,8 +15,10 @@ import com.voicealarm.nativeapp.data.AlarmSyncStates
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
 import com.voicealarm.nativeapp.data.VibrationPatterns
+import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
+import com.voicealarm.nativeapp.network.FamilyGroupMember
 import java.io.File
 import java.time.Instant
 import java.time.ZoneId
@@ -146,6 +148,17 @@ internal fun hasCoupleOrFamilyAccess(
         plan?.key == "couple" ||
         plan?.planType == "family" ||
         plan?.planType == "couple"
+}
+
+internal fun familyAlarmRecipients(
+    familyGroup: FamilyGroupCurrentResponse?,
+    authSession: AuthSession?,
+): List<FamilyGroupMember> {
+    val currentUserId = authSession?.user?.id
+    val currentEmail = authSession?.user?.email
+    return familyGroup?.members.orEmpty().filterNot { member ->
+        member.userId == currentUserId || member.email == currentEmail
+    }
 }
 
 internal fun roleLabel(role: String?): String = when (role) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -13,6 +13,7 @@ import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.data.AlarmPlayModes
 import com.voicealarm.nativeapp.data.AlarmSyncStates
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
+import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
@@ -99,6 +100,20 @@ internal fun repeatLabel(mask: Int): String {
     val days = listOf("일", "월", "화", "수", "목", "금", "토")
     return days.filterIndexed { index, _ -> mask and (1 shl index) != 0 }.joinToString(", ")
 }
+
+internal fun snoozeRepeatLabel(limit: Int): String = when (limit) {
+    SnoozeRepeatLimits.THREE -> "3회"
+    SnoozeRepeatLimits.FIVE -> "5회"
+    SnoozeRepeatLimits.FOREVER -> "계속 반복"
+    else -> "${limit}회"
+}
+
+internal fun snoozeListLabel(enabled: Boolean, minutes: Int, repeatLimit: Int): String =
+    if (enabled) {
+        "다시 울림 ${minutes}분 · ${snoozeRepeatLabel(repeatLimit)}"
+    } else {
+        "다시 울림 꺼짐"
+    }
 
 internal fun vibrationLabel(pattern: String): String = when (pattern) {
     VibrationPatterns.STRONG -> "강한 진동"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -108,11 +108,11 @@ internal fun snoozeRepeatLabel(limit: Int): String = when (limit) {
     else -> "${limit}회"
 }
 
-internal fun snoozeListLabel(enabled: Boolean, minutes: Int, repeatLimit: Int): String =
+internal fun snoozeListLabel(enabled: Boolean, minutes: Int, repeatLimit: Int): String? =
     if (enabled) {
-        "다시 울림 ${minutes}분 · ${snoozeRepeatLabel(repeatLimit)}"
+        "${minutes}분 · ${snoozeRepeatLabel(repeatLimit)}"
     } else {
-        "다시 울림 꺼짐"
+        null
     }
 
 internal fun vibrationLabel(pattern: String): String = when (pattern) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -58,6 +58,8 @@ import com.voicealarm.nativeapp.data.AlarmAudioStore
 import com.voicealarm.nativeapp.data.AlarmVoiceRecorder
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VoiceProfileAudioLimits
+import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
+import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.VoiceProfile
 import com.voicealarm.nativeapp.network.VoiceSpeakerSegment
 import kotlinx.coroutines.Dispatchers
@@ -65,25 +67,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private enum class VoiceProfileInputMode {
-    Record,
-    File,
-}
-
-private fun recordingTimeLabel(millis: Long): String {
-    val totalSeconds = (millis / 1000).coerceAtMost(VoiceProfileAudioLimits.MAX_DURATION_MILLIS / 1000)
-    return "%02d:%02d".format(totalSeconds / 60, totalSeconds % 60)
-}
-
-private fun voiceProfilePlaceholder(existingCount: Int): String = "음성 ${existingCount + 1}"
-
-private fun compactTimeLabel(millis: Long): String {
-    val totalSeconds = (millis / 1000).coerceAtLeast(0L)
-    return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
-}
+private fun voiceProfilePlaceholder(existingCount: Int): String = "음성${existingCount + 1}"
 
 private fun speakerDurationLabel(speaker: VoiceSpeakerSegment): String =
-    compactTimeLabel((speaker.endMs - speaker.startMs).coerceAtLeast(0L))
+    audioTimeLabel((speaker.endMs - speaker.startMs).coerceAtLeast(0L))
 
 private fun voiceProfileDurationError(durationMillis: Long?): String? = when {
     durationMillis == null -> "오디오 길이를 확인할 수 없어요"
@@ -119,8 +106,10 @@ internal fun VoiceLoginRequiredCard() {
 internal fun VoiceProfileManagementPanel(
     voiceProfiles: List<VoiceProfile>,
     voiceProfileBusy: Boolean,
-    onCreateVoiceProfile: (String, CachedAlarmAudio) -> Unit,
-    onCreateVoiceProfiles: (List<Pair<String, CachedAlarmAudio>>) -> Unit,
+    subscriptionResponse: BillingSubscriptionResponse?,
+    familyGroup: FamilyGroupCurrentResponse?,
+    onCreateVoiceProfile: (String, CachedAlarmAudio, Boolean) -> Unit,
+    onCreateVoiceProfiles: (List<Triple<String, CachedAlarmAudio, Boolean>>) -> Unit,
     onSeparateVoiceSpeakers: suspend (CachedAlarmAudio) -> List<VoiceSpeakerSegment>,
     onRenameVoiceProfile: (String, String) -> Unit,
     onDeleteVoiceProfile: (String) -> Unit,
@@ -131,15 +120,17 @@ internal fun VoiceProfileManagementPanel(
     val recorder = remember(appContext) { AlarmVoiceRecorder(appContext, audioStore) }
     val scope = rememberCoroutineScope()
     var profileName by remember { mutableStateOf("") }
+    var shareVoice by remember { mutableStateOf(false) }
     var selectedAudio by remember { mutableStateOf<CachedAlarmAudio?>(null) }
     var localMessage by remember { mutableStateOf<String?>(null) }
-    var inputMode by remember { mutableStateOf(VoiceProfileInputMode.Record) }
+    var inputMode by remember { mutableStateOf(VoiceCaptureMode.Record) }
     var isRecording by remember { mutableStateOf(false) }
     var recordingElapsedMillis by remember { mutableStateOf(0L) }
     var recordingLevels by remember { mutableStateOf(List(18) { 0.08f }) }
     var selectedFileUri by remember { mutableStateOf<Uri?>(null) }
     var selectedFileDurationMillis by remember { mutableStateOf<Long?>(null) }
     var cropStartMillis by remember { mutableStateOf(0L) }
+    var cropEndMillis by remember { mutableStateOf(VoiceProfileAudioLimits.MAX_DURATION_MILLIS) }
     var speakerCount by remember { mutableStateOf(1) }
     var detectedSpeakers by remember { mutableStateOf<List<VoiceSpeakerSegment>>(emptyList()) }
     var selectedSpeakerIds by remember { mutableStateOf<Set<String>>(emptySet()) }
@@ -152,6 +143,7 @@ internal fun VoiceProfileManagementPanel(
     var mediaPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
     val isLimitReached = voiceProfiles.size >= MAX_VOICE_PROFILES
     val remainingProfileSlots = (MAX_VOICE_PROFILES - voiceProfiles.size).coerceAtLeast(0)
+    val canShareVoice = hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
 
     fun applySelectedAudio(audio: CachedAlarmAudio) {
         selectedAudio = audio
@@ -168,6 +160,7 @@ internal fun VoiceProfileManagementPanel(
                 selectedFileUri = uri
                 selectedFileDurationMillis = durationMillis
                 cropStartMillis = 0L
+                cropEndMillis = durationMillis.coerceAtMost(VoiceProfileAudioLimits.MAX_DURATION_MILLIS)
                 detectedSpeakers = emptyList()
                 selectedSpeakerIds = emptySet()
                 removedSpeakerIds = emptySet()
@@ -222,12 +215,14 @@ internal fun VoiceProfileManagementPanel(
         selectedFileUri = null
         selectedFileDurationMillis = null
         cropStartMillis = 0L
+        cropEndMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS
         speakerCount = 1
         detectedSpeakers = emptyList()
         selectedSpeakerIds = emptySet()
         removedSpeakerIds = emptySet()
         separatingBusy = false
         profileName = ""
+        shareVoice = false
         selectedAudio = null
         mediaPlayer?.release()
         mediaPlayer = null
@@ -263,6 +258,10 @@ internal fun VoiceProfileManagementPanel(
         }
     }
 
+    LaunchedEffect(canShareVoice) {
+        if (!canShareVoice) shareVoice = false
+    }
+
     DisposableEffect(Unit) {
         onDispose {
             if (recorder.isRecording) recorder.cancel()
@@ -272,10 +271,11 @@ internal fun VoiceProfileManagementPanel(
 
     suspend fun croppedFileAudio(): CachedAlarmAudio {
         val uri = selectedFileUri ?: throw IllegalStateException("파일을 선택해 주세요")
+        val cropDurationMillis = (cropEndMillis - cropStartMillis).coerceIn(1_000L, VoiceProfileAudioLimits.MAX_DURATION_MILLIS)
         return withContext(Dispatchers.IO) {
             audioStore.cacheFromUri(
                 sourceUri = uri,
-                maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                maxDurationMillis = cropDurationMillis,
                 startMillis = cropStartMillis,
             )
         }
@@ -337,11 +337,31 @@ internal fun VoiceProfileManagementPanel(
         }
     }
 
+    fun playFileCropPreview() {
+        scope.launch {
+            runCatching {
+                croppedFileAudio()
+            }.onSuccess { audio ->
+                mediaPlayer?.release()
+                mediaPlayer = MediaPlayer.create(context, Uri.parse(audio.localAudioUri))?.apply {
+                    setOnCompletionListener {
+                        it.release()
+                        if (mediaPlayer === it) mediaPlayer = null
+                    }
+                    start()
+                }
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to play cropped voice preview", error)
+                localMessage = userFacingError(error, "선택한 구간을 재생하지 못했어요")
+            }
+        }
+    }
+
     fun submitCreateProfile(name: String) {
-        if (inputMode == VoiceProfileInputMode.Record) {
+        if (inputMode == VoiceCaptureMode.Record) {
             val audio = selectedAudio ?: return
             if (voiceProfileDurationError(audio.durationMillis) != null) return
-            onCreateVoiceProfile(name, audio)
+            onCreateVoiceProfile(name, audio, shareVoice)
             closeCreateDialog()
             return
         }
@@ -349,10 +369,20 @@ internal fun VoiceProfileManagementPanel(
         val uri = selectedFileUri ?: return
         val durationMillis = selectedFileDurationMillis ?: return
         if (voiceProfileFileDurationError(durationMillis) != null) return
+        val selectedDurationMillis = cropEndMillis - cropStartMillis
+        val selectedDurationError = voiceProfileDurationError(selectedDurationMillis)
+        if (selectedDurationError != null) {
+            localMessage = selectedDurationError
+            return
+        }
         if (speakerCount > 1) {
             val selectedSpeakers = detectedSpeakers.filter { it.id in selectedSpeakerIds }
             if (selectedSpeakers.isEmpty()) {
                 localMessage = "등록할 화자를 선택해 주세요"
+                return
+            }
+            if (selectedSpeakers.any { (it.endMs - it.startMs) < VoiceProfileAudioLimits.MIN_DURATION_MILLIS }) {
+                localMessage = "프로필로 만들 화자 음성은 30초 이상이어야 해요"
                 return
             }
             scope.launch {
@@ -371,7 +401,7 @@ internal fun VoiceProfileManagementPanel(
                         } else {
                             "$name ${index + 1}"
                         }
-                        resolvedName to audio
+                        Triple(resolvedName, audio, shareVoice)
                     }
                 }.onSuccess { drafts ->
                     onCreateVoiceProfiles(drafts)
@@ -388,12 +418,15 @@ internal fun VoiceProfileManagementPanel(
                 withContext(Dispatchers.IO) {
                     audioStore.cacheFromUri(
                         sourceUri = uri,
-                        maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                        maxDurationMillis = selectedDurationMillis.coerceIn(
+                            VoiceProfileAudioLimits.MIN_DURATION_MILLIS,
+                            VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                        ),
                         startMillis = cropStartMillis,
                     )
                 }
             }.onSuccess { audio ->
-                onCreateVoiceProfile(name, audio)
+                onCreateVoiceProfile(name, audio, shareVoice)
                 closeCreateDialog()
             }.onFailure { error ->
                 Log.e(TAG, "Failed to prepare cropped voice profile audio", error)
@@ -444,13 +477,14 @@ internal fun VoiceProfileManagementPanel(
 
     if (showCreateForm && !isLimitReached) {
         val audio = selectedAudio
-        val durationError = if (inputMode == VoiceProfileInputMode.Record) {
+        val durationError = if (inputMode == VoiceCaptureMode.Record) {
             voiceProfileDurationError(audio?.durationMillis)
         } else {
             voiceProfileFileDurationError(selectedFileDurationMillis)
+                ?: voiceProfileDurationError(cropEndMillis - cropStartMillis)
         }
         val resolvedProfileName = profileName.trim().ifBlank { voiceProfilePlaceholder(voiceProfiles.size) }
-        val canRegister = if (inputMode == VoiceProfileInputMode.Record) {
+        val canRegister = if (inputMode == VoiceCaptureMode.Record) {
             audio != null && durationError == null
         } else if (speakerCount > 1) {
             selectedSpeakerIds.isNotEmpty() && selectedSpeakerIds.size <= remainingProfileSlots
@@ -475,112 +509,70 @@ internal fun VoiceProfileManagementPanel(
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        VoiceInputModeButton(
-                            label = "녹음",
-                            selected = inputMode == VoiceProfileInputMode.Record,
-                            onClick = {
-                                if (!isRecording) inputMode = VoiceProfileInputMode.Record
-                            },
-                            modifier = Modifier.weight(1f),
-                        )
-                        VoiceInputModeButton(
-                            label = "파일 선택",
-                            selected = inputMode == VoiceProfileInputMode.File,
-                            onClick = {
-                                if (!isRecording) inputMode = VoiceProfileInputMode.File
-                            },
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-
-                    if (inputMode == VoiceProfileInputMode.Record) {
-                        Column(
+                    if (canShareVoice) {
+                        Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Button(
-                                onClick = {
-                                    if (isRecording) {
-                                        stopRecording()
-                                    } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
-                                        PackageManager.PERMISSION_GRANTED
-                                    ) {
-                                        startRecording()
-                                    } else {
-                                        recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                                    }
-                                },
-                                enabled = !voiceProfileBusy,
-                                modifier = Modifier.size(92.dp),
-                                shape = CircleShape,
-                                contentPadding = ButtonDefaults.ContentPadding,
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = if (isRecording) {
-                                        MaterialTheme.colorScheme.error
-                                    } else {
-                                        MaterialTheme.colorScheme.primary
-                                    },
-                                ),
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.Mic,
-                                    contentDescription = if (isRecording) "녹음 종료" else "녹음",
-                                    modifier = Modifier.size(34.dp),
-                                )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text("음성 공유", fontWeight = FontWeight.SemiBold)
+                                MutedText("가족/커플 플랜에서만 공유돼요. 기본은 공유 안 함이에요.")
                             }
-                            Text(
-                                text = "${recordingTimeLabel(recordingElapsedMillis)} / 01:00",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = if (isRecording) {
-                                    MaterialTheme.colorScheme.error
-                                } else {
-                                    MaterialTheme.colorScheme.onSurface
-                                },
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                            RecordingLevelBars(
-                                levels = recordingLevels,
-                                active = isRecording,
+                            VoiceAlarmSwitch(
+                                checked = shareVoice,
+                                onCheckedChange = { shareVoice = it },
                             )
                         }
+                    }
+                    VoiceCaptureModeSelector(
+                        selected = inputMode,
+                        enabled = !isRecording,
+                        onSelect = { inputMode = it },
+                    )
+
+                    if (inputMode == VoiceCaptureMode.Record) {
+                        VoiceRecordControls(
+                            isRecording = isRecording,
+                            elapsedMillis = recordingElapsedMillis,
+                            maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                            levels = recordingLevels,
+                            enabled = !voiceProfileBusy,
+                            notice = "30초 이상 1분 이하로 녹음해 주세요.",
+                            onRecordClick = {
+                                if (isRecording) {
+                                    stopRecording()
+                                } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
+                                    PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    startRecording()
+                                } else {
+                                    recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                }
+                            },
+                        )
                     } else {
                         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                            Button(
-                                onClick = { pickAudioLauncher.launch("audio/*") },
+                            VoiceFileControls(
+                                durationMillis = selectedFileDurationMillis,
+                                cropStartMillis = cropStartMillis,
+                                cropEndMillis = cropEndMillis,
+                                minDurationMillis = VoiceProfileAudioLimits.MIN_DURATION_MILLIS,
+                                maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
                                 enabled = !voiceProfileBusy && !isRecording,
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(16.dp),
-                            ) {
-                                Text("파일 선택")
-                            }
-                            selectedFileDurationMillis?.let { durationMillis ->
-                                val maxStartMillis = (durationMillis - VoiceProfileAudioLimits.MAX_DURATION_MILLIS)
-                                    .coerceAtLeast(0L)
-                                val cropEndMillis = (cropStartMillis + VoiceProfileAudioLimits.MAX_DURATION_MILLIS)
-                                    .coerceAtMost(durationMillis)
-                                Text(
-                                    text = "${compactTimeLabel(cropStartMillis)} - ${compactTimeLabel(cropEndMillis)}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                if (maxStartMillis > 0) {
-                                    Slider(
-                                        value = cropStartMillis.toFloat(),
-                                        onValueChange = { value ->
-                                            val nextStartMillis = value.toLong()
-                                            if (nextStartMillis != cropStartMillis) {
-                                                cropStartMillis = nextStartMillis
-                                                resetSpeakers()
-                                            }
-                                        },
-                                        valueRange = 0f..maxStartMillis.toFloat(),
-                                    )
-                                }
+                                uploadLabel = "파일 업로드",
+                                notice = "30초 이상 1분 이하 구간을 선택해 주세요.",
+                                onPickFile = { pickAudioLauncher.launch("audio/*") },
+                                onCropChange = { start, end ->
+                                    if (start != cropStartMillis || end != cropEndMillis) {
+                                        cropStartMillis = start
+                                        cropEndMillis = end
+                                        resetSpeakers()
+                                    }
+                                },
+                                onPreviewCrop = { playFileCropPreview() },
+                            )
+                            selectedFileDurationMillis?.let {
                                 SpeakerCountSelector(
                                     selected = speakerCount,
                                     onSelect = {
@@ -636,26 +628,6 @@ internal fun VoiceProfileManagementPanel(
                         }
                     }
 
-                    if (isRecording) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(6.dp)
-                                .background(MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(999.dp)),
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth(
-                                        (
-                                            recordingElapsedMillis.toFloat() /
-                                                VoiceProfileAudioLimits.MAX_DURATION_MILLIS.toFloat()
-                                            ).coerceIn(0f, 1f),
-                                    )
-                                    .height(6.dp)
-                                    .background(MaterialTheme.colorScheme.error, RoundedCornerShape(999.dp)),
-                            )
-                        }
-                    }
                     if (localMessage != null) {
                         MutedText(localMessage.orEmpty())
                     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -112,6 +112,7 @@ internal fun VoiceProfileManagementPanel(
     onCreateVoiceProfiles: (List<Triple<String, CachedAlarmAudio, Boolean>>) -> Unit,
     onSeparateVoiceSpeakers: suspend (CachedAlarmAudio) -> List<VoiceSpeakerSegment>,
     onRenameVoiceProfile: (String, String) -> Unit,
+    onShareVoiceProfile: (String, Boolean) -> Unit,
     onDeleteVoiceProfile: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -465,10 +466,12 @@ internal fun VoiceProfileManagementPanel(
                 VoiceProfileRow(
                     profile = profile,
                     enabled = !voiceProfileBusy,
+                    canShareVoice = canShareVoice,
                     onRename = {
                         renameTarget = profile
                         renameName = profile.name
                     },
+                    onShareChange = { shared -> onShareVoiceProfile(profile.id, shared) },
                     onDelete = { deleteTarget = profile },
                 )
             }
@@ -839,7 +842,9 @@ private fun SpeakerCandidateRow(
 internal fun VoiceProfileRow(
     profile: VoiceProfile,
     enabled: Boolean,
+    canShareVoice: Boolean,
     onRename: () -> Unit,
+    onShareChange: (Boolean) -> Unit,
     onDelete: () -> Unit,
 ) {
     OutlinedCard {
@@ -866,6 +871,23 @@ internal fun VoiceProfileRow(
                     IconButton(onClick = onDelete, enabled = enabled) {
                         Icon(Icons.Outlined.Delete, contentDescription = "삭제")
                     }
+                }
+            }
+            if (canShareVoice) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("공유", fontWeight = FontWeight.SemiBold)
+                        MutedText(if (profile.isShared == true) "가족/커플에게 공유 중" else "나만 사용")
+                    }
+                    VoiceAlarmSwitch(
+                        checked = profile.isShared == true,
+                        onCheckedChange = onShareChange,
+                        enabled = enabled,
+                    )
                 }
             }
         }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -60,6 +60,7 @@ import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VoiceProfileAudioLimits
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
+import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.VoiceProfile
 import com.voicealarm.nativeapp.network.VoiceSpeakerSegment
 import kotlinx.coroutines.Dispatchers
@@ -105,6 +106,7 @@ internal fun VoiceLoginRequiredCard() {
 @Composable
 internal fun VoiceProfileManagementPanel(
     voiceProfiles: List<VoiceProfile>,
+    familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
     subscriptionResponse: BillingSubscriptionResponse?,
     familyGroup: FamilyGroupCurrentResponse?,
@@ -474,6 +476,17 @@ internal fun VoiceProfileManagementPanel(
                     onShareChange = { shared -> onShareVoiceProfile(profile.id, shared) },
                     onDelete = { deleteTarget = profile },
                 )
+            }
+        }
+
+        if (canShareVoice && familyVoices.isNotEmpty()) {
+            Text(
+                text = "공유 받은 음성",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            familyVoices.forEach { profile ->
+                SharedVoiceProfileRow(profile = profile)
             }
         }
     }
@@ -890,6 +903,19 @@ internal fun VoiceProfileRow(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun SharedVoiceProfileRow(profile: FamilyVoiceProfile) {
+    OutlinedCard {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(profile.name, fontWeight = FontWeight.SemiBold)
+            MutedText(profile.ownerName?.takeIf { it.isNotBlank() } ?: "공유 음성")
         }
     }
 }

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/network/RemoteAlarmMapperTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/network/RemoteAlarmMapperTest.kt
@@ -82,6 +82,8 @@ class RemoteAlarmMapperTest {
             holidayOff = false,
             snoozeEnabled = true,
             snoozeMinutes = 5,
+            snoozeRepeatLimit = 3,
+            snoozeCount = 0,
             vibrationPattern = VibrationPatterns.DEFAULT,
             playMode = playMode,
             defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,

--- a/packages/backend/src/lib/invites.ts
+++ b/packages/backend/src/lib/invites.ts
@@ -1,37 +1,59 @@
-// 가족 플랜 초대권 코드 — INV-123456 형식, 10분 만료, 일회용.
+// 가족 플랜 초대권 코드 — INV-XXXX-XXXX-XXXX 형식, 10분 만료, 일회용.
 // 코드는 탈취 위험을 줄이기 위해 짧은 만료를 두고, 딥링크에 그대로 임베드한다.
 
 export const INVITE_CODE_PREFIX = 'INV';
-export const INVITE_CODE_DIGITS = 6;
-export const INVITE_CODE_LENGTH = INVITE_CODE_PREFIX.length + 1 + INVITE_CODE_DIGITS;
+export const INVITE_CODE_GROUP_SIZE = 4;
+export const INVITE_CODE_GROUP_COUNT = 3;
+export const INVITE_CODE_LENGTH =
+  INVITE_CODE_PREFIX.length +
+  1 +
+  INVITE_CODE_GROUP_COUNT * INVITE_CODE_GROUP_SIZE +
+  (INVITE_CODE_GROUP_COUNT - 1);
 export const INVITE_TTL_MINUTES = 10;
 export const INVITE_WEB_HOST = 'https://voicealarm.pages.dev';
 export const INVITE_APP_SCHEME = 'voicealarm';
 
-const INVITE_CODE_RE = /^INV-[0-9]{6}$/;
+const INVITE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const INVITE_CODE_RE = /^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+const LEGACY_TAGGED_INVITE_CODE_RE = /^INV-[0-9]{6}$/;
 const LEGACY_INVITE_CODE_RE = /^[0-9]{6}$/;
 
-/** 암호학적 난수로 6자리 숫자 문자열을 생성 (leading zero 허용) */
-function generateInviteDigits(): string {
-  const bytes = new Uint8Array(INVITE_CODE_DIGITS);
+function generateInviteGroup(): string {
+  const bytes = new Uint8Array(INVITE_CODE_GROUP_SIZE);
   crypto.getRandomValues(bytes);
   let out = '';
-  for (let i = 0; i < INVITE_CODE_DIGITS; i++) {
-    out += String(bytes[i]! % 10);
+  for (let i = 0; i < INVITE_CODE_GROUP_SIZE; i++) {
+    out += INVITE_ALPHABET[bytes[i]! % INVITE_ALPHABET.length]!;
   }
   return out;
 }
 
-/** 'INV-123456' 형태의 초대권 코드를 생성 */
+/** 'INV-XXXX-XXXX-XXXX' 형태의 초대권 코드를 생성 */
 export function generateInviteCode(): string {
-  return `${INVITE_CODE_PREFIX}-${generateInviteDigits()}`;
+  const groups: string[] = [];
+  for (let i = 0; i < INVITE_CODE_GROUP_COUNT; i++) {
+    groups.push(generateInviteGroup());
+  }
+  return `${INVITE_CODE_PREFIX}-${groups.join('-')}`;
 }
 
 export function normalizeInviteCode(raw: string): string {
   const upper = raw.trim().toUpperCase();
   const compact = upper.replace(/-/g, '');
-  const taggedPattern = new RegExp(`^${INVITE_CODE_PREFIX}[0-9]{${INVITE_CODE_DIGITS}}$`);
+  const taggedPattern = new RegExp(
+    `^${INVITE_CODE_PREFIX}[A-Z0-9]{${INVITE_CODE_GROUP_COUNT * INVITE_CODE_GROUP_SIZE}}$`,
+  );
   if (taggedPattern.test(compact)) {
+    const body = compact.slice(INVITE_CODE_PREFIX.length);
+    const groups: string[] = [];
+    for (let i = 0; i < INVITE_CODE_GROUP_COUNT; i++) {
+      const start = i * INVITE_CODE_GROUP_SIZE;
+      groups.push(body.slice(start, start + INVITE_CODE_GROUP_SIZE));
+    }
+    return `${INVITE_CODE_PREFIX}-${groups.join('-')}`;
+  }
+  const legacyTaggedPattern = new RegExp(`^${INVITE_CODE_PREFIX}[0-9]{6}$`);
+  if (legacyTaggedPattern.test(compact)) {
     return `${INVITE_CODE_PREFIX}-${compact.slice(INVITE_CODE_PREFIX.length)}`;
   }
   return upper;
@@ -39,15 +61,19 @@ export function normalizeInviteCode(raw: string): string {
 
 export function isValidInviteCodeFormat(raw: string): boolean {
   const normalized = normalizeInviteCode(raw);
-  return INVITE_CODE_RE.test(normalized) || LEGACY_INVITE_CODE_RE.test(normalized);
+  return (
+    INVITE_CODE_RE.test(normalized) ||
+    LEGACY_TAGGED_INVITE_CODE_RE.test(normalized) ||
+    LEGACY_INVITE_CODE_RE.test(normalized)
+  );
 }
 
-/** 모바일 앱 딥링크 (`voicealarm://invite/INV-123456`) */
+/** 모바일 앱 딥링크 (`voicealarm://invite/INV-XXXX-XXXX-XXXX`) */
 export function buildInviteDeepLink(code: string): string {
   return `${INVITE_APP_SCHEME}://invite/${code}`;
 }
 
-/** 웹 fallback URL (`https://voicealarm.pages.dev/invite/INV-123456`) */
+/** 웹 fallback URL (`https://voicealarm.pages.dev/invite/INV-XXXX-XXXX-XXXX`) */
 export function buildInviteWebUrl(code: string): string {
   return `${INVITE_WEB_HOST}/invite/${code}`;
 }

--- a/packages/backend/src/lib/invites.ts
+++ b/packages/backend/src/lib/invites.ts
@@ -1,34 +1,53 @@
-// 가족 플랜 초대 코드 — 6자리 숫자 문자열, 10분 만료, 일회용.
+// 가족 플랜 초대권 코드 — INV-123456 형식, 10분 만료, 일회용.
 // 코드는 탈취 위험을 줄이기 위해 짧은 만료를 두고, 딥링크에 그대로 임베드한다.
 
-export const INVITE_CODE_LENGTH = 6;
+export const INVITE_CODE_PREFIX = 'INV';
+export const INVITE_CODE_DIGITS = 6;
+export const INVITE_CODE_LENGTH = INVITE_CODE_PREFIX.length + 1 + INVITE_CODE_DIGITS;
 export const INVITE_TTL_MINUTES = 10;
 export const INVITE_WEB_HOST = 'https://voicealarm.pages.dev';
 export const INVITE_APP_SCHEME = 'voicealarm';
 
-const INVITE_CODE_RE = /^[0-9]{6}$/;
+const INVITE_CODE_RE = /^INV-[0-9]{6}$/;
+const LEGACY_INVITE_CODE_RE = /^[0-9]{6}$/;
 
 /** 암호학적 난수로 6자리 숫자 문자열을 생성 (leading zero 허용) */
-export function generateInviteCode(): string {
-  const bytes = new Uint8Array(INVITE_CODE_LENGTH);
+function generateInviteDigits(): string {
+  const bytes = new Uint8Array(INVITE_CODE_DIGITS);
   crypto.getRandomValues(bytes);
   let out = '';
-  for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
+  for (let i = 0; i < INVITE_CODE_DIGITS; i++) {
     out += String(bytes[i]! % 10);
   }
   return out;
 }
 
-export function isValidInviteCodeFormat(raw: string): boolean {
-  return INVITE_CODE_RE.test(raw);
+/** 'INV-123456' 형태의 초대권 코드를 생성 */
+export function generateInviteCode(): string {
+  return `${INVITE_CODE_PREFIX}-${generateInviteDigits()}`;
 }
 
-/** 모바일 앱 딥링크 (`voicealarm://invite/123456`) */
+export function normalizeInviteCode(raw: string): string {
+  const upper = raw.trim().toUpperCase();
+  const compact = upper.replace(/-/g, '');
+  const taggedPattern = new RegExp(`^${INVITE_CODE_PREFIX}[0-9]{${INVITE_CODE_DIGITS}}$`);
+  if (taggedPattern.test(compact)) {
+    return `${INVITE_CODE_PREFIX}-${compact.slice(INVITE_CODE_PREFIX.length)}`;
+  }
+  return upper;
+}
+
+export function isValidInviteCodeFormat(raw: string): boolean {
+  const normalized = normalizeInviteCode(raw);
+  return INVITE_CODE_RE.test(normalized) || LEGACY_INVITE_CODE_RE.test(normalized);
+}
+
+/** 모바일 앱 딥링크 (`voicealarm://invite/INV-123456`) */
 export function buildInviteDeepLink(code: string): string {
   return `${INVITE_APP_SCHEME}://invite/${code}`;
 }
 
-/** 웹 fallback URL (`https://voicealarm.pages.dev/invite/123456`) */
+/** 웹 fallback URL (`https://voicealarm.pages.dev/invite/INV-123456`) */
 export function buildInviteWebUrl(code: string): string {
   return `${INVITE_WEB_HOST}/invite/${code}`;
 }

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -292,7 +292,7 @@ export const migrations: Migration[] = [
     id: 9,
     name: 'plan-group-invites',
     statements: [
-      // 가족 플랜 초대 코드 — 6자리 숫자 문자열, 10분 만료, 일회용.
+      // 가족 플랜 초대권 코드 — INV-XXXX-XXXX-XXXX 형식, 10분 만료, 일회용.
       // status 전이: pending → used | revoked | expired.
       `CREATE TABLE IF NOT EXISTS plan_group_invites (
         id TEXT PRIMARY KEY,
@@ -475,9 +475,7 @@ export const migrations: Migration[] = [
     // Cleanup orphaned `alarms_new` left behind by a half-applied earlier
     // attempt at the table-recreation migration. No-op on fresh DBs.
     name: 'alarm-raw-audio-cleanup',
-    statements: [
-      'DROP TABLE IF EXISTS alarms_new',
-    ],
+    statements: ['DROP TABLE IF EXISTS alarms_new'],
   },
   {
     id: 21,

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -613,6 +613,22 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_generated_audio_assets_message ON generated_audio_assets(message_id)',
     ],
   },
+  {
+    id: 25,
+    name: 'voice-profile-sharing',
+    statements: [
+      `ALTER TABLE voice_profiles ADD COLUMN is_shared INTEGER NOT NULL DEFAULT 0`,
+      'CREATE INDEX IF NOT EXISTS idx_voice_profiles_family_shared ON voice_profiles(user_id, status, is_shared)',
+    ],
+  },
+  {
+    id: 26,
+    name: 'couple-plan-seed',
+    statements: [
+      `INSERT OR IGNORE INTO plans (id, key, name, plan_type, period_days, max_members, price_krw, is_active)
+        VALUES ('70000000-0000-4000-8000-000000000004', 'couple', '커플', 'family', 30, 2, 7900, 1)`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/oauth.ts
+++ b/packages/backend/src/lib/oauth.ts
@@ -1,0 +1,39 @@
+export interface ExternalTokenPayload {
+  sub: string;
+  email?: string;
+  email_verified?: boolean | string;
+  name?: string;
+  picture?: string;
+  iss: string;
+  aud: string;
+  exp: number;
+}
+
+export function decodeJwtPayload(token: string): ExternalTokenPayload {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Invalid token format');
+  const b64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(b64));
+}
+
+export async function verifyGoogleIdToken(
+  idToken: string,
+  expectedClientId: string,
+): Promise<ExternalTokenPayload> {
+  const res = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${idToken}`);
+  if (!res.ok) throw new Error('Google token verification failed');
+
+  const payload = (await res.json()) as ExternalTokenPayload & { exp: number | string };
+
+  if (payload.iss !== 'accounts.google.com' && payload.iss !== 'https://accounts.google.com') {
+    throw new Error('Invalid Google token issuer');
+  }
+  if (expectedClientId && payload.aud !== expectedClientId) {
+    throw new Error('Token audience mismatch');
+  }
+  if (Number(payload.exp) < Date.now() / 1000) {
+    throw new Error('Token expired');
+  }
+
+  return { ...payload, exp: Number(payload.exp) };
+}

--- a/packages/backend/src/lib/plan-groups.ts
+++ b/packages/backend/src/lib/plan-groups.ts
@@ -1,0 +1,144 @@
+import { getDB } from './db';
+
+type DB = ReturnType<typeof getDB>;
+
+export class PlanGroupCapacityError extends Error {
+  constructor(readonly maxMembers: number) {
+    super(`Plan group is full: max ${maxMembers}`);
+    this.name = 'PlanGroupCapacityError';
+  }
+}
+
+async function ensurePlanGroupMember(
+  db: DB,
+  planGroupId: string,
+  userPk: string,
+  maxMembers: number,
+  role: 'owner' | 'member',
+): Promise<void> {
+  const existingMemberRes = await db.execute({
+    sql: `SELECT id FROM plan_group_members WHERE plan_group_id = ? AND user_id = ?`,
+    args: [planGroupId, userPk],
+  });
+  if (existingMemberRes.rows.length > 0) return;
+
+  const countRes = await db.execute({
+    sql: `SELECT COUNT(*) AS c FROM plan_group_members WHERE plan_group_id = ?`,
+    args: [planGroupId],
+  });
+  const memberCount = Number(countRes.rows[0]?.c) || 0;
+  if (memberCount >= maxMembers) {
+    throw new PlanGroupCapacityError(maxMembers);
+  }
+
+  await db.execute({
+    sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role)
+          VALUES (?, ?, ?, ?)`,
+    args: [crypto.randomUUID(), planGroupId, userPk, role],
+  });
+}
+
+export async function createOwnedPlanGroupForFamilyPlan(
+  db: DB,
+  userPk: string,
+  planId: string,
+  maxMembers: number,
+): Promise<string> {
+  const planGroupId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO plan_groups (id, owner_user_id, plan_id, max_members)
+          VALUES (?, ?, ?, ?)`,
+    args: [planGroupId, userPk, planId, maxMembers],
+  });
+  await db.execute({
+    sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role)
+          VALUES (?, ?, ?, 'owner')`,
+    args: [crypto.randomUUID(), planGroupId, userPk],
+  });
+  return planGroupId;
+}
+
+export async function resolveFamilyPlanGroupForRedeemedVoucher(
+  db: DB,
+  params: {
+    userPk: string;
+    planId: string;
+    planType: string;
+    maxMembers: number;
+    issuerSubscriptionId?: string | null;
+    issuerUserId?: string | null;
+  },
+): Promise<string | null> {
+  if (params.planType !== 'family') return null;
+
+  const issuerSubscriptionId = params.issuerSubscriptionId?.trim() || null;
+  const issuerUserId = params.issuerUserId?.trim() || null;
+  if (issuerSubscriptionId && issuerUserId) {
+    const issuerGroupRes = await db.execute({
+      sql: `SELECT pg.id, pg.max_members
+            FROM subscriptions s
+            JOIN plan_groups pg ON pg.id = s.plan_group_id
+            WHERE s.id = ? AND s.user_id = ?
+            LIMIT 1`,
+      args: [issuerSubscriptionId, issuerUserId],
+    });
+
+    if (issuerGroupRes.rows.length > 0) {
+      const group = issuerGroupRes.rows[0]!;
+      const planGroupId = String(group.id);
+      const maxMembers = Number(group.max_members) || params.maxMembers;
+      await ensurePlanGroupMember(db, planGroupId, params.userPk, maxMembers, 'member');
+      return planGroupId;
+    }
+  }
+
+  return createOwnedPlanGroupForFamilyPlan(
+    db,
+    params.userPk,
+    params.planId,
+    params.maxMembers,
+  );
+}
+
+export async function repairFamilyPlanGroupForUser(
+  db: DB,
+  userPk: string,
+): Promise<string | null> {
+  const subscriptionRes = await db.execute({
+    sql: `SELECT s.id AS subscription_id, s.plan_id, p.plan_type, p.max_members,
+                 v.issuer_subscription_id, v.issuer_user_id
+          FROM subscriptions s
+          JOIN plans p ON p.id = s.plan_id
+          LEFT JOIN voucher_codes v
+            ON v.redeemed_by_user_id = s.user_id
+           AND v.plan_id = s.plan_id
+           AND v.status = 'used'
+          WHERE s.user_id = ?
+            AND s.status = 'active'
+            AND p.plan_type = 'family'
+            AND (s.plan_group_id IS NULL OR s.plan_group_id = '')
+          ORDER BY COALESCE(v.used_at, s.starts_at) DESC
+          LIMIT 1`,
+    args: [userPk],
+  });
+  if (subscriptionRes.rows.length === 0) return null;
+
+  const subscription = subscriptionRes.rows[0]!;
+  const planGroupId = await resolveFamilyPlanGroupForRedeemedVoucher(db, {
+    userPk,
+    planId: String(subscription.plan_id),
+    planType: String(subscription.plan_type),
+    maxMembers: Number(subscription.max_members) || 6,
+    issuerSubscriptionId: (subscription.issuer_subscription_id as string | null) ?? null,
+    issuerUserId: (subscription.issuer_user_id as string | null) ?? null,
+  });
+
+  if (!planGroupId) return null;
+
+  await db.execute({
+    sql: `UPDATE subscriptions SET plan_group_id = ? WHERE id = ?`,
+    args: [planGroupId, String(subscription.subscription_id)],
+  });
+
+  return planGroupId;
+}

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import type { Context, Next } from 'hono';
 import type { AppEnv } from '../types';
 import { verifyAppJwt, APP_JWT_ISSUER } from '../lib/jwt';
+import { decodeJwtPayload, verifyGoogleIdToken } from '../lib/oauth';
 
 interface TokenPayload {
   sub: string;
@@ -51,8 +52,10 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
       };
     } else if (payload.iss === 'https://appleid.apple.com') {
       verified = await verifyAppleToken(token);
+    } else if (payload.iss === 'accounts.google.com' || payload.iss === 'https://accounts.google.com') {
+      verified = await verifyGoogleIdToken(token, c.env.GOOGLE_CLIENT_ID);
     } else {
-      verified = await verifyGoogleToken(token, c.env.GOOGLE_CLIENT_ID);
+      throw new Error('Invalid token issuer');
     }
 
     // Legacy convention: most routes still query `WHERE google_id = ?`, so
@@ -114,29 +117,6 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
     console.log('[AUTH 401]', code, '|', message, '| GOOGLE_CLIENT_ID set:', !!c.env.GOOGLE_CLIENT_ID);
     return c.json({ error: message, error_code: code }, 401);
   }
-}
-
-function decodeJwtPayload(token: string): TokenPayload {
-  const parts = token.split('.');
-  if (parts.length !== 3) throw new Error('Invalid token format');
-  const b64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/');
-  return JSON.parse(atob(b64));
-}
-
-async function verifyGoogleToken(idToken: string, expectedClientId: string): Promise<TokenPayload> {
-  const res = await fetch(`https://oauth2.googleapis.com/tokeninfo?id_token=${idToken}`);
-  if (!res.ok) throw new Error('Google token verification failed');
-
-  const payload = (await res.json()) as TokenPayload;
-
-  if (expectedClientId && payload.aud !== expectedClientId) {
-    throw new Error('Token audience mismatch');
-  }
-  if (Number(payload.exp) < Date.now() / 1000) {
-    throw new Error('Token expired');
-  }
-
-  return payload;
 }
 
 async function verifyAppleToken(idToken: string): Promise<TokenPayload> {

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -16,6 +16,8 @@ const alarmMutation = new Hono<AppEnv>();
 
 alarmMutation.post('/', async (c) => {
   const userId = c.get('userId');
+  const userPk = c.get('userIdPK') || userId;
+  const ownerIds = [userPk, userId] as [string, string];
   const db = getDB(c.env);
 
   const body = await c.req.json<{
@@ -113,8 +115,8 @@ alarmMutation.post('/', async (c) => {
   let resolvedMessageId: string | null = body.message_id ?? null;
   if (!resolvedMessageId && body.raw_audio_url) {
     const firstVoice = await db.execute({
-      sql: 'SELECT id FROM voice_profiles WHERE user_id = ? LIMIT 1',
-      args: [userId],
+      sql: 'SELECT id FROM voice_profiles WHERE user_id IN (?, ?) LIMIT 1',
+      args: ownerIds,
     });
     if (firstVoice.rows.length === 0) {
       return c.json(
@@ -131,7 +133,7 @@ alarmMutation.post('/', async (c) => {
             VALUES (?, ?, ?, '', ?, 'raw')`,
       args: [
         placeholderMsgId,
-        userId,
+        userPk,
         firstVoice.rows[0]!.id as string,
         body.raw_audio_url,
       ],
@@ -139,8 +141,8 @@ alarmMutation.post('/', async (c) => {
     resolvedMessageId = placeholderMsgId;
   } else if (resolvedMessageId) {
     const msg = await db.execute({
-      sql: 'SELECT id FROM messages WHERE id = ? AND user_id = ?',
-      args: [resolvedMessageId, userId],
+      sql: 'SELECT id FROM messages WHERE id = ? AND user_id IN (?, ?)',
+      args: [resolvedMessageId, ...ownerIds],
     });
     if (msg.rows.length === 0) {
       return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { UUID_RE } from '../lib/validate';
+import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import {
   validateAlarmFields,
   normalizeAlarmRow,
@@ -44,19 +45,51 @@ alarmMutation.post('/', async (c) => {
   const fieldError = validateAlarmFields(body);
   if (fieldError) return c.json(fieldError, 400);
 
-  if (body.target_user_id && body.target_user_id !== userId) {
-    const friendship = await db.execute({
-      sql: `SELECT id FROM friendships
-            WHERE ((user_a = ? AND user_b = ?) OR (user_a = ? AND user_b = ?))
-              AND status = 'accepted'`,
-      args: [userId, body.target_user_id, body.target_user_id, userId],
-    });
-    if (friendship.rows.length === 0) {
-      return c.json({ error: '친구 관계인 사용자에게만 알람을 설정할 수 있습니다.', error_code: 'NOT_FRIENDS' }, 403);
+  let targetUserIdForAlarm: string | null = null;
+  if (body.target_user_id) {
+    const rawTargetUserId = body.target_user_id.trim();
+    if (!rawTargetUserId) {
+      return c.json({ error: 'Invalid target_user_id', error_code: 'INVALID_TARGET_USER' }, 400);
+    }
+    if (rawTargetUserId !== userId) {
+      const friendship = await db.execute({
+        sql: `SELECT id FROM friendships
+              WHERE ((user_a = ? AND user_b = ?) OR (user_a = ? AND user_b = ?))
+                AND status = 'accepted'`,
+        args: [userId, rawTargetUserId, rawTargetUserId, userId],
+      });
+
+      if (friendship.rows.length > 0) {
+        targetUserIdForAlarm = rawTargetUserId;
+      } else {
+        const targetRes = await db.execute({
+          sql: `SELECT id, google_id, allow_family_alarms FROM users
+                WHERE google_id = ? OR id = ?
+                LIMIT 1`,
+          args: [rawTargetUserId, rawTargetUserId],
+        });
+        if (targetRes.rows.length === 0) {
+          return c.json({ error: '친구 관계인 사용자에게만 알람을 설정할 수 있습니다.', error_code: 'NOT_FRIENDS' }, 403);
+        }
+
+        const target = targetRes.rows[0]!;
+        const targetPk = String(target.id);
+        const targetGoogleId = String(target.google_id);
+        const senderPk = await resolveUserPk(db, userId);
+        const allowed = targetGoogleId !== userId && !!senderPk && (await assertSameGroup(db, senderPk, targetPk));
+
+        if (!allowed) {
+          return c.json(
+            { error: '친구 또는 같은 커플/가족 그룹 멤버에게만 알람을 설정할 수 있습니다.', error_code: 'NOT_CONNECTED' },
+            403,
+          );
+        }
+        targetUserIdForAlarm = targetGoogleId;
+      }
     }
   }
 
-  const alarmOwner = body.target_user_id || userId;
+  const alarmOwner = targetUserIdForAlarm || userId;
 
   const user = await db.execute({
     sql: 'SELECT plan FROM users WHERE google_id = ?',
@@ -127,7 +160,7 @@ alarmMutation.post('/', async (c) => {
     args: [
       alarmId,
       userId,
-      body.target_user_id ?? null,
+      targetUserIdForAlarm,
       resolvedMessageId,
       body.time,
       JSON.stringify(body.repeat_days ?? []),
@@ -147,6 +180,7 @@ alarmMutation.post('/', async (c) => {
       alarm: {
         id: alarmId,
         ...body,
+        target_user_id: targetUserIdForAlarm,
         mode,
         vibration_pattern: vibPattern,
         voice_profile_id: body.voice_profile_id ?? null,

--- a/packages/backend/src/routes/alarm-query.ts
+++ b/packages/backend/src/routes/alarm-query.ts
@@ -7,16 +7,25 @@ import { normalizeAlarmRow, type AlarmRow } from './alarm-helpers';
 
 const alarmQuery = new Hono<AppEnv>();
 
+function viewerIds(c: { get: (key: 'userId' | 'userIdPK') => string }): string[] {
+  return Array.from(new Set([c.get('userIdPK') || c.get('userId'), c.get('userId')]));
+}
+
+function inPlaceholders(values: unknown[]): string {
+  return values.map(() => '?').join(', ');
+}
+
 alarmQuery.get('/tick', async (c) => {
-  const userId = c.get('userId');
+  const ids = viewerIds(c);
+  const idPlaceholders = inPlaceholders(ids);
   const db = getDB(c.env);
 
   const result = await db.execute({
     sql: `SELECT id, user_id, target_user_id, time, repeat_days, is_active,
                  mode, voice_profile_id, speaker_id
           FROM alarms
-          WHERE (user_id = ? OR target_user_id = ?) AND is_active = 1`,
-    args: [userId, userId],
+          WHERE (user_id IN (${idPlaceholders}) OR target_user_id IN (${idPlaceholders})) AND is_active = 1`,
+    args: [...ids, ...ids],
   });
 
   const alarms: ScheduledAlarm[] = (result.rows as AlarmRow[]).map((r) => {
@@ -51,14 +60,16 @@ alarmQuery.get('/tick', async (c) => {
 
 alarmQuery.get('/', async (c) => {
   const userId = c.get('userId');
+  const ids = viewerIds(c);
+  const idPlaceholders = inPlaceholders(ids);
   const db = getDB(c.env);
   const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100);
   const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
   const isActiveParam = c.req.query('is_active');
   const voiceProfileId = c.req.query('voice_profile_id');
 
-  let whereClause = 'WHERE (a.user_id = ? OR a.target_user_id = ?)';
-  const whereArgs: (string | number)[] = [userId, userId];
+  let whereClause = `WHERE (a.user_id IN (${idPlaceholders}) OR a.target_user_id IN (${idPlaceholders}))`;
+  const whereArgs: (string | number)[] = [...ids, ...ids];
 
   if (isActiveParam === 'true' || isActiveParam === 'false') {
     whereClause += ' AND a.is_active = ?';
@@ -83,11 +94,12 @@ alarmQuery.get('/', async (c) => {
     }),
     db.execute({
       sql: `SELECT a.*, m.text as message_text, m.category, vp.name as voice_name,
+              m.audio_url as message_audio_url,
               creator.email as creator_email, creator.name as creator_name
             FROM alarms a
             LEFT JOIN messages m ON a.message_id = m.id
             LEFT JOIN voice_profiles vp ON m.voice_profile_id = vp.id
-            LEFT JOIN users creator ON creator.google_id = a.user_id
+            LEFT JOIN users creator ON creator.google_id = a.user_id OR creator.id = a.user_id
             ${whereClause}
             ORDER BY a.time ASC
             LIMIT ? OFFSET ?`,
@@ -102,6 +114,8 @@ alarmQuery.get('/', async (c) => {
 
 alarmQuery.get('/:id', async (c) => {
   const userId = c.get('userId');
+  const ids = viewerIds(c);
+  const idPlaceholders = inPlaceholders(ids);
   const db = getDB(c.env);
   const id = c.req.param('id');
 
@@ -111,13 +125,14 @@ alarmQuery.get('/:id', async (c) => {
 
   const result = await db.execute({
     sql: `SELECT a.*, m.text as message_text, m.category, vp.name as voice_name,
+            m.audio_url as message_audio_url,
             creator.email as creator_email, creator.name as creator_name
           FROM alarms a
           LEFT JOIN messages m ON a.message_id = m.id
           LEFT JOIN voice_profiles vp ON m.voice_profile_id = vp.id
-          LEFT JOIN users creator ON creator.google_id = a.user_id
-          WHERE a.id = ? AND (a.user_id = ? OR a.target_user_id = ?)`,
-    args: [id, userId, userId],
+          LEFT JOIN users creator ON creator.google_id = a.user_id OR creator.id = a.user_id
+          WHERE a.id = ? AND (a.user_id IN (${idPlaceholders}) OR a.target_user_id IN (${idPlaceholders}))`,
+    args: [id, ...ids, ...ids],
   });
 
   if (result.rows.length === 0) {

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -5,7 +5,12 @@ import { logRouteError } from '../lib/logger';
 import { typedRow } from '../lib/db-types';
 import { hashPassword, verifyPassword } from '../lib/password';
 import { signAppJwt, verifyAppJwt } from '../lib/jwt';
-import { RegisterRequestSchema, LoginRequestSchema } from '@voice-alarm/shared';
+import {
+  RegisterRequestSchema,
+  LoginRequestSchema,
+  GoogleLoginRequestSchema,
+} from '@voice-alarm/shared';
+import { verifyGoogleIdToken } from '../lib/oauth';
 
 const auth = new Hono<{ Bindings: Env }>();
 
@@ -131,6 +136,93 @@ auth.post('/login', async (c) => {
   }
 });
 
+auth.post('/google', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('AUTH_INVALID_JSON', 'Invalid JSON body'), 400);
+  }
+
+  const parsed = GoogleLoginRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(jsonError('AUTH_VALIDATION_FAILED', 'Validation failed'), 400);
+  }
+
+  const db = getDB(c.env);
+
+  try {
+    const google = await verifyGoogleIdToken(parsed.data.id_token, c.env.GOOGLE_CLIENT_ID);
+    const googleId = google.sub;
+    const email = (google.email || `${googleId}@google.local`).toLowerCase().trim();
+    const name = google.name ?? '';
+
+    const existing = await db.execute({
+      sql: `SELECT id, google_id, email, name, plan
+            FROM users
+            WHERE google_id = ? OR email = ?
+            LIMIT 1`,
+      args: [googleId, email],
+    });
+
+    let userId: string;
+    let plan: 'free' | 'plus' | 'family';
+
+    if (existing.rows.length > 0) {
+      const row = typedRow<{
+        id: string;
+        google_id: string | null;
+        email: string;
+        name: string | null;
+        plan: 'free' | 'plus' | 'family' | null;
+      }>(existing.rows[0]!);
+      userId = row.id;
+      plan = row.plan ?? 'free';
+
+      await db.execute({
+        sql: `UPDATE users
+              SET google_id = ?, email = ?, name = ?, picture = ?, updated_at = datetime('now')
+              WHERE id = ?`,
+        args: [googleId, email, name || row.name || null, google.picture || null, userId],
+      });
+    } else {
+      userId = googleId;
+      plan = 'free';
+      await db.execute({
+        sql: `INSERT INTO users (id, google_id, email, name, picture)
+              VALUES (?, ?, ?, ?, ?)`,
+        args: [userId, googleId, email, name || null, google.picture || null],
+      });
+    }
+
+    const token = await signAppJwt(
+      { sub: googleId, email, name: name || undefined },
+      c.env.JWT_SECRET,
+    );
+
+    return c.json({
+      token,
+      user: {
+        id: userId,
+        email,
+        name,
+        plan,
+      },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const status =
+      detail.includes('Google token') ||
+      detail.includes('issuer') ||
+      detail.includes('audience') ||
+      detail.includes('expired') ||
+      detail.includes('Token')
+        ? 401
+        : 500;
+    return c.json(jsonError('AUTH_GOOGLE_FAILED', detail), status);
+  }
+});
+
 auth.get('/me', async (c) => {
   const authHeader = c.req.header('Authorization');
   if (!authHeader?.startsWith('Bearer ')) {
@@ -141,8 +233,8 @@ auth.get('/me', async (c) => {
     const payload = await verifyAppJwt(token, c.env.JWT_SECRET);
     const db = getDB(c.env);
     const result = await db.execute({
-      sql: `SELECT id, email, name, plan FROM users WHERE id = ?`,
-      args: [payload.sub],
+      sql: `SELECT id, email, name, plan FROM users WHERE id = ? OR google_id = ? LIMIT 1`,
+      args: [payload.sub, payload.sub],
     });
     if (result.rows.length === 0) {
       return c.json(jsonError('AUTH_USER_NOT_FOUND', 'User not found'), 404);

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -10,10 +10,11 @@ billingMutation.post('/checkout', async (c) => {
   const db = getDB(c.env);
 
   const body = await c.req
-    .json<{ plan_key?: unknown }>()
-    .catch(() => ({ plan_key: undefined }));
+    .json<{ plan_key?: unknown; gift?: unknown }>()
+    .catch((): { plan_key?: unknown; gift?: unknown } => ({ plan_key: undefined, gift: undefined }));
 
   const planKey = typeof body.plan_key === 'string' ? body.plan_key.trim() : '';
+  const gift = body.gift === true;
   if (!planKey) {
     return c.json({ error: 'plan_key 는 필수입니다', error_code: 'PLAN_KEY_REQUIRED' }, 400);
   }
@@ -40,14 +41,14 @@ billingMutation.post('/checkout', async (c) => {
     return c.json({ error: '사용자를 찾을 수 없습니다', error_code: 'USER_NOT_FOUND' }, 404);
   }
 
-  const subscriptionId = crypto.randomUUID();
   const periodDays = Number(plan.period_days) || 30;
   const startsAt = new Date();
   const expiresAt = new Date(startsAt.getTime() + periodDays * 24 * 60 * 60 * 1000);
   const maxMembers = Number(plan.max_members) || 1;
 
   let planGroupId: string | null = null;
-  if (planType === 'family') {
+  const subscriptionId = gift ? null : crypto.randomUUID();
+  if (!gift && planType === 'family') {
     planGroupId = crypto.randomUUID();
     await db.execute({
       sql: `INSERT INTO plan_groups (id, owner_user_id, plan_id, max_members)
@@ -61,24 +62,26 @@ billingMutation.post('/checkout', async (c) => {
     });
   }
 
-  await db.execute({
-    sql: `INSERT INTO subscriptions (id, user_id, plan_id, plan_group_id, status, starts_at, expires_at)
-          VALUES (?, ?, ?, ?, 'active', ?, ?)`,
-    args: [
-      subscriptionId,
-      userPk,
-      String(plan.id),
-      planGroupId,
-      startsAt.toISOString(),
-      expiresAt.toISOString(),
-    ],
-  });
+  if (!gift && subscriptionId) {
+    await db.execute({
+      sql: `INSERT INTO subscriptions (id, user_id, plan_id, plan_group_id, status, starts_at, expires_at)
+            VALUES (?, ?, ?, ?, 'active', ?, ?)`,
+      args: [
+        subscriptionId,
+        userPk,
+        String(plan.id),
+        planGroupId,
+        startsAt.toISOString(),
+        expiresAt.toISOString(),
+      ],
+    });
 
-  const mirroredPlan = planTypeToUserPlan(planType);
-  await db.execute({
-    sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
-    args: [mirroredPlan, userPk],
-  });
+    const mirroredPlan = planTypeToUserPlan(planType);
+    await db.execute({
+      sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+      args: [mirroredPlan, userPk],
+    });
+  }
 
   const voucherId = crypto.randomUUID();
   const { code: voucherCode, hash: voucherHash } = await generateVoucherCode();
@@ -101,15 +104,17 @@ billingMutation.post('/checkout', async (c) => {
   return c.json({
     success: true,
     checkout_stub: true,
-    subscription: {
-      id: subscriptionId,
-      user_id: userPk,
-      plan_id: String(plan.id),
-      plan_group_id: planGroupId,
-      status: 'active',
-      starts_at: startsAt.toISOString(),
-      expires_at: expiresAt.toISOString(),
-    },
+    subscription: subscriptionId
+      ? {
+          id: subscriptionId,
+          user_id: userPk,
+          plan_id: String(plan.id),
+          plan_group_id: planGroupId,
+          status: 'active',
+          starts_at: startsAt.toISOString(),
+          expires_at: expiresAt.toISOString(),
+        }
+      : null,
     plan: {
       id: String(plan.id),
       key: String(plan.key),

--- a/packages/backend/src/routes/code.ts
+++ b/packages/backend/src/routes/code.ts
@@ -20,9 +20,7 @@ codeRoutes.post('/register', async (c) => {
   const userId = c.get('userId');
   const db = getDB(c.env);
 
-  const body = await c.req
-    .json<{ code?: unknown }>()
-    .catch(() => ({ code: undefined }));
+  const body = await c.req.json<{ code?: unknown }>().catch(() => ({ code: undefined }));
 
   const raw = typeof body.code === 'string' ? body.code.trim() : '';
   if (!raw) {
@@ -74,7 +72,10 @@ codeRoutes.post('/register', async (c) => {
     }
 
     if (String(voucher.issuer_user_id) === userPk) {
-      return c.json({ error: '본인이 발급한 코드는 등록할 수 없습니다', error_code: 'SELF_ISSUED' }, 400);
+      return c.json(
+        { error: '본인이 발급한 코드는 등록할 수 없습니다', error_code: 'SELF_ISSUED' },
+        400,
+      );
     }
 
     const planRes = await db.execute({
@@ -159,7 +160,7 @@ codeRoutes.post('/register', async (c) => {
     });
   }
 
-  // ── Family invite code: INV-123456 (legacy 123456 accepted) ──
+  // ── Family invite code: INV-XXXX-XXXX-XXXX (legacy INV-123456/123456 accepted) ──
   const inviteCode = normalizeInviteCode(raw);
   if (isValidInviteCodeFormat(inviteCode)) {
     const inviteRes = await db.execute({
@@ -168,7 +169,10 @@ codeRoutes.post('/register', async (c) => {
       args: [inviteCode],
     });
     if (inviteRes.rows.length === 0) {
-      return c.json({ error: '해당 초대 코드를 찾을 수 없습니다', error_code: 'CODE_NOT_FOUND' }, 404);
+      return c.json(
+        { error: '해당 초대 코드를 찾을 수 없습니다', error_code: 'CODE_NOT_FOUND' },
+        404,
+      );
     }
     const invite = inviteRes.rows[0]!;
     const inviteId = String(invite.id);
@@ -196,7 +200,10 @@ codeRoutes.post('/register', async (c) => {
     }
 
     if (String(invite.inviter_user_id) === userPk) {
-      return c.json({ error: '본인이 발급한 초대는 수락할 수 없습니다', error_code: 'SELF_ISSUED' }, 400);
+      return c.json(
+        { error: '본인이 발급한 초대는 수락할 수 없습니다', error_code: 'SELF_ISSUED' },
+        400,
+      );
     }
 
     const memberRes = await db.execute({

--- a/packages/backend/src/routes/code.ts
+++ b/packages/backend/src/routes/code.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { isValidVoucherCodeFormat, hashVoucherCode } from '../lib/vouchers';
-import { isValidInviteCodeFormat } from '../lib/invites';
+import { isValidInviteCodeFormat, normalizeInviteCode } from '../lib/invites';
+import {
+  PlanGroupCapacityError,
+  resolveFamilyPlanGroupForRedeemedVoucher,
+} from '../lib/plan-groups';
 
 const codeRoutes = new Hono<AppEnv>();
 
@@ -40,7 +44,7 @@ codeRoutes.post('/register', async (c) => {
   if (isValidVoucherCodeFormat(upper)) {
     const codeHash = await hashVoucherCode(upper);
     const voucherRes = await db.execute({
-      sql: `SELECT id, plan_id, issuer_user_id, status, expires_at
+      sql: `SELECT id, plan_id, issuer_user_id, issuer_subscription_id, status, expires_at
             FROM voucher_codes WHERE code_hash = ?`,
       args: [codeHash],
     });
@@ -84,14 +88,42 @@ codeRoutes.post('/register', async (c) => {
     const plan = planRes.rows[0]!;
     const planType = String(plan.plan_type);
     const periodDays = Number(plan.period_days) || 30;
+    const maxMembers = Number(plan.max_members) || 1;
     const startsAt = now;
     const newExpiresAt = new Date(startsAt.getTime() + periodDays * 24 * 60 * 60 * 1000);
 
+    let planGroupId: string | null = null;
+    try {
+      planGroupId = await resolveFamilyPlanGroupForRedeemedVoucher(db, {
+        userPk,
+        planId,
+        planType,
+        maxMembers,
+        issuerSubscriptionId: (voucher.issuer_subscription_id as string | null) ?? null,
+        issuerUserId: String(voucher.issuer_user_id),
+      });
+    } catch (error) {
+      if (error instanceof PlanGroupCapacityError) {
+        return c.json(
+          { error: `정원 초과 (최대 ${error.maxMembers}명)`, error_code: 'GROUP_FULL' },
+          409,
+        );
+      }
+      throw error;
+    }
+
     const subscriptionId = crypto.randomUUID();
     await db.execute({
-      sql: `INSERT INTO subscriptions (id, user_id, plan_id, status, starts_at, expires_at)
-            VALUES (?, ?, ?, 'active', ?, ?)`,
-      args: [subscriptionId, userPk, planId, startsAt.toISOString(), newExpiresAt.toISOString()],
+      sql: `INSERT INTO subscriptions (id, user_id, plan_id, plan_group_id, status, starts_at, expires_at)
+            VALUES (?, ?, ?, ?, 'active', ?, ?)`,
+      args: [
+        subscriptionId,
+        userPk,
+        planId,
+        planGroupId,
+        startsAt.toISOString(),
+        newExpiresAt.toISOString(),
+      ],
     });
 
     await db.execute({
@@ -113,6 +145,7 @@ codeRoutes.post('/register', async (c) => {
       subscription: {
         id: subscriptionId,
         plan_id: planId,
+        plan_group_id: planGroupId,
         status: 'active',
         starts_at: startsAt.toISOString(),
         expires_at: newExpiresAt.toISOString(),
@@ -126,12 +159,13 @@ codeRoutes.post('/register', async (c) => {
     });
   }
 
-  // ── Family invite code: 6 digits ──
-  if (isValidInviteCodeFormat(raw)) {
+  // ── Family invite code: INV-123456 (legacy 123456 accepted) ──
+  const inviteCode = normalizeInviteCode(raw);
+  if (isValidInviteCodeFormat(inviteCode)) {
     const inviteRes = await db.execute({
       sql: `SELECT id, plan_group_id, inviter_user_id, status, expires_at
             FROM plan_group_invites WHERE code = ?`,
-      args: [raw],
+      args: [inviteCode],
     });
     if (inviteRes.rows.length === 0) {
       return c.json({ error: '해당 초대 코드를 찾을 수 없습니다', error_code: 'CODE_NOT_FOUND' }, 404);

--- a/packages/backend/src/routes/family-group.ts
+++ b/packages/backend/src/routes/family-group.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { resolveUserPk } from '../lib/family-helpers';
+import { PlanGroupCapacityError, repairFamilyPlanGroupForUser } from '../lib/plan-groups';
 
 const familyGroup = new Hono<AppEnv>();
 
@@ -12,7 +13,7 @@ familyGroup.get('/groups/current', async (c) => {
   const userPk = await resolveUserPk(db, userId);
   if (!userPk) return c.json({ group: null, members: [], role: null });
 
-  const groupRes = await db.execute({
+  let groupRes = await db.execute({
     sql: `SELECT pg.id, pg.owner_user_id, pg.plan_id, pg.max_members, pg.created_at,
                  m.role AS my_role
           FROM plan_group_members m
@@ -22,6 +23,25 @@ familyGroup.get('/groups/current', async (c) => {
           LIMIT 1`,
     args: [userPk],
   });
+  if (groupRes.rows.length === 0) {
+    try {
+      const repairedGroupId = await repairFamilyPlanGroupForUser(db, userPk);
+      if (repairedGroupId) {
+        groupRes = await db.execute({
+          sql: `SELECT pg.id, pg.owner_user_id, pg.plan_id, pg.max_members, pg.created_at,
+                       m.role AS my_role
+                FROM plan_group_members m
+                JOIN plan_groups pg ON pg.id = m.plan_group_id
+                WHERE m.user_id = ?
+                ORDER BY m.joined_at DESC
+                LIMIT 1`,
+          args: [userPk],
+        });
+      }
+    } catch (error) {
+      if (!(error instanceof PlanGroupCapacityError)) throw error;
+    }
+  }
   if (groupRes.rows.length === 0) {
     return c.json({ group: null, members: [], role: null });
   }

--- a/packages/backend/src/routes/family-invite.ts
+++ b/packages/backend/src/routes/family-invite.ts
@@ -4,6 +4,7 @@ import { getDB } from '../lib/db';
 import {
   generateInviteCode,
   isValidInviteCodeFormat,
+  normalizeInviteCode,
   computeInviteExpiresAt,
   buildInviteDeepLink,
   buildInviteWebUrl,
@@ -131,7 +132,7 @@ familyInvite.post('/invites/:code/accept', async (c) => {
   const userId = c.get('userId');
   const db = getDB(c.env);
 
-  const code = c.req.param('code').trim();
+  const code = normalizeInviteCode(c.req.param('code'));
   if (!isValidInviteCodeFormat(code)) {
     return c.json({ error: '잘못된 초대 코드 형식입니다', error_code: 'INVALID_CODE_FORMAT' }, 400);
   }
@@ -232,7 +233,7 @@ familyInvite.post('/invites/:code/revoke', async (c) => {
   const userId = c.get('userId');
   const db = getDB(c.env);
 
-  const code = c.req.param('code').trim();
+  const code = normalizeInviteCode(c.req.param('code'));
   if (!isValidInviteCodeFormat(code)) {
     return c.json({ error: '잘못된 초대 코드 형식입니다', error_code: 'INVALID_CODE_FORMAT' }, 400);
   }

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -17,11 +17,12 @@ const tts = new Hono<AppEnv>();
 async function findUsableVoiceProfile(
   db: ReturnType<typeof getDB>,
   userId: string,
+  userPk: string,
   voiceProfileId: string,
 ): Promise<Record<string, unknown> | null> {
   const owned = await db.execute({
-    sql: 'SELECT * FROM voice_profiles WHERE id = ? AND user_id = ?',
-    args: [voiceProfileId, userId],
+    sql: 'SELECT * FROM voice_profiles WHERE id = ? AND user_id IN (?, ?)',
+    args: [voiceProfileId, userPk, userId],
   });
   if (owned.rows.length > 0) return owned.rows[0] as Record<string, unknown>;
 
@@ -36,7 +37,7 @@ async function findUsableVoiceProfile(
   if (shared.rows.length === 0) return null;
 
   const row = shared.rows[0] as Record<string, unknown>;
-  const viewerPk = await resolveUserPk(db, userId);
+  const viewerPk = userPk || await resolveUserPk(db, userId);
   const ownerPk = typeof row.owner_pk === 'string' ? row.owner_pk : null;
   if (!viewerPk || !ownerPk || viewerPk === ownerPk) return null;
 
@@ -46,6 +47,8 @@ async function findUsableVoiceProfile(
 
 tts.post('/generate', async (c) => {
   const userId = c.get('userId');
+  const userPk = c.get('userIdPK') || userId;
+  const ownerIds = [userPk, userId] as [string, string];
   const db = getDB(c.env);
 
   const body = await c.req.json<{
@@ -90,8 +93,8 @@ tts.post('/generate', async (c) => {
 
   let dailyLimitExceeded = false;
   const user = await db.execute({
-    sql: 'SELECT * FROM users WHERE google_id = ?',
-    args: [userId],
+    sql: 'SELECT * FROM users WHERE id = ? OR google_id = ? LIMIT 1',
+    args: ownerIds,
   });
 
   if (user.rows.length > 0) {
@@ -101,8 +104,8 @@ tts.post('/generate', async (c) => {
 
     if (u.daily_tts_reset_at !== today) {
       await db.execute({
-        sql: `UPDATE users SET daily_tts_count = 0, daily_tts_reset_at = ? WHERE google_id = ?`,
-        args: [today, userId],
+        sql: `UPDATE users SET daily_tts_count = 0, daily_tts_reset_at = ? WHERE id = ? OR google_id = ?`,
+        args: [today, ...ownerIds],
       });
     } else {
       const count = Number(u.daily_tts_count);
@@ -113,7 +116,7 @@ tts.post('/generate', async (c) => {
     }
   }
 
-  const vp = await findUsableVoiceProfile(db, userId, body.voice_profile_id);
+  const vp = await findUsableVoiceProfile(db, userId, userPk, body.voice_profile_id);
   if (!vp) {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
   }
@@ -151,7 +154,7 @@ tts.post('/generate', async (c) => {
     }));
 
     for (const { cacheKey } of preparedAttempts) {
-      const cached = await findCachedGeneratedAudio(c, userId, cacheKey);
+      const cached = await findCachedGeneratedAudio(c, ownerIds, cacheKey);
       if (cached) {
         return c.json(
           {
@@ -192,10 +195,10 @@ tts.post('/generate', async (c) => {
         let audioUrl: string | null = null;
         if (c.env.VOICE_BUCKET) {
           const storage = new R2VoiceStorage(c.env.VOICE_BUCKET);
-          audioObjectKey = generatedTtsObjectKey(userId, cacheKey, generated.outputFormat);
+          audioObjectKey = generatedTtsObjectKey(userPk, cacheKey, generated.outputFormat);
           await storage.storeAtKey(audioObjectKey, {
             bytes,
-            userId,
+            userId: userPk,
             mimeType: generated.mimeType,
             originalName: `tts_${cacheKey}.${generated.outputFormat}`,
           });
@@ -206,7 +209,7 @@ tts.post('/generate', async (c) => {
         await db.execute({
           sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, category, audio_url)
                 VALUES (?, ?, ?, ?, ?, ?)`,
-          args: [messageId, userId, body.voice_profile_id, body.text, body.category ?? 'custom', audioUrl],
+          args: [messageId, userPk, body.voice_profile_id, body.text, body.category ?? 'custom', audioUrl],
         });
 
         if (audioUrl) {
@@ -218,7 +221,7 @@ tts.post('/generate', async (c) => {
                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             args: [
               crypto.randomUUID(),
-              userId,
+              userPk,
               body.voice_profile_id,
               messageId,
               generated.provider,
@@ -238,13 +241,13 @@ tts.post('/generate', async (c) => {
         }
 
         await db.execute({
-          sql: `UPDATE users SET daily_tts_count = daily_tts_count + 1 WHERE google_id = ?`,
-          args: [userId],
+          sql: `UPDATE users SET daily_tts_count = daily_tts_count + 1 WHERE id = ? OR google_id = ?`,
+          args: ownerIds,
         });
 
         await db.execute({
           sql: `INSERT INTO message_library (id, user_id, message_id) VALUES (?, ?, ?)`,
-          args: [crypto.randomUUID(), userId, messageId],
+          args: [crypto.randomUUID(), userPk, messageId],
         });
 
         return c.json(
@@ -285,14 +288,16 @@ tts.post('/generate', async (c) => {
 
 tts.get('/messages', async (c) => {
   const userId = c.get('userId');
+  const userPk = c.get('userIdPK') || userId;
+  const ownerIds = [userPk, userId] as [string, string];
   const db = getDB(c.env);
   const category = c.req.query('category');
   const voiceProfileId = c.req.query('voice_profile_id');
   const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100);
   const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
 
-  let whereClause = 'WHERE m.user_id = ?';
-  const filterArgs: (string | number)[] = [userId];
+  let whereClause = 'WHERE m.user_id IN (?, ?)';
+  const filterArgs: (string | number)[] = [...ownerIds];
 
   if (category) {
     whereClause += ' AND m.category = ?';
@@ -329,6 +334,8 @@ tts.get('/messages', async (c) => {
 
 tts.get('/messages/:id/audio', async (c) => {
   const userId = c.get('userId');
+  const userPk = c.get('userIdPK') || userId;
+  const ownerIds = [userPk, userId] as [string, string];
   const db = getDB(c.env);
   const id = c.req.param('id');
 
@@ -339,8 +346,8 @@ tts.get('/messages/:id/audio', async (c) => {
   const result = await db.execute({
     sql: `SELECT id, user_id, voice_profile_id, text, audio_url, category
           FROM messages
-          WHERE id = ? AND user_id = ?`,
-    args: [id, userId],
+          WHERE id = ? AND user_id IN (?, ?)`,
+    args: [id, ...ownerIds],
   });
 
   if (result.rows.length === 0) {
@@ -377,6 +384,8 @@ tts.get('/messages/:id/audio', async (c) => {
 
 tts.delete('/messages/:id', async (c) => {
   const userId = c.get('userId');
+  const userPk = c.get('userIdPK') || userId;
+  const ownerIds = [userPk, userId] as [string, string];
   const db = getDB(c.env);
   const id = c.req.param('id');
 
@@ -400,18 +409,18 @@ tts.delete('/messages/:id', async (c) => {
   }
 
   await db.execute({
-    sql: 'DELETE FROM message_library WHERE message_id = ? AND user_id = ?',
-    args: [id, userId],
+    sql: 'DELETE FROM message_library WHERE message_id = ? AND user_id IN (?, ?)',
+    args: [id, ...ownerIds],
   });
 
   await db.execute({
-    sql: 'DELETE FROM generated_audio_assets WHERE message_id = ? AND user_id = ?',
-    args: [id, userId],
+    sql: 'DELETE FROM generated_audio_assets WHERE message_id = ? AND user_id IN (?, ?)',
+    args: [id, ...ownerIds],
   });
 
   const result = await db.execute({
-    sql: 'DELETE FROM messages WHERE id = ? AND user_id = ?',
-    args: [id, userId],
+    sql: 'DELETE FROM messages WHERE id = ? AND user_id IN (?, ?)',
+    args: [id, ...ownerIds],
   });
 
   if (result.rowsAffected === 0) {
@@ -436,7 +445,7 @@ function uint8ToBase64(bytes: Uint8Array): string {
 
 async function findCachedGeneratedAudio(
   c: Context<AppEnv>,
-  userId: string,
+  userIds: [string, string],
   cacheKey: string,
 ): Promise<{
   messageId: string;
@@ -453,9 +462,9 @@ async function findCachedGeneratedAudio(
                  ga.audio_format, ga.mime_type
           FROM generated_audio_assets ga
           JOIN messages m ON m.id = ga.message_id
-          WHERE ga.user_id = ? AND ga.request_hash = ?
+          WHERE ga.user_id IN (?, ?) AND ga.request_hash = ?
           LIMIT 1`,
-    args: [userId, cacheKey],
+    args: [...userIds, cacheKey],
   });
 
   if (result.rows.length === 0) return null;

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -346,8 +346,16 @@ tts.get('/messages/:id/audio', async (c) => {
   const result = await db.execute({
     sql: `SELECT id, user_id, voice_profile_id, text, audio_url, category
           FROM messages
-          WHERE id = ? AND user_id IN (?, ?)`,
-    args: [id, ...ownerIds],
+          WHERE id = ?
+            AND (
+              user_id IN (?, ?)
+              OR EXISTS (
+                SELECT 1 FROM alarms a
+                WHERE a.message_id = messages.id
+                  AND a.target_user_id IN (?, ?)
+              )
+            )`,
+    args: [id, ...ownerIds, ...ownerIds],
   });
 
   if (result.rows.length === 0) {
@@ -511,6 +519,11 @@ async function loadAudioBytes(
     if (!audioRes.ok) return null;
     bytes = new Uint8Array(await audioRes.arrayBuffer());
     format = audioFormatFromMime(audioRes.headers.get('content-type')) ?? format;
+  } else if (c.env.VOICE_BUCKET) {
+    const stored = await new R2VoiceStorage(c.env.VOICE_BUCKET).get(audioUrl);
+    if (!stored) return null;
+    bytes = stored.bytes;
+    format = audioFormatFromMime(stored.meta.mimeType) ?? format;
   } else {
     return null;
   }

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -5,6 +5,7 @@ import { typedRow } from '../lib/db-types';
 import { UUID_RE } from '../lib/validate';
 import { R2VoiceStorage } from '../lib/r2-storage';
 import { computeTtsCacheKey, generatedTtsObjectKey } from '../lib/audio-cache';
+import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import {
   createSynthesisAttempts,
   noVoiceProviderError,
@@ -12,6 +13,36 @@ import {
 } from '../lib/voice-provider';
 
 const tts = new Hono<AppEnv>();
+
+async function findUsableVoiceProfile(
+  db: ReturnType<typeof getDB>,
+  userId: string,
+  voiceProfileId: string,
+): Promise<Record<string, unknown> | null> {
+  const owned = await db.execute({
+    sql: 'SELECT * FROM voice_profiles WHERE id = ? AND user_id = ?',
+    args: [voiceProfileId, userId],
+  });
+  if (owned.rows.length > 0) return owned.rows[0] as Record<string, unknown>;
+
+  const shared = await db.execute({
+    sql: `SELECT vp.*, u.id AS owner_pk
+          FROM voice_profiles vp
+          LEFT JOIN users u ON u.google_id = vp.user_id OR u.id = vp.user_id
+          WHERE vp.id = ? AND COALESCE(vp.is_shared, 0) = 1
+          LIMIT 1`,
+    args: [voiceProfileId],
+  });
+  if (shared.rows.length === 0) return null;
+
+  const row = shared.rows[0] as Record<string, unknown>;
+  const viewerPk = await resolveUserPk(db, userId);
+  const ownerPk = typeof row.owner_pk === 'string' ? row.owner_pk : null;
+  if (!viewerPk || !ownerPk || viewerPk === ownerPk) return null;
+
+  const inSameGroup = await assertSameGroup(db, viewerPk, ownerPk);
+  return inSameGroup ? row : null;
+}
 
 tts.post('/generate', async (c) => {
   const userId = c.get('userId');
@@ -82,16 +113,11 @@ tts.post('/generate', async (c) => {
     }
   }
 
-  const profile = await db.execute({
-    sql: 'SELECT * FROM voice_profiles WHERE id = ? AND user_id = ?',
-    args: [body.voice_profile_id, userId],
-  });
-
-  if (profile.rows.length === 0) {
+  const vp = await findUsableVoiceProfile(db, userId, body.voice_profile_id);
+  if (!vp) {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
   }
 
-  const vp = profile.rows[0]!;
   if (vp.status !== 'ready') {
     return c.json({ error: 'Voice profile is not ready yet', error_code: 'VOICE_PROFILE_NOT_READY' }, 400);
   }

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -148,7 +148,15 @@ voiceProfile.get('/', async (c) => {
   ]);
 
   const total = Number(countRes.rows[0]!.total);
-  return c.json({ profiles: result.rows, total, limit, offset });
+  return c.json({
+    profiles: result.rows.map((row) => ({
+      ...row,
+      is_shared: Boolean(Number(row.is_shared ?? 0)),
+    })),
+    total,
+    limit,
+    offset,
+  });
 });
 
 voiceProfile.get('/family', async (c) => {
@@ -190,15 +198,20 @@ voiceProfile.get('/family', async (c) => {
 
   const placeholders = memberIds.map(() => '?').join(',');
   const voicesRes = await db.execute({
-    sql: `SELECT vp.id, vp.name, vp.status, vp.created_at, vp.user_id, u.name as owner_name
+    sql: `SELECT vp.id, vp.name, vp.status, vp.created_at, vp.user_id, vp.is_shared, u.name as owner_name
           FROM voice_profiles vp
           LEFT JOIN users u ON vp.user_id = u.google_id OR vp.user_id = u.id
-          WHERE vp.user_id IN (${placeholders}) AND vp.status = 'ready'
+          WHERE vp.user_id IN (${placeholders}) AND vp.status = 'ready' AND COALESCE(vp.is_shared, 0) = 1
           ORDER BY vp.created_at DESC`,
     args: memberIds,
   });
 
-  return c.json({ profiles: voicesRes.rows });
+  return c.json({
+    profiles: voicesRes.rows.map((row) => ({
+      ...row,
+      is_shared: Boolean(Number(row.is_shared ?? 0)),
+    })),
+  });
 });
 
 voiceProfile.get('/:id', async (c) => {
@@ -219,7 +232,8 @@ voiceProfile.get('/:id', async (c) => {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
   }
 
-  return c.json({ profile: result.rows[0] });
+  const row = result.rows[0]!;
+  return c.json({ profile: { ...row, is_shared: Boolean(Number(row.is_shared ?? 0)) } });
 });
 
 voiceProfile.patch('/:id', async (c) => {
@@ -231,15 +245,22 @@ voiceProfile.patch('/:id', async (c) => {
     return c.json({ error: 'Invalid voice profile ID format', error_code: 'INVALID_VOICE_PROFILE_ID' }, 400);
   }
 
-  let body: { name?: unknown };
+  let body: { name?: unknown; is_shared?: unknown; isShared?: unknown };
   try {
     body = await c.req.json();
   } catch {
     return c.json({ error: 'JSON body required', error_code: 'JSON_BODY_REQUIRED' }, 400);
   }
 
+  const hasName = body.name !== undefined;
   const name = typeof body.name === 'string' ? body.name.trim() : '';
-  if (name.length === 0 || name.length > 50) {
+  const sharedValue = body.is_shared ?? body.isShared;
+  const isSharedUpdate = typeof sharedValue === 'boolean' ? sharedValue : undefined;
+  const hasShared = isSharedUpdate !== undefined;
+  if (!hasName && !hasShared) {
+    return c.json({ error: 'name must be 1-50 characters', error_code: 'INVALID_NAME_LENGTH' }, 400);
+  }
+  if (hasName && (name.length === 0 || name.length > 50)) {
     return c.json({ error: 'name must be 1-50 characters', error_code: 'INVALID_NAME_LENGTH' }, 400);
   }
 
@@ -251,12 +272,31 @@ voiceProfile.patch('/:id', async (c) => {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
   }
 
+  const updates: string[] = [];
+  const args: (string | number)[] = [];
+  if (hasName) {
+    updates.push('name = ?');
+    args.push(name);
+  }
+  if (hasShared) {
+    updates.push('is_shared = ?');
+    args.push(isSharedUpdate ? 1 : 0);
+  }
+  updates.push("updated_at = datetime('now')");
+  args.push(id);
+
   await db.execute({
-    sql: "UPDATE voice_profiles SET name = ?, updated_at = datetime('now') WHERE id = ?",
-    args: [name, id],
+    sql: `UPDATE voice_profiles SET ${updates.join(', ')} WHERE id = ?`,
+    args,
   });
 
-  return c.json({ profile: { id, name } });
+  return c.json({
+    profile: {
+      id,
+      ...(hasName ? { name } : {}),
+      ...(hasShared ? { is_shared: Boolean(isSharedUpdate) } : {}),
+    },
+  });
 });
 
 voiceProfile.post('/clone', async (c) => {
@@ -282,6 +322,7 @@ voiceProfile.post('/clone', async (c) => {
     const formData = await c.req.formData();
     const audioFile = getFormFile(formData, 'audio');
     const name = formData.get('name') as string | null;
+    const isShared = ['true', '1', 'yes'].includes(String(formData.get('isShared') ?? formData.get('is_shared') ?? 'false'));
     if (!audioFile || !name) {
       return c.json({ error: 'audio file and name are required', error_code: 'AUDIO_AND_NAME_REQUIRED' }, 400);
     }
@@ -294,9 +335,9 @@ voiceProfile.post('/clone', async (c) => {
     const profileId = crypto.randomUUID();
 
     await db.execute({
-      sql: `INSERT INTO voice_profiles (id, user_id, name, status)
-            VALUES (?, ?, ?, 'processing')`,
-      args: [profileId, userId, name],
+      sql: `INSERT INTO voice_profiles (id, user_id, name, status, is_shared)
+            VALUES (?, ?, ?, 'processing', ?)`,
+      args: [profileId, userId, name, isShared ? 1 : 0],
     });
 
     const attempts = createEnrollmentAttempts({
@@ -343,6 +384,7 @@ voiceProfile.post('/clone', async (c) => {
           voice_id: voiceId,
           provider,
           status: 'ready',
+          is_shared: isShared,
         },
       },
       201,

--- a/packages/backend/test/auth-middleware.test.ts
+++ b/packages/backend/test/auth-middleware.test.ts
@@ -358,7 +358,7 @@ describe('authMiddleware — Apple token', () => {
 });
 
 describe('authMiddleware — 토큰 발급자 분기', () => {
-  it('알 수 없는 issuer는 Google 경로로 처리', async () => {
+  it('알 수 없는 issuer는 거부한다', async () => {
     const payload = {
       sub: 'user-unknown',
       iss: 'https://unknown-issuer.example.com',
@@ -374,8 +374,10 @@ describe('authMiddleware — 토큰 발급자 분기', () => {
 
     const app = buildApp();
     const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(200);
-    expect(globalThis.fetch).toHaveBeenCalled();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe('AUTH_INVALID_ISSUER');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(mockVerifyAppJwt).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import type { Env } from '../src/types';
 import { createMockDB, jsonReq } from './helpers';
@@ -31,6 +31,12 @@ function buildApp() {
 
 beforeEach(() => {
   mockDB.reset();
+});
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
 });
 
 describe('POST /auth/register', () => {
@@ -205,6 +211,123 @@ describe('POST /auth/login', () => {
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error_code).toBe('AUTH_OAUTH_ONLY');
+  });
+});
+
+describe('POST /auth/google', () => {
+  it('Google ID 토큰을 검증하고 앱 JWT를 발급한다', async () => {
+    const googlePayload = {
+      sub: 'google-user-1',
+      email: 'user@gmail.com',
+      name: 'Google User',
+      picture: 'https://lh3.googleusercontent.com/photo.jpg',
+      iss: 'accounts.google.com',
+      aud: ENV.GOOGLE_CLIENT_ID,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => googlePayload,
+    }) as unknown as typeof fetch;
+    mockDB.pushResult([]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/google', {
+        id_token: 'google-id-token',
+      }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toMatch(/^[^.]+\.[^.]+\.[^.]+$/);
+    expect(body.user).toMatchObject({
+      id: 'google-user-1',
+      email: 'user@gmail.com',
+      name: 'Google User',
+      plan: 'free',
+    });
+    expect(mockDB.calls[1]?.args.slice(0, 3)).toEqual([
+      'google-user-1',
+      'google-user-1',
+      'user@gmail.com',
+    ]);
+  });
+
+  it('같은 이메일의 기존 계정은 Google ID를 연결하고 기존 플랜을 유지한다', async () => {
+    const googlePayload = {
+      sub: 'google-user-2',
+      email: 'linked@gmail.com',
+      name: 'Linked User',
+      iss: 'accounts.google.com',
+      aud: ENV.GOOGLE_CLIENT_ID,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => googlePayload,
+    }) as unknown as typeof fetch;
+    mockDB.pushResult([
+      {
+        id: 'existing-user-id',
+        google_id: null,
+        email: 'linked@gmail.com',
+        name: 'Old Name',
+        plan: 'family',
+      },
+    ]);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/google', {
+        id_token: 'google-id-token',
+      }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user).toMatchObject({
+      id: 'existing-user-id',
+      email: 'linked@gmail.com',
+      name: 'Linked User',
+      plan: 'family',
+    });
+    expect(mockDB.calls[1]?.args).toEqual([
+      'google-user-2',
+      'linked@gmail.com',
+      'Linked User',
+      null,
+      'existing-user-id',
+    ]);
+  });
+
+  it('Google 검증 실패 시 401을 반환한다', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'invalid_token' }),
+    }) as unknown as typeof fetch;
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/google', {
+        id_token: 'bad-google-id-token',
+      }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe('AUTH_GOOGLE_FAILED');
   });
 });
 

--- a/packages/backend/test/billing-mutation.test.ts
+++ b/packages/backend/test/billing-mutation.test.ts
@@ -119,6 +119,25 @@ describe('POST /billing/checkout (billingMutation)', () => {
     expect(mockDB.calls[4]!.sql).toContain('INSERT INTO voucher_codes');
   });
 
+  it('gift checkout 은 구독을 바꾸지 않고 voucher 만 발급', async () => {
+    mockDB.pushResult([PLAN_PLUS]);
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([], 1);
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'plus_personal', gift: true }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.subscription).toBeNull();
+    expect(body.plan.key).toBe('plus_personal');
+    expect(body.voucher.code).toMatch(/^VA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(mockDB.calls).toHaveLength(3);
+    expect(mockDB.calls[2]!.sql).toContain('INSERT INTO voucher_codes');
+    expect(mockDB.calls[2]!.args[5]).toBeNull();
+  });
+
   it('family checkout DB 쿼리 순서: plan → user → plan_groups → plan_group_members → subscription → users.plan → voucher', async () => {
     mockDB.pushResult([PLAN_FAMILY]);
     mockDB.pushResult([{ id: 'user-pk-1' }]);

--- a/packages/backend/test/code.test.ts
+++ b/packages/backend/test/code.test.ts
@@ -201,16 +201,51 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
     setupUserLookup();
     mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
     mockDB.pushResult([{ id: 'p1', key: 'family_yearly', name: 'Family Yearly', plan_type: 'family', period_days: 365, max_members: 6, price_krw: 49000 }]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1); // INSERT plan_groups
+    mockDB.pushResult([], 1); // INSERT plan_group_members
+    mockDB.pushResult([], 1); // INSERT subscription
+    mockDB.pushResult([], 1); // UPDATE voucher_codes
+    mockDB.pushResult([], 1); // UPDATE users plan
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
     const body = await res.json();
     expect(body.plan.plan_type).toBe('family');
+    expect(body.subscription.plan_group_id).toBeTruthy();
 
-    const updateUserArgs = mockDB.calls[5].args;
+    const updateUserArgs = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'))!.args;
     expect(updateUserArgs[0]).toBe('family');
+  });
+
+  it('구매자의 커플/가족 이용권이면 구매자 그룹에 멤버로 연결한다', async () => {
+    setupUserLookup();
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        issuer_subscription_id: 'sub-owner',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
+    mockDB.pushResult([{ id: 'p1', key: 'couple', name: 'Couple', plan_type: 'family', period_days: 30, max_members: 2, price_krw: 7900 }]);
+    mockDB.pushResult([{ id: 'g1', max_members: 2 }]); // issuer subscription group
+    mockDB.pushResult([]); // existing member
+    mockDB.pushResult([{ c: 1 }]); // member count
+    mockDB.pushResult([], 1); // INSERT plan_group_members
+    mockDB.pushResult([], 1); // INSERT subscription
+    mockDB.pushResult([], 1); // UPDATE voucher_codes
+    mockDB.pushResult([], 1); // UPDATE users plan
+
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.subscription.plan_group_id).toBe('g1');
+    const insertMember = mockDB.calls.find((c) => c.sql.includes('INSERT INTO plan_group_members'));
+    expect(insertMember?.args[1]).toBe('g1');
+    expect(insertMember?.args[2]).toBe('pk1');
   });
 });
 
@@ -354,5 +389,19 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
     expect(insertSql).toContain('INSERT INTO plan_group_members');
     const updateSql = mockDB.calls[6].sql;
     expect(updateSql).toContain("SET status = 'used'");
+  });
+
+  it('태그형 초대권 코드를 정규화해서 수락한다', async () => {
+    setupUserLookup();
+    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([]);
+    mockDB.pushResult([{ max_members: 6 }]);
+    mockDB.pushResult([{ c: 2 }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/code/register', { code: 'inv123456' }));
+    expect(res.status).toBe(200);
+    expect(mockDB.calls[1].args[0]).toBe('INV-123456');
   });
 });

--- a/packages/backend/test/code.test.ts
+++ b/packages/backend/test/code.test.ts
@@ -98,7 +98,9 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('이미 사용된 코드 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'used', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      { id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'used', expires_at: '2099-12-31' },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
     expect(res.status).toBe(409);
@@ -107,7 +109,15 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('만료된 코드 (status=expired) 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'expired', expires_at: '2020-01-01' }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'expired',
+        expires_at: '2020-01-01',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
     expect(res.status).toBe(409);
@@ -116,7 +126,15 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('만료 날짜 지남 → expired 업데이트 후 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2020-01-01' }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2020-01-01',
+      },
+    ]);
     mockDB.pushResult([], 1);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
@@ -128,7 +146,15 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('본인 발급 코드 400 SELF_ISSUED', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk1', status: 'issued', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk1',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
     expect(res.status).toBe(400);
@@ -137,7 +163,15 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('연결된 플랜 없으면 404 PLAN_NOT_FOUND', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: 'VA-AAAA-BBBB-CCCC' }));
@@ -147,8 +181,26 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('정상 이용권 등록 성공', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
-    mockDB.pushResult([{ id: 'p1', key: 'plus_monthly', name: 'Plus Monthly', plan_type: 'personal', period_days: 30, max_members: 1, price_krw: 4900 }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: 'p1',
+        key: 'plus_monthly',
+        name: 'Plus Monthly',
+        plan_type: 'personal',
+        period_days: 30,
+        max_members: 1,
+        price_krw: 4900,
+      },
+    ]);
     mockDB.pushResult([], 1); // INSERT subscription
     mockDB.pushResult([], 1); // UPDATE voucher_codes
     mockDB.pushResult([], 1); // UPDATE users plan
@@ -172,8 +224,26 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('알 수 없는 plan_type → user plan "free"로 업데이트', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
-    mockDB.pushResult([{ id: 'p1', key: 'trial_7', name: 'Trial', plan_type: 'trial', period_days: 7, max_members: 1, price_krw: 0 }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: 'p1',
+        key: 'trial_7',
+        name: 'Trial',
+        plan_type: 'trial',
+        period_days: 7,
+        max_members: 1,
+        price_krw: 0,
+      },
+    ]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
@@ -186,8 +256,26 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('period_days 누락 시 기본값 30일 적용', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
-    mockDB.pushResult([{ id: 'p1', key: 'custom', name: 'Custom', plan_type: 'personal', period_days: null, max_members: 1, price_krw: 0 }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: 'p1',
+        key: 'custom',
+        name: 'Custom',
+        plan_type: 'personal',
+        period_days: null,
+        max_members: 1,
+        price_krw: 0,
+      },
+    ]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
@@ -199,8 +287,26 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
 
   it('family 플랜 타입 → user plan "family"로 업데이트', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'v1', plan_id: 'p1', issuer_user_id: 'pk2', status: 'issued', expires_at: '2099-12-31' }]);
-    mockDB.pushResult([{ id: 'p1', key: 'family_yearly', name: 'Family Yearly', plan_type: 'family', period_days: 365, max_members: 6, price_krw: 49000 }]);
+    mockDB.pushResult([
+      {
+        id: 'v1',
+        plan_id: 'p1',
+        issuer_user_id: 'pk2',
+        status: 'issued',
+        expires_at: '2099-12-31',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: 'p1',
+        key: 'family_yearly',
+        name: 'Family Yearly',
+        plan_type: 'family',
+        period_days: 365,
+        max_members: 6,
+        price_krw: 49000,
+      },
+    ]);
     mockDB.pushResult([], 1); // INSERT plan_groups
     mockDB.pushResult([], 1); // INSERT plan_group_members
     mockDB.pushResult([], 1); // INSERT subscription
@@ -228,7 +334,17 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
         expires_at: '2099-12-31',
       },
     ]);
-    mockDB.pushResult([{ id: 'p1', key: 'couple', name: 'Couple', plan_type: 'family', period_days: 30, max_members: 2, price_krw: 7900 }]);
+    mockDB.pushResult([
+      {
+        id: 'p1',
+        key: 'couple',
+        name: 'Couple',
+        plan_type: 'family',
+        period_days: 30,
+        max_members: 2,
+        price_krw: 7900,
+      },
+    ]);
     mockDB.pushResult([{ id: 'g1', max_members: 2 }]); // issuer subscription group
     mockDB.pushResult([]); // existing member
     mockDB.pushResult([{ c: 1 }]); // member count
@@ -249,7 +365,7 @@ describe('POST /code/register — 이용권 코드 (VA-XXXX-XXXX-XXXX)', () => {
   });
 });
 
-describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => {
+describe('POST /code/register — 가족 초대권 코드', () => {
   function setupUserLookup() {
     mockDB.pushResult([{ id: 'pk1' }]);
   }
@@ -265,7 +381,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('사용 완료된 초대 코드 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'used', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'used',
+        expires_at: '2099-12-31',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
     expect(res.status).toBe(409);
@@ -274,7 +398,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('취소된 초대 코드 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'revoked', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'revoked',
+        expires_at: '2099-12-31',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
     expect(res.status).toBe(409);
@@ -283,7 +415,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('만료 날짜 지남 → expired 업데이트 후 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2020-01-01' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2020-01-01',
+      },
+    ]);
     mockDB.pushResult([], 1);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
@@ -293,7 +433,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('본인 발급 초대 400 SELF_ISSUED', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk1', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk1',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
     expect(res.status).toBe(400);
@@ -302,7 +450,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('이미 그룹 멤버이면 409 ALREADY_MEMBER', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([{ id: 'm1' }]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
@@ -312,7 +468,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('그룹 미존재 시 404', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([]);
     const app = buildApp();
@@ -323,7 +487,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('정원 초과 시 409 GROUP_FULL', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([{ max_members: 2 }]);
     mockDB.pushResult([{ c: 2 }]);
@@ -335,7 +507,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('상태가 expired인 초대 코드 409', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'expired', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'expired',
+        expires_at: '2099-12-31',
+      },
+    ]);
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/code/register', { code: '123456' }));
     expect(res.status).toBe(409);
@@ -344,7 +524,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('max_members null 시 기본값 6 적용 — 5명이면 가입 허용', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([{ max_members: null }]);
     mockDB.pushResult([{ c: 5 }]);
@@ -358,7 +546,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('max_members null + 6명이면 정원 초과', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([{ max_members: null }]);
     mockDB.pushResult([{ c: 6 }]);
@@ -370,7 +566,15 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
 
   it('정상 가족 초대 수락 성공', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([{ max_members: 6 }]);
     mockDB.pushResult([{ c: 2 }]);
@@ -391,17 +595,25 @@ describe('POST /code/register — 가족 초대 코드 (6자리 숫자)', () => 
     expect(updateSql).toContain("SET status = 'used'");
   });
 
-  it('태그형 초대권 코드를 정규화해서 수락한다', async () => {
+  it('긴 태그형 초대권 코드를 정규화해서 수락한다', async () => {
     setupUserLookup();
-    mockDB.pushResult([{ id: 'i1', plan_group_id: 'g1', inviter_user_id: 'pk2', status: 'pending', expires_at: '2099-12-31' }]);
+    mockDB.pushResult([
+      {
+        id: 'i1',
+        plan_group_id: 'g1',
+        inviter_user_id: 'pk2',
+        status: 'pending',
+        expires_at: '2099-12-31',
+      },
+    ]);
     mockDB.pushResult([]);
     mockDB.pushResult([{ max_members: 6 }]);
     mockDB.pushResult([{ c: 2 }]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     const app = buildApp();
-    const res = await app.request(jsonReq('POST', '/code/register', { code: 'inv123456' }));
+    const res = await app.request(jsonReq('POST', '/code/register', { code: 'invabcd1234efgh' }));
     expect(res.status).toBe(200);
-    expect(mockDB.calls[1].args[0]).toBe('INV-123456');
+    expect(mockDB.calls[1].args[0]).toBe('INV-ABCD-1234-EFGH');
   });
 });

--- a/packages/backend/test/family-group.test.ts
+++ b/packages/backend/test/family-group.test.ts
@@ -115,6 +115,71 @@ describe('GET /family/groups/current', () => {
     expect(data.role).toBeNull();
   });
 
+  it('repairs family voucher subscription without membership and returns the linked group', async () => {
+    pushResolveUserPk(MEMBER_PK);
+    mockDB.pushResult([]); // initial current group lookup
+    mockDB.pushResult([
+      {
+        subscription_id: 'sub-member',
+        plan_id: PLAN_ID,
+        plan_type: 'family',
+        max_members: 2,
+        issuer_subscription_id: 'sub-owner',
+        issuer_user_id: OWNER_PK,
+      },
+    ]);
+    mockDB.pushResult([{ id: GROUP_ID, max_members: 2 }]); // issuer subscription group
+    mockDB.pushResult([]); // existing member lookup
+    mockDB.pushResult([{ c: 1 }]); // member count
+    mockDB.pushResult([], 1); // INSERT plan_group_members
+    mockDB.pushResult([], 1); // UPDATE subscription.plan_group_id
+    mockDB.pushResult([
+      {
+        id: GROUP_ID,
+        owner_user_id: OWNER_PK,
+        plan_id: PLAN_ID,
+        max_members: 2,
+        created_at: '2026-01-01T00:00:00Z',
+        my_role: 'member',
+      },
+    ]);
+    mockDB.pushResult([
+      {
+        id: MEMBER_ROW_ID,
+        user_id: OWNER_PK,
+        role: 'owner',
+        joined_at: '2026-01-01T00:00:00Z',
+        email: 'owner@test.com',
+        name: 'Owner',
+        picture: null,
+        allow_family_alarms: 1,
+      },
+      {
+        id: MEMBER_ROW_ID_2,
+        user_id: MEMBER_PK,
+        role: 'member',
+        joined_at: '2026-01-02T00:00:00Z',
+        email: 'member@test.com',
+        name: 'Member',
+        picture: null,
+        allow_family_alarms: 0,
+      },
+    ]);
+
+    const res = await app.request('/family/groups/current');
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.group.id).toBe(GROUP_ID);
+    expect(data.role).toBe('member');
+    expect(data.members).toHaveLength(2);
+
+    const insertMember = mockDB.calls.find((c) => c.sql.includes('INSERT INTO plan_group_members'));
+    expect(insertMember?.args[1]).toBe(GROUP_ID);
+    expect(insertMember?.args[2]).toBe(MEMBER_PK);
+    const updateSubscription = mockDB.calls.find((c) => c.sql.includes('UPDATE subscriptions SET plan_group_id'));
+    expect(updateSubscription?.args).toEqual([GROUP_ID, 'sub-member']);
+  });
+
   it('maps null email/name/picture to null', async () => {
     pushResolveUserPk(OWNER_PK);
     mockDB.pushResult([

--- a/packages/backend/test/family-invite.test.ts
+++ b/packages/backend/test/family-invite.test.ts
@@ -51,7 +51,7 @@ describe('POST /family/invites', () => {
     expect(body.invite).toBeDefined();
     expect(body.invite.plan_group_id).toBe(GROUP_ID);
     expect(body.invite.status).toBe('pending');
-    expect(body.invite.code).toMatch(/^INV-[0-9]{6}$/);
+    expect(body.invite.code).toMatch(/^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
     expect(body.invite.deep_link).toContain('voicealarm://invite/');
     expect(body.invite.web_url).toContain('/invite/');
   });
@@ -62,9 +62,7 @@ describe('POST /family/invites', () => {
     mockDB.pushResult([{ member_count: 1, pending_count: 0 }]);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.invite.plan_group_id).toBe(GROUP_ID);
@@ -105,9 +103,7 @@ describe('POST /family/invites', () => {
     pushResolveUserPk(MEMBER_PK);
     mockDB.pushResult([{ id: GROUP_ID, owner_user_id: OWNER_PK, max_members: 6 }]);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error_code).toBe('OWNER_ONLY');
@@ -118,9 +114,7 @@ describe('POST /family/invites', () => {
     mockDB.pushResult([{ id: GROUP_ID, owner_user_id: OWNER_PK, max_members: 4 }]);
     mockDB.pushResult([{ member_count: 3, pending_count: 1 }]);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('GROUP_FULL');
@@ -244,9 +238,7 @@ describe('POST /family/invites/:code/accept', () => {
     mockDB.pushResult([], 1); // INSERT member
     mockDB.pushResult([], 1); // UPDATE invite
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -256,9 +248,7 @@ describe('POST /family/invites/:code/accept', () => {
   });
 
   it('returns 400 for invalid code format', async () => {
-    const res = await app.request(
-      jsonReq('POST', '/family/invites/abc/accept'),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites/abc/accept'));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error_code).toBe('INVALID_CODE_FORMAT');
@@ -267,9 +257,7 @@ describe('POST /family/invites/:code/accept', () => {
   it('returns 404 when user not found', async () => {
     pushResolveUserPk(null);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error_code).toBe('USER_NOT_FOUND');
@@ -279,9 +267,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushResolveUserPk(MEMBER_PK);
     mockDB.pushResult([]); // no invite
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error_code).toBe('INVITE_NOT_FOUND');
@@ -291,9 +277,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushResolveUserPk(MEMBER_PK);
     pushValidInvite({ status: 'used' });
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('CODE_ALREADY_USED');
@@ -303,9 +287,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushResolveUserPk(MEMBER_PK);
     pushValidInvite({ status: 'revoked' });
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('CODE_REVOKED');
@@ -315,9 +297,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushResolveUserPk(MEMBER_PK);
     pushValidInvite({ status: 'expired' });
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('CODE_EXPIRED');
@@ -329,9 +309,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushValidInvite({ expires_at: past });
     mockDB.pushResult([], 1); // UPDATE to expired
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('CODE_EXPIRED');
@@ -341,9 +319,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushResolveUserPk(OWNER_PK);
     pushValidInvite({ inviter_user_id: OWNER_PK });
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error_code).toBe('SELF_ACCEPT');
@@ -354,9 +330,7 @@ describe('POST /family/invites/:code/accept', () => {
     pushValidInvite();
     mockDB.pushResult([{ id: 'existing-membership' }]); // already member
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('ALREADY_MEMBER');
@@ -368,9 +342,7 @@ describe('POST /family/invites/:code/accept', () => {
     mockDB.pushResult([]); // not already member
     mockDB.pushResult([]); // group not found
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error_code).toBe('GROUP_NOT_FOUND');
@@ -383,9 +355,7 @@ describe('POST /family/invites/:code/accept', () => {
     mockDB.pushResult([{ max_members: 4 }]);
     mockDB.pushResult([{ c: 4 }]); // already at max
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('GROUP_FULL');
@@ -402,9 +372,7 @@ describe('POST /family/invites/:code/revoke', () => {
     mockDB.pushResult([{ id: INVITE_ID, inviter_user_id: OWNER_PK, status: 'pending' }]);
     mockDB.pushResult([], 1); // UPDATE
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -412,9 +380,7 @@ describe('POST /family/invites/:code/revoke', () => {
   });
 
   it('returns 400 for invalid code format', async () => {
-    const res = await app.request(
-      jsonReq('POST', '/family/invites/bad!/revoke'),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites/bad!/revoke'));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error_code).toBe('INVALID_CODE_FORMAT');
@@ -423,9 +389,7 @@ describe('POST /family/invites/:code/revoke', () => {
   it('returns 404 when user not found', async () => {
     pushResolveUserPk(null);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error_code).toBe('USER_NOT_FOUND');
@@ -435,9 +399,7 @@ describe('POST /family/invites/:code/revoke', () => {
     pushResolveUserPk(OWNER_PK);
     mockDB.pushResult([]); // no invite
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error_code).toBe('INVITE_NOT_FOUND');
@@ -447,9 +409,7 @@ describe('POST /family/invites/:code/revoke', () => {
     pushResolveUserPk(OTHER_PK);
     mockDB.pushResult([{ id: INVITE_ID, inviter_user_id: OWNER_PK, status: 'pending' }]);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error_code).toBe('NOT_INVITER');
@@ -459,9 +419,7 @@ describe('POST /family/invites/:code/revoke', () => {
     pushResolveUserPk(OWNER_PK);
     mockDB.pushResult([{ id: INVITE_ID, inviter_user_id: OWNER_PK, status: 'used' }]);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('NOT_PENDING');
@@ -471,9 +429,7 @@ describe('POST /family/invites/:code/revoke', () => {
     pushResolveUserPk(OWNER_PK);
     mockDB.pushResult([{ id: INVITE_ID, inviter_user_id: OWNER_PK, status: 'expired' }]);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/revoke`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('NOT_PENDING');
@@ -484,9 +440,7 @@ describe('POST /family/invites/:code/revoke', () => {
     mockDB.pushResult([{ id: INVITE_ID, inviter_user_id: OWNER_PK, status: 'pending' }]);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/ ${INVITE_CODE} /revoke`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/ ${INVITE_CODE} /revoke`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -505,9 +459,7 @@ describe('POST /family/invites — edge cases', () => {
     mockDB.pushResult([{ member_count: 1, pending_count: 0 }]);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: 99999 }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: 99999 }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.invite.plan_group_id).toBe(GROUP_ID);
@@ -520,9 +472,7 @@ describe('POST /family/invites — edge cases', () => {
     mockDB.pushResult([{ member_count: 0, pending_count: 0 }]);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: '   ' }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: '   ' }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.invite.plan_group_id).toBe(GROUP_ID);
@@ -534,9 +484,7 @@ describe('POST /family/invites — edge cases', () => {
     mockDB.pushResult([{ member_count: 5, pending_count: 0 }]);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.invite).toBeDefined();
@@ -547,9 +495,7 @@ describe('POST /family/invites — edge cases', () => {
     mockDB.pushResult([{ id: GROUP_ID, owner_user_id: OWNER_PK, max_members: null }]);
     mockDB.pushResult([{ member_count: 4, pending_count: 2 }]);
 
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: GROUP_ID }));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('GROUP_FULL');
@@ -590,9 +536,7 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     mockDB.pushResult([], 1); // INSERT member
     mockDB.pushResult([], 1); // UPDATE invite
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -616,9 +560,7 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -640,9 +582,7 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     mockDB.pushResult([{ max_members: null }]);
     mockDB.pushResult([{ c: 6 }]); // at default max
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error_code).toBe('GROUP_FULL');
@@ -666,9 +606,7 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/ ${INVITE_CODE} /accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/ ${INVITE_CODE} /accept`));
     expect(res.status).toBe(200);
   });
 
@@ -690,9 +628,7 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.membership.plan_group_id).toBe(GROUP_ID);
@@ -700,16 +636,12 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     expect(body.membership.role).toBe('member');
     expect(body.invite.id).toBe(INVITE_ID);
 
-    const insertCall = mockDB.calls.find(
-      (c) => c.sql.includes('INSERT INTO plan_group_members'),
-    );
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO plan_group_members'));
     expect(insertCall).toBeDefined();
     expect(insertCall!.args).toContain(GROUP_ID);
     expect(insertCall!.args).toContain(MEMBER_PK);
 
-    const updateCall = mockDB.calls.find(
-      (c) => c.sql.includes('UPDATE plan_group_invites'),
-    );
+    const updateCall = mockDB.calls.find((c) => c.sql.includes('UPDATE plan_group_invites'));
     expect(updateCall).toBeDefined();
     expect(updateCall!.args).toContain(MEMBER_PK);
     expect(updateCall!.args).toContain(INVITE_ID);
@@ -729,14 +661,10 @@ describe('POST /family/invites/:code/accept — edge cases', () => {
     ]);
     mockDB.pushResult([], 1); // UPDATE to expired
 
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${INVITE_CODE}/accept`));
     expect(res.status).toBe(409);
 
-    const updateCall = mockDB.calls.find(
-      (c) => c.sql.includes("SET status = 'expired'"),
-    );
+    const updateCall = mockDB.calls.find((c) => c.sql.includes("SET status = 'expired'"));
     expect(updateCall).toBeDefined();
     expect(updateCall!.args).toContain(INVITE_ID);
   });

--- a/packages/backend/test/family-invite.test.ts
+++ b/packages/backend/test/family-invite.test.ts
@@ -51,7 +51,7 @@ describe('POST /family/invites', () => {
     expect(body.invite).toBeDefined();
     expect(body.invite.plan_group_id).toBe(GROUP_ID);
     expect(body.invite.status).toBe('pending');
-    expect(body.invite.code).toBeDefined();
+    expect(body.invite.code).toMatch(/^INV-[0-9]{6}$/);
     expect(body.invite.deep_link).toContain('voicealarm://invite/');
     expect(body.invite.web_url).toContain('/invite/');
   });

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -40,7 +40,7 @@ describe('POST /family/invites', () => {
     const body = await res.json();
     expect(body.invite.plan_group_id).toBe('group-1');
     expect(body.invite.status).toBe('pending');
-    expect(body.invite.code).toMatch(/^[0-9]{6}$/);
+    expect(body.invite.code).toMatch(/^INV-[0-9]{6}$/);
     expect(body.invite.deep_link).toBe(`voicealarm://invite/${body.invite.code}`);
     expect(body.invite.web_url).toContain(body.invite.code);
 

--- a/packages/backend/test/family.test.ts
+++ b/packages/backend/test/family.test.ts
@@ -40,13 +40,11 @@ describe('POST /family/invites', () => {
     const body = await res.json();
     expect(body.invite.plan_group_id).toBe('group-1');
     expect(body.invite.status).toBe('pending');
-    expect(body.invite.code).toMatch(/^INV-[0-9]{6}$/);
+    expect(body.invite.code).toMatch(/^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
     expect(body.invite.deep_link).toBe(`voicealarm://invite/${body.invite.code}`);
     expect(body.invite.web_url).toContain(body.invite.code);
 
-    const insertInvite = mockDB.calls.find((c) =>
-      c.sql.includes('INSERT INTO plan_group_invites'),
-    );
+    const insertInvite = mockDB.calls.find((c) => c.sql.includes('INSERT INTO plan_group_invites'));
     expect(insertInvite).toBeDefined();
     expect(insertInvite?.args[1]).toBe('group-1');
     expect(insertInvite?.args[2]).toBe('user-owner');
@@ -57,9 +55,7 @@ describe('POST /family/invites', () => {
     mockDB.pushResult([{ id: 'group-1', owner_user_id: 'user-other', max_members: 6 }]);
 
     const app = buildApp();
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toContain('소유자');
@@ -71,9 +67,7 @@ describe('POST /family/invites', () => {
     mockDB.pushResult([{ member_count: 1, pending_count: 1 }]);
 
     const app = buildApp();
-    const res = await app.request(
-      jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }),
-    );
+    const res = await app.request(jsonReq('POST', '/family/invites', { plan_group_id: 'group-1' }));
     expect(res.status).toBe(409);
     const body = await res.json();
     expect(body.error).toContain('정원');
@@ -154,9 +148,7 @@ describe('POST /family/invites/:code/accept', () => {
     mockDB.pushResult([], 1); // UPDATE invite
 
     const app = buildApp('google-member');
-    const res = await app.request(
-      jsonReq('POST', `/family/invites/${VALID_CODE}/accept`),
-    );
+    const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/accept`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);
@@ -165,14 +157,12 @@ describe('POST /family/invites/:code/accept', () => {
     expect(body.membership.role).toBe('member');
     expect(body.invite.status).toBe('used');
 
-    const insertMember = mockDB.calls.find((c) =>
-      c.sql.includes('INSERT INTO plan_group_members'),
-    );
+    const insertMember = mockDB.calls.find((c) => c.sql.includes('INSERT INTO plan_group_members'));
     expect(insertMember?.args[1]).toBe('group-1');
     expect(insertMember?.args[2]).toBe('user-member');
 
-    const updInvite = mockDB.calls.find((c) =>
-      c.sql.includes('UPDATE plan_group_invites') && c.sql.includes("status = 'used'"),
+    const updInvite = mockDB.calls.find(
+      (c) => c.sql.includes('UPDATE plan_group_invites') && c.sql.includes("status = 'used'"),
     );
     expect(updInvite?.args[0]).toBe('user-member');
   });
@@ -420,15 +410,15 @@ describe('POST /family/groups/:groupId/transfer-ownership', () => {
     expect(updates[1].sql).toContain("role = 'owner'");
     expect(updates[1].args[1]).toBe('user-target');
 
-    const groupUpd = mockDB.calls.find((c) => c.sql.includes('UPDATE plan_groups SET owner_user_id'));
+    const groupUpd = mockDB.calls.find((c) =>
+      c.sql.includes('UPDATE plan_groups SET owner_user_id'),
+    );
     expect(groupUpd?.args[0]).toBe('user-target');
   });
 
   it('target_user_id 누락 → 400', async () => {
     const app = buildApp('google-owner');
-    const res = await app.request(
-      jsonReq('POST', '/family/groups/group-1/transfer-ownership', {}),
-    );
+    const res = await app.request(jsonReq('POST', '/family/groups/group-1/transfer-ownership', {}));
     expect(res.status).toBe(400);
   });
 
@@ -532,9 +522,7 @@ describe('DELETE /family/groups/:groupId/members/:userId', () => {
 describe('POST /family/invites/:code/revoke', () => {
   it('발급자 + pending → 200, status=revoked', async () => {
     mockDB.pushResult([{ id: 'user-owner' }]);
-    mockDB.pushResult([
-      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' },
-    ]);
+    mockDB.pushResult([{ id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' }]);
     mockDB.pushResult([], 1);
 
     const app = buildApp('google-owner');
@@ -546,9 +534,7 @@ describe('POST /family/invites/:code/revoke', () => {
 
   it('발급자가 아니면 → 403', async () => {
     mockDB.pushResult([{ id: 'user-other' }]);
-    mockDB.pushResult([
-      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' },
-    ]);
+    mockDB.pushResult([{ id: 'inv-1', inviter_user_id: 'user-owner', status: 'pending' }]);
 
     const app = buildApp('google-other');
     const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/revoke`));
@@ -557,9 +543,7 @@ describe('POST /family/invites/:code/revoke', () => {
 
   it('pending 이 아닌 상태 (used 등) → 409', async () => {
     mockDB.pushResult([{ id: 'user-owner' }]);
-    mockDB.pushResult([
-      { id: 'inv-1', inviter_user_id: 'user-owner', status: 'used' },
-    ]);
+    mockDB.pushResult([{ id: 'inv-1', inviter_user_id: 'user-owner', status: 'used' }]);
 
     const app = buildApp('google-owner');
     const res = await app.request(jsonReq('POST', `/family/invites/${VALID_CODE}/revoke`));
@@ -577,13 +561,15 @@ describe('POST /family/alarms (text mode)', () => {
     };
   }
 
-  function queueHappyPath(opts: {
-    senderPk?: string;
-    recipientPk?: string;
-    recipientGoogleId?: string;
-    allowFamily?: number;
-    voiceProfileId?: string | null;
-  } = {}) {
+  function queueHappyPath(
+    opts: {
+      senderPk?: string;
+      recipientPk?: string;
+      recipientGoogleId?: string;
+      allowFamily?: number;
+      voiceProfileId?: string | null;
+    } = {},
+  ) {
     const senderPk = opts.senderPk ?? 'user-sender';
     const recipientPk = opts.recipientPk ?? 'user-recipient';
     const recipientGoogleId = opts.recipientGoogleId ?? 'google-recipient';
@@ -606,7 +592,9 @@ describe('POST /family/alarms (text mode)', () => {
   it('정상 — 수신자 가장 최근 voice_profile 자동 선택', async () => {
     queueHappyPath();
     const app = buildApp('google-sender');
-    const res = await app.request(jsonReq('POST', '/family/alarms', validBody({ repeat_days: [1, 3, 5] })));
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms', validBody({ repeat_days: [1, 3, 5] })),
+    );
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.alarm.voice_profile_id).toBe('vp-recipient-1');
@@ -698,11 +686,7 @@ describe('POST /family/alarms (text mode)', () => {
   it('wake_at 포맷 오류 → 400', async () => {
     const app = buildApp('google-sender');
     const res = await app.request(
-      jsonReq(
-        'POST',
-        '/family/alarms',
-        validBody({ wake_at: '7:30 AM' }),
-      ),
+      jsonReq('POST', '/family/alarms', validBody({ wake_at: '7:30 AM' })),
     );
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -738,9 +722,7 @@ describe('POST /family/alarms (text mode)', () => {
   it('자기 자신에게 보내면 → 400', async () => {
     mockDB.pushResult([{ id: 'user-recipient' }]); // sender pk == recipient pk
     const app = buildApp('google-recipient');
-    const res = await app.request(
-      jsonReq('POST', '/family/alarms', validBody()),
-    );
+    const res = await app.request(jsonReq('POST', '/family/alarms', validBody()));
     expect(res.status).toBe(400);
   });
 });
@@ -755,13 +737,15 @@ describe('POST /family/alarms/voice', () => {
     };
   }
 
-  function queueVoiceHappyPath(opts: {
-    allowFamily?: number;
-    dub?: boolean;
-    noVoiceProfile?: boolean;
-    uploadOwner?: string;
-    uploadMissing?: boolean;
-  } = {}) {
+  function queueVoiceHappyPath(
+    opts: {
+      allowFamily?: number;
+      dub?: boolean;
+      noVoiceProfile?: boolean;
+      uploadOwner?: string;
+      uploadMissing?: boolean;
+    } = {},
+  ) {
     mockDB.pushResult([{ id: 'user-sender' }]); // sender pk
     mockDB.pushResult([{ plan_group_id: 'group-1' }]); // sender groups
     mockDB.pushResult([{ plan_group_id: 'group-1' }]); // recipient groups
@@ -796,7 +780,9 @@ describe('POST /family/alarms/voice', () => {
   it('정상 — 더빙 없음, audio_url 에 object_key 채움', async () => {
     queueVoiceHappyPath();
     const app = buildApp('google-sender');
-    const res = await app.request(jsonReq('POST', '/family/alarms/voice', voiceBody({ repeat_days: [0, 6] })));
+    const res = await app.request(
+      jsonReq('POST', '/family/alarms/voice', voiceBody({ repeat_days: [0, 6] })),
+    );
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.alarm.mode).toBe('sound-only');

--- a/packages/backend/test/invites.test.ts
+++ b/packages/backend/test/invites.test.ts
@@ -11,33 +11,35 @@ import {
 } from '../src/lib/invites';
 
 describe('generateInviteCode', () => {
-  it('INV-6자리 숫자 문자열을 반환한다', () => {
+  it('INV-XXXX-XXXX-XXXX 형식의 문자열을 반환한다', () => {
     const code = generateInviteCode();
     expect(code).toHaveLength(INVITE_CODE_LENGTH);
-    expect(/^INV-[0-9]{6}$/.test(code)).toBe(true);
+    expect(
+      /^INV-[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{4}-[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{4}-[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{4}$/.test(
+        code,
+      ),
+    ).toBe(true);
   });
 
   it('연속 호출 시 서로 다른 코드를 주로 생성한다 (통계적 고유성)', () => {
     const set = new Set<string>();
     for (let i = 0; i < 200; i++) set.add(generateInviteCode());
-    // 200건 중 최소 150건 이상은 유니크해야 한다 (6자리 = 100만 경우의 수)
+    // 12자리 영숫자 코드라 200건 중 대부분은 유니크해야 한다.
     expect(set.size).toBeGreaterThanOrEqual(150);
   });
 
-  it('leading zero 를 허용한다 — 문자열로 유지', () => {
-    let sawLeadingZero = false;
-    for (let i = 0; i < 500; i++) {
-      if (generateInviteCode().slice(4).startsWith('0')) {
-        sawLeadingZero = true;
-        break;
-      }
+  it('시각적으로 헷갈리는 문자는 생성하지 않는다', () => {
+    for (let i = 0; i < 100; i++) {
+      const body = generateInviteCode().replace(/^INV-/, '').replace(/-/g, '');
+      expect(body).not.toMatch(/[0O1IL]/);
     }
-    expect(sawLeadingZero).toBe(true);
   });
 });
 
 describe('isValidInviteCodeFormat', () => {
-  it('INV-6자리 숫자와 레거시 6자리 숫자를 true로 본다', () => {
+  it('INV-XXXX-XXXX-XXXX와 레거시 6자리 숫자를 true로 본다', () => {
+    expect(isValidInviteCodeFormat('INV-ABCD-1234-EFGH')).toBe(true);
+    expect(isValidInviteCodeFormat('invabcd1234efgh')).toBe(true);
     expect(isValidInviteCodeFormat('INV-123456')).toBe(true);
     expect(isValidInviteCodeFormat('inv123456')).toBe(true);
     expect(isValidInviteCodeFormat('123456')).toBe(true);
@@ -45,6 +47,8 @@ describe('isValidInviteCodeFormat', () => {
   });
 
   it('길이가 다르거나 문자가 섞이면 false', () => {
+    expect(isValidInviteCodeFormat('INV-ABC-1234-EFGH')).toBe(false);
+    expect(isValidInviteCodeFormat('INV-ABCDE-1234-EFGH')).toBe(false);
     expect(isValidInviteCodeFormat('INV-12345')).toBe(false);
     expect(isValidInviteCodeFormat('INV-12345A')).toBe(false);
     expect(isValidInviteCodeFormat('12345')).toBe(false);
@@ -56,6 +60,8 @@ describe('isValidInviteCodeFormat', () => {
 
 describe('normalizeInviteCode', () => {
   it('태그형 코드를 서버 저장 형식으로 정규화한다', () => {
+    expect(normalizeInviteCode(' invabcd1234efgh ')).toBe('INV-ABCD-1234-EFGH');
+    expect(normalizeInviteCode('inv-abcd-1234-efgh')).toBe('INV-ABCD-1234-EFGH');
     expect(normalizeInviteCode(' inv123456 ')).toBe('INV-123456');
     expect(normalizeInviteCode('inv-123456')).toBe('INV-123456');
     expect(normalizeInviteCode('123456')).toBe('123456');
@@ -64,10 +70,14 @@ describe('normalizeInviteCode', () => {
 
 describe('buildInviteDeepLink / buildInviteWebUrl', () => {
   it('딥링크는 voicealarm 스킴 + /invite/{code}', () => {
-    expect(buildInviteDeepLink('INV-123456')).toBe('voicealarm://invite/INV-123456');
+    expect(buildInviteDeepLink('INV-ABCD-1234-EFGH')).toBe(
+      'voicealarm://invite/INV-ABCD-1234-EFGH',
+    );
   });
   it('웹 URL 은 voicealarm.pages.dev 호스트 + /invite/{code}', () => {
-    expect(buildInviteWebUrl('INV-123456')).toBe('https://voicealarm.pages.dev/invite/INV-123456');
+    expect(buildInviteWebUrl('INV-ABCD-1234-EFGH')).toBe(
+      'https://voicealarm.pages.dev/invite/INV-ABCD-1234-EFGH',
+    );
   });
 });
 

--- a/packages/backend/test/invites.test.ts
+++ b/packages/backend/test/invites.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   generateInviteCode,
   isValidInviteCodeFormat,
+  normalizeInviteCode,
   buildInviteDeepLink,
   buildInviteWebUrl,
   computeInviteExpiresAt,
@@ -10,10 +11,10 @@ import {
 } from '../src/lib/invites';
 
 describe('generateInviteCode', () => {
-  it('6자리 숫자 문자열을 반환한다', () => {
+  it('INV-6자리 숫자 문자열을 반환한다', () => {
     const code = generateInviteCode();
     expect(code).toHaveLength(INVITE_CODE_LENGTH);
-    expect(/^[0-9]{6}$/.test(code)).toBe(true);
+    expect(/^INV-[0-9]{6}$/.test(code)).toBe(true);
   });
 
   it('연속 호출 시 서로 다른 코드를 주로 생성한다 (통계적 고유성)', () => {
@@ -26,7 +27,7 @@ describe('generateInviteCode', () => {
   it('leading zero 를 허용한다 — 문자열로 유지', () => {
     let sawLeadingZero = false;
     for (let i = 0; i < 500; i++) {
-      if (generateInviteCode().startsWith('0')) {
+      if (generateInviteCode().slice(4).startsWith('0')) {
         sawLeadingZero = true;
         break;
       }
@@ -36,26 +37,37 @@ describe('generateInviteCode', () => {
 });
 
 describe('isValidInviteCodeFormat', () => {
-  it('정확히 6자리 숫자만 true', () => {
+  it('INV-6자리 숫자와 레거시 6자리 숫자를 true로 본다', () => {
+    expect(isValidInviteCodeFormat('INV-123456')).toBe(true);
+    expect(isValidInviteCodeFormat('inv123456')).toBe(true);
     expect(isValidInviteCodeFormat('123456')).toBe(true);
     expect(isValidInviteCodeFormat('000001')).toBe(true);
   });
 
   it('길이가 다르거나 문자가 섞이면 false', () => {
+    expect(isValidInviteCodeFormat('INV-12345')).toBe(false);
+    expect(isValidInviteCodeFormat('INV-12345A')).toBe(false);
     expect(isValidInviteCodeFormat('12345')).toBe(false);
     expect(isValidInviteCodeFormat('1234567')).toBe(false);
     expect(isValidInviteCodeFormat('12345a')).toBe(false);
     expect(isValidInviteCodeFormat('')).toBe(false);
-    expect(isValidInviteCodeFormat(' 123456')).toBe(false);
+  });
+});
+
+describe('normalizeInviteCode', () => {
+  it('태그형 코드를 서버 저장 형식으로 정규화한다', () => {
+    expect(normalizeInviteCode(' inv123456 ')).toBe('INV-123456');
+    expect(normalizeInviteCode('inv-123456')).toBe('INV-123456');
+    expect(normalizeInviteCode('123456')).toBe('123456');
   });
 });
 
 describe('buildInviteDeepLink / buildInviteWebUrl', () => {
   it('딥링크는 voicealarm 스킴 + /invite/{code}', () => {
-    expect(buildInviteDeepLink('123456')).toBe('voicealarm://invite/123456');
+    expect(buildInviteDeepLink('INV-123456')).toBe('voicealarm://invite/INV-123456');
   });
   it('웹 URL 은 voicealarm.pages.dev 호스트 + /invite/{code}', () => {
-    expect(buildInviteWebUrl('123456')).toBe('https://voicealarm.pages.dev/invite/123456');
+    expect(buildInviteWebUrl('INV-123456')).toBe('https://voicealarm.pages.dev/invite/INV-123456');
   });
 });
 

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -18,6 +18,11 @@ export const LoginRequestSchema = z.object({
 });
 export type LoginRequest = z.infer<typeof LoginRequestSchema>;
 
+export const GoogleLoginRequestSchema = z.object({
+  id_token: z.string().min(1),
+});
+export type GoogleLoginRequest = z.infer<typeof GoogleLoginRequestSchema>;
+
 export const AuthResponseSchema = z.object({
   token: z.string().min(1),
   user: z.object({


### PR DESCRIPTION
## 작업 내용
- 음성 프로필 등록 화면에 30초~1분 안내, 기본 이름, 공유 여부, 파일 구간 선택/미리듣기를 추가했습니다.
- 알람 설정의 녹음/파일 UI를 공통 컴포넌트로 재사용하고, 파일은 최대 30초 구간을 직접 고를 수 있게 했습니다.
- 다시 울림 간격과 반복 횟수를 한 모달에서 설정하도록 로컬 DB와 UI를 확장했습니다.
- 구독, 코드 등록, 메시지 화면 문구와 노출 요소를 정리하고 하단바에 메시지를 추가했습니다.
- 공유 허용된 음성만 가족 음성 목록에 노출되도록 백엔드 마이그레이션과 API를 수정했습니다.

## 검증
- `./gradlew.bat :app:assembleDebug`
- `./gradlew.bat :app:testDebugUnitTest`
- `npm run typecheck --workspace packages/backend`
- `npm test --workspace packages/backend`
- 연결된 Android 기기에 debug APK 설치 및 앱 실행

Closes #229