### PR TITLE
fix(android): Google 로그아웃과 화면 복귀 흐름 수정

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -51,7 +51,11 @@ import com.voicealarm.nativeapp.network.CharacterResponse
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
-import kotlinx.coroutines.launch
+import com.google.android.gms.tasks.Task
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 @Composable
 internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
@@ -76,11 +80,11 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     val receivedNotes = viewModel.receivedNotes
     var screen by remember { mutableStateOf<AlarmScreen>(AlarmScreen.List) }
     var selectedTab by remember { mutableStateOf(NativeTab.Home) }
-    var tabBackStack by remember { mutableStateOf<List<NativeTab>>(emptyList()) }
     var planGateMessage by remember { mutableStateOf<String?>(null) }
     var authRoute by remember { mutableStateOf<AuthRoute>(AuthRoute.Landing) }
     val themeMode = viewModel.themeMode
     val snackbarHostState = remember { SnackbarHostState() }
+    val sessionRouteKey = authSession?.user?.id
 
     LaunchedEffect(message) {
         val currentMessage = message ?: return@LaunchedEffect
@@ -89,6 +93,13 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     LoginPermissionGate(authSession = authSession)
+
+    LaunchedEffect(sessionRouteKey) {
+        screen = AlarmScreen.List
+        selectedTab = NativeTab.Home
+        planGateMessage = null
+        authRoute = AuthRoute.Landing
+    }
 
     LaunchedEffect(authSession?.token) {
         if (authSession != null) {
@@ -160,11 +171,20 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             viewModel.showGoogleSetupRequired()
             return
         }
-        val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(clientId)
-            .requestEmail()
-            .build()
+        val options = buildGoogleSignInOptions(requestIdToken = true)
         googleSignInLauncher.launch(GoogleSignIn.getClient(context, options).signInIntent)
+    }
+
+    fun logout() {
+        viewModel.logout {
+            signOutGoogleAccount(context)
+        }
+    }
+
+    fun deleteAccount() {
+        viewModel.deleteAccount {
+            revokeGoogleAccountAccess(context)
+        }
     }
 
     fun navigateToTab(tab: NativeTab) {
@@ -177,7 +197,6 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             planGateMessage = "메시지는 커플/가족 플랜에서 사용할 수 있어요. 초대 코드나 이용권을 등록하거나 플랜을 구매해 주세요."
             return
         }
-        tabBackStack = tabBackStack + selectedTab
         selectedTab = tab
     }
 
@@ -186,10 +205,8 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             screen = AlarmScreen.List
             return
         }
-        val previousTab = tabBackStack.lastOrNull()
-        if (previousTab != null) {
-            tabBackStack = tabBackStack.dropLast(1)
-            selectedTab = previousTab
+        if (selectedTab != NativeTab.Home) {
+            selectedTab = NativeTab.Home
         }
     }
 
@@ -199,7 +216,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         }
     } else {
         BackHandler(
-            enabled = screen !is AlarmScreen.List || tabBackStack.isNotEmpty(),
+            enabled = screen !is AlarmScreen.List || selectedTab != NativeTab.Home,
             onBack = ::goBackInApp,
         )
     }
@@ -217,7 +234,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         DeleteAccountConfirmDialog(
             busy = authBusy,
             onDismiss = viewModel::dismissDeleteAccount,
-            onConfirm = viewModel::deleteAccount,
+            onConfirm = ::deleteAccount,
         )
     }
 
@@ -334,7 +351,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onRegister = viewModel::register,
                 onGoogleSignIn = ::launchGoogleSignIn,
                 onSyncNow = viewModel::syncNow,
-                onLogout = viewModel::logout,
+                onLogout = ::logout,
                 onCreateVoiceProfile = viewModel::createVoiceProfile,
                 onCreateVoiceProfiles = viewModel::createVoiceProfiles,
                 onSeparateVoiceSpeakers = viewModel::separateVoiceSpeakers,
@@ -417,7 +434,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 onBack = ::goBackInApp,
                 onChangeTheme = viewModel::setThemeMode,
                 onEditNickname = viewModel::requestEditNickname,
-                onLogout = viewModel::logout,
+                onLogout = ::logout,
                 onDeleteAccount = viewModel::requestDeleteAccount,
             )
         }
@@ -438,6 +455,49 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
         }
       }
