### PR TITLE
refactor(android): Navigation Compose 화면 전환 구조 적용

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.navigation:navigation-compose:2.8.5")
     implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.work:work-runtime-ktx:2.9.1")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -1,6 +1,7 @@
 package com.voicealarm.nativeapp
 
 import android.content.Context
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.activity.compose.BackHandler
@@ -45,6 +46,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.CharacterResponse
@@ -78,8 +86,10 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     val vouchers = viewModel.vouchers
     val noteBusy = viewModel.noteBusy
     val receivedNotes = viewModel.receivedNotes
-    var screen by remember { mutableStateOf<AlarmScreen>(AlarmScreen.List) }
-    var selectedTab by remember { mutableStateOf(NativeTab.Home) }
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentTab = navBackStackEntry?.destination?.route.toNativeTab()
+    val selectedTab = currentTab ?: NativeTab.Home
     var planGateMessage by remember { mutableStateOf<String?>(null) }
     var authRoute by remember { mutableStateOf<AuthRoute>(AuthRoute.Landing) }
     val themeMode = viewModel.themeMode
@@ -95,8 +105,9 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     LoginPermissionGate(authSession = authSession)
 
     LaunchedEffect(sessionRouteKey) {
-        screen = AlarmScreen.List
-        selectedTab = NativeTab.Home
+        if (sessionRouteKey != null) {
+            navController.navigateHomeClearingStack()
+        }
         planGateMessage = null
         authRoute = AuthRoute.Landing
     }
@@ -110,9 +121,9 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         }
     }
 
-    LaunchedEffect(selectedTab, authSession?.token) {
+    LaunchedEffect(currentTab, authSession?.token) {
         if (authSession == null) return@LaunchedEffect
-        when (selectedTab) {
+        when (currentTab) {
             NativeTab.Home -> {
                 viewModel.refreshCharacterAndBilling()
                 viewModel.refreshSocial()
@@ -129,6 +140,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
             NativeTab.Growth,
             NativeTab.Billing -> viewModel.refreshCharacterAndBilling()
+            null -> Unit
         }
     }
 
@@ -197,17 +209,11 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             planGateMessage = "메시지는 커플/가족 플랜에서 사용할 수 있어요. 초대 코드나 이용권을 등록하거나 플랜을 구매해 주세요."
             return
         }
-        selectedTab = tab
+        navController.navigateTopLevelTab(tab)
     }
 
     fun goBackInApp() {
-        if (screen !is AlarmScreen.List) {
-            screen = AlarmScreen.List
-            return
-        }
-        if (selectedTab != NativeTab.Home) {
-            selectedTab = NativeTab.Home
-        }
+        navController.popBackStackOrHome()
     }
 
     if (authSession == null) {
@@ -216,8 +222,8 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         }
     } else {
         BackHandler(
-            enabled = screen !is AlarmScreen.List || selectedTab != NativeTab.Home,
-            onBack = ::goBackInApp,
+            enabled = currentTab != null && currentTab != NativeTab.Home,
+            onBack = { navController.navigateTopLevelTab(NativeTab.Home) },
         )
     }
 
