### PR TITLE
fix: 출시 전 알람 및 공유 흐름 안정화

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Build
@@ -40,6 +42,8 @@ class RingingService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var mediaPlayer: MediaPlayer? = null
     private var vibrator: Vibrator? = null
+    private var audioManager: AudioManager? = null
+    private var audioFocusRequest: AudioFocusRequest? = null
     private var audioSequenceActive = false
     private var currentAlarm: AlarmEntity? = null
     private var voiceAfterAlarmStarted = false
@@ -53,6 +57,7 @@ class RingingService : Service() {
             @Suppress("DEPRECATION")
             getSystemService(VIBRATOR_SERVICE) as Vibrator
         }
+        audioManager = getSystemService(AudioManager::class.java)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -106,6 +111,7 @@ class RingingService : Service() {
             val alarm = AlarmAppContainer.repository(applicationContext).getAlarm(alarmId)
             currentAlarm = alarm
             voiceAfterAlarmStarted = false
+            requestAlarmAudioFocus()
             startRingingAudio(alarm)
             val pattern = alarm?.vibrationPattern ?: VibrationPatterns.DEFAULT
             startVibration(pattern)
@@ -367,6 +373,7 @@ class RingingService : Service() {
         runCatching {
             stopForeground(STOP_FOREGROUND_REMOVE)
         }
+        abandonAlarmAudioFocus()
     }
 
     private fun stopMediaAndVibration() {
@@ -379,6 +386,44 @@ class RingingService : Service() {
         }
         mediaPlayer = null
         vibrator?.cancel()
+    }
+
+    private fun requestAlarmAudioFocus() {
+        val manager = audioManager ?: return
+        val attributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ALARM)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+        val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(attributes)
+                .setWillPauseWhenDucked(false)
+                .setOnAudioFocusChangeListener { }
+                .build()
+            audioFocusRequest = request
+            manager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            manager.requestAudioFocus(
+                null,
+                AudioManager.STREAM_ALARM,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            )
+        }
+        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            Log.w(TAG, "Alarm audio focus was not granted result=$result")
+        }
+    }
+
+    private fun abandonAlarmAudioFocus() {
+        val manager = audioManager ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let(manager::abandonAudioFocusRequest)
+            audioFocusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            manager.abandonAudioFocus(null)
+        }
     }
 
     companion object {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/members/MemberManagementScreen.kt
@@ -67,6 +67,7 @@ internal fun MemberManagementScreen(
     }
     val sortedMembers = familyGroup?.members.orEmpty()
         .sortedWith(compareByDescending<FamilyGroupMember> { it.role == "owner" }.thenBy { it.joinedAt })
+    val isCapacityFull = group != null && sortedMembers.size >= group.maxMembers
     val activePlanKey = subscriptionResponse?.plan?.key
     val shareVoucher = remember(vouchers, activePlanKey) {
         vouchers.firstOrNull { voucher ->
@@ -146,7 +147,11 @@ internal fun MemberManagementScreen(
             if (shareVoucher == null) {
                 item {
                     Text(
-                        text = "공유 코드가 아직 없어요. $planLabel 구성원을 초대할 INV 코드를 만들어 주세요.",
+                        text = if (isCapacityFull) {
+                            "정원이 가득 차서 더 이상 공유할 수 없어요."
+                        } else {
+                            "공유 코드가 아직 없어요. $planLabel 구성원을 초대할 INV 코드를 만들어 주세요."
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -154,16 +159,16 @@ internal fun MemberManagementScreen(
                 item {
                     OutlinedButton(
                         onClick = onEnsureFamilyShareCode,
-                        enabled = !billingBusy,
+                        enabled = !billingBusy && !isCapacityFull,
                         modifier = Modifier.fillMaxWidth(),
                         shape = RoundedCornerShape(14.dp),
                     ) {
-                        Text("공유 코드 만들기")
+                        Text(if (isCapacityFull) "공유 불가" else "공유 코드 만들기")
                     }
                 }
             } else {
                 item {
-                    val isFull = shareVoucher.useCount >= shareVoucher.maxUses
+                    val isFull = isCapacityFull || shareVoucher.useCount >= shareVoucher.maxUses
                     Surface(
                         color = MaterialTheme.colorScheme.surfaceVariant,
                         shape = RoundedCornerShape(14.dp),
@@ -179,7 +184,7 @@ internal fun MemberManagementScreen(
                             )
                             Text(
                                 text = if (isFull) {
-                                    "${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용 · 정원이 가득 찼어요"
+                                    "${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용 · 정원이 가득 차서 공유할 수 없어요"
                                 } else {
                                     "${shareVoucher.useCount}/${shareVoucher.maxUses}명 사용"
                                 },
@@ -192,7 +197,7 @@ internal fun MemberManagementScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = RoundedCornerShape(14.dp),
                             ) {
-                                Text(if (isFull) "정원 가득" else "공유하기")
+                                Text(if (isFull) "공유 불가" else "공유하기")
                             }
                         }
                     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/social/SocialPanels.kt
@@ -21,8 +21,6 @@ import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -622,16 +620,13 @@ internal fun NoteRow(
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.SemiBold,
                 )
-                    if (unread) {
-                        AssistChip(
-                            onClick = onMarkRead,
-                            label = { Text("새") },
-                            colors = AssistChipDefaults.assistChipColors(
-                                containerColor = MaterialTheme.colorScheme.secondary,
-                                labelColor = MaterialTheme.colorScheme.onSecondary,
-                            ),
-                        )
-                    }
+                if (unread) {
+                    Surface(
+                        modifier = Modifier.size(9.dp),
+                        color = MaterialTheme.colorScheme.secondary,
+                        shape = CircleShape,
+                    ) {}
+                }
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -53,9 +53,9 @@ auth.post('/register', async (c) => {
     const today = new Date().toISOString().split('T')[0]!;
 
     await db.execute({
-      sql: `INSERT INTO users (id, email, password_hash, name, daily_tts_reset_at)
-            VALUES (?, ?, ?, ?, ?)`,
-      args: [id, normalizedEmail, passwordHash, name, today],
+      sql: `INSERT INTO users (id, email, google_id, password_hash, name, daily_tts_reset_at)
+            VALUES (?, ?, ?, ?, ?, ?)`,
+      args: [id, normalizedEmail, id, passwordHash, name, today],
     });
 
     const token = await signAppJwt({ sub: id, email: normalizedEmail, name }, c.env.JWT_SECRET);
@@ -102,7 +102,7 @@ auth.post('/login', async (c) => {
 
   try {
     const result = await db.execute({
-      sql: `SELECT id, email, password_hash, name, plan,
+      sql: `SELECT id, google_id, email, password_hash, name, plan,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows
@@ -116,6 +116,7 @@ auth.post('/login', async (c) => {
 
     const row = typedRow<{
       id: string;
+      google_id: string | null;
       email: string;
       password_hash: string | null;
       name: string | null;
@@ -129,6 +130,13 @@ auth.post('/login', async (c) => {
     const ok = await verifyPassword(password, row.password_hash, c.env.PASSWORD_PEPPER);
     if (!ok) {
       return c.json(jsonError('AUTH_INVALID_CREDENTIALS', 'Invalid email or password'), 401);
+    }
+
+    if (!row.google_id) {
+      await db.execute({
+        sql: `UPDATE users SET google_id = ?, updated_at = datetime('now') WHERE id = ?`,
+        args: [row.id, row.id],
+      });
     }
 
     const token = await signAppJwt(

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -68,7 +68,7 @@ type FamilyShareCodeResult =
   | { voucher: ShareableVoucherCode }
   | {
       error: {
-        status: 404;
+        status: 404 | 409;
         body: {
           error: string;
           error_code: string;
@@ -306,6 +306,8 @@ billingMutation.post('/vouchers/family-share', async (c) => {
   const result: FamilyShareCodeResult = await withWriteTransaction(db, async (tx) => {
     const subscriptionRes = await tx.execute({
       sql: `SELECT s.id AS subscription_id, s.plan_id, s.expires_at,
+                   pg.id AS plan_group_id, pg.max_members AS group_max_members,
+                   (SELECT COUNT(*) FROM plan_group_members WHERE plan_group_id = pg.id) AS member_count,
                    p.key AS plan_key, p.name AS plan_name, p.plan_type,
                    p.period_days, p.max_members, p.price_krw
             FROM subscriptions s
@@ -339,7 +341,19 @@ billingMutation.post('/vouchers/family-share', async (c) => {
     const planKey = String(subscription.plan_key);
     const planName = String(subscription.plan_name);
     const planType = String(subscription.plan_type);
-    const maxMembers = Number(subscription.max_members) || 6;
+    const maxMembers = Number(subscription.group_max_members ?? subscription.max_members) || 6;
+    const memberCount = Number(subscription.member_count ?? 0);
+    if (memberCount >= maxMembers) {
+      return {
+        error: {
+          status: 409,
+          body: {
+            error: `Group is full: max ${maxMembers}`,
+            error_code: 'GROUP_FULL',
+          },
+        },
+      };
+    }
     const maxUses = plannedMaxUses(planType, maxMembers);
 
     const existingRes = await tx.execute({

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -59,6 +59,7 @@ describe('POST /auth/register', () => {
     expect(body.token).toMatch(/^[^.]+\.[^.]+\.[^.]+$/);
     expect(body.user.email).toBe('kim@test.com');
     expect(body.user.plan).toBe('free');
+    expect(mockDB.calls[1]?.args[2]).toBe(body.user.id);
   });
 
   it('중복 이메일 → 409', async () => {

--- a/packages/backend/test/billing-mutation.test.ts
+++ b/packages/backend/test/billing-mutation.test.ts
@@ -686,11 +686,14 @@ describe.skip('POST /billing/redeem (billingMutation)', () => {
 describe('POST /billing/vouchers/family-share (billingMutation)', () => {
   const FUTURE = '2027-12-31T00:00:00.000Z';
 
-  function pushOwnerFamilySubscription() {
+  function pushOwnerFamilySubscription(memberCount = 1) {
     mockDB.pushResult([{
       subscription_id: 'sub-family-1',
       plan_id: PLAN_FAMILY.id,
       expires_at: FUTURE,
+      plan_group_id: 'group-family-1',
+      group_max_members: PLAN_FAMILY.max_members,
+      member_count: memberCount,
       plan_key: PLAN_FAMILY.key,
       plan_name: PLAN_FAMILY.name,
       plan_type: PLAN_FAMILY.plan_type,
@@ -748,6 +751,17 @@ describe('POST /billing/vouchers/family-share (billingMutation)', () => {
     expect(insertCall?.args[4]).toBe('user-pk-1');
     expect(insertCall?.args[5]).toBe('sub-family-1');
     expect(insertCall?.args[8]).toBe(5);
+  });
+
+  it('가족 플랜 정원이 가득 차면 공유 코드를 발급하지 않는다', async () => {
+    mockDB.pushResult([{ id: 'user-pk-1' }]);
+    pushOwnerFamilySubscription(PLAN_FAMILY.max_members);
+
+    const res = await buildApp().request(jsonReq('POST', '/billing/vouchers/family-share'));
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error_code).toBe('GROUP_FULL');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT OR IGNORE INTO voucher_codes'))).toBe(false);
   });
 
   it('가족 플랜 소유자가 아니면 404를 반환한다', async () => {


### PR DESCRIPTION
﻿## 변경 사항
- Android 알람 울림 시 알람 오디오 포커스를 명시적으로 요청하고 종료 시 해제합니다.
- 읽지 않은 메시지 카드의 `새` 텍스트 칩을 제거하고 작은 점 표시로 변경했습니다.
- 공유 플랜 정원이 가득 차면 멤버 관리 화면에서 공유 코드 생성/공유를 비활성화하고 `공유 불가`로 표시합니다.
- 공유 코드 생성 API가 정원 가득 상태에서 `GROUP_FULL`을 반환하도록 서버 검증을 추가했습니다.
- 이메일 가입 계정의 `google_id`를 사용자 id로 보정해 기존 google_id 기반 API와 호환되게 했습니다.

## 검증
- `npm test --workspace=backend -- auth.test.ts billing.test.ts billing-mutation.test.ts billing-query.test.ts family-alarm.test.ts family-group.test.ts notes.test.ts`
- `npm test --workspace=backend -- billing-mutation.test.ts`
- `npm run typecheck --workspace=backend`
- `./gradlew.bat :app:assembleDebug :app:testDebugUnitTest`
- 두 Android 기기에 debug APK 재설치 및 알람 스트림 실기기 확인

Closes #278
