### PR TITLE
fix: 수신 알람 토글과 상대 알람 진입 수정

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AlarmDao {
-    @Query("SELECT * FROM alarms ORDER BY enabled DESC, fireAtMillis ASC, updatedAtMillis DESC")
+    @Query("SELECT * FROM alarms ORDER BY hour ASC, minute ASC, createdAtMillis ASC")
     fun observeAlarms(): Flow<List<AlarmEntity>>
 
     @Query("SELECT * FROM alarms WHERE id = :id LIMIT 1")
@@ -26,7 +26,7 @@ interface AlarmDao {
     )
     suspend fun getEnabledAlarms(): List<AlarmEntity>
 
-    @Query("SELECT * FROM alarms ORDER BY enabled DESC, fireAtMillis ASC, updatedAtMillis DESC")
+    @Query("SELECT * FROM alarms ORDER BY hour ASC, minute ASC, createdAtMillis ASC")
     suspend fun getAllAlarms(): List<AlarmEntity>
 
     @Query(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -452,5 +452,9 @@ class AlarmRepository(
     }
 
     private fun AlarmEntity.nextLocalSyncState(): String =
-        if (remoteAlarmId == null) AlarmSyncStates.LOCAL_ONLY else AlarmSyncStates.DIRTY
+        when {
+            origin == AlarmOrigins.RECEIVED_REMOTE -> AlarmSyncStates.SYNCED
+            remoteAlarmId == null -> AlarmSyncStates.LOCAL_ONLY
+            else -> AlarmSyncStates.DIRTY
+        }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncService.kt
@@ -112,7 +112,7 @@ internal class RemoteAlarmPullSyncService(
         val time = parseTime(remote.time) ?: return null
         val repeatMask = repeatDaysToMask(remote.repeatDays.orEmpty())
         val now = System.currentTimeMillis()
-        val enabled = remote.isActive != false
+        val enabled = resolveReceivedRemoteEnabled(existing, remote.isActive)
 
         val cachedAudio = remote.messageId
             ?.takeIf { it.isNotBlank() }
@@ -193,4 +193,13 @@ internal class RemoteAlarmPullSyncService(
 
     private fun repeatDaysToMask(days: List<Int>): Int =
         days.filter { it in 0..6 }.fold(0) { mask, day -> mask or (1 shl day) }
+}
+
+internal fun resolveReceivedRemoteEnabled(existing: AlarmEntity?, remoteIsActive: Boolean?): Boolean {
+    val remoteEnabled = remoteIsActive != false
+    return if (existing?.origin == AlarmOrigins.RECEIVED_REMOTE) {
+        existing.enabled && remoteEnabled
+    } else {
+        remoteEnabled
+    }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/FamilyApi.kt
@@ -33,8 +33,7 @@ data class FamilyGroupMember(
     @SerializedName("family_alarm_quiet_days") val familyAlarmQuietDays: List<Int> = listOf(1, 2, 3, 4, 5),
     @SerializedName("family_alarm_quiet_start") val familyAlarmQuietStart: String = "09:00",
     @SerializedName("family_alarm_quiet_end") val familyAlarmQuietEnd: String = "18:30",
-    @SerializedName("family_alarm_quiet_windows") val familyAlarmQuietWindows: List<FamilyAlarmQuietWindow> =
-        listOf(FamilyAlarmQuietWindow()),
+    @SerializedName("family_alarm_quiet_windows") val familyAlarmQuietWindows: List<FamilyAlarmQuietWindow>? = null,
 )
 
 data class FamilyVoiceAlarmRequest(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ringing/RingingActivity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ringing/RingingActivity.kt
@@ -3,6 +3,7 @@ package com.voicealarm.nativeapp.ringing
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
@@ -51,6 +52,7 @@ class RingingActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         configureLockScreen()
+        blockBackNavigation()
         alarmId = intent.getStringExtra(EXTRA_ALARM_ID)
 
         setContent {
@@ -89,9 +91,30 @@ class RingingActivity : ComponentActivity() {
         alarmId = intent.getStringExtra(EXTRA_ALARM_ID)
     }
 
+    override fun onResume() {
+        super.onResume()
+        hideSystemBars()
+    }
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        hideSystemBars()
+    }
+
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) hideSystemBars()
+    }
+
+    private fun blockBackNavigation() {
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    hideSystemBars()
+                }
+            },
+        )
     }
 
     private fun configureLockScreen() {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -87,8 +87,9 @@ internal fun AlarmListScreen(
 ) {
     val sortedAlarms = remember(alarms) {
         alarms.sortedWith(
-            compareByDescending<AlarmEntity> { it.enabled }
-                .thenBy { it.fireAtMillis },
+            compareBy<AlarmEntity> { it.hour }
+                .thenBy { it.minute }
+                .thenBy { it.createdAtMillis },
         )
     }
     val nextAlarm = remember(alarms) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -17,16 +17,22 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,6 +42,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -60,6 +67,9 @@ import com.voicealarm.nativeapp.network.FamilyVoiceProfile
 import com.voicealarm.nativeapp.network.TtsGenerateRequest
 import com.voicealarm.nativeapp.network.TtsGenerateResponse
 import com.voicealarm.nativeapp.network.VoiceProfile
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -257,6 +267,11 @@ internal fun AlarmEditorScreen(
     fun saveEditor() {
         if (isSaving) return
         if (familyAlarmMode) {
+            val recipient = selectedFamilyRecipient()
+            if (recipient == null) {
+                audioMessage = "알람을 받을 사람을 선택해 주세요."
+                return
+            }
             val fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
                 hour = editor.hour,
                 minute = editor.minute,
@@ -265,6 +280,12 @@ internal fun AlarmEditorScreen(
             )
             if (fireAtMillis - System.currentTimeMillis() < FAMILY_ALARM_MIN_LEAD_MILLIS) {
                 val message = "상대방 알람은 최소 30분 이후로 설정해 주세요."
+                audioMessage = message
+                showFamilyAlarmToast(message)
+                return
+            }
+            if (isFamilyAlarmTimeUnavailable(recipient, editor.hour, editor.minute, editor.repeatDaysMask)) {
+                val message = "상대가 받지 않도록 설정한 시간이에요."
                 audioMessage = message
                 showFamilyAlarmToast(message)
                 return
@@ -459,6 +480,10 @@ internal fun AlarmEditorScreen(
                     FamilyAlarmTargetCard(
                         recipients = familyRecipients,
                         selectedRecipientId = selectedFamilyRecipientId,
+                        hour = editor.hour,
+                        minute = editor.minute,
+                        repeatDaysMask = editor.repeatDaysMask,
+                        holidayOff = editor.holidayOff,
                         onSelectRecipient = { selectedFamilyRecipientId = it },
                     )
                 }
@@ -631,8 +656,46 @@ internal fun EditorSectionTitle(title: String) {
 internal fun FamilyAlarmTargetCard(
     recipients: List<FamilyGroupMember>,
     selectedRecipientId: String?,
+    hour: Int,
+    minute: Int,
+    repeatDaysMask: Int,
+    holidayOff: Boolean,
     onSelectRecipient: (String) -> Unit,
 ) {
+    var recipientDialogOpen by remember { mutableStateOf(false) }
+    val selectedRecipient = recipients.firstOrNull { it.userId == selectedRecipientId }
+        ?: recipients.firstOrNull()
+    val leadTooSoon = isFamilyAlarmLeadTooSoon(hour, minute, repeatDaysMask, holidayOff)
+    val quietUnavailable = selectedRecipient?.let {
+        isFamilyAlarmTimeUnavailable(it, hour, minute, repeatDaysMask)
+    } ?: false
+
+    if (recipientDialogOpen) {
+        AlertDialog(
+            onDismissRequest = { recipientDialogOpen = false },
+            title = { Text("받는 사람 선택") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    recipients.forEach { recipient ->
+                        RecipientPickerRow(
+                            recipient = recipient,
+                            selected = recipient.userId == selectedRecipient?.userId,
+                            onClick = {
+                                onSelectRecipient(recipient.userId)
+                                recipientDialogOpen = false
+                            },
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { recipientDialogOpen = false }) {
+                    Text("닫기")
+                }
+            },
+        )
+    }
+
     Card(
         shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -640,26 +703,175 @@ internal fun FamilyAlarmTargetCard(
     ) {
         Column(
             modifier = Modifier.padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text("받는 사람", fontWeight = FontWeight.SemiBold)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("받는 사람", fontWeight = FontWeight.SemiBold)
+                if (recipients.size > 1) {
+                    TextButton(onClick = { recipientDialogOpen = true }) {
+                        Text("변경")
+                    }
+                }
+            }
             if (recipients.isEmpty()) {
                 MutedText("상대가 알람 설정을 허용하면 여기에 표시돼요.")
             } else {
-                ChipGrid(
-                    options = recipients.map { it.userId to familyMemberLabel(it) },
-                    selected = selectedRecipientId.orEmpty(),
-                    onSelect = onSelectRecipient,
-                    selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    selectedLabelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                RecipientSummaryRow(
+                    recipient = requireNotNull(selectedRecipient),
+                    clickable = recipients.size > 1,
+                    onClick = { recipientDialogOpen = true },
                 )
-                MutedText("30분 뒤부터 설정할 수 있어요.")
-                recipients.firstOrNull { it.userId == selectedRecipientId }?.let { recipient ->
-                    MutedText("설정 불가: ${familyAlarmQuietScheduleLabel(recipient)}")
+
+                FamilyAlarmTargetStatus(
+                    leadTooSoon = leadTooSoon,
+                    quietUnavailable = quietUnavailable,
+                    quietLabel = familyAlarmQuietScheduleLabel(selectedRecipient),
+                )
+
+                if (recipients.size == 1) {
+                    MutedText("수신자는 한 명이라 바로 이 사람에게 설정돼요.")
                 }
             }
         }
     }
+}
+
+@Composable
+private fun RecipientSummaryRow(
+    recipient: FamilyGroupMember,
+    clickable: Boolean,
+    onClick: () -> Unit,
+) {
+    val content: @Composable () -> Unit = {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Text(
+                    text = familyMemberLabel(recipient),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                recipient.email?.takeIf { it.isNotBlank() }?.let { email ->
+                    MutedText(email)
+                }
+            }
+            if (clickable) {
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = ">",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+
+    if (clickable) {
+        Surface(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.52f),
+        ) {
+            content()
+        }
+    } else {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.52f),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun RecipientPickerRow(
+    recipient: FamilyGroupMember,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+        color = if (selected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f)
+        },
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(familyMemberLabel(recipient), fontWeight = FontWeight.SemiBold)
+                MutedText("설정 불가: ${familyAlarmQuietScheduleLabel(recipient)}")
+            }
+            if (selected) {
+                Text(
+                    text = "선택됨",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FamilyAlarmTargetStatus(
+    leadTooSoon: Boolean,
+    quietUnavailable: Boolean,
+    quietLabel: String,
+) {
+    val blocked = leadTooSoon || quietUnavailable
+    val statusText = when {
+        leadTooSoon -> "30분 뒤부터 설정할 수 있어요."
+        quietUnavailable -> "이 시간은 상대가 받지 않도록 설정한 시간이에요."
+        else -> "설정 가능"
+    }
+    Surface(
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(999.dp),
+        color = if (blocked) {
+            MaterialTheme.colorScheme.errorContainer
+        } else {
+            MaterialTheme.colorScheme.primaryContainer
+        },
+        contentColor = if (blocked) {
+            MaterialTheme.colorScheme.onErrorContainer
+        } else {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        },
+    ) {
+        Text(
+            text = statusText,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+    MutedText("설정 불가: $quietLabel")
 }
 
 private const val FAMILY_ALARM_MIN_LEAD_MILLIS = 30 * 60 * 1_000L
@@ -675,12 +887,49 @@ internal fun familyMemberLabel(member: FamilyGroupMember): String =
         ?: "멤버"
 
 internal fun familyAlarmQuietScheduleLabel(member: FamilyGroupMember): String {
+    val windows = familyAlarmQuietWindows(member)
+    return windows.joinToString(" · ") { window ->
+        "${quietDaysLabelForFamily(window.days)} ${window.start}-${window.end}"
+    }
+}
+
+internal fun isFamilyAlarmLeadTooSoon(
+    hour: Int,
+    minute: Int,
+    repeatDaysMask: Int,
+    holidayOff: Boolean,
+    nowMillis: Long = System.currentTimeMillis(),
+): Boolean {
+    val fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
+        hour = hour,
+        minute = minute,
+        repeatDaysMask = repeatDaysMask,
+        holidayOff = holidayOff,
+        nowMillis = nowMillis,
+    )
+    return fireAtMillis - nowMillis < FAMILY_ALARM_MIN_LEAD_MILLIS
+}
+
+internal fun isFamilyAlarmTimeUnavailable(
+    member: FamilyGroupMember,
+    hour: Int,
+    minute: Int,
+    repeatDaysMask: Int,
+    nowMillis: Long = System.currentTimeMillis(),
+): Boolean {
+    val dayIndices = familyAlarmTargetDayIndices(hour, minute, repeatDaysMask, nowMillis)
+    return familyAlarmQuietWindows(member).any { window ->
+        dayIndices.any { dayIndex -> window.blocks(dayIndex, hour, minute) }
+    }
+}
+
+private fun familyAlarmQuietWindows(member: FamilyGroupMember): List<FamilyAlarmQuietWindow> {
     val fallback = FamilyAlarmQuietWindow(
         days = safeQuietDays(runCatching { member.familyAlarmQuietDays }.getOrNull()),
         start = safeQuietTime(runCatching { member.familyAlarmQuietStart }.getOrNull(), "09:00"),
         end = safeQuietTime(runCatching { member.familyAlarmQuietEnd }.getOrNull(), "18:30"),
     )
-    val windows = runCatching { member.familyAlarmQuietWindows }.getOrNull()
+    return runCatching { member.familyAlarmQuietWindows }.getOrNull()
         ?.mapNotNull { window ->
             val start = safeQuietTime(runCatching { window.start }.getOrNull(), "")
             val end = safeQuietTime(runCatching { window.end }.getOrNull(), "")
@@ -696,10 +945,42 @@ internal fun familyAlarmQuietScheduleLabel(member: FamilyGroupMember): String {
         }
         ?.takeIf { it.isNotEmpty() }
         ?: listOf(fallback)
-    return windows.joinToString(" · ") { window ->
-        "${quietDaysLabelForFamily(window.days)} ${window.start}-${window.end}"
+}
+
+private fun familyAlarmTargetDayIndices(
+    hour: Int,
+    minute: Int,
+    repeatDaysMask: Int,
+    nowMillis: Long,
+): List<Int> {
+    if (repeatDaysMask != 0) {
+        return (0..6).filter { dayIndex -> repeatDaysMask and (1 shl dayIndex) != 0 }
+    }
+    val nextFireDate = Instant.ofEpochMilli(
+        AlarmTimeCalculator.nextFireAtMillis(
+            hour = hour,
+            minute = minute,
+            repeatDaysMask = 0,
+            nowMillis = nowMillis,
+        ),
+    ).atZone(ZoneId.systemDefault()).toLocalDate()
+    return listOf(nextFireDate.dayOfWeek.value % 7)
+}
+
+private fun FamilyAlarmQuietWindow.blocks(dayIndex: Int, hour: Int, minute: Int): Boolean {
+    if (dayIndex !in safeQuietDays(days)) return false
+    val startTime = parseQuietTime(start) ?: return false
+    val endTime = parseQuietTime(end) ?: return false
+    val target = LocalTime.of(hour, minute)
+    return if (startTime <= endTime) {
+        !target.isBefore(startTime) && target.isBefore(endTime)
+    } else {
+        !target.isBefore(startTime) || target.isBefore(endTime)
     }
 }
+
+private fun parseQuietTime(value: String): LocalTime? =
+    runCatching { LocalTime.parse(value) }.getOrNull()
 
 private fun safeQuietDays(days: List<Int>?): List<Int> =
     days

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -53,6 +53,7 @@ import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.AuthSession
+import com.voicealarm.nativeapp.network.FamilyAlarmQuietWindow
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyGroupMember
 import com.voicealarm.nativeapp.network.FamilyVoiceProfile
@@ -673,19 +674,43 @@ internal fun familyMemberLabel(member: FamilyGroupMember): String =
         ?: member.email?.takeIf { it.isNotBlank() }
         ?: "멤버"
 
-private fun familyAlarmQuietScheduleLabel(member: FamilyGroupMember): String {
-    val windows = member.familyAlarmQuietWindows.takeIf { it.isNotEmpty() }
-        ?: listOf(
-            com.voicealarm.nativeapp.network.FamilyAlarmQuietWindow(
-                days = member.familyAlarmQuietDays,
-                start = member.familyAlarmQuietStart,
-                end = member.familyAlarmQuietEnd,
-            ),
-        )
+internal fun familyAlarmQuietScheduleLabel(member: FamilyGroupMember): String {
+    val fallback = FamilyAlarmQuietWindow(
+        days = safeQuietDays(runCatching { member.familyAlarmQuietDays }.getOrNull()),
+        start = safeQuietTime(runCatching { member.familyAlarmQuietStart }.getOrNull(), "09:00"),
+        end = safeQuietTime(runCatching { member.familyAlarmQuietEnd }.getOrNull(), "18:30"),
+    )
+    val windows = runCatching { member.familyAlarmQuietWindows }.getOrNull()
+        ?.mapNotNull { window ->
+            val start = safeQuietTime(runCatching { window.start }.getOrNull(), "")
+            val end = safeQuietTime(runCatching { window.end }.getOrNull(), "")
+            if (start.isBlank() || end.isBlank()) {
+                null
+            } else {
+                FamilyAlarmQuietWindow(
+                    days = safeQuietDays(runCatching { window.days }.getOrNull()),
+                    start = start,
+                    end = end,
+                )
+            }
+        }
+        ?.takeIf { it.isNotEmpty() }
+        ?: listOf(fallback)
     return windows.joinToString(" · ") { window ->
         "${quietDaysLabelForFamily(window.days)} ${window.start}-${window.end}"
     }
 }
+
+private fun safeQuietDays(days: List<Int>?): List<Int> =
+    days
+        ?.filter { it in 0..6 }
+        ?.distinct()
+        ?.sorted()
+        ?.takeIf { it.isNotEmpty() }
+        ?: listOf(1, 2, 3, 4, 5)
+
+private fun safeQuietTime(value: String?, fallback: String): String =
+    value?.takeIf { it.isNotBlank() } ?: fallback
 
 private fun quietDaysLabelForFamily(days: List<Int>): String {
     val sorted = days.distinct().sorted()

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
@@ -1,0 +1,34 @@
+package com.voicealarm.nativeapp
+
+import com.google.gson.Gson
+import com.voicealarm.nativeapp.network.FamilyGroupMember
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlarmEditorScreenTest {
+    @Test
+    fun familyAlarmQuietScheduleFallsBackWhenQuietWindowsIsNull() {
+        val member = Gson().fromJson(
+            """
+            {
+              "id": "member-id",
+              "user_id": "recipient-id",
+              "role": "member",
+              "joined_at": "2026-05-11T00:00:00.000Z",
+              "email": "recipient@example.com",
+              "name": "Recipient",
+              "allow_family_alarms": true,
+              "family_alarm_quiet_days": [1, 2, 3, 4, 5],
+              "family_alarm_quiet_start": "09:00",
+              "family_alarm_quiet_end": "18:30",
+              "family_alarm_quiet_windows": null
+            }
+            """.trimIndent(),
+            FamilyGroupMember::class.java,
+        )
+
+        val label = familyAlarmQuietScheduleLabel(member)
+
+        assertTrue(label.contains("09:00-18:30"))
+    }
+}

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
@@ -1,7 +1,11 @@
 package com.voicealarm.nativeapp
 
 import com.google.gson.Gson
+import com.voicealarm.nativeapp.network.FamilyAlarmQuietWindow
 import com.voicealarm.nativeapp.network.FamilyGroupMember
+import java.time.LocalDateTime
+import java.time.ZoneId
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -31,4 +35,77 @@ class AlarmEditorScreenTest {
 
         assertTrue(label.contains("09:00-18:30"))
     }
+
+    @Test
+    fun familyAlarmTimeUnavailableWhenSelectedTimeIsInsideRecipientQuietWindow() {
+        val member = member(
+            windows = listOf(FamilyAlarmQuietWindow(days = listOf(1, 2, 3, 4, 5), start = "09:00", end = "18:30")),
+        )
+
+        assertTrue(
+            isFamilyAlarmTimeUnavailable(
+                member = member,
+                hour = 10,
+                minute = 0,
+                repeatDaysMask = 1 shl 1,
+            ),
+        )
+    }
+
+    @Test
+    fun familyAlarmTimeAvailableWhenSelectedTimeIsOutsideRecipientQuietWindow() {
+        val member = member(
+            windows = listOf(FamilyAlarmQuietWindow(days = listOf(1, 2, 3, 4, 5), start = "09:00", end = "18:30")),
+        )
+
+        assertFalse(
+            isFamilyAlarmTimeUnavailable(
+                member = member,
+                hour = 6,
+                minute = 0,
+                repeatDaysMask = 1 shl 1,
+            ),
+        )
+    }
+
+    @Test
+    fun familyAlarmLeadRequiresAtLeastThirtyMinutes() {
+        val nowMillis = LocalDateTime.of(2026, 5, 11, 6, 0)
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+
+        assertTrue(
+            isFamilyAlarmLeadTooSoon(
+                hour = 6,
+                minute = 20,
+                repeatDaysMask = 0,
+                holidayOff = false,
+                nowMillis = nowMillis,
+            ),
+        )
+        assertFalse(
+            isFamilyAlarmLeadTooSoon(
+                hour = 6,
+                minute = 30,
+                repeatDaysMask = 0,
+                holidayOff = false,
+                nowMillis = nowMillis,
+            ),
+        )
+    }
+
+    private fun member(
+        windows: List<FamilyAlarmQuietWindow>? = listOf(FamilyAlarmQuietWindow()),
+    ): FamilyGroupMember =
+        FamilyGroupMember(
+            id = "member-id",
+            userId = "recipient-id",
+            role = "member",
+            joinedAt = "2026-05-11T00:00:00.000Z",
+            email = "recipient@example.com",
+            name = "Recipient",
+            allowFamilyAlarms = true,
+            familyAlarmQuietWindows = windows,
+        )
 }

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncServiceTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/data/RemoteAlarmPullSyncServiceTest.kt
@@ -1,0 +1,76 @@
+package com.voicealarm.nativeapp.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteAlarmPullSyncServiceTest {
+    @Test
+    fun newReceivedRemoteAlarmUsesRemoteActiveState() {
+        assertTrue(resolveReceivedRemoteEnabled(existing = null, remoteIsActive = true))
+        assertTrue(resolveReceivedRemoteEnabled(existing = null, remoteIsActive = null))
+        assertFalse(resolveReceivedRemoteEnabled(existing = null, remoteIsActive = false))
+    }
+
+    @Test
+    fun locallyDisabledReceivedRemoteAlarmStaysDisabledWhenPulledAgain() {
+        val existing = alarm(enabled = false, origin = AlarmOrigins.RECEIVED_REMOTE)
+
+        assertFalse(resolveReceivedRemoteEnabled(existing, remoteIsActive = true))
+    }
+
+    @Test
+    fun remotelyDisabledReceivedRemoteAlarmDisablesLocalCopy() {
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+
+        assertFalse(resolveReceivedRemoteEnabled(existing, remoteIsActive = false))
+    }
+
+    @Test
+    fun locallyEnabledReceivedRemoteAlarmStaysEnabledWhenRemoteIsActive() {
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+
+        assertTrue(resolveReceivedRemoteEnabled(existing, remoteIsActive = true))
+    }
+
+    private fun alarm(
+        enabled: Boolean,
+        origin: String,
+    ): AlarmEntity =
+        AlarmEntity(
+            id = "alarm-id",
+            label = "remote alarm",
+            hour = 7,
+            minute = 30,
+            fireAtMillis = 1_000L,
+            repeatDaysMask = 0,
+            holidayOff = false,
+            snoozeEnabled = true,
+            snoozeMinutes = 5,
+            snoozeRepeatLimit = SnoozeRepeatLimits.THREE,
+            snoozeCount = 0,
+            vibrationPattern = VibrationPatterns.DEFAULT,
+            playMode = AlarmPlayModes.ALARM_ONLY,
+            defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,
+            localAudioUri = null,
+            audioCacheKey = null,
+            rawAudioUri = null,
+            voiceSource = VoiceSources.LOCAL_AUDIO,
+            voiceProfileId = null,
+            voiceText = null,
+            voiceCategory = null,
+            voiceLanguage = null,
+            ttsMessageId = null,
+            remoteAlarmId = "remote-id",
+            lastSyncedAtMillis = 1_000L,
+            syncState = AlarmSyncStates.SYNCED,
+            origin = origin,
+            alarmVolumePercent = 100,
+            alarmSoundUri = null,
+            alarmSoundLabel = null,
+            enabled = enabled,
+            state = if (enabled) AlarmStates.SCHEDULED else AlarmStates.DISABLED,
+            createdAtMillis = 1_000L,
+            updatedAtMillis = 1_000L,
+        )
+}


### PR DESCRIPTION
Closes #275

## 작업 내용
- 알람 목록 정렬에서 활성 상태 우선 정렬을 제거하고 시간순 정렬로 유지했습니다.
- 상대가 설정한 수신 알람을 사용자가 끄면 pull sync 이후에도 로컬 off 상태가 유지되도록 수정했습니다.
- 서버에서 수신 알람이 비활성화된 경우에는 로컬 알람도 꺼지도록 유지했습니다.
- 수신 알람 활성 상태 병합 로직 단위 테스트를 추가했습니다.

## 검증
- .\\gradlew.bat :app:assembleDebug :app:testDebugUnitTest
- 실제 기기 2대에 debug APK 설치 후 알람 탭 UI 확인