@@ -284,7 +290,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
         },
         bottomBar = {
-            if (authSession != null && !viewModel.showOnboarding && screen is AlarmScreen.List) {
+            if (authSession != null && !viewModel.showOnboarding && currentTab != null) {
                 VoiceAlarmBottomBar(
                     selectedTab = selectedTab,
                     onSelectTab = ::navigateToTab,
@@ -325,135 +331,163 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
           return@Scaffold
       }
       Box(modifier = Modifier.fillMaxSize()) {
-        when (val current = screen) {
-            AlarmScreen.List -> AlarmListScreen(
-                contentPadding = padding,
-                selectedTab = selectedTab,
-                onSelectTab = ::navigateToTab,
-                alarms = alarms,
-                authSession = authSession,
-                authBusy = authBusy,
-                syncBusy = syncBusy,
-                voiceProfiles = voiceProfiles,
-                voiceProfileBusy = voiceProfileBusy,
-                socialBusy = socialBusy,
-                familyGroup = familyGroup,
-                familyVoices = familyVoices,
-                characterEvents = characterEvents,
-                characterBusy = characterBusy,
-                characterResponse = characterResponse,
-                billingBusy = billingBusy,
-                subscriptionResponse = subscriptionResponse,
-                vouchers = vouchers,
-                noteBusy = noteBusy,
-                receivedNotes = receivedNotes,
-                onLogin = viewModel::login,
-                onRegister = viewModel::register,
-                onGoogleSignIn = ::launchGoogleSignIn,
-                onSyncNow = viewModel::syncNow,
-                onLogout = ::logout,
-                onCreateVoiceProfile = viewModel::createVoiceProfile,
-                onCreateVoiceProfiles = viewModel::createVoiceProfiles,
-                onSeparateVoiceSpeakers = viewModel::separateVoiceSpeakers,
-                onRenameVoiceProfile = viewModel::renameVoiceProfile,
-                onShareVoiceProfile = viewModel::setVoiceProfileShared,
-                onDeleteVoiceProfile = viewModel::deleteVoiceProfile,
-                onRefreshSocial = viewModel::refreshSocial,
-                onLeaveFamilyGroup = viewModel::leaveFamilyGroup,
-                onRefreshCharacterBilling = viewModel::refreshCharacterAndBilling,
-                onSyncCharacterEvents = viewModel::syncCharacterEvents,
-                onRegisterCode = viewModel::registerCode,
-                onRefreshNotes = viewModel::refreshNotes,
-                onSendNote = viewModel::sendNote,
-                onMarkNoteRead = viewModel::markNoteRead,
-                onCheckoutPlan = viewModel::checkoutPlan,
-                onCancelSubscription = viewModel::cancelSubscription,
-                onChangePlan = viewModel::changePlan,
-                onCreateAlarm = {
-                    if (!context.hasAlarmPermissions()) {
-                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
-                    } else {
-                        screen = AlarmScreen.Create()
-                    }
-                },
-                onCreateFamilyAlarm = {
-                    if (!context.hasAlarmPermissions()) {
-                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
-                    } else {
-                        screen = AlarmScreen.Create(familyTargetMode = true)
-                    }
-                },
-                onToggleEnabled = { id, enabled ->
-                    if (enabled && !context.hasAlarmPermissions()) {
-                        viewModel.requestPermissionGate(PermissionTarget.Alarm)
-                    } else {
-                        viewModel.setAlarmEnabled(id, enabled)
-                    }
-                },
-                onEditAlarm = { screen = AlarmScreen.Edit(it) },
-                onDeleteAlarm = viewModel::deleteAlarm,
-                onRequestPermissionGate = viewModel::requestPermissionGate,
-            )
-
-            is AlarmScreen.Create -> AlarmEditorScreen(
-                contentPadding = padding,
-                alarm = null,
-                authSession = authSession,
-                familyGroup = familyGroup,
-                familyAlarmMode = current.familyTargetMode,
-                voiceProfiles = voiceProfiles,
-                familyVoices = familyVoices,
-                voiceProfileBusy = voiceProfileBusy,
-                onCancel = ::goBackInApp,
-                onGenerateTts = viewModel::generateTtsAudio,
-                onSave = { draft ->
-                    viewModel.createAlarm(draft) { screen = AlarmScreen.List }
-                },
-            )
-
-            is AlarmScreen.Edit -> AlarmEditorScreen(
-                contentPadding = padding,
-                alarm = current.alarm,
-                authSession = authSession,
-                familyGroup = familyGroup,
-                familyAlarmMode = false,
-                voiceProfiles = voiceProfiles,
-                familyVoices = familyVoices,
-                voiceProfileBusy = voiceProfileBusy,
-                onCancel = ::goBackInApp,
-                onGenerateTts = viewModel::generateTtsAudio,
-                onSave = { draft ->
-                    viewModel.updateAlarm(current.alarm.id, draft) { screen = AlarmScreen.List }
-                },
-            )
-
-            AlarmScreen.Settings -> SettingsScreen(
-                contentPadding = padding,
-                authSession = authSession,
-                themeMode = themeMode,
-                onBack = ::goBackInApp,
-                onChangeTheme = viewModel::setThemeMode,
-                onEditNickname = viewModel::requestEditNickname,
-                onLogout = ::logout,
-                onDeleteAccount = viewModel::requestDeleteAccount,
-            )
-        }
-        if (screen is AlarmScreen.List) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(
-                        top = padding.calculateTopPadding() + 8.dp,
-                        end = 8.dp,
-                    ),
-            ) {
-                ProfileMenu(
-                    authSession = authSession,
-                    onSelectTab = ::navigateToTab,
-                    onOpenSettings = { screen = AlarmScreen.Settings },
-                )
-            }
-        }
+          NavHost(
+              navController = navController,
+              startDestination = NativeTab.Home.route,
+              modifier = Modifier.fillMaxSize(),
+          ) {
+              NativeTab.values().forEach { tab ->
+                  composable(tab.route) {
+                      AlarmListScreen(
+                          contentPadding = padding,
+                          selectedTab = tab,
+                          onSelectTab = ::navigateToTab,
+                          alarms = alarms,
+                          authSession = authSession,
+                          authBusy = authBusy,
+                          syncBusy = syncBusy,
+                          voiceProfiles = voiceProfiles,
+                          voiceProfileBusy = voiceProfileBusy,
+                          socialBusy = socialBusy,
+                          familyGroup = familyGroup,
+                          familyVoices = familyVoices,
+                          characterEvents = characterEvents,
+                          characterBusy = characterBusy,
+                          characterResponse = characterResponse,
+                          billingBusy = billingBusy,
+                          subscriptionResponse = subscriptionResponse,
+                          vouchers = vouchers,
+                          noteBusy = noteBusy,
+                          receivedNotes = receivedNotes,
+                          onLogin = viewModel::login,
+                          onRegister = viewModel::register,
+                          onGoogleSignIn = ::launchGoogleSignIn,
+                          onSyncNow = viewModel::syncNow,
+                          onLogout = ::logout,
+                          onCreateVoiceProfile = viewModel::createVoiceProfile,
+                          onCreateVoiceProfiles = viewModel::createVoiceProfiles,
+                          onSeparateVoiceSpeakers = viewModel::separateVoiceSpeakers,
+                          onRenameVoiceProfile = viewModel::renameVoiceProfile,
+                          onShareVoiceProfile = viewModel::setVoiceProfileShared,
+                          onDeleteVoiceProfile = viewModel::deleteVoiceProfile,
+                          onRefreshSocial = viewModel::refreshSocial,
+                          onLeaveFamilyGroup = viewModel::leaveFamilyGroup,
+                          onRefreshCharacterBilling = viewModel::refreshCharacterAndBilling,
+                          onSyncCharacterEvents = viewModel::syncCharacterEvents,
+                          onRegisterCode = viewModel::registerCode,
+                          onRefreshNotes = viewModel::refreshNotes,
+                          onSendNote = viewModel::sendNote,
+                          onMarkNoteRead = viewModel::markNoteRead,
+                          onCheckoutPlan = viewModel::checkoutPlan,
+                          onCancelSubscription = viewModel::cancelSubscription,
+                          onChangePlan = viewModel::changePlan,
+                          onCreateAlarm = {
+                              if (!context.hasAlarmPermissions()) {
+                                  viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                              } else {
+                                  navController.navigate(AppRoute.alarmCreate(familyTargetMode = false))
+                              }
+                          },
+                          onCreateFamilyAlarm = {
+                              if (!context.hasAlarmPermissions()) {
+                                  viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                              } else {
+                                  navController.navigate(AppRoute.alarmCreate(familyTargetMode = true))
+                              }
+                          },
+                          onToggleEnabled = { id, enabled ->
+                              if (enabled && !context.hasAlarmPermissions()) {
+                                  viewModel.requestPermissionGate(PermissionTarget.Alarm)
+                              } else {
+                                  viewModel.setAlarmEnabled(id, enabled)
+                              }
+                          },
+                          onEditAlarm = { navController.navigate(AppRoute.alarmEdit(it.id)) },
+                          onDeleteAlarm = viewModel::deleteAlarm,
+                          onRequestPermissionGate = viewModel::requestPermissionGate,
+                      )
+                  }
+              }
+              composable(
+                  route = AppRoute.AlarmCreate,
+                  arguments = listOf(navArgument(AppRoute.FamilyTargetModeArg) { type = NavType.BoolType }),
+              ) { entry ->
+                  val familyTargetMode = entry.arguments?.getBoolean(AppRoute.FamilyTargetModeArg) ?: false
+                  AlarmEditorScreen(
+                      contentPadding = padding,
+                      alarm = null,
+                      authSession = authSession,
+                      familyGroup = familyGroup,
+                      familyAlarmMode = familyTargetMode,
+                      voiceProfiles = voiceProfiles,
+                      familyVoices = familyVoices,
+                      voiceProfileBusy = voiceProfileBusy,
+                      onCancel = ::goBackInApp,
+                      onGenerateTts = viewModel::generateTtsAudio,
+                      onSave = { draft ->
+                          viewModel.createAlarm(draft) { navController.popBackStackOrHome() }
+                      },
+                  )
+              }
+              composable(
+                  route = AppRoute.AlarmEdit,
+                  arguments = listOf(navArgument(AppRoute.AlarmIdArg) { type = NavType.StringType }),
+              ) { entry ->
+                  val alarmId = entry.arguments?.getString(AppRoute.AlarmIdArg)
+                  val currentAlarm = alarms.firstOrNull { it.id == alarmId }
+                  if (currentAlarm == null) {
+                      LaunchedEffect(alarmId) {
+                          navController.popBackStackOrHome()
+                      }
+                  } else {
+                      AlarmEditorScreen(
+                          contentPadding = padding,
+                          alarm = currentAlarm,
+                          authSession = authSession,
+                          familyGroup = familyGroup,
+                          familyAlarmMode = false,
+                          voiceProfiles = voiceProfiles,
+                          familyVoices = familyVoices,
+                          voiceProfileBusy = voiceProfileBusy,
+                          onCancel = ::goBackInApp,
+                          onGenerateTts = viewModel::generateTtsAudio,
+                          onSave = { draft ->
+                              viewModel.updateAlarm(currentAlarm.id, draft) {
+                                  navController.popBackStackOrHome()
+                              }
+                          },
+                      )
+                  }
+              }
+              composable(AppRoute.Settings) {
+                  SettingsScreen(
+                      contentPadding = padding,
+                      authSession = authSession,
+                      themeMode = themeMode,
+                      onBack = ::goBackInApp,
+                      onChangeTheme = viewModel::setThemeMode,
+                      onEditNickname = viewModel::requestEditNickname,
+                      onLogout = ::logout,
+                      onDeleteAccount = viewModel::requestDeleteAccount,
+                  )
+              }
+          }
+          if (currentTab != null) {
+              Box(
+                  modifier = Modifier
+                      .align(Alignment.TopEnd)
+                      .padding(
+                          top = padding.calculateTopPadding() + 8.dp,
+                          end = 8.dp,
+                      ),
+              ) {
+                  ProfileMenu(
+                      authSession = authSession,
+                      onSelectTab = ::navigateToTab,
+                      onOpenSettings = { navController.navigate(AppRoute.Settings) },
+                  )
+              }
+          }
       }
     }
 }
