### PR TITLE
feat: 공유 플랜 멤버 관리 및 코드 등록 UX 개선

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
@@ -2,6 +2,7 @@ package com.voicealarm.nativeapp.network
 
 import com.google.gson.annotations.SerializedName
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
@@ -55,6 +56,11 @@ data class LeaveFamilyGroupResponse(
     @SerializedName("left_group_id") val leftGroupId: String,
 )
 
+data class RemoveFamilyMemberResponse(
+    val success: Boolean,
+    @SerializedName("removed_user_id") val removedUserId: String? = null,
+)
+
 interface FamilyApi {
     @GET("family/groups/current")
     suspend fun getFamilyGroup(@Header("Authorization") authorization: String): FamilyGroupCurrentResponse
@@ -65,6 +71,13 @@ interface FamilyApi {
         @Path("groupId") groupId: String,
         @Body request: Map<String, String> = emptyMap(),
     ): LeaveFamilyGroupResponse
+
+    @DELETE("family/groups/{groupId}/members/{userId}")
+    suspend fun removeFamilyMember(
+        @Header("Authorization") authorization: String,
+        @Path("groupId") groupId: String,
+        @Path("userId") userId: String,
+    ): RemoveFamilyMemberResponse
 
     @POST("family/alarms/voice")
     suspend fun createFamilyVoiceAlarm(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -260,12 +260,14 @@ internal fun AlarmListScreen(
                     SubscriptionPanel(
                         billingBusy = billingBusy,
                         subscriptionResponse = subscriptionResponse,
+                        familyGroup = familyGroup,
                         vouchers = vouchers,
                         onRefresh = onRefreshCharacterBilling,
                         onRegisterCode = onRegisterCode,
                         onCheckoutPlan = onCheckoutPlan,
                         onCancelSubscription = onCancelSubscription,
                         onChangePlan = onChangePlan,
+                        onLeaveFamilyGroup = onLeaveFamilyGroup,
                     )
                 }
             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -475,8 +475,22 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                       onDeleteAccount = viewModel::requestDeleteAccount,
                   )
               }
+              composable(AppRoute.MemberManagement) {
+                  MemberManagementScreen(
+                      contentPadding = padding,
+                      familyGroup = familyGroup,
+                      subscriptionResponse = subscriptionResponse,
+                      currentUserId = authSession?.user?.id,
+                      socialBusy = socialBusy,
+                      onBack = ::goBackInApp,
+                      onRemoveFamilyMember = viewModel::removeFamilyMember,
+                  )
+              }
           }
           if (currentTab != null) {
+              val isPlanOwner = familyGroup?.role == "owner" &&
+                  familyGroup.group != null &&
+                  subscriptionResponse?.plan?.planType == "family"
               Box(
                   modifier = Modifier
                       .align(Alignment.TopEnd)
@@ -487,8 +501,10 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
               ) {
                   ProfileMenu(
                       authSession = authSession,
+                      isPlanOwner = isPlanOwner,
                       onSelectTab = ::navigateToTab,
                       onOpenSettings = { navController.navigate(AppRoute.Settings) },
+                      onOpenMemberManagement = { navController.navigate(AppRoute.MemberManagement) },
                   )
               }
           }
