### PR TITLE
feat: 프로필/계정 관리 + 설정 페이지 도입 (#241)

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/MainActivity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/MainActivity.kt
@@ -4,14 +4,16 @@ import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContent {
-            VoiceAlarmTheme {
-                VoiceAlarmApp()
+            val viewModel: MainViewModel = viewModel()
+            VoiceAlarmTheme(themeMode = viewModel.themeMode) {
+                VoiceAlarmApp(viewModel = viewModel)
             }
         }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
@@ -2,8 +2,10 @@ package com.voicealarm.nativeapp.network
 
 import com.google.gson.annotations.SerializedName
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 
 data class AuthUser(
@@ -37,6 +39,19 @@ data class GoogleLoginRequest(
     @SerializedName("id_token") val idToken: String,
 )
 
+data class UpdateProfileRequest(
+    val name: String? = null,
+)
+
+data class UpdateProfileResponse(
+    val success: Boolean,
+    val name: String? = null,
+)
+
+data class DeleteAccountResponse(
+    val success: Boolean,
+)
+
 interface AuthApi {
     @POST("auth/register")
     suspend fun register(@Body request: RegisterRequest): AuthTokenResponse
@@ -49,4 +64,13 @@ interface AuthApi {
 
     @GET("auth/me")
     suspend fun me(@Header("Authorization") authorization: String): AuthMeResponse
+
+    @PATCH("user/me")
+    suspend fun updateProfile(
+        @Header("Authorization") authorization: String,
+        @Body request: UpdateProfileRequest,
+    ): UpdateProfileResponse
+
+    @DELETE("user/me")
+    suspend fun deleteAccount(@Header("Authorization") authorization: String): DeleteAccountResponse
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthSessionStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthSessionStore.kt
@@ -68,6 +68,9 @@ class AuthSessionStore(context: Context) {
         prefs.edit().clear().apply()
     }
 
+    fun save(session: AuthSession): AuthSession =
+        save(token = session.token, provider = session.provider, user = session.user)
+
     private fun save(token: String, provider: String, user: AuthUser): AuthSession {
         prefs.edit()
             .putString(KEY_TOKEN, token)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
@@ -41,6 +41,7 @@ data class VoucherItem(
     @SerializedName("plan_name") val planName: String,
     @SerializedName("plan_type") val planType: String,
     val status: String,
+    @SerializedName("issued_at") val issuedAt: String? = null,
     @SerializedName("expires_at") val expiresAt: String,
 )
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -102,15 +102,7 @@ internal fun AlarmListScreen(
     ) {
         when (selectedTab) {
             NativeTab.Home -> {
-                item {
-                    HomeHeader(
-                        authSession = authSession,
-                        syncBusy = syncBusy,
-                        onSelectTab = onSelectTab,
-                        onSyncNow = onSyncNow,
-                        onLogout = onLogout,
-                    )
-                }
+                item { HomeHeader() }
                 item {
                     NextAlarmHeroCard(
                         nextAlarm = nextAlarm,
@@ -327,10 +319,7 @@ internal fun AlarmListScreen(
 
             NativeTab.Billing -> {
                 item {
-                    ScreenHeader(
-                        title = "구독",
-                        subtitle = "플랜을 확인하고 구매해요.",
-                    )
+                    ScreenHeader(title = "구독")
                 }
                 if (authSession == null) {
                     item {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -6,8 +6,10 @@ import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -77,6 +79,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     var selectedTab by remember { mutableStateOf(NativeTab.Home) }
     var tabBackStack by remember { mutableStateOf<List<NativeTab>>(emptyList()) }
     var planGateMessage by remember { mutableStateOf<String?>(null) }
+    val themeMode = viewModel.themeMode
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(message) {
@@ -98,10 +101,15 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     LaunchedEffect(selectedTab, authSession?.token) {
         if (authSession == null) return@LaunchedEffect
         when (selectedTab) {
+            NativeTab.Home -> {
+                viewModel.refreshCharacterAndBilling()
+                viewModel.refreshSocial()
+            }
             NativeTab.Voices -> {
                 viewModel.preloadVoiceProfiles()
                 viewModel.preloadSocial()
             }
+            NativeTab.Alarms -> viewModel.syncNow()
             NativeTab.People -> viewModel.refreshSocial()
             NativeTab.Messages -> {
                 viewModel.refreshSocial()
@@ -109,7 +117,6 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
             NativeTab.Growth,
             NativeTab.Billing -> viewModel.refreshCharacterAndBilling()
-            else -> Unit
         }
     }
 
@@ -190,6 +197,23 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         onBack = ::goBackInApp,
     )
 
+    if (viewModel.nicknameEditDialogOpen) {
+        NicknameEditDialog(
+            initial = authSession?.user?.name.orEmpty(),
+            busy = authBusy,
+            onDismiss = viewModel::dismissEditNickname,
+            onConfirm = viewModel::updateNickname,
+        )
+    }
+
+    if (viewModel.deleteAccountConfirmOpen) {
+        DeleteAccountConfirmDialog(
+            busy = authBusy,
+            onDismiss = viewModel::dismissDeleteAccount,
+            onConfirm = viewModel::deleteAccount,
+        )
+    }
+
     planGateMessage?.let { gateMessage ->
         AlertDialog(
             onDismissRequest = { planGateMessage = null },
@@ -233,6 +257,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
         },
     ) { padding ->
+      Box(modifier = Modifier.fillMaxSize()) {
         when (val current = screen) {
             AlarmScreen.List -> AlarmListScreen(
                 contentPadding = padding,
@@ -316,7 +341,35 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                     viewModel.updateAlarm(current.alarm.id, draft) { screen = AlarmScreen.List }
                 },
             )
+
+            AlarmScreen.Settings -> SettingsScreen(
+                contentPadding = padding,
+                authSession = authSession,
+                themeMode = themeMode,
+                onBack = ::goBackInApp,
+                onChangeTheme = viewModel::setThemeMode,
+                onEditNickname = viewModel::requestEditNickname,
+                onLogout = viewModel::logout,
+                onDeleteAccount = viewModel::requestDeleteAccount,
+            )
         }
+        if (screen is AlarmScreen.List) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(
+                        top = padding.calculateTopPadding() + 8.dp,
+                        end = 8.dp,
+                    ),
+            ) {
+                ProfileMenu(
+                    authSession = authSession,
+                    onSelectTab = ::navigateToTab,
+                    onOpenSettings = { screen = AlarmScreen.Settings },
+                )
+            }
+        }
+      }
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -61,30 +61,30 @@ internal fun SubscriptionPanel(
             SubscriptionPlanOption(
                 key = "free",
                 name = "무료",
-                price = "무료",
-                description = "일반 알람",
-                features = listOf("로컬 일반 알람", "스누즈", "반복 요일"),
+                price = "",
+                description = "",
+                features = listOf("일반 알람만 사용 가능", "캐릭터"),
             ),
             SubscriptionPlanOption(
                 key = "plus_personal",
                 name = "개인",
                 price = "월 4,900원",
                 description = "AI 음성 알람과 캐릭터",
-                features = listOf("AI 음성 프로필 2개", "TTS 알람", "캐릭터/스트릭"),
+                features = listOf("AI 음성 프로필 2개", "TTS 알람"),
             ),
             SubscriptionPlanOption(
                 key = "couple",
                 name = "커플",
                 price = "월 7,900원",
-                description = "두 사람이 음성과 메시지를 공유",
-                features = listOf("초대 코드", "공유 음성", "메시지", "최대 2명"),
+                description = "두 사람이 음성, 메시지 공유",
+                features = listOf("음성 공유 가능", "메시지 전송 가능", "최대 2명"),
             ),
             SubscriptionPlanOption(
                 key = "family",
                 name = "가족",
                 price = "월 9,900원",
-                description = "가족과 음성, 메시지를 공유",
-                features = listOf("초대 코드", "공유 음성", "메시지", "최대 6명"),
+                description = "가족이 음성, 메시지 공유",
+                features = listOf("음성 공유 가능", "메시지 전송 가능", "최대 6명"),
             ),
         )
     }
@@ -110,12 +110,6 @@ internal fun SubscriptionPanel(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(
-                text = "구독",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
-
             options.forEach { option ->
                 val isCurrent = if (option.key == "free") {
                     currentPlan == null
@@ -178,9 +172,15 @@ internal fun SubscriptionPanel(
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     shareTarget.forEach { voucher ->
+                        val issuedAtLabel = formatVoucherIssuedAt(voucher.issuedAt)
+                        val subtitle = if (issuedAtLabel != null) {
+                            "미등록 · 결제일 $issuedAtLabel"
+                        } else {
+                            "미등록"
+                        }
                         CompactActionRow(
                             title = voucher.code,
-                            subtitle = "${voucher.planName} · ${voucherStatusLabel(voucher.status)}",
+                            subtitle = subtitle,
                             actionLabel = "공유",
                             enabled = true,
                             onAction = {
@@ -235,18 +235,22 @@ internal fun SubscriptionPlanCard(
             ) {
                 Column {
                     Text(option.name, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        option.price,
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.primary,
-                        fontWeight = FontWeight.SemiBold,
-                    )
+                    if (option.price.isNotBlank()) {
+                        Text(
+                            option.price,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
                 }
                 if (isCurrent) {
                     AssistChip(onClick = {}, label = { Text("현재") })
                 }
             }
-            MutedText(option.description)
+            if (option.description.isNotBlank()) {
+                MutedText(option.description)
+            }
             option.features.forEach { feature ->
                 MutedText("• $feature")
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -7,6 +7,7 @@ import android.media.MediaPlayer
 import android.net.Uri
 import android.util.Base64
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -106,6 +107,13 @@ internal fun AlarmEditorScreen(
         audioMessage = null
     }
 
+    // 가족(상대방) 알람 등록 흐름의 핵심 안내는 카드 안 텍스트만으론 놓치기 쉬워
+    // 토스트로도 함께 띄운다. 알람만/음성만/둘다 모드 전부 동일.
+    fun showFamilyAlarmToast(message: String) {
+        if (!familyAlarmMode) return
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
     fun prepareSelectedAudio(uri: Uri) {
         scope.launch {
             runCatching {
@@ -187,6 +195,7 @@ internal fun AlarmEditorScreen(
             audioMessage = "알람을 받을 사람을 선택해 주세요"
             return
         }
+        showFamilyAlarmToast("상대방 알람을 등록했어요")
         onSave(
             draft.copy(
                 targetUserId = recipient.userId,
@@ -236,7 +245,9 @@ internal fun AlarmEditorScreen(
                 holidayOff = editor.holidayOff,
             )
             if (fireAtMillis - System.currentTimeMillis() < FAMILY_ALARM_MIN_LEAD_MILLIS) {
-                audioMessage = "상대방 알람은 최소 30분 이후로 설정해 주세요."
+                val message = "상대방 알람은 최소 30분 이후로 설정해 주세요."
+                audioMessage = message
+                showFamilyAlarmToast(message)
                 return
             }
         }
@@ -310,6 +321,7 @@ internal fun AlarmEditorScreen(
         scope.launch {
             isSaving = true
             audioMessage = "음성을 생성해서 저장하는 중..."
+            showFamilyAlarmToast("음성을 생성하는 중...")
             runCatching {
                 val response = onGenerateTts(
                     TtsGenerateRequest(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -17,6 +17,8 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -25,8 +27,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,13 +48,7 @@ import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.CharacterResponse
 
 @Composable
-internal fun HomeHeader(
-    authSession: AuthSession?,
-    syncBusy: Boolean,
-    onSelectTab: (NativeTab) -> Unit,
-    onSyncNow: () -> Unit,
-    onLogout: () -> Unit,
-) {
+internal fun HomeHeader() {
     val hour = java.time.LocalTime.now().hour
     val greeting = when {
         hour < 6 -> "좋은 밤이에요"
@@ -58,40 +57,27 @@ internal fun HomeHeader(
         hour < 21 -> "좋은 저녁이에요"
         else -> "좋은 밤이에요"
     }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = if (hour in 6..20) Icons.Outlined.Home else Icons.Outlined.Alarm,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.secondary,
-                )
-                Text(
-                    text = greeting,
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onBackground,
-                )
-            }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = if (hour in 6..20) Icons.Outlined.Home else Icons.Outlined.Alarm,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary,
+            )
             Text(
-                text = "소중한 사람의 목소리가 기다리고 있어요",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = greeting,
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
             )
         }
-        ProfileMenu(
-            authSession = authSession,
-            syncBusy = syncBusy,
-            onSelectTab = onSelectTab,
-            onSyncNow = onSyncNow,
-            onLogout = onLogout,
+        Text(
+            text = "소중한 사람의 목소리가 기다리고 있어요",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -99,15 +85,17 @@ internal fun HomeHeader(
 @Composable
 internal fun ProfileMenu(
     authSession: AuthSession?,
-    syncBusy: Boolean,
     onSelectTab: (NativeTab) -> Unit,
-    onSyncNow: () -> Unit,
-    onLogout: () -> Unit,
+    onOpenSettings: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box {
         IconButton(onClick = { expanded = true }) {
-            AvatarBubble(label = authSession?.user?.name ?: authSession?.user?.email)
+            Icon(
+                imageVector = Icons.Outlined.Person,
+                contentDescription = "프로필",
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
         }
         DropdownMenu(
             expanded = expanded,
@@ -136,10 +124,6 @@ internal fun ProfileMenu(
                 expanded = false
                 onSelectTab(NativeTab.People)
             }
-            ProfileMenuItem("음성 메시지") {
-                expanded = false
-                onSelectTab(NativeTab.Messages)
-            }
             ProfileMenuItem("캐릭터") {
                 expanded = false
                 onSelectTab(NativeTab.Growth)
@@ -149,15 +133,9 @@ internal fun ProfileMenu(
                 onSelectTab(NativeTab.Billing)
             }
             HorizontalDivider()
-            ProfileMenuItem(if (syncBusy) "동기화 중" else "지금 동기화") {
+            ProfileMenuItem("설정") {
                 expanded = false
-                onSyncNow()
-            }
-            if (authSession != null) {
-                ProfileMenuItem("로그아웃") {
-                    expanded = false
-                    onLogout()
-                }
+                onOpenSettings()
             }
         }
     }
@@ -174,26 +152,111 @@ internal fun ProfileMenuItem(
     )
 }
 
+enum class ThemeMode { System, Light, Dark }
+
+internal fun themeModeLabel(mode: ThemeMode): String = when (mode) {
+    ThemeMode.System -> "시스템"
+    ThemeMode.Light -> "라이트"
+    ThemeMode.Dark -> "다크"
+}
+
 @Composable
-internal fun AvatarBubble(label: String?) {
-    Box(
-        modifier = Modifier
-            .size(42.dp)
-            .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = label?.firstOrNull()?.uppercaseChar()?.toString() ?: "V",
-            color = MaterialTheme.colorScheme.primary,
-            fontWeight = FontWeight.Bold,
-        )
-    }
+internal fun ThemeModePickerDialog(
+    current: ThemeMode,
+    onDismiss: () -> Unit,
+    onSelect: (ThemeMode) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("화면 모드") },
+        text = {
+            Column {
+                ThemeMode.entries.forEach { mode ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = mode == current,
+                            onClick = { onSelect(mode) },
+                        )
+                        Text(themeModeLabel(mode))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("닫기") }
+        },
+    )
+}
+
+@Composable
+internal fun NicknameEditDialog(
+    initial: String,
+    busy: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var value by remember { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = { if (!busy) onDismiss() },
+        title = { Text("닉네임 수정") },
+        text = {
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it.take(30) },
+                label = { Text("닉네임") },
+                singleLine = true,
+                enabled = !busy,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(value) },
+                enabled = !busy && value.trim().isNotEmpty() && value.trim() != initial,
+            ) { Text("저장") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !busy) { Text("취소") }
+        },
+    )
+}
+
+@Composable
+internal fun DeleteAccountConfirmDialog(
+    busy: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { if (!busy) onDismiss() },
+        title = { Text("회원 탈퇴") },
+        text = {
+            Text(
+                "정말 탈퇴할까요? 알람, 음성, 메시지 등 모든 데이터가 삭제되고 복구할 수 없어요.",
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = !busy) {
+                Text(
+                    text = "탈퇴",
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !busy) { Text("취소") }
+        },
+    )
 }
 
 @Composable
 internal fun ScreenHeader(
     title: String,
-    subtitle: String,
+    subtitle: String? = null,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(
@@ -201,10 +264,12 @@ internal fun ScreenHeader(
             style = MaterialTheme.typography.displaySmall,
             fontWeight = FontWeight.Bold,
         )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (!subtitle.isNullOrBlank()) {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
@@ -120,6 +120,45 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var message by mutableStateOf<String?>(null)
         internal set
 
+    private val themePrefs = application.getSharedPreferences("voice_alarm_theme", android.content.Context.MODE_PRIVATE)
+    var themeMode by mutableStateOf(loadInitialThemeMode(themePrefs))
+        internal set
+
+    var nicknameEditDialogOpen by mutableStateOf(false)
+        internal set
+
+    var deleteAccountConfirmOpen by mutableStateOf(false)
+        internal set
+
+    fun setThemeMode(mode: ThemeMode) {
+        themeMode = mode
+        themePrefs.edit().putString("mode", mode.name).apply()
+    }
+
+    fun requestEditNickname() {
+        if (authSession == null) {
+            message = "로그인 후 사용할 수 있어요"
+            return
+        }
+        nicknameEditDialogOpen = true
+    }
+
+    fun dismissEditNickname() {
+        nicknameEditDialogOpen = false
+    }
+
+    fun requestDeleteAccount() {
+        if (authSession == null) {
+            message = "로그인 후 사용할 수 있어요"
+            return
+        }
+        deleteAccountConfirmOpen = true
+    }
+
+    fun dismissDeleteAccount() {
+        deleteAccountConfirmOpen = false
+    }
+
     init {
         RemoteAlarmSyncScheduler.ensurePeriodic(application)
         if (authSession != null) {
@@ -137,4 +176,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         refreshAppSession()
     }
 
+}
+
+private fun loadInitialThemeMode(prefs: android.content.SharedPreferences): ThemeMode {
+    val raw = prefs.getString("mode", ThemeMode.System.name) ?: return ThemeMode.System
+    return runCatching { ThemeMode.valueOf(raw) }.getOrDefault(ThemeMode.System)
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -127,6 +127,59 @@ internal fun MainViewModel.logout() {
     message = "로그아웃했어요"
 }
 
+internal fun MainViewModel.updateNickname(name: String) {
+    val session = authSession
+    if (session == null) {
+        message = "로그인 후 사용할 수 있어요"
+        return
+    }
+    val trimmed = name.trim()
+    if (trimmed.isEmpty() || trimmed.length > 30) {
+        message = "닉네임은 1~30자여야 해요"
+        return
+    }
+    val authorization = com.voicealarm.nativeapp.network.VoiceAlarmApiClient.bearer(session.token)
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.updateProfile(authorization, com.voicealarm.nativeapp.network.UpdateProfileRequest(name = trimmed))
+        }.onSuccess {
+            val updated = session.copy(user = session.user.copy(name = trimmed))
+            authSession = authSessionStore.save(updated)
+            dismissEditNickname()
+            message = "닉네임을 변경했어요"
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to update nickname", error)
+            message = userFacingError(error, "닉네임 변경에 실패했어요")
+        }
+        authBusy = false
+    }
+}
+
+internal fun MainViewModel.deleteAccount() {
+    val session = authSession
+    if (session == null) {
+        message = "로그인 후 사용할 수 있어요"
+        return
+    }
+    val authorization = com.voicealarm.nativeapp.network.VoiceAlarmApiClient.bearer(session.token)
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.deleteAccount(authorization)
+        }.onSuccess {
+            authSessionStore.clear()
+            authSession = null
+            dismissDeleteAccount()
+            message = "회원 탈퇴가 완료되었어요"
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to delete account", error)
+            message = userFacingError(error, "회원 탈퇴에 실패했어요")
+        }
+        authBusy = false
+    }
+}
+
 internal fun MainViewModel.syncNow() {
     val session = authSession
     if (session == null) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
@@ -33,6 +33,7 @@ internal data class SubscriptionPlanOption(
 
 internal sealed interface AlarmScreen {
     data object List : AlarmScreen
+    data object Settings : AlarmScreen
     data class Create(val familyTargetMode: Boolean = false) : AlarmScreen
     data class Edit(val alarm: AlarmEntity) : AlarmScreen
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/settings/SettingsScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/settings/SettingsScreen.kt
@@ -1,0 +1,178 @@
+package com.voicealarm.nativeapp
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.voicealarm.nativeapp.network.AuthSession
+
+@Composable
+internal fun SettingsScreen(
+    contentPadding: PaddingValues,
+    authSession: AuthSession?,
+    themeMode: ThemeMode,
+    onBack: () -> Unit,
+    onChangeTheme: (ThemeMode) -> Unit,
+    onEditNickname: () -> Unit,
+    onLogout: () -> Unit,
+    onDeleteAccount: () -> Unit,
+) {
+    var showThemeDialog by remember { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "뒤로",
+                    )
+                }
+                Text(
+                    text = "설정",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+
+        item {
+            SettingsCard(title = "화면") {
+                SettingsRow(
+                    label = "화면 모드",
+                    value = themeModeLabel(themeMode),
+                    onClick = { showThemeDialog = true },
+                )
+            }
+        }
+
+        if (authSession != null) {
+            item {
+                SettingsCard(title = "계정") {
+                    SettingsRow(
+                        label = "닉네임",
+                        value = authSession.user.name.ifBlank { "이름 없음" },
+                        onClick = onEditNickname,
+                    )
+                    HorizontalDivider()
+                    SettingsRow(
+                        label = "로그아웃",
+                        value = null,
+                        onClick = onLogout,
+                    )
+                }
+            }
+
+            item {
+                SettingsCard(title = null) {
+                    SettingsRow(
+                        label = "회원 탈퇴",
+                        value = null,
+                        labelColor = MaterialTheme.colorScheme.error,
+                        onClick = onDeleteAccount,
+                    )
+                }
+            }
+        }
+    }
+
+    if (showThemeDialog) {
+        ThemeModePickerDialog(
+            current = themeMode,
+            onDismiss = { showThemeDialog = false },
+            onSelect = { mode ->
+                showThemeDialog = false
+                onChangeTheme(mode)
+            },
+        )
+    }
+}
+
+@Composable
+private fun SettingsCard(
+    title: String?,
+    content: @Composable () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (title != null) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp),
+            )
+        }
+        OutlinedCard {
+            Column { content() }
+        }
+    }
+}
+
+@Composable
+private fun SettingsRow(
+    label: String,
+    value: String?,
+    labelColor: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            color = labelColor,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f),
+        )
+        if (value != null) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = 4.dp),
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/theme/VoiceAlarmTheme.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/theme/VoiceAlarmTheme.kt
@@ -10,8 +10,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 
 @Composable
-internal fun VoiceAlarmTheme(content: @Composable () -> Unit) {
-    val colorScheme = if (androidx.compose.foundation.isSystemInDarkTheme()) {
+internal fun VoiceAlarmTheme(
+    themeMode: ThemeMode = ThemeMode.System,
+    content: @Composable () -> Unit,
+) {
+    val systemDark = androidx.compose.foundation.isSystemInDarkTheme()
+    val isDark = when (themeMode) {
+        ThemeMode.System -> systemDark
+        ThemeMode.Dark -> true
+        ThemeMode.Light -> false
+    }
+    val colorScheme = if (isDark) {
         androidx.compose.material3.darkColorScheme(
             primary = Color(0xFFF0C25C),
             onPrimary = Color(0xFF1F1B14),

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -84,6 +84,16 @@ internal fun formatFireTime(millis: Long): String {
         .format(formatter)
 }
 
+internal fun formatVoucherIssuedAt(isoString: String?): String? {
+    if (isoString.isNullOrBlank()) return null
+    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+    return runCatching {
+        Instant.parse(isoString)
+            .atZone(ZoneId.systemDefault())
+            .format(formatter)
+    }.getOrNull()
+}
+
 internal fun audioFileLabel(localAudioUri: String): String =
     Uri.parse(localAudioUri).lastPathSegment
         ?.substringAfterLast('/')

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -73,7 +73,7 @@ user.patch('/me', async (c) => {
     .catch(() => ({}));
 
   const updates: string[] = [];
-  const args: unknown[] = [];
+  const args: (string | number)[] = [];
   let resolvedName: string | null = null;
 
   if ('name' in body && body.name !== undefined) {

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -69,27 +69,56 @@ user.patch('/me', async (c) => {
   const db = getDB(c.env);
 
   const body = await c.req
-    .json<{ allow_family_alarms?: unknown }>()
-    .catch(() => ({ allow_family_alarms: undefined }));
+    .json<{ allow_family_alarms?: unknown; name?: unknown }>()
+    .catch(() => ({}));
 
-  if (!('allow_family_alarms' in body) || body.allow_family_alarms === undefined) {
+  const updates: string[] = [];
+  const args: unknown[] = [];
+  let resolvedName: string | null = null;
+
+  if ('name' in body && body.name !== undefined) {
+    if (typeof body.name !== 'string') {
+      return c.json({ error: 'name 은 문자열이어야 합니다', error_code: 'INVALID_NAME' }, 400);
+    }
+    const trimmed = body.name.trim();
+    if (trimmed.length === 0 || trimmed.length > 30) {
+      return c.json({ error: '닉네임은 1~30자여야 합니다', error_code: 'INVALID_NAME_LENGTH' }, 400);
+    }
+    updates.push('name = ?');
+    args.push(trimmed);
+    resolvedName = trimmed;
+  }
+
+  let resolvedFlag: 0 | 1 | null = null;
+  if ('allow_family_alarms' in body && body.allow_family_alarms !== undefined) {
+    const flag = toBoolFlag(body.allow_family_alarms);
+    if (flag === null) {
+      return c.json({ error: 'allow_family_alarms 는 boolean 이어야 합니다', error_code: 'INVALID_BOOLEAN' }, 400);
+    }
+    updates.push('allow_family_alarms = ?');
+    args.push(flag);
+    resolvedFlag = flag;
+  }
+
+  if (updates.length === 0) {
     return c.json({ error: '변경할 필드가 없습니다', error_code: 'NO_FIELDS_TO_UPDATE' }, 400);
   }
-  const flag = toBoolFlag(body.allow_family_alarms);
-  if (flag === null) {
-    return c.json({ error: 'allow_family_alarms 는 boolean 이어야 합니다', error_code: 'INVALID_BOOLEAN' }, 400);
-  }
 
+  args.push(userId);
   const result = await db.execute({
-    sql: `UPDATE users SET allow_family_alarms = ?, updated_at = datetime('now')
+    sql: `UPDATE users SET ${updates.join(', ')}, updated_at = datetime('now')
           WHERE google_id = ?`,
-    args: [flag, userId],
+    args,
   });
   if (result.rowsAffected === 0) {
     return c.json({ error: '사용자를 찾을 수 없습니다', error_code: 'USER_NOT_FOUND' }, 404);
   }
 
-  return c.json({ success: true, allow_family_alarms: flag === 1 });
+  return c.json({
+    success: true,
+    name: resolvedName,
+    allow_family_alarms: resolvedFlag === null ? null : resolvedFlag === 1,
+  });
 });
 
 user.patch('/plan', async (c) => {


### PR DESCRIPTION
Closes #241

## 변경 요약
- backend: \`PATCH /user/me\` 닉네임 변경, \`DELETE /user/me\` 회원 탈퇴
- android: 닉네임 수정 / 회원 탈퇴 / 화면 모드(시스템·라이트·다크) 추가
- android: 프로필 드롭다운에서 분리해 \`SettingsScreen\` 도입, 진입 메뉴 일원화
- android: 구독 카드 카피 정돈 + 이용권 결제일 표시
- android: 가족 알람 등록 흐름 토스트 보강

## 커밋 구성
1. \`feat(backend): 프로필 갱신/탈퇴 엔드포인트 추가\`
2. \`feat(android): 프로필/계정 관리 + 설정 페이지 신설\`
3. \`feat(android): 구독 카드 카피 정돈 + 이용권 발급일 표시\`
4. \`feat(android): 가족 알람 등록 흐름에 토스트 알림 보강\`

## 동작 확인
- [x] \`./gradlew :app:compileDebugKotlin\` 통과
- [x] 두 에뮬레이터 \`installDebug\` 정상
- [ ] 닉네임 변경 → 토큰 유지 확인
- [ ] 회원 탈퇴 → 세션 클리어 + 데이터 삭제 확인
- [ ] 화면 모드 변경 → 앱 재시작 후 유지 확인

## 후속 (별도 PR 예정)
- 비회원 풀스크린 랜딩 → 로그인/회원가입 분리
- 신규 가입자 1회성 온보딩
- 권한 강제 게이팅(하이브리드)