### PR TITLE
fix(android): 하단 탭 중앙 정렬 수정

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmBottomBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -98,9 +99,9 @@ internal fun VoiceAlarmTabItem(
     val interactionSource = remember { MutableInteractionSource() }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically),
         modifier = modifier
-            .height(64.dp)
+            .fillMaxHeight()
             .clickable(
                 enabled = !selected,
                 interactionSource = interactionSource,


### PR DESCRIPTION
## 변경 내용
- 하단 nav 탭 아이템이 슬롯 전체 높이를 채우도록 수정
- 아이콘과 라벨 묶음을 가로/세로 중앙 정렬하도록 조정

## 검증
- .\\gradlew.bat testDebugUnitTest
- .\\gradlew.bat assembleDebug
- git diff --check
- SM-S918N, SM-A325N 디버그 APK 설치 확인