### PR TITLE
fix: 수신 알람 동기화 누락과 로그인 직후 권한 요청 보정

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -396,8 +396,12 @@ class AlarmRepository(
     suspend fun syncWithBackend(api: VoiceAlarmApi, token: String): AlarmSyncResult =
         alarmSyncService.syncWithBackend(api, token)
 
-    suspend fun pullReceivedAlarms(api: VoiceAlarmApi, token: String): RemoteAlarmPullResult =
-        remoteAlarmPullSyncService.pullReceivedAlarms(api, token)
+    suspend fun pullReceivedAlarms(
+        api: VoiceAlarmApi,
+        token: String,
+        myUserId: String,
+    ): RemoteAlarmPullResult =
+        remoteAlarmPullSyncService.pullReceivedAlarms(api, token, myUserId)
 
     suspend fun syncCharacterEvents(api: VoiceAlarmApi, token: String): CharacterEventSyncResult =
         characterEventSyncService.sync(api, token)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
@@ -22,10 +22,24 @@ internal class RemoteAlarmPullSyncService(
     private val alarmScheduler: AlarmScheduler,
     private val alarmAudioStore: AlarmAudioStore,
 ) {
-    suspend fun pullReceivedAlarms(api: VoiceAlarmApi, token: String): RemoteAlarmPullResult {
+    suspend fun pullReceivedAlarms(
+        api: VoiceAlarmApi,
+        token: String,
+        myUserId: String,
+    ): RemoteAlarmPullResult {
         val authorization = VoiceAlarmApiClient.bearer(token)
+        // 서버는 user_id IN (...) OR target_user_id IN (...) 로 이미 스코프해서 보내준다.
+        // 그중 "내가 만든 게 아니라 누군가가 나를 target 으로 만든" 알람만 가져온다.
+        // 기존에는 isReceivedFamilyAlarm(=family/family-voice 카테고리)로 좁혀져 있어서
+        // 일반 /api/alarm 경로(target_user_id 포함)로 보낸 알람이 누락됐다.
         val remoteAlarms = api.listAlarms(authorization).alarms
-            .filter { it.isReceivedFamilyAlarm }
+            .filter { remote ->
+                val sender = remote.senderUserId
+                val target = remote.targetUserId
+                !target.isNullOrBlank() &&
+                    !sender.isNullOrBlank() &&
+                    sender != myUserId
+            }
 
         var imported = 0
         var updated = 0
@@ -48,10 +62,15 @@ internal class RemoteAlarmPullSyncService(
                 if (existing != null) {
                     alarmScheduler.cancel(existing.id)
                 }
-                if (local.enabled) {
-                    alarmScheduler.schedule(local)
-                }
+                // upsert 를 먼저. schedule 이 권한 부족 등으로 throw 해도 알람은
+                // 로컬 DB 에 남아 리스트에 표시되고, 권한 받은 뒤 reschedule 가능.
                 alarmDao.upsert(local)
+                if (local.enabled) {
+                    runCatching { alarmScheduler.schedule(local) }
+                        .onFailure { error ->
+                            Log.w(TAG, "Saved received alarm but failed to schedule id=${local.id}", error)
+                        }
+                }
                 if (existing == null) imported += 1 else updated += 1
             }.onFailure { error ->
                 failed += 1

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/sync/RemoteAlarmSyncWorker.kt
@@ -18,7 +18,7 @@ class RemoteAlarmSyncWorker(
         return runCatching {
             val api = VoiceAlarmApiClient.create()
             val result = AlarmAppContainer.repository(applicationContext)
-                .pullReceivedAlarms(api, session.token)
+                .pullReceivedAlarms(api, session.token, session.user.id)
             Log.i(
                 TAG,
                 "Remote alarm worker complete total=${result.total} imported=${result.imported} updated=${result.updated} failed=${result.failed}",

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/LoginPermissionGate.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/LoginPermissionGate.kt
@@ -1,0 +1,133 @@
+package com.voicealarm.nativeapp
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.voicealarm.nativeapp.network.AuthSession
+
+private enum class SpecialPermissionStep { None, ExactAlarm, FullScreenIntent }
+
+/**
+ * 로그인 직후 한 번 권한을 모아서 요청한다.
+ *  1) 런타임 권한 (POST_NOTIFICATIONS, RECORD_AUDIO) → 시스템 다이얼로그
+ *  2) SCHEDULE_EXACT_ALARM (Android 12+)            → 설정 화면 안내 다이얼로그
+ *  3) USE_FULL_SCREEN_INTENT (Android 14+)         → 설정 화면 안내 다이얼로그
+ *
+ * 이미 허용된 권한은 건너뛴다. 사용자가 "나중에" 를 누르면 그 세션에선 더 묻지 않는다.
+ */
+@Composable
+internal fun LoginPermissionGate(authSession: AuthSession?) {
+    val context = LocalContext.current
+    var lastHandledToken by remember { mutableStateOf<String?>(null) }
+    var step by remember { mutableStateOf(SpecialPermissionStep.None) }
+
+    val runtimePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) {
+        // 런타임 권한 결과와 무관하게 다음 단계로 진행한다. 거부했어도 알람 자체는 동작.
+        step = nextSpecialStep(context, SpecialPermissionStep.None)
+    }
+
+    LaunchedEffect(authSession?.token) {
+        val token = authSession?.token
+        if (token == null) {
+            lastHandledToken = null
+            step = SpecialPermissionStep.None
+            return@LaunchedEffect
+        }
+        if (token == lastHandledToken) return@LaunchedEffect
+        lastHandledToken = token
+
+        val needed = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            needed += Manifest.permission.POST_NOTIFICATIONS
+        }
+        if (
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            needed += Manifest.permission.RECORD_AUDIO
+        }
+
+        if (needed.isNotEmpty()) {
+            runtimePermissionLauncher.launch(needed.toTypedArray())
+        } else {
+            step = nextSpecialStep(context, SpecialPermissionStep.None)
+        }
+    }
+
+    when (step) {
+        SpecialPermissionStep.ExactAlarm -> AlertDialog(
+            onDismissRequest = { step = SpecialPermissionStep.None },
+            title = { Text("정확한 알람 권한 필요") },
+            text = {
+                Text(
+                    "알람이 정해진 시간에 정확하게 울리려면 권한이 필요해요. " +
+                        "‘설정으로 이동’ 을 눌러 ‘알람 및 리마인더’ 를 허용해 주세요.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    context.openExactAlarmSettings()
+                    step = nextSpecialStep(context, SpecialPermissionStep.ExactAlarm)
+                }) { Text("설정으로 이동") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    step = nextSpecialStep(context, SpecialPermissionStep.ExactAlarm)
+                }) { Text("나중에") }
+            },
+        )
+
+        SpecialPermissionStep.FullScreenIntent -> AlertDialog(
+            onDismissRequest = { step = SpecialPermissionStep.None },
+            title = { Text("전체 화면 알림 권한") },
+            text = {
+                Text(
+                    "화면이 잠겨 있어도 알람 화면이 잘 뜨도록 권한이 필요해요. " +
+                        "‘설정으로 이동’ 을 눌러 허용해 주세요.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    context.openFullScreenIntentSettings()
+                    step = SpecialPermissionStep.None
+                }) { Text("설정으로 이동") }
+            },
+            dismissButton = {
+                TextButton(onClick = { step = SpecialPermissionStep.None }) { Text("나중에") }
+            },
+        )
+
+        SpecialPermissionStep.None -> Unit
+    }
+}
+
+private fun nextSpecialStep(
+    context: android.content.Context,
+    after: SpecialPermissionStep,
+): SpecialPermissionStep {
+    if (after == SpecialPermissionStep.None && !context.canScheduleExactAlarms()) {
+        return SpecialPermissionStep.ExactAlarm
+    }
+    if (after <= SpecialPermissionStep.ExactAlarm && !context.canUseFullScreenIntent()) {
+        return SpecialPermissionStep.FullScreenIntent
+    }
+    return SpecialPermissionStep.None
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -85,6 +85,8 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         viewModel.clearMessage()
     }
 
+    LoginPermissionGate(authSession = authSession)
+
     LaunchedEffect(authSession?.token) {
         if (authSession != null) {
             viewModel.preloadVoiceProfiles()

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -137,7 +137,7 @@ internal fun MainViewModel.syncNow() {
         syncBusy = true
         runCatching {
             val push = repository.syncWithBackend(api, session.token)
-            val pull = repository.pullReceivedAlarms(api, session.token)
+            val pull = repository.pullReceivedAlarms(api, session.token, session.user.id)
             push to pull
         }.onSuccess { (push, pull) ->
             message = "동기화 완료: 생성 ${push.created}개, 수정 ${push.updated}개, 수신 ${pull.imported + pull.updated}개, 실패 ${push.failed + pull.failed}개"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -1,6 +1,8 @@
 package com.voicealarm.nativeapp
 
+import android.app.AlarmManager
 import android.app.Application
+import android.app.NotificationManager
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
@@ -26,6 +28,18 @@ import java.time.format.DateTimeFormatter
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
+
+internal fun Context.canScheduleExactAlarms(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+    val am = getSystemService(AlarmManager::class.java) ?: return false
+    return am.canScheduleExactAlarms()
+}
+
+internal fun Context.canUseFullScreenIntent(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return true
+    val nm = getSystemService(NotificationManager::class.java) ?: return false
+    return nm.canUseFullScreenIntent()
+}
 
 internal fun Context.openExactAlarmSettings() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return


### PR DESCRIPTION
## 요약

- 다른 사용자가 보낸 알람이 안드로이드에 들어오지 않던 문제 수정
- 로그인 직후 알람 동작에 필요한 권한을 한 번에 안내하는 단계 추가

Closes #239

## 변경 사항

### 1) 수신 알람 풀 동기화 필터 확장

`RemoteAlarmPullSyncService` 가 `isReceivedFamilyAlarm` (= family/family-voice 카테고리) 알람만 가져오고 있어서, 일반 \`/api/alarm\` 경로로 \`target_user_id\` 만 채워서 보낸 알람이 누락됐음.

서버는 이미 \`user_id IN (...) OR target_user_id IN (...)\` 로 스코프해서 내려주므로, 클라에선 "내가 만든 게 아니고 (sender != myUserId) target 이 비어있지 않은" 알람을 모두 수신 알람으로 다루도록 변경.

- `AlarmRepository.pullReceivedAlarms` / `RemoteAlarmSyncWorker` / `MainViewModel.syncNow` 시그니처에 `myUserId` 전달

### 2) schedule 실패 시 알람 보존

기존: `alarmScheduler.schedule(local)` → `alarmDao.upsert(local)` 순서. 정확한 알람 / Full screen intent 권한이 없으면 schedule 단계에서 throw → DB 에도 안 남아 리스트에 표시조차 안 됐음.

변경: `upsert` 를 먼저 호출하고 `schedule` 은 `runCatching` 으로 감싸 실패는 로그만 남김. 알람은 보존되고 권한 받은 뒤 reschedule 가능.

### 3) 로그인 직후 권한 요청 단계 추가

`LoginPermissionGate` 컴포저블을 `VoiceAlarmApp` 에 부착. authSession 토큰 변화 시 한 번에 처리.

1. 런타임 권한 — `POST_NOTIFICATIONS` (13+), `RECORD_AUDIO`
2. `SCHEDULE_EXACT_ALARM` (Android 12+) — 설정 화면 안내 다이얼로그
3. `USE_FULL_SCREEN_INTENT` (Android 14+) — 설정 화면 안내 다이얼로그

이미 허용된 항목은 건너뛰고, "나중에" 누르면 같은 세션에선 재차 묻지 않음.

`Context.canScheduleExactAlarms()` / `Context.canUseFullScreenIntent()` 헬퍼로 SDK 분기 캡슐화.

## 검증 체크리스트

- [ ] 다른 계정에서 알람을 \`target_user_id\` 로 보냈을 때 수신측 기기에 알람이 나타나는지
- [ ] 정확한 알람 권한이 꺼진 상태에서도 알람이 로컬 리스트에 보이는지 (schedule 실패해도 보존)
- [ ] 안드로이드 12 / 13 / 14 각 버전에서 권한 게이트 흐름이 정상인지
- [ ] 이미 모든 권한이 허용된 상태에서 다시 로그인했을 때 다이얼로그가 안 뜨는지

## 비고

`AGENTS.md` 의 알람 동작 규칙(로컬 DB + 로컬 오디오 기반, 푸시/서버 크론 의존 금지)을 깨지 않는 범위의 수정.