@@ -510,6 +526,7 @@ private fun buildGoogleSignInOptions(requestIdToken: Boolean = false): GoogleSig
 
 private object AppRoute {
     const val Settings = "settings"
+    const val MemberManagement = "members"
     const val FamilyTargetModeArg = "familyTargetMode"
     const val AlarmCreate = "alarm/create/{$FamilyTargetModeArg}"
     const val AlarmIdArg = "alarmId"

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/billing/BillingPanels.kt
@@ -40,28 +40,34 @@ import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.CharacterEventEntity
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.CharacterResponse
+import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.VoucherItem
 
 @Composable
 internal fun SubscriptionPanel(
     billingBusy: Boolean,
     subscriptionResponse: BillingSubscriptionResponse?,
+    familyGroup: FamilyGroupCurrentResponse?,
     vouchers: List<VoucherItem>,
     onRefresh: () -> Unit,
     onRegisterCode: (String) -> Unit,
     onCheckoutPlan: (String, Boolean) -> Unit,
     onCancelSubscription: (Boolean) -> Unit,
     onChangePlan: (String, Boolean) -> Unit,
+    onLeaveFamilyGroup: (String) -> Unit,
 ) {
     var checkoutTarget by remember { mutableStateOf<CheckoutSelection?>(null) }
     var changeTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
     var showCancelDialog by remember { mutableStateOf(false) }
+    var showLeaveDialog by remember { mutableStateOf(false) }
     var shareTarget by remember { mutableStateOf<List<VoucherItem>>(emptyList()) }
     val subscription = subscriptionResponse?.subscription
     val currentPlan = subscriptionResponse?.plan
     val nextPlan = subscriptionResponse?.nextPlan
     val hasActive = subscription != null && currentPlan != null
     val cancelScheduled = subscription?.cancelAtPeriodEnd == true
+    val isSharedMember = familyGroup?.role == "member" && familyGroup.group != null
+    val sharedGroupId = familyGroup?.group?.id
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val options = remember {
@@ -135,11 +141,7 @@ internal fun SubscriptionPanel(
                 val vouchersForPlan = vouchers.filter { voucher ->
                     voucher.status in listOf("issued", "active", "pending") &&
                         voucher.useCount < voucher.maxUses &&
-                        (
-                            voucher.planKey == option.key ||
-                                voucher.planType == option.key ||
-                                voucher.planName.contains(option.name)
-                            )
+                        voucher.planKey == option.key
                 }
                 SubscriptionPlanCard(
                     option = option,
@@ -155,13 +157,15 @@ internal fun SubscriptionPanel(
             }
             if (hasActive) {
                 OutlinedButton(
-                    onClick = { showCancelDialog = true },
+                    onClick = {
+                        if (isSharedMember) showLeaveDialog = true else showCancelDialog = true
+                    },
                     enabled = !billingBusy,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(14.dp),
                 ) {
                     Text(
-                        text = "해지하기",
+                        text = if (isSharedMember) "플랜에서 나가기" else "해지하기",
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
@@ -175,6 +179,34 @@ internal fun SubscriptionPanel(
             onConfirm = { atPeriodEnd ->
                 showCancelDialog = false
                 onCancelSubscription(atPeriodEnd)
+            },
+        )
+    }
+
+    if (showLeaveDialog && sharedGroupId != null) {
+        AlertDialog(
+            onDismissRequest = { showLeaveDialog = false },
+            title = { Text("플랜에서 나가기") },
+            text = {
+                MutedText("정말 플랜에서 나가시겠어요? 다시 들어오려면 새 초대 코드가 필요해요.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showLeaveDialog = false
+                        onLeaveFamilyGroup(sharedGroupId)
+                    },
+                ) {
+                    Text(
+                        text = "나가기",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLeaveDialog = false }) {
+                    Text("취소")
+                }
             },
         )
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -85,8 +85,10 @@ internal fun HomeHeader() {
 @Composable
 internal fun ProfileMenu(
     authSession: AuthSession?,
+    isPlanOwner: Boolean,
     onSelectTab: (NativeTab) -> Unit,
     onOpenSettings: () -> Unit,
+    onOpenMemberManagement: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box {
@@ -131,6 +133,12 @@ internal fun ProfileMenu(
             ProfileMenuItem("구독") {
                 expanded = false
                 onSelectTab(NativeTab.Billing)
+            }
+            if (isPlanOwner) {
+                ProfileMenuItem("멤버 관리") {
+                    expanded = false
+                    onOpenMemberManagement()
+                }
             }
             HorizontalDivider()
             ProfileMenuItem("설정") {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -237,18 +237,23 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
 
 internal fun MainViewModel.ensureFamilyShareCode() {
     val authorization = bearerOrMessage("공유 코드를 만들려면 먼저 로그인해 주세요") ?: return
+    val planLabel = when (subscriptionResponse?.plan?.key) {
+        "couple" -> "커플"
+        "family" -> "가족"
+        else -> "공유"
+    }
     viewModelScope.launch {
         billingBusy = true
         runCatching {
             api.ensureFamilyShareCode(authorization).voucher
         }.onSuccess { voucher ->
             vouchers = listOf(voucher) + vouchers.filterNot { it.id == voucher.id }
-            message = "가족 공유 코드를 준비했어요"
+            message = "$planLabel 공유 코드를 준비했어요"
             refreshSocial()
             refreshCharacterAndBilling()
         }.onFailure { error ->
             Log.e(TAG, "Failed to ensure family share code", error)
-            message = userFacingError(error, "가족 공유 코드를 불러오지 못했어요")
+            message = userFacingError(error, "$planLabel 공유 코드를 불러오지 못했어요")
         }
         billingBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelSocialActions.kt
@@ -45,19 +45,37 @@ private fun MainViewModel.refreshSocialData(showMessage: Boolean) {
 }
 
 internal fun MainViewModel.leaveFamilyGroup(groupId: String) {
-    val authorization = bearerOrMessage("Login is required to leave the shared plan.") ?: return
+    val authorization = bearerOrMessage("플랜에서 나가려면 먼저 로그인해 주세요") ?: return
     viewModelScope.launch {
         socialBusy = true
         runCatching {
             api.leaveFamilyGroup(authorization, groupId, emptyMap())
         }.onSuccess {
-            message = "Shared plan left. Your plan is now free."
+            message = "플랜에서 나갔어요. 무료 플랜으로 전환됐어요."
             refreshSocial()
             refreshCharacterAndBilling()
             refreshAppSession()
         }.onFailure { error ->
             Log.e(TAG, "Failed to leave family group id=$groupId", error)
-            message = userFacingError(error, "Failed to leave the shared plan")
+            message = userFacingError(error, "플랜에서 나가지 못했어요")
+        }
+        socialBusy = false
+    }
+}
+
+internal fun MainViewModel.removeFamilyMember(groupId: String, userId: String) {
+    val authorization = bearerOrMessage("멤버를 내보내려면 먼저 로그인해 주세요") ?: return
+    viewModelScope.launch {
+        socialBusy = true
+        runCatching {
+            api.removeFamilyMember(authorization, groupId, userId)
+        }.onSuccess {
+            message = "멤버를 내보냈어요"
+            refreshSocial()
+            refreshCharacterAndBilling()
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to remove family member group=$groupId user=$userId", error)
+            message = userFacingError(error, "멤버를 내보내지 못했어요")
         }
         socialBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
@@ -1,0 +1,270 @@
+package com.voicealarm.nativeapp
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
+import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
+import com.voicealarm.nativeapp.network.FamilyGroupMember
+
+@Composable
+internal fun MemberManagementScreen(
+    contentPadding: PaddingValues,
+    familyGroup: FamilyGroupCurrentResponse?,
+    subscriptionResponse: BillingSubscriptionResponse?,
+    currentUserId: String?,
+    socialBusy: Boolean,
+    onBack: () -> Unit,
+    onRemoveFamilyMember: (String, String) -> Unit,
+) {
+    val group = familyGroup?.group
+    val isOwner = familyGroup?.role == "owner" && group != null
+    val planLabel = when (subscriptionResponse?.plan?.key) {
+        "couple" -> "커플"
+        "family" -> "가족"
+        else -> "공유"
+    }
+    val sortedMembers = familyGroup?.members.orEmpty()
+        .sortedWith(compareByDescending<FamilyGroupMember> { it.role == "owner" }.thenBy { it.joinedAt })
+
+    var selectedMember by remember { mutableStateOf<FamilyGroupMember?>(null) }
+    var pendingRemoveMember by remember { mutableStateOf<FamilyGroupMember?>(null) }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "뒤로",
+                    )
+                }
+                Text(
+                    text = "$planLabel 멤버 관리",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+
+        if (group == null) {
+            item {
+                Text(
+                    text = "참여 중인 공유 플랜이 없어요.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@LazyColumn
+        }
+
+        item {
+            Text(
+                text = "현재 ${sortedMembers.size}/${group.maxMembers}명",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (isOwner) {
+            item {
+                Text(
+                    text = "멤버를 탭하면 정보와 내보내기 버튼이 나타납니다.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        items(sortedMembers) { member ->
+            MemberRow(
+                member = member,
+                isMe = member.userId == currentUserId,
+                onClick = { selectedMember = member },
+            )
+        }
+    }
+
+    selectedMember?.let { member ->
+        val isMe = member.userId == currentUserId
+        val canRemove = isOwner && !isMe && member.role != "owner"
+        AlertDialog(
+            onDismissRequest = { selectedMember = null },
+            title = { Text(member.name ?: member.email ?: "멤버") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = member.email ?: "이메일 없음",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = when {
+                            member.role == "owner" -> "관리자"
+                            isMe -> "나"
+                            else -> "구성원"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            confirmButton = {
+                if (canRemove) {
+                    TextButton(
+                        enabled = !socialBusy,
+                        onClick = {
+                            pendingRemoveMember = member
+                            selectedMember = null
+                        },
+                    ) {
+                        Text(
+                            text = "내보내기",
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                } else {
+                    TextButton(onClick = { selectedMember = null }) {
+                        Text("닫기")
+                    }
+                }
+            },
+            dismissButton = if (canRemove) {
+                {
+                    TextButton(onClick = { selectedMember = null }) {
+                        Text("닫기")
+                    }
+                }
+            } else null,
+        )
+    }
+
+    pendingRemoveMember?.let { member ->
+        AlertDialog(
+            onDismissRequest = { pendingRemoveMember = null },
+            title = { Text("멤버 내보내기") },
+            text = {
+                Text(
+                    text = "${member.name ?: member.email ?: "이 멤버"}을(를) 정말 내보낼까요? 다시 들어오려면 새 초대 코드가 필요해요.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            confirmButton = {
+                val groupId = group?.id
+                TextButton(
+                    enabled = !socialBusy && groupId != null,
+                    onClick = {
+                        if (groupId != null) {
+                            onRemoveFamilyMember(groupId, member.userId)
+                        }
+                        pendingRemoveMember = null
+                    },
+                ) {
+                    Text(
+                        text = "내보내기",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemoveMember = null }) {
+                    Text("취소")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun MemberRow(
+    member: FamilyGroupMember,
+    isMe: Boolean,
+    onClick: () -> Unit,
+) {
+    Card(
+        onClick = onClick,
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isMe) {
+                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
+            } else {
+                MaterialTheme.colorScheme.surface
+            },
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = member.name ?: member.email ?: "멤버",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                if (member.email != null && member.name != null) {
+                    Text(
+                        text = member.email,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            AssistChip(
+                onClick = onClick,
+                label = {
+                    Text(
+                        when {
+                            member.role == "owner" -> "관리자"
+                            isMe -> "나"
+                            else -> "구성원"
+                        },
+                    )
+                },
+            )
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -28,6 +29,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -46,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
+import com.voicealarm.nativeapp.network.FamilyGroupMember
 import com.voicealarm.nativeapp.network.ReceivedNote
 import com.voicealarm.nativeapp.network.VoucherItem
 
@@ -65,10 +68,17 @@ internal fun FamilyConnectionPanel(
     val currentGroup = familyGroup?.group
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
-    val familyShareCodes = remember(vouchers) {
+    val activePlanKey = subscriptionResponse?.plan?.key
+    val sharedPlanLabel = when (activePlanKey) {
+        "couple" -> "커플"
+        "family" -> "가족"
+        else -> "공유"
+    }
+    val familyShareCodes = remember(vouchers, activePlanKey) {
         vouchers.filter { voucher ->
             voucher.code.startsWith("INV-") &&
                 voucher.planType == "family" &&
+                (activePlanKey == null || voucher.planKey == activePlanKey) &&
                 voucher.status in listOf("issued", "active", "pending") &&
                 voucher.useCount < voucher.maxUses
         }
@@ -76,6 +86,12 @@ internal fun FamilyConnectionPanel(
     val canManageShareCode = currentGroup != null &&
         familyGroup?.role == "owner" &&
         subscriptionResponse?.plan?.planType == "family"
+
+    val activePlanName = subscriptionResponse?.plan?.takeIf { subscriptionResponse.subscription != null }?.name
+    val hasActivePlan = activePlanName != null
+    var showCodeInputs by remember(hasActivePlan) { mutableStateOf(!hasActivePlan) }
+    var pendingRegisterCode by remember { mutableStateOf<String?>(null) }
+    var showLeaveDialog by remember { mutableStateOf(false) }
 
     fun shareCode(code: String) {
         clipboard.setText(AnnotatedString(code))
@@ -92,10 +108,10 @@ internal fun FamilyConnectionPanel(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             if (canManageShareCode) {
-                Text("내 가족 공유 코드", fontWeight = FontWeight.SemiBold)
+                Text("내 $sharedPlanLabel 공유 코드", fontWeight = FontWeight.SemiBold)
                 val shareVoucher = familyShareCodes.firstOrNull()
                 if (shareVoucher == null) {
-                    MutedText("공유 코드가 아직 없어요. 가족 구성원을 초대할 INV 코드를 만들어 주세요.")
+                    MutedText("공유 코드가 아직 없어요. $sharedPlanLabel 구성원을 초대할 INV 코드를 만들어 주세요.")
                     OutlinedButton(
                         onClick = onEnsureFamilyShareCode,
                         enabled = !billingBusy,
@@ -134,72 +150,146 @@ internal fun FamilyConnectionPanel(
 
             if (currentGroup != null && familyGroup.role == "member") {
                 OutlinedButton(
-                    onClick = { onLeaveFamilyGroup(currentGroup.id) },
+                    onClick = { showLeaveDialog = true },
                     enabled = !socialBusy,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(14.dp),
                 ) {
-                    Text("Leave shared plan")
+                    Text(
+                        text = "플랜에서 나가기",
+                        color = MaterialTheme.colorScheme.error,
+                    )
                 }
             }
 
-            Text("초대 코드 등록(가족/커플)", fontWeight = FontWeight.SemiBold)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedTextField(
-                    value = inviteCode,
-                    onValueChange = { value ->
-                        inviteCode = value
-                            .uppercase()
-                            .filter { it.isLetterOrDigit() || it == '-' }
-                            .take(18)
-                    },
-                    placeholder = { Text("INV-XXXX-XXXX-XXXX") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                Button(
-                    onClick = {
-                        onRegisterCode(inviteCode)
-                        inviteCode = ""
-                    },
-                    enabled = inviteCode.isNotBlank() && !socialBusy,
+            if (hasActivePlan && !showCodeInputs) {
+                MutedText("$activePlanName 플랜 사용중이라 등록은 플랜이 종료된 다음에 가능합니다.")
+                OutlinedButton(
+                    onClick = { showCodeInputs = true },
+                    enabled = !socialBusy,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(14.dp),
                 ) {
-                    Text("참여")
+                    Text("다른 코드 등록하기")
                 }
-            }
-
-            Text("선물받은 코드 등록", fontWeight = FontWeight.SemiBold)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedTextField(
-                    value = voucherCode,
-                    onValueChange = { value ->
-                        voucherCode = value
-                            .uppercase()
-                            .filter { it.isLetterOrDigit() || it == '-' }
-                            .take(19)
-                    },
-                    placeholder = { Text("GIFT-XXXX-XXXX-XXXX") },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                )
-                Button(
-                    onClick = {
-                        onRegisterCode(voucherCode)
-                        voucherCode = ""
-                    },
-                    enabled = voucherCode.isNotBlank() && !socialBusy,
+            } else {
+                if (hasActivePlan) {
+                    MutedText("유효한 코드를 등록하면 현재 $activePlanName 플랜은 해지돼요.")
+                }
+                Text("초대 코드 등록(가족/커플)", fontWeight = FontWeight.SemiBold)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Text("등록")
+                    OutlinedTextField(
+                        value = inviteCode,
+                        onValueChange = { value ->
+                            inviteCode = value
+                                .uppercase()
+                                .filter { it.isLetterOrDigit() || it == '-' }
+                                .take(18)
+                        },
+                        placeholder = { Text("INV-XXXX-XXXX-XXXX") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(
+                        onClick = { pendingRegisterCode = inviteCode },
+                        enabled = inviteCode.isNotBlank() && !socialBusy,
+                    ) {
+                        Text("참여")
+                    }
+                }
+
+                Text("선물받은 코드 등록", fontWeight = FontWeight.SemiBold)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedTextField(
+                        value = voucherCode,
+                        onValueChange = { value ->
+                            voucherCode = value
+                                .uppercase()
+                                .filter { it.isLetterOrDigit() || it == '-' }
+                                .take(19)
+                        },
+                        placeholder = { Text("GIFT-XXXX-XXXX-XXXX") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(
+                        onClick = { pendingRegisterCode = voucherCode },
+                        enabled = voucherCode.isNotBlank() && !socialBusy,
+                    ) {
+                        Text("등록")
+                    }
                 }
             }
         }
     }
+
+    if (showLeaveDialog && currentGroup != null) {
+        AlertDialog(
+            onDismissRequest = { showLeaveDialog = false },
+            title = { Text("플랜에서 나가기") },
+            text = {
+                MutedText("정말 플랜에서 나가시겠어요? 다시 들어오려면 새 초대 코드가 필요해요.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showLeaveDialog = false
+                        onLeaveFamilyGroup(currentGroup.id)
+                    },
+                ) {
+                    Text(
+                        text = "나가기",
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLeaveDialog = false }) {
+                    Text("취소")
+                }
+            },
+        )
+    }
+
+    pendingRegisterCode?.let { code ->
+        AlertDialog(
+            onDismissRequest = { pendingRegisterCode = null },
+            title = { Text("코드 등록") },
+            text = {
+                MutedText(
+                    if (hasActivePlan) {
+                        "유효한 코드면 현재 $activePlanName 플랜은 해지되고 새 플랜으로 전환돼요. 등록하시겠어요?"
+                    } else {
+                        "이 코드를 등록할까요?"
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onRegisterCode(code)
+                        inviteCode = ""
+                        voucherCode = ""
+                        pendingRegisterCode = null
+                    },
+                ) {
+                    Text("등록")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRegisterCode = null }) {
+                    Text("취소")
+                }
+            },
+        )
+    }
+
 }
 
 @Composable

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -59,6 +59,41 @@ async function expireUnusedVouchersFor(db: DbExecutor, subscriptionId: string): 
   });
 }
 
+async function releaseInviteUseForMember(
+  db: DbExecutor,
+  userPk: string,
+  planGroupId: string,
+): Promise<void> {
+  const redemptionRes = await db.execute({
+    sql: `SELECT vr.id AS redemption_id, vr.voucher_id
+          FROM voucher_redemptions vr
+          JOIN voucher_codes v ON v.id = vr.voucher_id
+          JOIN subscriptions s ON s.id = v.issuer_subscription_id
+          WHERE vr.user_id = ? AND s.plan_group_id = ?`,
+    args: [userPk, planGroupId],
+  });
+
+  for (const row of redemptionRes.rows) {
+    const redemptionId = String(row.redemption_id);
+    const voucherId = String(row.voucher_id);
+
+    await db.execute({
+      sql: `DELETE FROM voucher_redemptions WHERE id = ?`,
+      args: [redemptionId],
+    });
+
+    await db.execute({
+      sql: `UPDATE voucher_codes
+            SET status = 'issued',
+                used_at = NULL
+            WHERE id = ?
+              AND status = 'used'
+              AND (SELECT COUNT(*) FROM voucher_redemptions WHERE voucher_id = ?) < COALESCE(max_uses, 1)`,
+      args: [voucherId, voucherId],
+    });
+  }
+}
+
 function plannedMaxUses(planType: string, maxMembers: number): number {
   if (planType === 'family') return Math.max(1, maxMembers - 1);
   return 1;
@@ -104,6 +139,7 @@ export async function cancelSubscriptionImmediate(
       sql: `DELETE FROM plan_group_members WHERE plan_group_id = ? AND user_id = ?`,
       args: [subscription.planGroupId, subscription.userPk],
     });
+    await releaseInviteUseForMember(db, subscription.userPk, subscription.planGroupId);
     return;
   }
 
@@ -172,6 +208,8 @@ export async function leavePlanGroupMember(
     sql: `DELETE FROM plan_group_members WHERE id = ?`,
     args: [params.membershipId],
   });
+
+  await releaseInviteUseForMember(db, params.userPk, params.planGroupId);
 }
 
 export async function scheduleCancelAtPeriodEnd(


### PR DESCRIPTION
Closes #261

## 개요
공유 플랜(가족·커플) 운영에서 발견된 UX/데이터 정합성 이슈를 한 번에 정리합니다.

## 주요 변경
### 백엔드
- `releaseInviteUseForMember` 헬퍼 추가 → `leavePlanGroupMember` 와 비-소유자의 `cancelSubscriptionImmediate` 경로에서 voucher 사용 카운트(`n/5`)가 실제 멤버 수에 맞춰 줄어들도록 복구.

### Android
- 코드 등록 화면: 활성 플랜 시 입력창 숨김 + 토글, 등록·나가기 모두 확인 다이얼로그.
- 초대 코드 멤버: BillingPanels 해지 버튼을 `플랜에서 나가기`로 분기 (leave API 호출). SocialPanels 의 `Leave shared plan` 도 한글화.
- 공유 코드 라벨/안내·토스트: `plan.key` 기반으로 `커플`/`가족` 동적 표시.
- 플랜 카드 voucher 필터: `planKey` 단일 기준으로 좁힘 → 커플·가족 카드 양쪽에 voucher 가 잘못 노출되던 현상 해결.
- 프로필 메뉴: owner 한정 `멤버 관리` 항목 추가.
- `MemberManagementScreen` 신설: 멤버 정보 다이얼로그 + owner 한정 내보내기 (확인 다이얼로그 후 DELETE 호출).

## 테스트 플랜
- [ ] 가족 owner: 공유 코드 카드 라벨이 `내 가족 공유 코드` 인지 확인.
- [ ] 커플 owner: 라벨이 `내 커플 공유 코드` 인지 확인.
- [ ] 멤버가 `플랜에서 나가기` 했을 때 owner 화면의 사용 카운트가 줄어드는지 확인.
- [ ] owner 의 프로필 메뉴에서 `멤버 관리` 진입 → 비-owner 멤버 카드 탭 → 정보·내보내기 다이얼로그 노출, 확인 후 멤버가 제거되는지 확인.
- [ ] 활성 플랜 보유 시 코드 입력창이 숨겨지고 토글 버튼이 보이는지 확인.
- [ ] 등록·나가기 동작에 확인 다이얼로그가 뜨는지 확인.
- [ ] BillingPanels 의 커플/가족 카드에 표시되는 voucher 가 각 플랜 키에만 매칭되는지 확인.