@@ -468,6 +502,54 @@ private fun buildGoogleSignInOptions(requestIdToken: Boolean = false): GoogleSig
         }
     }
     return builder.build()
+}
+
+private object AppRoute {
+    const val Settings = "settings"
+    const val FamilyTargetModeArg = "familyTargetMode"
+    const val AlarmCreate = "alarm/create/{$FamilyTargetModeArg}"
+    const val AlarmIdArg = "alarmId"
+    const val AlarmEdit = "alarm/edit/{$AlarmIdArg}"
+
+    fun alarmCreate(familyTargetMode: Boolean): String = "alarm/create/$familyTargetMode"
+    fun alarmEdit(alarmId: String): String = "alarm/edit/${Uri.encode(alarmId)}"
+}
+
+private val NativeTab.route: String
+    get() = when (this) {
+        NativeTab.Home -> "home"
+        NativeTab.Voices -> "voices"
+        NativeTab.Alarms -> "alarms"
+        NativeTab.People -> "people"
+        NativeTab.Messages -> "messages"
+        NativeTab.Growth -> "growth"
+        NativeTab.Billing -> "billing"
+    }
+
+private fun String?.toNativeTab(): NativeTab? =
+    NativeTab.values().firstOrNull { it.route == this }
+
+private fun NavHostController.navigateTopLevelTab(tab: NativeTab) {
+    navigate(tab.route) {
+        popUpTo(NativeTab.Home.route) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
+}
+
+private fun NavHostController.navigateHomeClearingStack() {
+    navigate(NativeTab.Home.route) {
+        popUpTo(NativeTab.Home.route)
+        launchSingleTop = true
+    }
+}
+
+private fun NavHostController.popBackStackOrHome() {
+    if (!popBackStack()) {
+        navigateHomeClearingStack()
+    }
 }
 
 private suspend fun signOutGoogleAccount(context: Context) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/navigation/NavigationModels.kt
@@ -3,7 +3,6 @@ package com.voicealarm.nativeapp
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.People
-import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.CharacterResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
@@ -28,13 +27,6 @@ internal data class SubscriptionPlanOption(
     val description: String,
     val features: List<String>,
 )
-
-internal sealed interface AlarmScreen {
-    data object List : AlarmScreen
-    data object Settings : AlarmScreen
-    data class Create(val familyTargetMode: Boolean = false) : AlarmScreen
-    data class Edit(val alarm: AlarmEntity) : AlarmScreen
-}
 
 internal enum class NativeTab {
     Home,


### PR DESCRIPTION
## 변경 내용
- Android 앱 화면 전환을 수동 상태 관리에서 Navigation Compose NavHost 기반으로 전환
- 하단 탭, 설정, 알람 생성/수정 화면을 명시적 route로 분리
- 로그아웃/계정 전환 시 홈 route로 스택 초기화 유지
- 기존 AlarmScreen 임시 모델 제거 및 navigation-compose 의존성 추가

## 검증
- .\\gradlew.bat testDebugUnitTest
- .\\gradlew.bat assembleDebug
- git diff --check
- SM-S918N, SM-A325N 디버그 APK 설치 확인

Closes #256