### PR TITLE
fix(subscription): 가족 공유 코드 표시와 생성 보완

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/BillingApi.kt
@@ -79,6 +79,11 @@ data class CheckoutVoucher(
     @SerializedName("use_count") val useCount: Int = 0,
 )
 
+data class EnsureFamilyShareCodeResponse(
+    val success: Boolean,
+    val voucher: VoucherItem,
+)
+
 data class CancelSubscriptionRequest(
     val mode: String, // "immediate" | "at_period_end"
 )
@@ -115,6 +120,11 @@ interface BillingApi {
         @Header("Authorization") authorization: String,
         @Body request: CheckoutRequest,
     ): CheckoutResponse
+
+    @POST("billing/vouchers/family-share")
+    suspend fun ensureFamilyShareCode(
+        @Header("Authorization") authorization: String,
+    ): EnsureFamilyShareCodeResponse
 
     @POST("billing/cancel")
     suspend fun cancelSubscription(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -67,6 +67,7 @@ internal fun AlarmListScreen(
     onRefreshCharacterBilling: () -> Unit,
     onSyncCharacterEvents: () -> Unit,
     onRegisterCode: (String) -> Unit,
+    onEnsureFamilyShareCode: () -> Unit,
     onRefreshNotes: () -> Unit,
     onSendNote: (String, String) -> Unit,
     onMarkNoteRead: (String) -> Unit,
@@ -192,9 +193,13 @@ internal fun AlarmListScreen(
                 item {
                     FamilyConnectionPanel(
                         socialBusy = socialBusy,
+                        billingBusy = billingBusy,
                         familyGroup = familyGroup,
+                        subscriptionResponse = subscriptionResponse,
+                        vouchers = vouchers,
                         onLeaveFamilyGroup = onLeaveFamilyGroup,
                         onRegisterCode = onRegisterCode,
+                        onEnsureFamilyShareCode = onEnsureFamilyShareCode,
                     )
                 }
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -133,7 +133,10 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                 viewModel.preloadSocial()
             }
             NativeTab.Alarms -> viewModel.syncNow()
-            NativeTab.People -> viewModel.refreshSocial()
+            NativeTab.People -> {
+                viewModel.refreshSocial()
+                viewModel.refreshCharacterAndBilling()
+            }
             NativeTab.Messages -> {
                 viewModel.refreshSocial()
                 viewModel.refreshNotes()
@@ -375,6 +378,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                           onRefreshCharacterBilling = viewModel::refreshCharacterAndBilling,
                           onSyncCharacterEvents = viewModel::syncCharacterEvents,
                           onRegisterCode = viewModel::registerCode,
+                          onEnsureFamilyShareCode = viewModel::ensureFamilyShareCode,
                           onRefreshNotes = viewModel::refreshNotes,
                           onSendNote = viewModel::sendNote,
                           onMarkNoteRead = viewModel::markNoteRead,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -134,7 +134,12 @@ internal fun SubscriptionPanel(
                 }
                 val vouchersForPlan = vouchers.filter { voucher ->
                     voucher.status in listOf("issued", "active", "pending") &&
-                        (voucher.planKey == option.key || voucher.planName.contains(option.name))
+                        voucher.useCount < voucher.maxUses &&
+                        (
+                            voucher.planKey == option.key ||
+                                voucher.planType == option.key ||
+                                voucher.planName.contains(option.name)
+                            )
                 }
                 SubscriptionPlanCard(
                     option = option,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -235,6 +235,25 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
     }
 }
 
+internal fun MainViewModel.ensureFamilyShareCode() {
+    val authorization = bearerOrMessage("공유 코드를 만들려면 먼저 로그인해 주세요") ?: return
+    viewModelScope.launch {
+        billingBusy = true
+        runCatching {
+            api.ensureFamilyShareCode(authorization).voucher
+        }.onSuccess { voucher ->
+            vouchers = listOf(voucher) + vouchers.filterNot { it.id == voucher.id }
+            message = "가족 공유 코드를 준비했어요"
+            refreshSocial()
+            refreshCharacterAndBilling()
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to ensure family share code", error)
+            message = userFacingError(error, "가족 공유 코드를 불러오지 못했어요")
+        }
+        billingBusy = false
+    }
+}
+
 internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
     val authorization = bearerOrMessage("로그인 후 사용할 수 있어요") ?: return
     val mode = if (atPeriodEnd) "at_period_end" else "immediate"
@@ -280,6 +299,7 @@ internal fun MainViewModel.changePlan(planKey: String, atPeriodEnd: Boolean) {
             }
             refreshCharacterAndBilling()
             refreshAppSession()
+            refreshSocial()
         }.onFailure { error ->
             Log.e(TAG, "Failed to change plan key=$planKey mode=$mode", error)
             message = userFacingError(error, "플랜 변경에 실패했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -1,5 +1,6 @@
 package com.voicealarm.nativeapp
 
+import android.content.Intent
 import android.media.MediaPlayer
 import android.net.Uri
 import androidx.compose.foundation.BorderStroke
@@ -37,30 +38,100 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.ReceivedNote
+import com.voicealarm.nativeapp.network.VoucherItem
 
 @Composable
 internal fun FamilyConnectionPanel(
     socialBusy: Boolean,
+    billingBusy: Boolean,
     familyGroup: FamilyGroupCurrentResponse?,
+    subscriptionResponse: BillingSubscriptionResponse?,
+    vouchers: List<VoucherItem>,
     onLeaveFamilyGroup: (String) -> Unit,
     onRegisterCode: (String) -> Unit,
+    onEnsureFamilyShareCode: () -> Unit,
 ) {
     var inviteCode by remember { mutableStateOf("") }
     var voucherCode by remember { mutableStateOf("") }
     val currentGroup = familyGroup?.group
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val familyShareCodes = remember(vouchers) {
+        vouchers.filter { voucher ->
+            voucher.code.startsWith("INV-") &&
+                voucher.planType == "family" &&
+                voucher.status in listOf("issued", "active", "pending") &&
+                voucher.useCount < voucher.maxUses
+        }
+    }
+    val canManageShareCode = currentGroup != null &&
+        familyGroup?.role == "owner" &&
+        subscriptionResponse?.plan?.planType == "family"
+
+    fun shareCode(code: String) {
+        clipboard.setText(AnnotatedString(code))
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, code)
+        }
+        context.startActivity(Intent.createChooser(sendIntent, "코드 공유"))
+    }
 
     OutlinedCard {
         Column(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            if (canManageShareCode) {
+                Text("내 가족 공유 코드", fontWeight = FontWeight.SemiBold)
+                val shareVoucher = familyShareCodes.firstOrNull()
+                if (shareVoucher == null) {
+                    MutedText("공유 코드가 아직 없어요. 가족 구성원을 초대할 INV 코드를 만들어 주세요.")
+                    OutlinedButton(
+                        onClick = onEnsureFamilyShareCode,
+                        enabled = !billingBusy,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text("공유 코드 만들기")
+                    }
+                } else {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(14.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = shareVoucher.code,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            MutedText("${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용")
+                            Button(
+                                onClick = { shareCode(shareVoucher.code) },
+                                enabled = !billingBusy,
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text("공유하기")
+                            }
+                        }
+                    }
+                }
+            }
+
             if (currentGroup != null && familyGroup.role == "member") {
                 OutlinedButton(
                     onClick = { onLeaveFamilyGroup(currentGroup.id) },

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -49,6 +49,33 @@ interface CreatedSubscriptionArtifacts {
   voucher: IssuedVoucherCode | null;
 }
 
+interface ShareableVoucherCode {
+  id: string;
+  code: string;
+  plan_id: string;
+  plan_key: string;
+  plan_name: string;
+  plan_type: string;
+  subscription_id: string;
+  status: 'issued';
+  issued_at: string;
+  expires_at: string;
+  max_uses: number;
+  use_count: number;
+}
+
+type FamilyShareCodeResult =
+  | { voucher: ShareableVoucherCode }
+  | {
+      error: {
+        status: 404;
+        body: {
+          error: string;
+          error_code: string;
+        };
+      };
+    };
+
 function normalizeBillablePlan(row: Record<string, unknown>): BillablePlan {
   return {
     id: String(row.id),
@@ -267,6 +294,123 @@ billingMutation.post('/redeem', async (c) => {
     }
     throw error;
   }
+});
+
+billingMutation.post('/vouchers/family-share', async (c) => {
+  const userPk = await resolveUserPk(c);
+  if (!userPk) {
+    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
+  }
+
+  const db = getDB(c.env);
+  const result: FamilyShareCodeResult = await withWriteTransaction(db, async (tx) => {
+    const subscriptionRes = await tx.execute({
+      sql: `SELECT s.id AS subscription_id, s.plan_id, s.expires_at,
+                   p.key AS plan_key, p.name AS plan_name, p.plan_type,
+                   p.period_days, p.max_members, p.price_krw
+            FROM subscriptions s
+            JOIN plans p ON p.id = s.plan_id
+            JOIN plan_groups pg ON pg.id = s.plan_group_id
+            WHERE s.user_id = ?
+              AND pg.owner_user_id = ?
+              AND s.status = 'active'
+              AND s.expires_at > datetime('now')
+              AND p.plan_type = 'family'
+            ORDER BY s.starts_at DESC
+            LIMIT 1`,
+      args: [userPk, userPk],
+    });
+
+    if (subscriptionRes.rows.length === 0) {
+      return {
+        error: {
+          status: 404,
+          body: {
+            error: 'Active family plan ownership is required',
+            error_code: 'NO_ACTIVE_FAMILY_OWNER_SUBSCRIPTION',
+          },
+        },
+      };
+    }
+
+    const subscription = subscriptionRes.rows[0]!;
+    const subscriptionId = String(subscription.subscription_id);
+    const planId = String(subscription.plan_id);
+    const planKey = String(subscription.plan_key);
+    const planName = String(subscription.plan_name);
+    const planType = String(subscription.plan_type);
+    const maxMembers = Number(subscription.max_members) || 6;
+    const maxUses = plannedMaxUses(planType, maxMembers);
+
+    const existingRes = await tx.execute({
+      sql: `SELECT v.id, v.code, v.status, v.issued_at, v.expires_at, v.max_uses,
+                   (SELECT COUNT(*) FROM voucher_redemptions WHERE voucher_id = v.id) AS use_count
+            FROM voucher_codes v
+            WHERE v.issuer_user_id = ?
+              AND v.issuer_subscription_id = ?
+              AND v.status = 'issued'
+              AND v.expires_at > datetime('now')
+            ORDER BY v.issued_at DESC`,
+      args: [userPk, subscriptionId],
+    });
+
+    const existing = existingRes.rows.find((row) => {
+      const useCount = Number(row.use_count ?? 0);
+      const rowMaxUses = Number(row.max_uses ?? 1);
+      return useCount < rowMaxUses;
+    });
+
+    if (existing) {
+      const voucher: ShareableVoucherCode = {
+        id: String(existing.id),
+        code: String(existing.code),
+        plan_id: planId,
+        plan_key: planKey,
+        plan_name: planName,
+        plan_type: planType,
+        subscription_id: subscriptionId,
+        status: 'issued',
+        issued_at: String(existing.issued_at),
+        expires_at: String(existing.expires_at),
+        max_uses: Number(existing.max_uses ?? maxUses),
+        use_count: Number(existing.use_count ?? 0),
+      };
+      return { voucher };
+    }
+
+    const issuedAt = new Date().toISOString();
+    const issued = await issueVoucherCode(tx, {
+      kind: 'invite',
+      planId,
+      issuerUserId: userPk,
+      issuerSubscriptionId: subscriptionId,
+      issuedAt,
+      expiresAt: String(subscription.expires_at),
+      maxUses,
+    });
+
+    const voucher: ShareableVoucherCode = {
+      id: issued.id,
+      code: issued.code,
+      plan_id: planId,
+      plan_key: planKey,
+      plan_name: planName,
+      plan_type: planType,
+      subscription_id: subscriptionId,
+      status: 'issued',
+      issued_at: issuedAt,
+      expires_at: issued.expires_at,
+      max_uses: issued.max_uses,
+      use_count: issued.use_count,
+    };
+    return { voucher };
+  });
+
+  if ('error' in result) {
+    return c.json(result.error.body, result.error.status);
+  }
+
+  return c.json({ success: true, voucher: result.voucher });
 });
 
 billingMutation.post('/cancel', async (c) => {

--- a/packages/backend/test/billing-mutation.test.ts
+++ b/packages/backend/test/billing-mutation.test.ts
@@ -682,3 +682,81 @@ describe.skip('POST /billing/redeem (billingMutation)', () => {
     expect((await res.json()).error_code).toBe('CODE_REQUIRED');
   });
 });
+
+describe('POST /billing/vouchers/family-share (billingMutation)', () => {
+  const FUTURE = '2027-12-31T00:00:00.000Z';
+
+  function pushOwnerFamilySubscription() {
+    mockDB.pushResult([{
+      subscription_id: 'sub-family-1',
+      plan_id: PLAN_FAMILY.id,
+      expires_at: FUTURE,
+      plan_key: PLAN_FAMILY.key,
+      plan_name: PLAN_FAMILY.name,
+      plan_type: PLAN_FAMILY.plan_type,
+      period_days: PLAN_FAMILY.period_days,
+      max_members: PLAN_FAMILY.max_members,
+      price_krw: PLAN_FAMILY.price_krw,
+    }]);
+  }
+
+  it('기존에 사용 가능한 가족 공유 코드가 있으면 새로 만들지 않고 그대로 반환', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    pushOwnerFamilySubscription();
+    mockDB.pushResult([{
+      id: 'voucher-1',
+      code: 'INV-AAAA-BBBB-CCCC',
+      status: 'issued',
+      issued_at: '2026-05-01T00:00:00.000Z',
+      expires_at: FUTURE,
+      max_uses: 5,
+      use_count: 2,
+    }]);
+
+    const res = await buildApp().request(jsonReq('POST', '/billing/vouchers/family-share'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voucher).toMatchObject({
+      id: 'voucher-1',
+      code: 'INV-AAAA-BBBB-CCCC',
+      plan_key: 'family',
+      plan_type: 'family',
+      max_uses: 5,
+      use_count: 2,
+    });
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT OR IGNORE INTO voucher_codes'))).toBe(false);
+  });
+
+  it('가족 플랜 소유자인데 공유 코드가 없으면 INV 코드 하나를 발급한다', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    pushOwnerFamilySubscription();
+    mockDB.pushResult([]);
+    mockDB.pushResult([], 1);
+
+    const res = await buildApp().request(jsonReq('POST', '/billing/vouchers/family-share'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voucher.code).toMatch(/^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(body.voucher.subscription_id).toBe('sub-family-1');
+    expect(body.voucher.max_uses).toBe(5);
+
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT OR IGNORE INTO voucher_codes'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.args[3]).toBe(PLAN_FAMILY.id);
+    expect(insertCall?.args[4]).toBe('user-pk-1');
+    expect(insertCall?.args[5]).toBe('sub-family-1');
+    expect(insertCall?.args[8]).toBe(5);
+  });
+
+  it('가족 플랜 소유자가 아니면 404를 반환한다', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    mockDB.pushResult([]);
+
+    const res = await buildApp().request(jsonReq('POST', '/billing/vouchers/family-share'));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error_code).toBe('NO_ACTIVE_FAMILY_OWNER_SUBSCRIPTION');
+  });
+});


### PR DESCRIPTION
## 변경 내용
- 코드 등록 화면 상단에 가족 플랜 소유자의 INV 공유 코드를 표시
- 공유 코드가 없는 기존 가족 구독도 voucher_codes 기반으로 공유 코드를 생성할 수 있도록 API 추가
- 구독 탭 공유 코드 필터를 plan_key뿐 아니라 plan_type 기준으로도 동작하도록 보완
- 코드 등록 탭 진입 시 구독/이용권 정보도 함께 새로고침

## 검증
- npm run typecheck
- npm test --workspace packages/backend
- npm run lint (기존 reset-test-data.ts console warning만 있음)
- .\\gradlew.bat testDebugUnitTest
- .\\gradlew.bat assembleDebug
- git diff --check
- SM-S918N, SM-A325N 디버그 APK 설치 확인