### PR TITLE
feat: 공유 코드 노출과 진입점 UX 정리

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -102,6 +102,12 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         viewModel.clearMessage()
     }
 
+    LaunchedEffect(viewModel.navigateHomeTick) {
+        if (viewModel.navigateHomeTick > 0) {
+            navController.navigateHomeClearingStack()
+        }
+    }
+
     LoginPermissionGate(authSession = authSession)
 
     LaunchedEffect(sessionRouteKey) {
@@ -287,11 +293,6 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     Scaffold(
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState) { data ->
-                PrettySnackbar(message = data.visuals.message)
-            }
-        },
         bottomBar = {
             if (authSession != null && !viewModel.showOnboarding && currentTab != null) {
                 VoiceAlarmBottomBar(
@@ -480,10 +481,13 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                       contentPadding = padding,
                       familyGroup = familyGroup,
                       subscriptionResponse = subscriptionResponse,
+                      vouchers = vouchers,
                       currentUserId = authSession?.user?.id,
                       socialBusy = socialBusy,
+                      billingBusy = billingBusy,
                       onBack = ::goBackInApp,
                       onRemoveFamilyMember = viewModel::removeFamilyMember,
+                      onEnsureFamilyShareCode = viewModel::ensureFamilyShareCode,
                   )
               }
           }
@@ -495,18 +499,25 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                   modifier = Modifier
                       .align(Alignment.TopEnd)
                       .padding(
-                          top = padding.calculateTopPadding() + 8.dp,
-                          end = 8.dp,
+                          top = padding.calculateTopPadding() + 24.dp,
+                          end = 24.dp,
                       ),
               ) {
                   ProfileMenu(
-                      authSession = authSession,
                       isPlanOwner = isPlanOwner,
                       onSelectTab = ::navigateToTab,
                       onOpenSettings = { navController.navigate(AppRoute.Settings) },
                       onOpenMemberManagement = { navController.navigate(AppRoute.MemberManagement) },
                   )
               }
