### PR TITLE
feat: 스낵바 알람 정돈 + 디자인 개선

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -6,13 +6,25 @@ import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -23,7 +35,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
@@ -200,7 +217,11 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                PrettySnackbar(message = data.visuals.message)
+            }
+        },
         bottomBar = {
             if (screen is AlarmScreen.List) {
                 VoiceAlarmBottomBar(
@@ -292,6 +313,57 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onSave = { draft ->
                     viewModel.updateAlarm(current.alarm.id, draft) { screen = AlarmScreen.List }
                 },
+            )
+        }
+    }
+}
+
+private enum class MessageSeverity { Success, Error, Info }
+
+private fun messageSeverity(text: String): MessageSeverity = when {
+    "실패" in text || "못했어요" in text || "오류" in text -> MessageSeverity.Error
+    "했어요" in text || "었어요" in text || "완료" in text -> MessageSeverity.Success
+    else -> MessageSeverity.Info
+}
+
+@Composable
+private fun PrettySnackbar(message: String) {
+    val severity = messageSeverity(message)
+    val scheme = MaterialTheme.colorScheme
+    val containerColor = when (severity) {
+        MessageSeverity.Error -> scheme.error
+        MessageSeverity.Success -> scheme.secondary
+        MessageSeverity.Info -> scheme.primaryContainer
+    }
+    val contentColor = when (severity) {
+        MessageSeverity.Error -> scheme.onError
+        MessageSeverity.Success -> scheme.onSecondary
+        MessageSeverity.Info -> scheme.onPrimaryContainer
+    }
+    val iconVector = when (severity) {
+        MessageSeverity.Error -> Icons.Outlined.ErrorOutline
+        MessageSeverity.Success -> Icons.Outlined.CheckCircle
+        MessageSeverity.Info -> Icons.Outlined.Info
+    }
+    Snackbar(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .shadow(elevation = 12.dp, shape = RoundedCornerShape(20.dp), clip = false),
+        shape = RoundedCornerShape(20.dp),
+        containerColor = containerColor,
+        contentColor = contentColor,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = iconVector,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(22.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = message,
+                fontWeight = FontWeight.Medium,
             )
         }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -76,7 +76,6 @@ private fun MainViewModel.refreshCharacterAndBillingData(showMessage: Boolean) {
             characterResponse = snapshot.character
             subscriptionResponse = snapshot.subscription
             vouchers = snapshot.vouchers
-            if (showMessage) message = "캐릭터와 플랜 정보를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to load character or billing", error)
             if (showMessage) message = userFacingError(error, "성장 정보를 불러오지 못했어요")
@@ -133,7 +132,6 @@ internal fun MainViewModel.refreshNotes() {
             api.listReceivedNotes(authorization, limit = 20, offset = 0).notes
         }.onSuccess { notes ->
             receivedNotes = notes
-            message = "받은 메시지 ${notes.size}개를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to refresh notes", error)
             message = userFacingError(error, "음성 메시지를 불러오지 못했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
@@ -84,7 +84,6 @@ private fun MainViewModel.refreshSocialData(showMessage: Boolean) {
             familyGroup = snapshot.familyGroup
             familyInvites = snapshot.familyInvites
             familyVoices = snapshot.familyVoices
-            if (showMessage) message = "커플/가족 정보를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to refresh social data", error)
             if (showMessage) message = userFacingError(error, "커플/가족 정보를 불러오지 못했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -75,7 +75,6 @@ internal fun MainViewModel.fetchVoiceProfiles(showMessage: Boolean) {
             api.listVoiceProfiles(VoiceAlarmApiClient.bearer(session.token)).profiles
         }.onSuccess { profiles ->
             voiceProfiles = profiles
-            if (showMessage) message = "음성 프로필 ${profiles.size}개를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to load voice profiles", error)
             if (showMessage) message = userFacingError(error, "음성 프로필을 불러오지 못했어요")
@@ -273,7 +272,6 @@ internal fun MainViewModel.loadTtsMessages() {
             api.listTtsMessages(VoiceAlarmApiClient.bearer(session.token)).messages
         }.onSuccess { messages ->
             ttsMessages = messages
-            message = "저장된 음성 ${messages.size}개를 불러왔어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to load saved TTS messages", error)
             message = userFacingError(error, "저장된 음성을 불러오지 못했어요")


### PR DESCRIPTION
closes #237

## 작업 내용
앱에서 데이터 로딩 시 매번 토스트 띄우는 게 노이즈라 제거하고, 기본 회색 스낵바도 디자인 손봤어요.

### 1. 불필요한 로딩 알람 제거 (5곳)
정보 fetch 성공 → 토스트는 제거. 사용자 액션 결과/에러만 알람으로 띄움.

| 파일 | 제거된 메시지 |
|---|---|
| \`MainViewModelGrowthBillingActions.kt\` | "캐릭터와 플랜 정보를 불러왔어요" |
| \`MainViewModelGrowthBillingActions.kt\` | "받은 메시지 N개를 불러왔어요" |
| \`MainViewModelSocialActions.kt\` | "커플/가족 정보를 불러왔어요" |
| \`MainViewModelVoiceActions.kt\` | "음성 프로필 N개를 불러왔어요" |
| \`MainViewModelVoiceActions.kt\` | "저장된 음성 N개를 불러왔어요" |

유지: 동기화 결과("동기화 완료: 생성 X 수정 Y..."), 코드 등록, 로그인/로그아웃, 알람 저장/삭제, 모든 에러.

### 2. 스낵바 디자인 개선
\`VoiceAlarmApp.kt\` 내부에 \`PrettySnackbar\` 컴포저블 추가. 메시지 텍스트의 키워드로 종류 자동 판별.

| 종류 | 판별 키워드 | 컨테이너 | 아이콘 |
|---|---|---|---|
| 에러 | "실패", "못했어요", "오류" | \`error\` (와인) | ErrorOutline |
| 성공 | "했어요", "었어요", "완료" | \`secondary\` (네이비) | CheckCircle |
| 정보 | 그 외 ("로그인해 주세요" 등) | \`primaryContainer\` (머스타드) | Info |

기타: 모서리 라운드 20dp, 그림자 12dp, 좌우 16dp 여백, Medium weight 텍스트.

## 테스트
- 에뮬레이터(\`Pixel_7_API_34\`)에서 빌드/설치/재실행 OK
- 앱 새로고침 시 로딩 토스트 안 뜨는 거 확인
- 알람 저장(성공) / 잘못된 액션(에러) / 비로그인 액션(정보) 시 색상 다르게 표시되는 거 확인

## 영향 범위
- 모듈: \`apps/android-native\`
- 알람 동작 자체엔 영향 없음 (UI/메시지 노출 정책만 변경)