### PR TITLE
feat: 권한 강제 게이팅 (하이브리드) (#247)

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.outlined.People
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
@@ -79,6 +80,7 @@ internal fun AlarmListScreen(
     onToggleEnabled: (String, Boolean) -> Unit,
     onEditAlarm: (AlarmEntity) -> Unit,
     onDeleteAlarm: (String) -> Unit,
+    onRequestPermissionGate: (PermissionTarget) -> Unit,
 ) {
     val sortedAlarms = remember(alarms) {
         alarms.sortedWith(
@@ -92,6 +94,9 @@ internal fun AlarmListScreen(
     val canCreateFamilyAlarm = authSession != null &&
         hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup) &&
         familyAlarmRecipients(familyGroup, authSession).isNotEmpty()
+    val context = LocalContext.current
+    val voiceLocked = !context.hasRecordAudioPermission()
+    val alarmLocked = !context.hasAlarmPermissions()
 
     LazyColumn(
         modifier = Modifier
@@ -123,10 +128,15 @@ internal fun AlarmListScreen(
                 }
                 item {
                     QuickStartGrid(
-                        onRecordVoice = { onSelectTab(NativeTab.Voices) },
+                        onRecordVoice = {
+                            if (voiceLocked) onRequestPermissionGate(PermissionTarget.RecordAudio)
+                            else onSelectTab(NativeTab.Voices)
+                        },
                         onAddAlarm = onCreateAlarm,
                         canCreateFamilyAlarm = canCreateFamilyAlarm,
                         onAddFamilyAlarm = onCreateFamilyAlarm,
+                        voiceLocked = voiceLocked,
+                        alarmLocked = alarmLocked,
                     )
                 }
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -222,6 +222,17 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         )
     }
 
+    viewModel.permissionGateRequest?.let { target ->
+        PermissionGateDialog(
+            target = target,
+            onDismiss = viewModel::dismissPermissionGate,
+            onOpenSettings = {
+                context.openPermissionSettingsFor(target)
+                viewModel.dismissPermissionGate()
+            },
+        )
+    }
+
     planGateMessage?.let { gateMessage ->
         AlertDialog(
             onDismissRequest = { planGateMessage = null },
@@ -343,11 +354,30 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onSendNote = viewModel::sendNote,
                 onMarkNoteRead = viewModel::markNoteRead,
                 onCheckoutPlan = viewModel::checkoutPlan,
-                onCreateAlarm = { screen = AlarmScreen.Create() },
-                onCreateFamilyAlarm = { screen = AlarmScreen.Create(familyTargetMode = true) },
-                onToggleEnabled = viewModel::setAlarmEnabled,
+                onCreateAlarm = {
+                    if (!context.hasAlarmPermissions()) {
+                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                    } else {
+                        screen = AlarmScreen.Create()
+                    }
+                },
+                onCreateFamilyAlarm = {
+                    if (!context.hasAlarmPermissions()) {
+                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                    } else {
+                        screen = AlarmScreen.Create(familyTargetMode = true)
+                    }
+                },
+                onToggleEnabled = { id, enabled ->
+                    if (enabled && !context.hasAlarmPermissions()) {
+                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                    } else {
+                        viewModel.setAlarmEnabled(id, enabled)
+                    }
+                },
                 onEditAlarm = { screen = AlarmScreen.Edit(it) },
                 onDeleteAlarm = viewModel::deleteAlarm,
+                onRequestPermissionGate = viewModel::requestPermissionGate,
             )
 
             is AlarmScreen.Create -> AlarmEditorScreen(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeCards.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeCards.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material3.AssistChip
@@ -184,6 +185,8 @@ internal fun QuickStartGrid(
     onAddAlarm: () -> Unit,
     canCreateFamilyAlarm: Boolean,
     onAddFamilyAlarm: () -> Unit,
+    voiceLocked: Boolean = false,
+    alarmLocked: Boolean = false,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -196,12 +199,14 @@ internal fun QuickStartGrid(
                 label = "음성 녹음",
                 icon = Icons.Outlined.Mic,
                 onClick = onRecordVoice,
+                locked = voiceLocked,
                 modifier = Modifier.weight(1f),
             )
             HomeActionCard(
                 label = "알람 추가",
                 icon = Icons.Outlined.Alarm,
                 onClick = onAddAlarm,
+                locked = alarmLocked,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -210,6 +215,7 @@ internal fun QuickStartGrid(
                 label = "상대방 알람 맞춰주기",
                 icon = Icons.Outlined.People,
                 onClick = onAddFamilyAlarm,
+                locked = alarmLocked,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -222,6 +228,7 @@ internal fun HomeActionCard(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    locked: Boolean = false,
 ) {
     Card(
         onClick = onClick,
@@ -230,25 +237,40 @@ internal fun HomeActionCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 20.dp, horizontal = 14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.size(30.dp),
-            )
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 20.dp, horizontal = 14.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (locked) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.size(30.dp),
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (locked) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            if (locked) {
+                Icon(
+                    imageVector = Icons.Outlined.Lock,
+                    contentDescription = "권한 필요",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .size(16.dp),
+                )
+            }
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
@@ -134,6 +134,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var showOnboarding by mutableStateOf(false)
         internal set
 
+    var permissionGateRequest by mutableStateOf<PermissionTarget?>(null)
+        internal set
+
+    fun requestPermissionGate(target: PermissionTarget) {
+        permissionGateRequest = target
+    }
+
+    fun dismissPermissionGate() {
+        permissionGateRequest = null
+    }
+
     fun checkOnboardingFor(userId: String) {
         if (userId.isBlank()) return
         val seen = onboardingPrefs.getStringSet("seen_users", emptySet()) ?: emptySet()

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/permission/PermissionGate.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/permission/PermissionGate.kt
@@ -1,0 +1,82 @@
+package com.voicealarm.nativeapp
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.core.content.ContextCompat
+
+enum class PermissionTarget { Alarm, RecordAudio }
+
+internal fun Context.hasAlarmPermissions(): Boolean {
+    val notifGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+    } else {
+        true
+    }
+    return notifGranted && canScheduleExactAlarms() && canUseFullScreenIntent()
+}
+
+internal fun Context.hasRecordAudioPermission(): Boolean =
+    ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED
+
+internal fun Context.openPermissionSettingsFor(target: PermissionTarget) {
+    when (target) {
+        PermissionTarget.Alarm -> {
+            // 가장 사용자 행동이 필요한 항목부터 우선 안내. 그 외는 시스템 설정에서 함께 풀 수 있도록 앱 상세로.
+            when {
+                !canScheduleExactAlarms() -> openExactAlarmSettings()
+                !canUseFullScreenIntent() -> openFullScreenIntentSettings()
+                else -> openAppDetailsSettings()
+            }
+        }
+        PermissionTarget.RecordAudio -> openAppDetailsSettings()
+    }
+}
+
+private fun Context.openAppDetailsSettings() {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.parse("package:$packageName")
+    }
+    startSettingsActivity(intent)
+}
+
+@Composable
+internal fun PermissionGateDialog(
+    target: PermissionTarget,
+    onDismiss: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    val title: String
+    val body: String
+    when (target) {
+        PermissionTarget.Alarm -> {
+            title = "알람 권한이 필요해요"
+            body = "정해진 시간에 알람이 울리려면 ‘알림’, ‘알람 및 리마인더’, ‘전체 화면 알림’ 권한이 모두 필요해요. 설정에서 허용해 주세요."
+        }
+        PermissionTarget.RecordAudio -> {
+            title = "마이크 권한이 필요해요"
+            body = "내 목소리로 음성을 녹음하려면 마이크 권한이 필요해요. 설정에서 허용해 주세요."
+        }
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(body) },
+        confirmButton = {
+            TextButton(onClick = onOpenSettings) { Text("설정으로 이동") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("닫기") }
+        },
+    )
+}


### PR DESCRIPTION
Closes #247

> Stacked on top of #246 — 머지 순서: #242 → #244 → #246 → 본 PR.

## 변경 요약
- \`PermissionGate.kt\`: 알람/마이크 권한 헬퍼 + 게이트 다이얼로그 + 설정 화면 분기
- \`MainViewModel\`: \`permissionGateRequest\` 상태 + request/dismiss
- \`VoiceAlarmApp\`: 알람 생성/가족 알람/활성화 토글 진입 가드, 다이얼로그 라우팅
- \`HomeActionCard\` / \`QuickStartGrid\`: \`locked\` 인자로 자물쇠 + 색조, 음성/알람 카드에 적용
- \`AlarmListScreen\`: 마이크/알람 권한 상태 평가 후 QuickStartGrid 잠금 전달, 음성 녹음 카드 클릭 시 다이얼로그

## 동작 (수동 검증 필요)
- [x] \`./gradlew :app:compileDebugKotlin\` 통과
- [ ] 권한 거부 상태에서 음성/알람 카드에 자물쇠 + 비활성 색조
- [ ] 잠긴 카드 클릭 → 안내 다이얼로그
- [ ] "설정으로 이동" → 알람: SCHEDULE_EXACT_ALARM 화면, 마이크: 앱 상세 화면
- [ ] 권한 허용 후 카드 잠금 해제 (resume 시점에 갱신)
- [ ] 활성화 토글 시도 시 권한 부족이면 차단 + 다이얼로그

## 후속 (별도 이슈/PR)
- 음성 프로필 패널 / 알람 에디터 내부 녹음 버튼 가드
- 권한 변경 즉시 잠금 갱신 (LifecycleResumeEffect)