+          }
+          SnackbarHost(
+              hostState = snackbarHostState,
+              modifier = Modifier
+                  .align(Alignment.TopCenter)
+                  .padding(top = padding.calculateTopPadding() + 8.dp),
+          ) { data ->
+              PrettySnackbar(message = data.visuals.message)
           }
       }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -1,6 +1,8 @@
 package com.voicealarm.nativeapp
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -84,7 +86,6 @@ internal fun HomeHeader() {
 
 @Composable
 internal fun ProfileMenu(
-    authSession: AuthSession?,
     isPlanOwner: Boolean,
     onSelectTab: (NativeTab) -> Unit,
     onOpenSettings: () -> Unit,
@@ -92,39 +93,36 @@ internal fun ProfileMenu(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box {
-        IconButton(onClick = { expanded = true }) {
-            Icon(
-                imageVector = Icons.Outlined.Person,
-                contentDescription = "프로필",
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
+        Surface(
+            modifier = Modifier
+                .size(40.dp)
+                .clickable { expanded = true },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.surface),
+            shadowElevation = 4.dp,
+        ) {
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Person,
+                    contentDescription = "프로필",
+                    modifier = Modifier.size(22.dp),
+                )
+            }
         }
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            DropdownMenuItem(
-                text = {
-                    Column {
-                        Text(
-                            text = authSession?.user?.name?.takeIf { it.isNotBlank() }
-                                ?: authSession?.user?.email
-                                ?: "로그인이 필요해요",
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            text = authSession?.user?.email ?: "홈에서 로그인하면 모든 기능을 사용할 수 있어요.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                },
-                onClick = { expanded = false },
-            )
-            HorizontalDivider()
-            ProfileMenuItem("코드 등록") {
-                expanded = false
-                onSelectTab(NativeTab.People)
+            if (!isPlanOwner) {
+                ProfileMenuItem("코드 등록") {
+                    expanded = false
+                    onSelectTab(NativeTab.People)
+                }
             }
             ProfileMenuItem("캐릭터") {
                 expanded = false
@@ -135,7 +133,7 @@ internal fun ProfileMenu(
                 onSelectTab(NativeTab.Billing)
             }
             if (isPlanOwner) {
-                ProfileMenuItem("멤버 관리") {
+                ProfileMenuItem("멤버/공유 코드 관리") {
                     expanded = false
                     onOpenMemberManagement()
                 }
@@ -159,6 +157,7 @@ internal fun ProfileMenuItem(
         onClick = onClick,
     )
 }
+
 
 enum class ThemeMode { System, Light, Dark }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
@@ -133,6 +133,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var permissionGateRequest by mutableStateOf<PermissionTarget?>(null)
         internal set
 
+    var navigateHomeTick by mutableStateOf(0)
+        internal set
+
     fun requestPermissionGate(target: PermissionTarget) {
         permissionGateRequest = target
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAuthActions.kt
@@ -217,7 +217,10 @@ internal fun MainViewModel.syncNow() {
             val pull = repository.pullReceivedAlarms(api, session.token, session.user.id)
             push to pull
         }.onSuccess { (push, pull) ->
-            message = "동기화 완료: 생성 ${push.created}개, 수정 ${push.updated}개, 수신 ${pull.imported + pull.updated}개, 실패 ${push.failed + pull.failed}개"
+            val failed = push.failed + pull.failed
+            if (failed > 0) {
+                message = "동기화 일부 실패: 실패 ${failed}개"
+            }
         }.onFailure { error ->
             Log.e(TAG, "Backend sync failed", error)
             message = userFacingError(error, "동기화에 실패했어요")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -114,10 +114,11 @@ internal fun MainViewModel.registerCode(code: String) {
         runCatching {
             api.registerCode(authorization, CodeRegisterRequest(code.trim()))
         }.onSuccess { response ->
-            message = "코드를 등록했어요${response.type?.let { ": ${codeTypeLabel(it)}" } ?: ""}"
+            message = "코드를 등록했어요"
             refreshSocial()
             refreshCharacterAndBilling()
             refreshAppSession()
+            navigateHomeTick++
         }.onFailure { error ->
             Log.e(TAG, "Failed to register code", error)
             message = userFacingError(error, "코드 등록에 실패했어요")
@@ -226,6 +227,7 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
             if (!gift) {
                 refreshAppSession()
                 refreshSocial()
+                navigateHomeTick++
             }
         }.onFailure { error ->
             Log.e(TAG, "Failed to checkout plan key=$planKey gift=$gift", error)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
@@ -1,5 +1,6 @@
 package com.voicealarm.nativeapp
 
+import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,13 +14,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.PersonRemove
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -29,21 +34,28 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyGroupMember
+import com.voicealarm.nativeapp.network.VoucherItem
 
 @Composable
 internal fun MemberManagementScreen(
     contentPadding: PaddingValues,
     familyGroup: FamilyGroupCurrentResponse?,
     subscriptionResponse: BillingSubscriptionResponse?,
+    vouchers: List<VoucherItem>,
     currentUserId: String?,
     socialBusy: Boolean,
+    billingBusy: Boolean,
     onBack: () -> Unit,
     onRemoveFamilyMember: (String, String) -> Unit,
+    onEnsureFamilyShareCode: () -> Unit,
 ) {
     val group = familyGroup?.group
     val isOwner = familyGroup?.role == "owner" && group != null
@@ -54,8 +66,27 @@ internal fun MemberManagementScreen(
     }
     val sortedMembers = familyGroup?.members.orEmpty()
         .sortedWith(compareByDescending<FamilyGroupMember> { it.role == "owner" }.thenBy { it.joinedAt })
+    val activePlanKey = subscriptionResponse?.plan?.key
+    val shareVoucher = remember(vouchers, activePlanKey) {
+        vouchers.firstOrNull { voucher ->
+            voucher.code.startsWith("INV-") &&
+                voucher.planType == "family" &&
+                (activePlanKey == null || voucher.planKey == activePlanKey) &&
+                voucher.status !in listOf("expired", "revoked", "cancelled")
+        }
+    }
 
-    var selectedMember by remember { mutableStateOf<FamilyGroupMember?>(null) }
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    fun shareCode(code: String) {
+        clipboard.setText(AnnotatedString(code))
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, code)
+        }
+        context.startActivity(Intent.createChooser(sendIntent, "코드 공유"))
+    }
+
     var pendingRemoveMember by remember { mutableStateOf<FamilyGroupMember?>(null) }
 
     LazyColumn(
@@ -77,7 +108,7 @@ internal fun MemberManagementScreen(
                     )
                 }
                 Text(
-                    text = "$planLabel 멤버 관리",
+                    text = "$planLabel 멤버/공유 코드 관리",
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                 )
@@ -106,74 +137,85 @@ internal fun MemberManagementScreen(
         if (isOwner) {
             item {
                 Text(
-                    text = "멤버를 탭하면 정보와 내보내기 버튼이 나타납니다.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = "공유 코드",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
+            if (shareVoucher == null) {
+                item {
+                    Text(
+                        text = "공유 코드가 아직 없어요. $planLabel 구성원을 초대할 INV 코드를 만들어 주세요.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                item {
+                    OutlinedButton(
+                        onClick = onEnsureFamilyShareCode,
+                        enabled = !billingBusy,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text("공유 코드 만들기")
+                    }
+                }
+            } else {
+                item {
+                    val isFull = shareVoucher.useCount >= shareVoucher.maxUses
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(14.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = shareVoucher.code,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                text = if (isFull) {
+                                    "${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용 · 정원이 가득 찼어요"
+                                } else {
+                                    "${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용"
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Button(
+                                onClick = { shareCode(shareVoucher.code) },
+                                enabled = !billingBusy && !isFull,
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(14.dp),
+                            ) {
+                                Text(if (isFull) "정원 가득" else "공유하기")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Text(
+                text = "구성원",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
         }
 
         items(sortedMembers) { member ->
             MemberRow(
                 member = member,
                 isMe = member.userId == currentUserId,
-                onClick = { selectedMember = member },
+                showRemove = isOwner && member.role != "owner" && member.userId != currentUserId,
+                removeEnabled = !socialBusy,
+                onRemove = { pendingRemoveMember = member },
             )
         }
-    }
-
-    selectedMember?.let { member ->
-        val isMe = member.userId == currentUserId
-        val canRemove = isOwner && !isMe && member.role != "owner"
-        AlertDialog(
-            onDismissRequest = { selectedMember = null },
-            title = { Text(member.name ?: member.email ?: "멤버") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        text = member.email ?: "이메일 없음",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = when {
-                            member.role == "owner" -> "관리자"
-                            isMe -> "나"
-                            else -> "구성원"
-                        },
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            },
-            confirmButton = {
-                if (canRemove) {
-                    TextButton(
-                        enabled = !socialBusy,
-                        onClick = {
-                            pendingRemoveMember = member
-                            selectedMember = null
-                        },
-                    ) {
-                        Text(
-                            text = "내보내기",
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                } else {
-                    TextButton(onClick = { selectedMember = null }) {
-                        Text("닫기")
-                    }
-                }
-            },
-            dismissButton = if (canRemove) {
-                {
-                    TextButton(onClick = { selectedMember = null }) {
-                        Text("닫기")
-                    }
-                }
-            } else null,
-        )
     }
 
     pendingRemoveMember?.let { member ->
@@ -217,10 +259,11 @@ internal fun MemberManagementScreen(
 private fun MemberRow(
     member: FamilyGroupMember,
     isMe: Boolean,
-    onClick: () -> Unit,
+    showRemove: Boolean,
+    removeEnabled: Boolean,
+    onRemove: () -> Unit,
 ) {
     Card(
-        onClick = onClick,
         shape = RoundedCornerShape(14.dp),
         colors = CardDefaults.cardColors(
             containerColor = if (isMe) {
@@ -253,18 +296,27 @@ private fun MemberRow(
                     )
                 }
             }
-            AssistChip(
-                onClick = onClick,
-                label = {
-                    Text(
-                        when {
-                            member.role == "owner" -> "관리자"
-                            isMe -> "나"
-                            else -> "구성원"
-                        },
+            val chipLabel = when {
+                member.role == "owner" -> "관리자"
+                isMe -> "나"
+                else -> null
+            }
+            if (chipLabel != null) {
+                AssistChip(
+                    onClick = {},
+                    enabled = false,
+                    label = { Text(chipLabel) },
+                )
+            }
+            if (showRemove) {
+                IconButton(onClick = onRemove, enabled = removeEnabled) {
+                    Icon(
+                        imageVector = Icons.Outlined.PersonRemove,
+                        contentDescription = "내보내기",
+                        tint = MaterialTheme.colorScheme.error,
                     )
-                },
-            )
+                }
+            }
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -79,8 +79,7 @@ internal fun FamilyConnectionPanel(
             voucher.code.startsWith("INV-") &&
                 voucher.planType == "family" &&
                 (activePlanKey == null || voucher.planKey == activePlanKey) &&
-                voucher.status in listOf("issued", "active", "pending") &&
-                voucher.useCount < voucher.maxUses
+                voucher.status !in listOf("expired", "revoked", "cancelled")
         }
     }
     val canManageShareCode = currentGroup != null &&
@@ -107,70 +106,36 @@ internal fun FamilyConnectionPanel(
             modifier = Modifier.padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            if (canManageShareCode) {
-                Text("내 $sharedPlanLabel 공유 코드", fontWeight = FontWeight.SemiBold)
-                val shareVoucher = familyShareCodes.firstOrNull()
-                if (shareVoucher == null) {
-                    MutedText("공유 코드가 아직 없어요. $sharedPlanLabel 구성원을 초대할 INV 코드를 만들어 주세요.")
-                    OutlinedButton(
-                        onClick = onEnsureFamilyShareCode,
-                        enabled = !billingBusy,
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
-                    ) {
-                        Text("공유 코드 만들기")
-                    }
-                } else {
-                    Surface(
-                        color = MaterialTheme.colorScheme.surfaceVariant,
-                        shape = RoundedCornerShape(14.dp),
-                    ) {
-                        Column(
-                            modifier = Modifier.padding(14.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Text(
-                                text = shareVoucher.code,
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                            MutedText("${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용")
-                            Button(
-                                onClick = { shareCode(shareVoucher.code) },
-                                enabled = !billingBusy,
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(14.dp),
-                            ) {
-                                Text("공유하기")
-                            }
-                        }
-                    }
-                }
-            }
+            val isSharedMember = currentGroup != null && familyGroup?.role == "member"
 
-            if (currentGroup != null && familyGroup.role == "member") {
-                OutlinedButton(
-                    onClick = { showLeaveDialog = true },
-                    enabled = !socialBusy,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(14.dp),
-                ) {
-                    Text(
-                        text = "플랜에서 나가기",
-                        color = MaterialTheme.colorScheme.error,
-                    )
-                }
+            if (canManageShareCode) {
+                MutedText("공유 코드와 멤버 관리는 프로필 메뉴의 '멤버/공유 코드 관리'에서 가능합니다.")
+                return@Column
             }
 
             if (hasActivePlan && !showCodeInputs) {
                 MutedText("$activePlanName 플랜 사용중이라 등록은 플랜이 종료된 다음에 가능합니다.")
-                OutlinedButton(
-                    onClick = { showCodeInputs = true },
-                    enabled = !socialBusy,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(14.dp),
-                ) {
-                    Text("다른 코드 등록하기")
+                if (isSharedMember) {
+                    OutlinedButton(
+                        onClick = { showLeaveDialog = true },
+                        enabled = !socialBusy,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text(
+                            text = "플랜에서 나가고 다른 코드 등록하기",
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                } else {
+                    OutlinedButton(
+                        onClick = { showCodeInputs = true },
+                        enabled = !socialBusy,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text("다른 코드 등록하기")
+                    }
                 }
             } else {
                 if (hasActivePlan) {
@@ -232,19 +197,20 @@ internal fun FamilyConnectionPanel(
     if (showLeaveDialog && currentGroup != null) {
         AlertDialog(
             onDismissRequest = { showLeaveDialog = false },
-            title = { Text("플랜에서 나가기") },
+            title = { Text("플랜에서 나가고 다른 코드 등록") },
             text = {
-                MutedText("정말 플랜에서 나가시겠어요? 다시 들어오려면 새 초대 코드가 필요해요.")
+                MutedText("현재 플랜에서 나가고 새 코드를 등록할 수 있는 화면으로 이동할까요? 이 작업은 되돌릴 수 없어요.")
             },
             confirmButton = {
                 TextButton(
                     onClick = {
                         showLeaveDialog = false
+                        showCodeInputs = true
                         onLeaveFamilyGroup(currentGroup.id)
                     },
                 ) {
                     Text(
-                        text = "나가기",
+                        text = "나가고 등록하기",
                         color = MaterialTheme.colorScheme.error,
                     )
                 }


### PR DESCRIPTION
Closes #263

> 이 PR 은 #262 의 변경 위에 쌓여 있습니다. #262 가 develop 으로 머지된 뒤에는 이 PR diff 가 본 변경(3 커밋) 만 남습니다.

## 주요 변경
### 토스트 · 내비게이션
- 동기화 성공 토스트 제거 (부분 실패만 안내, 전체 실패는 기존 에러 메시지 유지).
- 스낵바를 화면 하단 → 상단(`Alignment.TopCenter`)으로 이동.
- 코드 등록 토스트의 종류 접미사 제거 → 항상 `코드를 등록했어요`.
- 코드 등록·결제 성공 시 자동 홈 이동 (`navigateHomeTick` 카운터 + `LaunchedEffect`).

### 공유 코드 노출
- 공유 코드 voucher 의 `useCount`/`status='used'` 가드를 풀고, 만료/취소 상태가 아니면 owner UI 에서 항상 노출.
- 정원 가득(`useCount >= maxUses`) 시 `n/m명 사용 · 정원이 가득 찼어요` + 공유 버튼은 `정원 가득` 라벨 비활성. 멤버가 나가 슬롯이 비면 자동 활성화.

### 멤버 관리 화면 재구성
- SocialPanels 의 owner 공유 코드 카드 제거, 안내문만 노출. 관리 동선은 `멤버/공유 코드 관리` 화면으로 일원화.
- ProfileMenu: owner 일 때 `코드 등록` 항목 숨김, `멤버 관리` → `멤버/공유 코드 관리` 라벨 변경.
- MemberManagementScreen: 인원 수 아래에 공유 코드 카드/공유 코드 만들기 버튼 통합. 멤버 카드는 탭 다이얼로그 없이 인라인 `PersonRemove` 아이콘으로 바로 확인 모달.
- 멤버 행 칩에서 `구성원` 제거 (관리자/나만 표시).
- 멤버용 통합 버튼 `플랜에서 나가고 다른 코드 등록하기` (확인 모달 → leave + 입력창 자동 노출).

### 프로필 진입점
- 프로필 아이콘을 40dp 원형 Surface (primary 컬러 + 흰 보더 + 그림자) 로 리스타일.
- 위치를 다음 알람 카드 우측 끝(콘텐츠 패딩 24dp)에 정렬, 인사말과 같은 수직 라인.
- 드롭다운에서 이름·이메일 행 + 구분선 제거.

## 테스트 플랜
- [ ] 동기화 성공 시 더 이상 \"동기화 완료\" 토스트가 뜨지 않는지 확인.
- [ ] 스낵바가 상단에 노출되는지, 다른 토스트 시나리오도 정상 동작하는지 확인.
- [ ] 코드 등록 / 결제 후 자동으로 홈 화면으로 이동하는지 확인.
- [ ] 정원 가득인 owner 공유 코드가 화면에 계속 노출되며 \"정원 가득\" 라벨로 비활성되는지 확인.
- [ ] 멤버가 나가면 공유 버튼이 다시 활성화되는지 확인 (백엔드 PR #262 의 voucher 카운트 복구가 머지 / 배포된 환경에서).
- [ ] owner 의 ProfileMenu 에 `코드 등록` 이 보이지 않고 `멤버/공유 코드 관리` 가 보이는지 확인.
- [ ] 멤버 관리 화면에서 PersonRemove 아이콘을 누르면 확인 모달이 바로 뜨는지 확인.
- [ ] 멤버용 통합 버튼이 leave 와 입력창 노출까지 한번에 처리되는지 확인.
- [ ] 프로필 아이콘이 다음 알람 카드의 우측 끝과 정렬되고 인사말과 같은 수직 라인에 있는지 확인.
- [ ] ProfileMenu 드롭다운에 이름·이메일 행이 더 이상 없는지 확인.