+    }
+}
+
+private fun buildGoogleSignInOptions(requestIdToken: Boolean = false): GoogleSignInOptions {
+    val builder = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+        .requestEmail()
+    if (requestIdToken) {
+        val clientId = BuildConfig.VOICE_ALARM_GOOGLE_WEB_CLIENT_ID
+        if (clientId.isNotBlank()) {
+            builder.requestIdToken(clientId)
+        }
+    }
+    return builder.build()
+}
+
+private suspend fun signOutGoogleAccount(context: Context) {
+    GoogleSignIn
+        .getClient(context.applicationContext, buildGoogleSignInOptions())
+        .signOut()
+        .awaitCompletion()
+}
+
+private suspend fun revokeGoogleAccountAccess(context: Context) {
+    GoogleSignIn
+        .getClient(context.applicationContext, buildGoogleSignInOptions())
+        .revokeAccess()
+        .awaitCompletion()
+}
+
+private suspend fun Task<Void>.awaitCompletion() {
+    suspendCancellableCoroutine { continuation ->
+        addOnCompleteListener { task ->
+            if (!continuation.isActive) return@addOnCompleteListener
+            when {
+                task.isCanceled -> continuation.resumeWithException(
+                    CancellationException("Google task was cancelled"),
+                )
+                task.isSuccessful -> continuation.resume(Unit)
+                else -> continuation.resumeWithException(
+                    task.exception ?: IllegalStateException("Google task failed"),
+                )
+            }
+        }
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -120,10 +120,22 @@ internal fun MainViewModel.finishGoogleLogin(idToken: String, id: String, email:
     }
 }
 
-internal fun MainViewModel.logout() {
-    authSessionStore.clear()
-    authSession = null
-    message = "로그아웃했어요"
+internal fun MainViewModel.logout(signOutGoogle: suspend () -> Unit = {}) {
+    val shouldSignOutGoogle = authSession?.provider == AuthSessionStore.PROVIDER_GOOGLE
+    viewModelScope.launch {
+        authBusy = true
+        if (shouldSignOutGoogle) {
+            runCatching {
+                signOutGoogle()
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to sign out Google account", error)
+            }
+        }
+        authSessionStore.clear()
+        authSession = null
+        message = "로그아웃했어요"
+        authBusy = false
+    }
 }
 
 internal fun MainViewModel.updateNickname(name: String) {
@@ -155,27 +167,40 @@ internal fun MainViewModel.updateNickname(name: String) {
     }
 }
 
-internal fun MainViewModel.deleteAccount() {
+internal fun MainViewModel.deleteAccount(revokeGoogleAccess: suspend () -> Unit = {}) {
     val session = authSession
     if (session == null) {
         message = "로그인 후 사용할 수 있어요"
         return
     }
     val authorization = com.voicealarm.nativeapp.network.VoiceAlarmApiClient.bearer(session.token)
+    val shouldRevokeGoogle = session.provider == AuthSessionStore.PROVIDER_GOOGLE
     viewModelScope.launch {
         authBusy = true
-        runCatching {
+        try {
             api.deleteAccount(authorization)
-        }.onSuccess {
+            val revokeError = if (shouldRevokeGoogle) {
+                runCatching { revokeGoogleAccess() }.exceptionOrNull()
+            } else {
+                null
+            }
+            if (revokeError != null) {
+                Log.w(TAG, "Failed to revoke Google account access after account deletion", revokeError)
+            }
             authSessionStore.clear()
             authSession = null
             dismissDeleteAccount()
-            message = "회원 탈퇴가 완료되었어요"
-        }.onFailure { error ->
+            message = if (revokeError == null) {
+                "회원 탈퇴가 완료되었어요"
+            } else {
+                "회원 탈퇴는 완료되었지만 Google 연결 해제에 실패했어요"
+            }
+        } catch (error: Throwable) {
             Log.e(TAG, "Failed to delete account", error)
             message = userFacingError(error, "회원 탈퇴에 실패했어요")
+        } finally {
+            authBusy = false
         }
-        authBusy = false
     }
 }
 


### PR DESCRIPTION
## 변경 내용
- Google 계정 로그아웃 시 GoogleSignIn `signOut()`을 호출한 뒤 앱 세션을 정리합니다.
- 회원 탈퇴 성공 후 Google 계정은 `revokeAccess()`로 앱 연결을 해제합니다.
- 로그인 계정이 바뀌거나 로그아웃되면 앱 화면 상태를 홈/목록으로 초기화합니다.
- 하단 탭 이동을 자체 back stack에 누적하지 않고, Android 일반 흐름에 맞게 뒤로가기를 정리합니다.

## 이유
- 로그아웃 후 다른 계정으로 로그인해도 이전 계정의 설정 화면으로 복귀하는 문제가 있었습니다.
- 회원 탈퇴 후 Google 로그인을 다시 누르면 기존 Google 연결 상태 때문에 바로 재로그인되는 UX를 줄여야 했습니다.

## 검증
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat assembleDebug`
- `git diff --check`
- 연결된 두 Android 기기에 debug APK 업데이트 설치 확인