### PR TITLE
feat: 알람 설정 옵션 화면 개선

### DIFF
--- a/apps/android-native/README.md
+++ b/apps/android-native/README.md
@@ -208,7 +208,7 @@ Opening the alarm list also performs a startup sync from Room to `AlarmManager`,
 - `Voice only`: requires a generated voice-profile TTS clip, a server-saved dubbed/TTS clip, or a recorded/selected local audio clip.
 - `Alarm + Voice`: rings the bundled alarm first. When the user dismisses the alarm tone, the cached voice clip plays once, then the alarm is dismissed/rescheduled.
 
-If no repeat days are selected, the alarm is a one-shot alarm and is disabled after Dismiss. Repeat alarms can enable `Holiday off`; this skips major fixed-date Korean public holidays locally without a network fetch.
+If no repeat days are selected, the alarm is a one-shot alarm and is disabled after Dismiss. Repeat alarms can enable `Holiday off`; this skips holidays from the local `holiday_dates` cache by country/region, with a bundled KR seed as fallback, without a ring-time network fetch.
 
 ### Local Voice Audio
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
@@ -30,6 +30,7 @@ import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.data.AlarmAppContainer
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.AlarmPlayModes
+import com.voicealarm.nativeapp.data.VibrationPatternLibrary
 import com.voicealarm.nativeapp.data.VibrationPatterns
 import com.voicealarm.nativeapp.ringing.RingingActivity
 import kotlinx.coroutines.CoroutineScope
@@ -273,10 +274,7 @@ class RingingService : Service() {
             return
         }
 
-        val pattern = when (patternName) {
-            VibrationPatterns.STRONG -> longArrayOf(0L, 1_000L, 250L, 1_000L, 250L)
-            else -> longArrayOf(0L, 700L, 350L, 900L)
-        }
+        val pattern = VibrationPatternLibrary.waveform(patternName)
         val alarmAttributes = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_ALARM)
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAppContainer.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAppContainer.kt
@@ -12,6 +12,7 @@ object AlarmAppContainer {
             repository ?: AlarmRepository(
                 alarmDao = AlarmDatabase.getInstance(context).alarmDao(),
                 characterEventDao = AlarmDatabase.getInstance(context).characterEventDao(),
+                holidayCalendarStore = HolidayCalendarStore(AlarmDatabase.getInstance(context).holidayDao()),
                 alarmScheduler = AlarmScheduler(context.applicationContext),
                 alarmAudioStore = AlarmAudioStore(context.applicationContext),
                 context = context.applicationContext,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDatabase.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDatabase.kt
@@ -8,13 +8,14 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [AlarmEntity::class, CharacterEventEntity::class],
-    version = 8,
+    entities = [AlarmEntity::class, CharacterEventEntity::class, HolidayEntity::class],
+    version = 9,
     exportSchema = false,
 )
 abstract class AlarmDatabase : RoomDatabase() {
     abstract fun alarmDao(): AlarmDao
     abstract fun characterEventDao(): CharacterEventDao
+    abstract fun holidayDao(): HolidayDao
 
     companion object {
         @Volatile
@@ -34,6 +35,7 @@ abstract class AlarmDatabase : RoomDatabase() {
                     MIGRATION_5_6,
                     MIGRATION_6_7,
                     MIGRATION_7_8,
+                    MIGRATION_8_9,
                 ).build()
                     .also { instance = it }
             }
@@ -112,6 +114,25 @@ abstract class AlarmDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE alarms ADD COLUMN alarmVolumePercent INTEGER NOT NULL DEFAULT 100")
                 db.execSQL("ALTER TABLE alarms ADD COLUMN alarmSoundUri TEXT")
                 db.execSQL("ALTER TABLE alarms ADD COLUMN alarmSoundLabel TEXT")
+            }
+        }
+
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS holiday_dates (
+                        countryCode TEXT NOT NULL,
+                        regionCode TEXT NOT NULL,
+                        epochDay INTEGER NOT NULL,
+                        localDate TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        source TEXT NOT NULL,
+                        updatedAtMillis INTEGER NOT NULL,
+                        PRIMARY KEY(countryCode, regionCode, epochDay)
+                    )
+                    """.trimIndent(),
+                )
             }
         }
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmEntity.kt
@@ -2,6 +2,7 @@ package com.voicealarm.nativeapp.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.time.LocalDate
 
 @Entity(tableName = "alarms")
 data class AlarmEntity(
@@ -67,9 +68,81 @@ object AlarmOrigins {
 object VibrationPatterns {
     const val DEFAULT = "default"
     const val STRONG = "strong"
+    const val SHORT = "short"
+    const val MEDIUM = "medium"
+    const val HEARTBEAT = "heartbeat"
+    const val TICKTOCK = "ticktock"
+    const val WALTZ = "waltz"
+    const val ZIGZAG = "zigzag"
+    const val OFF_BEAT = "off_beat"
+    const val RIPPLE = "ripple"
+    const val SIREN = "siren"
     const val NONE = "none"
 
-    val all = listOf(DEFAULT, STRONG, NONE)
+    val all = listOf(
+        DEFAULT,
+        STRONG,
+        SHORT,
+        MEDIUM,
+        HEARTBEAT,
+        TICKTOCK,
+        WALTZ,
+        ZIGZAG,
+        OFF_BEAT,
+        RIPPLE,
+        SIREN,
+        NONE,
+    )
+}
+
+object VibrationPatternLibrary {
+    fun waveform(patternName: String): LongArray =
+        when (patternName) {
+            VibrationPatterns.STRONG -> longArrayOf(0L, 1_000L, 240L, 1_000L, 240L)
+            VibrationPatterns.SHORT -> longArrayOf(0L, 260L, 520L)
+            VibrationPatterns.MEDIUM -> longArrayOf(0L, 560L, 420L)
+            VibrationPatterns.HEARTBEAT -> longArrayOf(0L, 120L, 120L, 240L, 580L)
+            VibrationPatterns.TICKTOCK -> longArrayOf(0L, 90L, 210L, 90L, 620L)
+            VibrationPatterns.WALTZ -> longArrayOf(0L, 280L, 140L, 150L, 140L, 150L, 620L)
+            VibrationPatterns.ZIGZAG -> longArrayOf(0L, 110L, 100L, 180L, 100L, 280L, 520L)
+            VibrationPatterns.OFF_BEAT -> longArrayOf(0L, 80L, 260L, 240L, 150L, 110L, 560L)
+            VibrationPatterns.RIPPLE -> longArrayOf(0L, 90L, 110L, 160L, 130L, 260L, 620L)
+            VibrationPatterns.SIREN -> longArrayOf(0L, 240L, 110L, 240L, 110L, 520L, 360L)
+            else -> longArrayOf(0L, 700L, 350L, 900L)
+        }
+}
+
+object HolidaySeedData {
+    fun holidays(countryCode: String, year: Int): List<HolidayDate> =
+        when (countryCode.uppercase()) {
+            "KR" -> koreanHolidaysByYear[year].orEmpty()
+            else -> emptyList()
+        }
+
+    private val koreanHolidaysByYear = mapOf(
+        2026 to listOf(
+            HolidayDate(LocalDate.of(2026, 1, 1), "신정"),
+            HolidayDate(LocalDate.of(2026, 2, 16), "설날 연휴"),
+            HolidayDate(LocalDate.of(2026, 2, 17), "설날"),
+            HolidayDate(LocalDate.of(2026, 2, 18), "설날 연휴"),
+            HolidayDate(LocalDate.of(2026, 3, 1), "삼일절"),
+            HolidayDate(LocalDate.of(2026, 3, 2), "대체공휴일"),
+            HolidayDate(LocalDate.of(2026, 5, 5), "어린이날"),
+            HolidayDate(LocalDate.of(2026, 5, 24), "부처님오신날"),
+            HolidayDate(LocalDate.of(2026, 5, 25), "대체공휴일"),
+            HolidayDate(LocalDate.of(2026, 6, 3), "전국동시지방선거"),
+            HolidayDate(LocalDate.of(2026, 6, 6), "현충일"),
+            HolidayDate(LocalDate.of(2026, 8, 15), "광복절"),
+            HolidayDate(LocalDate.of(2026, 8, 17), "대체공휴일"),
+            HolidayDate(LocalDate.of(2026, 9, 24), "추석 연휴"),
+            HolidayDate(LocalDate.of(2026, 9, 25), "추석"),
+            HolidayDate(LocalDate.of(2026, 9, 26), "추석 연휴"),
+            HolidayDate(LocalDate.of(2026, 10, 3), "개천절"),
+            HolidayDate(LocalDate.of(2026, 10, 5), "대체공휴일"),
+            HolidayDate(LocalDate.of(2026, 10, 9), "한글날"),
+            HolidayDate(LocalDate.of(2026, 12, 25), "기독탄신일"),
+        ),
+    )
 }
 
 object AlarmPlayModes {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -5,12 +5,15 @@ import android.util.Log
 import com.voicealarm.nativeapp.alarm.AlarmScheduler
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.network.VoiceAlarmApi
+import java.time.Instant
+import java.time.ZoneId
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 
 class AlarmRepository(
     private val alarmDao: AlarmDao,
     private val characterEventDao: CharacterEventDao,
+    private val holidayCalendarStore: HolidayCalendarStore,
     private val alarmScheduler: AlarmScheduler,
     private val alarmAudioStore: AlarmAudioStore,
     private val context: Context,
@@ -89,6 +92,7 @@ class AlarmRepository(
         requireUniqueTime(draft.hour, draft.minute)
 
         val now = System.currentTimeMillis()
+        val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
         val alarm = AlarmEntity(
             id = UUID.randomUUID().toString(),
             label = draft.label.trim().ifBlank { "알람" },
@@ -100,6 +104,7 @@ class AlarmRepository(
                 repeatDaysMask = draft.repeatDaysMask,
                 holidayOff = draft.holidayOff,
                 nowMillis = now,
+                isHoliday = holidayPredicate,
             ),
             repeatDaysMask = draft.repeatDaysMask,
             holidayOff = draft.holidayOff,
@@ -144,12 +149,14 @@ class AlarmRepository(
         val current = requireNotNull(alarmDao.getById(alarmId)) { "Alarm not found." }
         requireUniqueTime(draft.hour, draft.minute, excludeAlarmId = alarmId)
         val now = System.currentTimeMillis()
+        val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
         val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
             hour = draft.hour,
             minute = draft.minute,
             repeatDaysMask = draft.repeatDaysMask,
             holidayOff = draft.holidayOff,
             nowMillis = now,
+            isHoliday = holidayPredicate,
         )
         requireExactAlarmPermission()
         val updated = current.copy(
@@ -198,6 +205,7 @@ class AlarmRepository(
         alarmScheduler.cancel(alarmId)
 
         val updated = if (enabled) {
+            val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
             current.copy(
                 fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
                     hour = current.hour,
@@ -205,6 +213,7 @@ class AlarmRepository(
                     repeatDaysMask = current.repeatDaysMask,
                     holidayOff = current.holidayOff,
                     nowMillis = now,
+                    isHoliday = holidayPredicate,
                 ),
                 enabled = true,
                 snoozeCount = 0,
@@ -243,6 +252,7 @@ class AlarmRepository(
         val now = System.currentTimeMillis()
         val copiedTime = copyTargetTime(current.hour, current.minute)
         requireUniqueTime(copiedTime.hour, copiedTime.minute)
+        val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
         val copied = current.copy(
             id = UUID.randomUUID().toString(),
             label = current.label.takeIf { it.isNotBlank() }?.let { "$it 복사본" } ?: "복사한 알람",
@@ -254,6 +264,7 @@ class AlarmRepository(
                 repeatDaysMask = current.repeatDaysMask,
                 holidayOff = current.holidayOff,
                 nowMillis = now,
+                isHoliday = holidayPredicate,
             ),
             remoteAlarmId = null,
             lastSyncedAtMillis = null,
@@ -291,12 +302,14 @@ class AlarmRepository(
 
         val now = System.currentTimeMillis()
         if (current.repeatDaysMask != 0) {
+            val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
             val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
                 hour = current.hour,
                 minute = current.minute,
                 repeatDaysMask = current.repeatDaysMask,
                 holidayOff = current.holidayOff,
                 nowMillis = now,
+                isHoliday = holidayPredicate,
             )
             val next = current.copy(
                 fireAtMillis = nextFireAt,
@@ -371,6 +384,7 @@ class AlarmRepository(
                 val alarmToSchedule = if (alarm.fireAtMillis > now) {
                     alarm
                 } else if (alarm.repeatDaysMask != 0) {
+                    val holidayPredicate = holidayCalendarStore.holidayPredicate(startDate = currentLocalDate(now))
                     alarm.copy(
                         fireAtMillis = AlarmTimeCalculator.nextFireAtMillis(
                             hour = alarm.hour,
@@ -378,6 +392,7 @@ class AlarmRepository(
                             repeatDaysMask = alarm.repeatDaysMask,
                             holidayOff = alarm.holidayOff,
                             nowMillis = now,
+                            isHoliday = holidayPredicate,
                         ),
                         state = AlarmStates.SCHEDULED,
                         updatedAtMillis = now,
@@ -444,6 +459,11 @@ class AlarmRepository(
 
     private fun copyTargetTime(hour: Int, minute: Int): java.time.LocalTime =
         java.time.LocalTime.of(hour, minute).plusMinutes(10)
+
+    private fun currentLocalDate(nowMillis: Long): java.time.LocalDate =
+        Instant.ofEpochMilli(nowMillis)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
 
     private fun requireExactAlarmPermission() {
         require(alarmScheduler.canScheduleExactAlarms()) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmTimeCalculator.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmTimeCalculator.kt
@@ -13,6 +13,7 @@ object AlarmTimeCalculator {
         holidayOff: Boolean = false,
         nowMillis: Long = System.currentTimeMillis(),
         zoneId: ZoneId = ZoneId.systemDefault(),
+        isHoliday: (LocalDate) -> Boolean = { LocalHolidayCalendar.isHoliday(it) },
     ): Long {
         require(hour in 0..23) { "Hour must be between 0 and 23." }
         require(minute in 0..59) { "Minute must be between 0 and 59." }
@@ -33,7 +34,7 @@ object AlarmTimeCalculator {
         for (offset in 0..7) {
             val date = today.plusDays(offset.toLong())
             if (!isSelected(date, repeatDaysMask)) continue
-            if (holidayOff && LocalHolidayCalendar.isHoliday(date)) continue
+            if (holidayOff && isHoliday(date)) continue
 
             val candidate = LocalDateTime.of(date, java.time.LocalTime.of(hour, minute))
             if (candidate.isAfter(now)) {
@@ -44,7 +45,7 @@ object AlarmTimeCalculator {
         for (offset in 8..21) {
             val date = today.plusDays(offset.toLong())
             if (!isSelected(date, repeatDaysMask)) continue
-            if (holidayOff && LocalHolidayCalendar.isHoliday(date)) continue
+            if (holidayOff && isHoliday(date)) continue
             return candidateMillis(date, hour, minute, zoneId)
         }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/HolidayEntity.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/HolidayEntity.kt
@@ -1,0 +1,116 @@
+package com.voicealarm.nativeapp.data
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Query
+import androidx.room.Upsert
+import java.time.LocalDate
+
+@Entity(
+    tableName = "holiday_dates",
+    primaryKeys = ["countryCode", "regionCode", "epochDay"],
+)
+data class HolidayEntity(
+    val countryCode: String,
+    val regionCode: String,
+    val epochDay: Long,
+    val localDate: String,
+    val name: String,
+    val source: String,
+    val updatedAtMillis: Long,
+)
+
+@Dao
+interface HolidayDao {
+    @Query(
+        """
+        SELECT * FROM holiday_dates
+        WHERE countryCode = :countryCode
+          AND regionCode IN ('', :regionCode)
+          AND epochDay BETWEEN :startEpochDay AND :endEpochDay
+        """,
+    )
+    suspend fun getBetween(
+        countryCode: String,
+        regionCode: String,
+        startEpochDay: Long,
+        endEpochDay: Long,
+    ): List<HolidayEntity>
+
+    @Upsert
+    suspend fun upsertAll(holidays: List<HolidayEntity>)
+}
+
+class HolidayCalendarStore(
+    private val holidayDao: HolidayDao,
+) {
+    suspend fun holidayPredicate(
+        countryCode: String = DEFAULT_COUNTRY_CODE,
+        regionCode: String = "",
+        startDate: LocalDate,
+        daysAhead: Long = DEFAULT_LOOKAHEAD_DAYS,
+    ): (LocalDate) -> Boolean {
+        seedDefaultHolidaysIfAvailable(countryCode, regionCode, startDate.year)
+        seedDefaultHolidaysIfAvailable(countryCode, regionCode, startDate.plusDays(daysAhead).year)
+        val endDate = startDate.plusDays(daysAhead)
+        val cachedDates = holidayDao.getBetween(
+            countryCode = countryCode,
+            regionCode = regionCode,
+            startEpochDay = startDate.toEpochDay(),
+            endEpochDay = endDate.toEpochDay(),
+        ).mapTo(mutableSetOf()) { LocalDate.ofEpochDay(it.epochDay) }
+
+        return { date ->
+            date in cachedDates || LocalHolidayCalendar.isHoliday(countryCode, date)
+        }
+    }
+
+    suspend fun upsertHolidays(
+        countryCode: String,
+        regionCode: String = "",
+        holidays: List<HolidayDate>,
+        source: String,
+        nowMillis: Long = System.currentTimeMillis(),
+    ) {
+        holidayDao.upsertAll(
+            holidays.map { holiday ->
+                HolidayEntity(
+                    countryCode = countryCode,
+                    regionCode = regionCode,
+                    epochDay = holiday.date.toEpochDay(),
+                    localDate = holiday.date.toString(),
+                    name = holiday.name,
+                    source = source,
+                    updatedAtMillis = nowMillis,
+                )
+            },
+        )
+    }
+
+    companion object {
+        const val DEFAULT_COUNTRY_CODE = "KR"
+        private const val DEFAULT_LOOKAHEAD_DAYS = 370L
+        private const val SEED_SOURCE = "bundled_seed"
+    }
+
+    private suspend fun seedDefaultHolidaysIfAvailable(
+        countryCode: String,
+        regionCode: String,
+        year: Int,
+    ) {
+        val seedHolidays = HolidaySeedData.holidays(countryCode, year)
+        if (seedHolidays.isNotEmpty()) {
+            upsertHolidays(
+                countryCode = countryCode,
+                regionCode = regionCode,
+                holidays = seedHolidays,
+                source = SEED_SOURCE,
+            )
+        }
+    }
+}
+
+data class HolidayDate(
+    val date: LocalDate,
+    val name: String,
+)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/LocalHolidayCalendar.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/LocalHolidayCalendar.kt
@@ -4,7 +4,13 @@ import java.time.LocalDate
 
 object LocalHolidayCalendar {
     fun isHoliday(date: LocalDate): Boolean =
-        isKoreanFixedHoliday(date)
+        isHoliday(countryCode = HolidayCalendarStore.DEFAULT_COUNTRY_CODE, date = date)
+
+    fun isHoliday(countryCode: String, date: LocalDate): Boolean =
+        when (countryCode.uppercase()) {
+            "KR" -> isKoreanFixedHoliday(date) || isKoreanObservedFixedHoliday(date)
+            else -> false
+        }
 
     private fun isKoreanFixedHoliday(date: LocalDate): Boolean =
         when (date.monthValue to date.dayOfMonth) {
@@ -12,6 +18,24 @@ object LocalHolidayCalendar {
             3 to 1,
             5 to 5,
             6 to 6,
+            8 to 15,
+            10 to 3,
+            10 to 9,
+            12 to 25
+            -> true
+            else -> false
+        }
+
+    private fun isKoreanObservedFixedHoliday(date: LocalDate): Boolean {
+        if (date.dayOfWeek.value != 1) return false
+        return isSubstituteEligibleFixedHoliday(date.minusDays(1)) ||
+            isSubstituteEligibleFixedHoliday(date.minusDays(2))
+    }
+
+    private fun isSubstituteEligibleFixedHoliday(date: LocalDate): Boolean =
+        when (date.monthValue to date.dayOfMonth) {
+            3 to 1,
+            5 to 5,
             8 to 15,
             10 to 3,
             10 to 9,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListComponents.kt
@@ -38,7 +38,7 @@ internal fun AlarmsHeader(
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
     ) {
         Text(
             text = "알람",

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorControls.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorControls.kt
@@ -1,119 +1,188 @@
 package com.voicealarm.nativeapp
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Save
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.data.AlarmAudioLimits
 import com.voicealarm.nativeapp.data.AlarmPlayModes
-import com.voicealarm.nativeapp.data.VibrationPatterns
+import com.voicealarm.nativeapp.data.AlarmTimeCalculator
 import com.voicealarm.nativeapp.data.VoiceSources
 import com.voicealarm.nativeapp.network.VoiceProfile
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @Composable
 internal fun RepeatSelector(
+    hour: Int,
+    minute: Int,
     repeatDaysMask: Int,
     holidayOff: Boolean,
     onToggleDay: (Int) -> Unit,
     onHolidayOffChange: (Boolean) -> Unit,
 ) {
-    val days = listOf("일", "월", "화", "수", "목", "금", "토")
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    val holidayEnabled = repeatDaysMask != 0
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            text = repeatSummaryLabel(hour, minute, repeatDaysMask),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            days.forEachIndexed { index, label ->
-                DayCircleChip(
+            WeekdayLabels.forEachIndexed { index, label ->
+                DayTextChip(
                     label = label,
+                    dayIndex = index,
                     selected = repeatDaysMask and (1 shl index) != 0,
                     onClick = { onToggleDay(index) },
+                    modifier = Modifier.weight(1f),
                 )
             }
         }
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .alpha(if (holidayEnabled) 1f else 0.46f),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("공휴일 제외", fontWeight = FontWeight.SemiBold)
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 14.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text("공휴일에는 끄기", fontWeight = FontWeight.SemiBold)
+                Text(
+                    text = "대체 공휴일 및 임시 공휴일 포함",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
             VoiceAlarmSwitch(
-                checked = holidayOff,
-                onCheckedChange = onHolidayOffChange,
-            )
-        }
-        if (repeatDaysMask != 0) {
-            MutedText(repeatLabel(repeatDaysMask))
-        }
-    }
-}
-
-@Composable
-internal fun DayCircleChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    Surface(
-        onClick = onClick,
-        modifier = Modifier.size(42.dp),
-        shape = CircleShape,
-        color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
-        tonalElevation = 0.dp,
-        shadowElevation = 0.dp,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = if (selected) {
-                    MaterialTheme.colorScheme.onPrimary
-                } else {
-                    MaterialTheme.colorScheme.onSurface
+                checked = holidayEnabled && holidayOff,
+                enabled = holidayEnabled,
+                onCheckedChange = { enabled ->
+                    if (holidayEnabled) onHolidayOffChange(enabled)
                 },
             )
         }
     }
 }
+
+@Composable
+internal fun DayTextChip(
+    label: String,
+    dayIndex: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val weekendColor = when (dayIndex) {
+        0 -> MaterialTheme.colorScheme.error
+        6 -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val selectedContainerColor = when (dayIndex) {
+        0 -> MaterialTheme.colorScheme.errorContainer
+        6 -> MaterialTheme.colorScheme.secondaryContainer
+        else -> MaterialTheme.colorScheme.primaryContainer
+    }
+    val selectedContentColor = when (dayIndex) {
+        0 -> MaterialTheme.colorScheme.onErrorContainer
+        6 -> MaterialTheme.colorScheme.onSecondaryContainer
+        else -> MaterialTheme.colorScheme.onPrimaryContainer
+    }
+    val selectedBorderColor = when (dayIndex) {
+        0 -> MaterialTheme.colorScheme.error
+        6 -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val contentColor = if (selected) {
+        selectedContentColor
+    } else {
+        weekendColor
+    }
+    Surface(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        color = if (selected) selectedContainerColor else Color.Transparent,
+        border = if (selected) BorderStroke(1.dp, selectedBorderColor) else null,
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 9.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = if (selected) FontWeight.Bold else FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            color = contentColor,
+        )
+    }
+}
+
+internal fun repeatSummaryLabel(
+    hour: Int,
+    minute: Int,
+    repeatDaysMask: Int,
+    nowMillis: Long = System.currentTimeMillis(),
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): String {
+    if (repeatDaysMask != 0) {
+        if (repeatDaysMask == 0b1111111) return "매일"
+        val selectedDays = WeekdayLabels
+            .filterIndexed { index, _ -> repeatDaysMask and (1 shl index) != 0 }
+            .joinToString(", ")
+        return "매주 $selectedDays"
+    }
+
+    val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
+        hour = hour,
+        minute = minute,
+        repeatDaysMask = 0,
+        nowMillis = nowMillis,
+        zoneId = zoneId,
+    )
+    val today = Instant.ofEpochMilli(nowMillis).atZone(zoneId).toLocalDate()
+    val nextDate = Instant.ofEpochMilli(nextFireAt).atZone(zoneId).toLocalDate()
+    val dateLabel = koreanDateLabel(nextDate)
+    return when (nextDate) {
+        today -> "오늘 - $dateLabel"
+        today.plusDays(1) -> "내일 - $dateLabel"
+        else -> dateLabel
+    }
+}
+
+private fun koreanDateLabel(date: LocalDate): String {
+    val dayLabel = WeekdayLabels[date.dayOfWeek.value % 7]
+    return "${date.monthValue}월 ${date.dayOfMonth}일($dayLabel)"
+}
+
+private val WeekdayLabels = listOf("일", "월", "화", "수", "목", "금", "토")
 
 @Composable
 internal fun QuickChip(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.util.Base64
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -19,8 +20,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -46,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
@@ -442,15 +446,24 @@ internal fun AlarmEditorScreen(
     }
 
     val editorHorizontalPadding = 24.dp
+    val density = LocalDensity.current
+    val editorBottomPadding = with(density) {
+        WindowInsets.navigationBars.getBottom(this).toDp()
+    } + 36.dp
+    var settingsDetailPanel by remember { mutableStateOf<String?>(null) }
 
-    LazyColumn(
+    BackHandler(enabled = settingsDetailPanel != null) {
+        settingsDetailPanel = null
+    }
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(contentPadding),
-        contentPadding = PaddingValues(bottom = 36.dp),
-        verticalArrangement = Arrangement.spacedBy(22.dp),
     ) {
-        item {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
             AlarmTimePickerCard(
                 hour = editor.hour,
                 minute = editor.minute,
@@ -458,189 +471,230 @@ internal fun AlarmEditorScreen(
                     editor.hour = selectedHour
                     editor.minute = selectedMinute
                 },
-                modifier = Modifier.fillParentMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
             )
-        }
 
-        item {
-            Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
-                OutlinedTextField(
-                    value = editor.label,
-                    onValueChange = { editor.label = it },
-                    placeholder = { Text("알람 이름") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
-
-        if (familyAlarmMode) {
-            item {
-                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
-                    FamilyAlarmTargetCard(
-                        recipients = familyRecipients,
-                        selectedRecipientId = selectedFamilyRecipientId,
-                        hour = editor.hour,
-                        minute = editor.minute,
-                        repeatDaysMask = editor.repeatDaysMask,
-                        holidayOff = editor.holidayOff,
-                        onSelectRecipient = { selectedFamilyRecipientId = it },
-                    )
-                }
-            }
-        }
-
-        item {
-            Column(
-                modifier = Modifier.padding(horizontal = editorHorizontalPadding),
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(top = 18.dp, bottom = editorBottomPadding),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                RepeatSelector(
-                    repeatDaysMask = editor.repeatDaysMask,
-                    holidayOff = editor.holidayOff,
-                    onToggleDay = { dayIndex ->
-                        editor.repeatDaysMask = editor.repeatDaysMask xor (1 shl dayIndex)
-                    },
-                    onHolidayOffChange = { editor.holidayOff = it },
-                )
-            }
-        }
-
-        item {
-            Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
-                PlayModeSelector(
-                    selected = editor.playMode,
-                    onSelect = { selectedMode ->
-                        val wasAlarmOnly = editor.playMode == AlarmPlayModes.ALARM_ONLY
-                        editor.playMode = selectedMode
-                        if (selectedMode != AlarmPlayModes.ALARM_ONLY && authSession == null) {
-                            editor.voiceSource = VoiceSources.LOCAL_AUDIO
-                            editor.clearTtsMeta()
-                        } else if (selectedMode != AlarmPlayModes.ALARM_ONLY && wasAlarmOnly) {
-                            editor.voiceSource = VoiceSources.TTS_PROFILE
-                            editor.clearTtsMeta()
-                        }
-                    },
-                )
-            }
-        }
-
-        if (editor.playMode != AlarmPlayModes.ALARM_ONLY) {
-            item {
-                Column(
-                    modifier = Modifier.padding(horizontal = editorHorizontalPadding),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    EditorSectionTitle("음성")
-                    VoiceAudioCard(
-                        editor = editor,
-                        voiceProfiles = voiceProfiles,
-                        familyVoices = familyVoices,
-                        voiceProfileBusy = voiceProfileBusy,
-                        audioMessage = audioMessage,
-                        localInputMode = localInputMode,
-                        isRecording = isRecording,
-                        recordingElapsedMillis = recordingElapsedMillis,
-                        recordingLevels = recordingLevels,
-                        selectedFileDurationMillis = selectedFileDurationMillis,
-                        cropStartMillis = cropStartMillis,
-                        cropEndMillis = cropEndMillis,
-                        onLocalInputModeChange = { mode ->
-                            if (!isRecording && mode != localInputMode) {
-                                mediaPlayer?.release()
-                                mediaPlayer = null
-                                if (mode == VoiceCaptureMode.File) {
-                                    editor.clearAudio()
-                                } else {
-                                    selectedFileUri = null
-                                    selectedFileDurationMillis = null
-                                    cropStartMillis = 0L
-                                    cropEndMillis = AlarmAudioLimits.MAX_DURATION_MILLIS
-                                }
-                                audioMessage = null
-                                localInputMode = mode
-                            }
-                        },
-                        onPick = { pickAudioLauncher.launch("audio/*") },
-                        onRecord = {
-                            if (isRecording) {
-                                stopRecording()
-                            } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
-                                PackageManager.PERMISSION_GRANTED
-                            ) {
-                                startRecording()
-                            } else {
-                                recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                            }
-                        },
-                        onCropChange = { start, end ->
-                            cropStartMillis = start
-                            cropEndMillis = end
-                            editor.clearAudio()
-                        },
-                        onPreviewCrop = { playSelectedCrop() },
-                        onPreviewAudio = { playCachedAudio() },
-                        onClear = {
-                            editor.clearAudio()
-                            selectedFileUri = null
-                            selectedFileDurationMillis = null
-                            audioMessage = "음성 오디오를 지웠어요"
-                        },
-                    )
-                }
-            }
-        }
-
-        item {
-            Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
-                AlarmSettingsCard(
-                    snoozeEnabled = editor.snoozeEnabled,
-                    snoozeMinutes = editor.snoozeMinutes,
-                    snoozeRepeatLimit = editor.snoozeRepeatLimit,
-                    vibrationPattern = editor.vibrationPattern,
-                    alarmVolumePercent = editor.alarmVolumePercent,
-                    alarmSoundLabel = editor.alarmSoundLabel,
-                    onSnoozeEnabledChange = { editor.snoozeEnabled = it },
-                    onSnoozeMinutesChange = { editor.snoozeMinutes = it },
-                    onSnoozeRepeatLimitChange = { editor.snoozeRepeatLimit = it },
-                    onVibrationEnabledChange = {
-                        editor.vibrationPattern = if (it) VibrationPatterns.DEFAULT else VibrationPatterns.NONE
-                    },
-                    onVibrationSelect = { editor.vibrationPattern = it },
-                    onAlarmVolumeChange = { editor.alarmVolumePercent = it },
-                    onPickAlarmSound = {
-                        ringtonePickerLauncher.launch(
-                            Intent(RingtoneManager.ACTION_RINGTONE_PICKER).apply {
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALARM)
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true)
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true)
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "알람 소리 선택")
-                                val current = editor.alarmSoundUri?.let(Uri::parse)
-                                    ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, current)
+                item {
+                    Column(
+                        modifier = Modifier.padding(horizontal = editorHorizontalPadding),
+                    ) {
+                        RepeatSelector(
+                            hour = editor.hour,
+                            minute = editor.minute,
+                            repeatDaysMask = editor.repeatDaysMask,
+                            holidayOff = editor.holidayOff,
+                            onToggleDay = { dayIndex ->
+                                val nextMask = editor.repeatDaysMask xor (1 shl dayIndex)
+                                editor.repeatDaysMask = nextMask
+                                if (nextMask == 0) editor.holidayOff = false
+                            },
+                            onHolidayOffChange = { enabled ->
+                                if (editor.repeatDaysMask != 0) editor.holidayOff = enabled
                             },
                         )
-                    },
-                    onUseDefaultAlarmSound = {
-                        editor.alarmSoundUri = null
-                        editor.alarmSoundLabel = null
-                        if (editor.alarmVolumePercent == 0) editor.alarmVolumePercent = 100
-                    },
-                )
+                    }
+                }
+
+            item {
+                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                    OutlinedTextField(
+                        value = editor.label,
+                        onValueChange = { editor.label = it },
+                        placeholder = { Text("알람 이름") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            if (familyAlarmMode) {
+                item {
+                    Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                        FamilyAlarmTargetCard(
+                            recipients = familyRecipients,
+                            selectedRecipientId = selectedFamilyRecipientId,
+                            hour = editor.hour,
+                            minute = editor.minute,
+                            repeatDaysMask = editor.repeatDaysMask,
+                            holidayOff = editor.holidayOff,
+                            onSelectRecipient = { selectedFamilyRecipientId = it },
+                        )
+                    }
+                }
+            }
+
+            item {
+                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                    PlayModeSelector(
+                        selected = editor.playMode,
+                        onSelect = { selectedMode ->
+                            val wasAlarmOnly = editor.playMode == AlarmPlayModes.ALARM_ONLY
+                            editor.playMode = selectedMode
+                            if (selectedMode != AlarmPlayModes.ALARM_ONLY && authSession == null) {
+                                editor.voiceSource = VoiceSources.LOCAL_AUDIO
+                                editor.clearTtsMeta()
+                            } else if (selectedMode != AlarmPlayModes.ALARM_ONLY && wasAlarmOnly) {
+                                editor.voiceSource = VoiceSources.TTS_PROFILE
+                                editor.clearTtsMeta()
+                            }
+                        },
+                    )
+                }
+            }
+
+            if (editor.playMode != AlarmPlayModes.ALARM_ONLY) {
+                item {
+                    Column(
+                        modifier = Modifier.padding(horizontal = editorHorizontalPadding),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        EditorSectionTitle("음성")
+                        VoiceAudioCard(
+                            editor = editor,
+                            voiceProfiles = voiceProfiles,
+                            familyVoices = familyVoices,
+                            voiceProfileBusy = voiceProfileBusy,
+                            audioMessage = audioMessage,
+                            localInputMode = localInputMode,
+                            isRecording = isRecording,
+                            recordingElapsedMillis = recordingElapsedMillis,
+                            recordingLevels = recordingLevels,
+                            selectedFileDurationMillis = selectedFileDurationMillis,
+                            cropStartMillis = cropStartMillis,
+                            cropEndMillis = cropEndMillis,
+                            onLocalInputModeChange = { mode ->
+                                if (!isRecording && mode != localInputMode) {
+                                    mediaPlayer?.release()
+                                    mediaPlayer = null
+                                    if (mode == VoiceCaptureMode.File) {
+                                        editor.clearAudio()
+                                    } else {
+                                        selectedFileUri = null
+                                        selectedFileDurationMillis = null
+                                        cropStartMillis = 0L
+                                        cropEndMillis = AlarmAudioLimits.MAX_DURATION_MILLIS
+                                    }
+                                    audioMessage = null
+                                    localInputMode = mode
+                                }
+                            },
+                            onPick = { pickAudioLauncher.launch("audio/*") },
+                            onRecord = {
+                                if (isRecording) {
+                                    stopRecording()
+                                } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
+                                    PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    startRecording()
+                                } else {
+                                    recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                }
+                            },
+                            onCropChange = { start, end ->
+                                cropStartMillis = start
+                                cropEndMillis = end
+                                editor.clearAudio()
+                            },
+                            onPreviewCrop = { playSelectedCrop() },
+                            onPreviewAudio = { playCachedAudio() },
+                            onClear = {
+                                editor.clearAudio()
+                                selectedFileUri = null
+                                selectedFileDurationMillis = null
+                                audioMessage = "음성 오디오를 지웠어요"
+                            },
+                        )
+                    }
+                }
+            }
+
+            item {
+                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                    AlarmSettingsCard(
+                        snoozeEnabled = editor.snoozeEnabled,
+                        snoozeMinutes = editor.snoozeMinutes,
+                        snoozeRepeatLimit = editor.snoozeRepeatLimit,
+                        vibrationPattern = editor.vibrationPattern,
+                        alarmVolumePercent = editor.alarmVolumePercent,
+                        alarmSoundLabel = editor.alarmSoundLabel,
+                        onSnoozeEnabledChange = { editor.snoozeEnabled = it },
+                        onSnoozeMinutesChange = { editor.snoozeMinutes = it },
+                        onSnoozeRepeatLimitChange = { editor.snoozeRepeatLimit = it },
+                        onVibrationEnabledChange = {
+                            editor.vibrationPattern = if (it) VibrationPatterns.DEFAULT else VibrationPatterns.NONE
+                        },
+                        onVibrationSelect = { editor.vibrationPattern = it },
+                        onAlarmVolumeChange = { editor.alarmVolumePercent = it },
+                        onOpenSnoozeSettings = { settingsDetailPanel = "snooze" },
+                        onOpenVibrationSettings = { settingsDetailPanel = "vibration" },
+                        onOpenAlarmSoundSettings = { settingsDetailPanel = "sound" },
+                    )
+                }
+            }
+
+            item {
+                Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
+                    EditorActionButtons(
+                        isEditing = alarm != null,
+                        isSaving = isSaving,
+                        onCancel = onCancel,
+                        onSave = ::saveEditor,
+                    )
+                }
             }
         }
+        }
 
-        item {
-            Box(modifier = Modifier.padding(horizontal = editorHorizontalPadding)) {
-                EditorActionButtons(
-                    isEditing = alarm != null,
-                    isSaving = isSaving,
-                    onCancel = onCancel,
-                    onSave = ::saveEditor,
-                )
-            }
+        when (settingsDetailPanel) {
+            "snooze" -> SnoozeSettingsPane(
+                snoozeEnabled = editor.snoozeEnabled,
+                snoozeMinutes = editor.snoozeMinutes,
+                snoozeRepeatLimit = editor.snoozeRepeatLimit,
+                onDismiss = { settingsDetailPanel = null },
+                onSnoozeEnabledChange = { editor.snoozeEnabled = it },
+                onSnoozeMinutesChange = { editor.snoozeMinutes = it },
+                onSnoozeRepeatLimitChange = { editor.snoozeRepeatLimit = it },
+            )
+
+            "vibration" -> VibrationSettingsPane(
+                vibrationPattern = editor.vibrationPattern,
+                onDismiss = { settingsDetailPanel = null },
+                onVibrationEnabledChange = {
+                    editor.vibrationPattern = if (it) VibrationPatterns.DEFAULT else VibrationPatterns.NONE
+                },
+                onVibrationSelect = { editor.vibrationPattern = it },
+            )
+
+            "sound" -> AlarmSoundSettingsPane(
+                alarmVolumePercent = editor.alarmVolumePercent,
+                alarmSoundLabel = editor.alarmSoundLabel,
+                onDismiss = { settingsDetailPanel = null },
+                onAlarmVolumeChange = { editor.alarmVolumePercent = it },
+                onPickAlarmSound = {
+                    ringtonePickerLauncher.launch(
+                        Intent(RingtoneManager.ACTION_RINGTONE_PICKER).apply {
+                            putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_ALARM)
+                            putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, true)
+                            putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, true)
+                            putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "알람음 선택")
+                            val current = editor.alarmSoundUri?.let(Uri::parse)
+                                ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+                            putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, current)
+                        },
+                    )
+                },
+            )
         }
     }
 }
+
 
 @Composable
 internal fun EditorSectionTitle(title: String) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmSettingsCard.kt
@@ -1,11 +1,20 @@
 package com.voicealarm.nativeapp
 
+import android.content.Context
+import android.media.AudioAttributes
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -13,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.AlertDialog
@@ -22,6 +32,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -29,25 +40,21 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.voicealarm.nativeapp.data.AlarmAudioLimits
-import com.voicealarm.nativeapp.data.AlarmPlayModes
 import com.voicealarm.nativeapp.data.SnoozeRepeatLimits
+import com.voicealarm.nativeapp.data.VibrationPatternLibrary
 import com.voicealarm.nativeapp.data.VibrationPatterns
-import com.voicealarm.nativeapp.data.VoiceSources
-import com.voicealarm.nativeapp.network.VoiceProfile
 
 @Composable
 internal fun ChipGrid(
@@ -77,13 +84,21 @@ internal fun ChipGrid(
     }
 }
 
-private val SnoozeIntervals = listOf(3, 5, 10, 15, 30)
+private val SnoozeIntervals = listOf(5, 10, 15, 30)
 
-private fun nextSnoozeInterval(current: Int): Int =
-    SnoozeIntervals.firstOrNull { it > current } ?: SnoozeIntervals.last()
-
-private fun previousSnoozeInterval(current: Int): Int =
-    SnoozeIntervals.lastOrNull { it < current } ?: SnoozeIntervals.first()
+private val VibrationOptions = listOf(
+    VibrationPatterns.DEFAULT to "Basic call",
+    VibrationPatterns.STRONG to "Strong",
+    VibrationPatterns.SHORT to "Short",
+    VibrationPatterns.MEDIUM to "Medium",
+    VibrationPatterns.HEARTBEAT to "Heartbeat",
+    VibrationPatterns.TICKTOCK to "Ticktock",
+    VibrationPatterns.WALTZ to "Waltz",
+    VibrationPatterns.ZIGZAG to "Zig-zig-zig",
+    VibrationPatterns.OFF_BEAT to "Off-beat",
+    VibrationPatterns.RIPPLE to "Ripple",
+    VibrationPatterns.SIREN to "Siren",
+)
 
 @Composable
 internal fun AlarmSettingsCard(
@@ -99,245 +114,620 @@ internal fun AlarmSettingsCard(
     onVibrationEnabledChange: (Boolean) -> Unit,
     onVibrationSelect: (String) -> Unit,
     onAlarmVolumeChange: (Int) -> Unit,
-    onPickAlarmSound: () -> Unit,
-    onUseDefaultAlarmSound: () -> Unit,
+    onOpenSnoozeSettings: () -> Unit,
+    onOpenVibrationSettings: () -> Unit,
+    onOpenAlarmSoundSettings: () -> Unit,
 ) {
-    var detailDialog by remember { mutableStateOf<String?>(null) }
     Card(
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
     ) {
-        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Surface(
-                    onClick = { detailDialog = "snooze" },
-                    color = Color.Transparent,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                        Text("다시 울림", fontWeight = FontWeight.SemiBold)
-                        MutedText(if (snoozeEnabled) "${snoozeMinutes}분 · ${snoozeRepeatLabel(snoozeRepeatLimit)}" else "꺼짐")
-                    }
-                }
-                VoiceAlarmSwitch(
-                    checked = snoozeEnabled,
-                    onCheckedChange = onSnoozeEnabledChange,
-                )
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(MaterialTheme.colorScheme.outlineVariant),
+        Column(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 8.dp),
+        ) {
+            AlarmSettingRow(
+                title = "다시 울림",
+                subtitle = if (snoozeEnabled) "${snoozeMinutes}분 · ${snoozeRepeatLabel(snoozeRepeatLimit)}" else "꺼짐",
+                onClick = onOpenSnoozeSettings,
+                trailing = {
+                    VoiceAlarmSwitch(
+                        checked = snoozeEnabled,
+                        onCheckedChange = onSnoozeEnabledChange,
+                    )
+                },
             )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Surface(
-                    onClick = { detailDialog = "vibration" },
-                    color = Color.Transparent,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                        Text("진동", fontWeight = FontWeight.SemiBold)
-                        MutedText(vibrationLabel(vibrationPattern))
-                    }
-                }
-                VoiceAlarmSwitch(
-                    checked = vibrationPattern != VibrationPatterns.NONE,
-                    onCheckedChange = onVibrationEnabledChange,
-                )
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(MaterialTheme.colorScheme.outlineVariant),
+            AlarmSettingDivider()
+            AlarmSettingRow(
+                title = "진동",
+                subtitle = vibrationLabel(vibrationPattern),
+                onClick = onOpenVibrationSettings,
+                trailing = {
+                    VoiceAlarmSwitch(
+                        checked = vibrationPattern != VibrationPatterns.NONE,
+                        onCheckedChange = onVibrationEnabledChange,
+                    )
+                },
             )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Surface(
-                    onClick = { detailDialog = "sound" },
-                    color = Color.Transparent,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                        Text("알람 소리", fontWeight = FontWeight.SemiBold)
-                        MutedText("${alarmSoundLabel ?: "기본 알람음"} · ${alarmVolumeLabel(alarmVolumePercent)}")
-                    }
-                }
-                VoiceAlarmSwitch(
-                    checked = alarmVolumePercent > 0,
-                    onCheckedChange = { enabled ->
-                        onAlarmVolumeChange(if (enabled) 100 else 0)
-                    },
-                )
-            }
+            AlarmSettingDivider()
+            AlarmSettingRow(
+                title = "알람음",
+                subtitle = "${alarmSoundLabel ?: "기본 알람음"} · ${alarmVolumeLabel(alarmVolumePercent)}",
+                onClick = onOpenAlarmSoundSettings,
+                trailing = {
+                    VoiceAlarmSwitch(
+                        checked = alarmVolumePercent > 0,
+                        onCheckedChange = { enabled ->
+                            onAlarmVolumeChange(if (enabled) 100 else 0)
+                        },
+                    )
+                },
+            )
         }
     }
+}
 
-    if (detailDialog == "snooze") {
-        AlertDialog(
-            onDismissRequest = { detailDialog = null },
-            title = { Text("다시 울림") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(if (snoozeEnabled) "켜짐" else "꺼짐", fontWeight = FontWeight.SemiBold)
-                        VoiceAlarmSwitch(
-                            checked = snoozeEnabled,
-                            onCheckedChange = onSnoozeEnabledChange,
-                        )
-                    }
-                    StepperField(
-                        label = "간격",
-                        valueLabel = "${snoozeMinutes}분",
-                        onDecrease = {
-                            onSnoozeMinutesChange(previousSnoozeInterval(snoozeMinutes))
-                        },
-                        onIncrease = {
-                            onSnoozeMinutesChange(nextSnoozeInterval(snoozeMinutes))
-                        },
-                    )
-                    Text("반복", fontWeight = FontWeight.SemiBold)
-                    OptionChips(
-                        options = listOf(
-                            SnoozeRepeatLimits.THREE.toString() to "3회",
-                            SnoozeRepeatLimits.FIVE.toString() to "5회",
-                            SnoozeRepeatLimits.FOREVER.toString() to "계속 반복",
-                        ),
-                        selected = snoozeRepeatLimit.toString(),
-                        onSelect = { onSnoozeRepeatLimitChange(it.toInt()) },
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { detailDialog = null }) {
-                    Text("완료")
-                }
-            },
-        )
+private fun alarmVolumeLabel(value: Int): String =
+    if (value <= 0) "무음" else "${value.coerceIn(0, 100)}%"
+
+@Composable
+private fun AlarmSoundActionRow(
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        color = Color.Transparent,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 11.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = ">",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+            )
+        }
     }
+}
 
-    if (detailDialog == "vibration") {
-        AlertDialog(
-            onDismissRequest = { detailDialog = null },
-            title = { Text("진동") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+@Composable
+internal fun AlarmSoundSettingsPane(
+    alarmVolumePercent: Int,
+    alarmSoundLabel: String?,
+    onDismiss: () -> Unit,
+    onAlarmVolumeChange: (Int) -> Unit,
+    onPickAlarmSound: () -> Unit,
+) {
+    val alarmEnabled = alarmVolumePercent > 0
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 8.dp, top = 4.dp, end = 16.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "뒤로",
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "알람음",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(18.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 9.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            if (vibrationPattern == VibrationPatterns.NONE) "꺼짐" else "켜짐",
-                            fontWeight = FontWeight.SemiBold,
+                            text = if (alarmEnabled) "사용 중" else "무음",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = if (alarmEnabled) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
                         )
                         VoiceAlarmSwitch(
-                            checked = vibrationPattern != VibrationPatterns.NONE,
-                            onCheckedChange = onVibrationEnabledChange,
-                        )
-                    }
-                    OptionChips(
-                        options = listOf(
-                            VibrationPatterns.DEFAULT to "기본",
-                            VibrationPatterns.STRONG to "강하게",
-                        ),
-                        selected = if (vibrationPattern == VibrationPatterns.NONE) {
-                            VibrationPatterns.DEFAULT
-                        } else {
-                            vibrationPattern
-                        },
-                        onSelect = {
-                            onVibrationEnabledChange(true)
-                            onVibrationSelect(it)
-                        },
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { detailDialog = null }) {
-                    Text("완료")
-                }
-            },
-        )
-    }
-
-    if (detailDialog == "sound") {
-        AlertDialog(
-            onDismissRequest = { detailDialog = null },
-            title = { Text("알람 소리") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(if (alarmVolumePercent > 0) "켜짐" else "무음", fontWeight = FontWeight.SemiBold)
-                        VoiceAlarmSwitch(
-                            checked = alarmVolumePercent > 0,
+                            checked = alarmEnabled,
                             onCheckedChange = { enabled ->
                                 onAlarmVolumeChange(if (enabled) 100 else 0)
                             },
                         )
                     }
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text("소리", fontWeight = FontWeight.SemiBold)
-                        MutedText(alarmSoundLabel ?: "기본 알람음")
-                    }
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        OutlinedButton(
-                            onClick = onPickAlarmSound,
-                            modifier = Modifier.weight(1f),
+                }
+
+                SnoozeOptionSection(title = "알람음") {
+                    AlarmSoundActionRow(
+                        title = "알람음",
+                        subtitle = alarmSoundLabel ?: "기본 알람음",
+                        onClick = onPickAlarmSound,
+                    )
+                }
+
+                SnoozeOptionSection(title = "볼륨") {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text("선택")
+                            Text(
+                                text = "볼륨",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                text = alarmVolumeLabel(alarmVolumePercent),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontWeight = FontWeight.SemiBold,
+                            )
                         }
-                        OutlinedButton(
-                            onClick = onUseDefaultAlarmSound,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Text("기본")
-                        }
-                    }
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text("볼륨 ${alarmVolumeLabel(alarmVolumePercent)}", fontWeight = FontWeight.SemiBold)
                         Slider(
                             value = alarmVolumePercent.toFloat(),
                             onValueChange = { onAlarmVolumeChange(it.toInt().coerceIn(0, 100)) },
                             valueRange = 0f..100f,
                             steps = 9,
-                            enabled = alarmVolumePercent > 0,
+                            enabled = alarmEnabled,
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun VibrationSettingsPane(
+    vibrationPattern: String,
+    onDismiss: () -> Unit,
+    onVibrationEnabledChange: (Boolean) -> Unit,
+    onVibrationSelect: (String) -> Unit,
+) {
+    val context = LocalContext.current
+    val vibrationEnabled = vibrationPattern != VibrationPatterns.NONE
+    val selectedPattern = if (vibrationEnabled) vibrationPattern else VibrationPatterns.DEFAULT
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 8.dp, top = 4.dp, end = 16.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "뒤로",
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "진동",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(18.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 9.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = if (vibrationEnabled) "사용 중" else "사용 안 함",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = if (vibrationEnabled) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                        VoiceAlarmSwitch(
+                            checked = vibrationEnabled,
+                            onCheckedChange = onVibrationEnabledChange,
+                        )
+                    }
+                }
+
+                SnoozeOptionSection(title = "패턴") {
+                    VibrationOptions.forEachIndexed { index, (pattern, label) ->
+                        SnoozeRadioRow(
+                            label = label,
+                            selected = selectedPattern == pattern,
+                            onClick = {
+                                onVibrationEnabledChange(true)
+                                onVibrationSelect(pattern)
+                                previewVibration(context, pattern)
+                            },
+                        )
+                        if (index != VibrationOptions.lastIndex) {
+                            SnoozeOptionDivider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun previewVibration(context: Context, patternName: String) {
+    if (patternName == VibrationPatterns.NONE) return
+    val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        context.getSystemService(VibratorManager::class.java)?.defaultVibrator
+    } else {
+        @Suppress("DEPRECATION")
+        context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+    } ?: return
+    val attributes = AudioAttributes.Builder()
+        .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+        .build()
+    vibrator.cancel()
+    @Suppress("DEPRECATION")
+    vibrator.vibrate(VibrationEffect.createWaveform(VibrationPatternLibrary.waveform(patternName), -1), attributes)
+}
+
+@Composable
+private fun AlarmSettingRow(
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    trailing: @Composable () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 14.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            MutedText(subtitle)
+        }
+        trailing()
+    }
+}
+
+@Composable
+private fun AlarmSettingDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant),
+    )
+}
+
+@Composable
+internal fun SnoozeSettingsPane(
+    snoozeEnabled: Boolean,
+    snoozeMinutes: Int,
+    snoozeRepeatLimit: Int,
+    onDismiss: () -> Unit,
+    onSnoozeEnabledChange: (Boolean) -> Unit,
+    onSnoozeMinutesChange: (Int) -> Unit,
+    onSnoozeRepeatLimitChange: (Int) -> Unit,
+) {
+    var customIntervalDialogOpen by remember { mutableStateOf(false) }
+    var customMinutesText by remember(snoozeMinutes) { mutableStateOf(snoozeMinutes.toString()) }
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 8.dp, top = 4.dp, end = 16.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "뒤로",
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "다시 울림",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(18.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 9.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = if (snoozeEnabled) "사용 중" else "사용 안 함",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = if (snoozeEnabled) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                        VoiceAlarmSwitch(
+                            checked = snoozeEnabled,
+                            onCheckedChange = onSnoozeEnabledChange,
+                        )
+                    }
+                }
+
+                SnoozeOptionSection(title = "간격") {
+                    SnoozeIntervals.forEachIndexed { index, minutes ->
+                        SnoozeRadioRow(
+                            label = "${minutes}분",
+                            selected = snoozeMinutes == minutes,
+                            onClick = { onSnoozeMinutesChange(minutes) },
+                        )
+                        if (index != SnoozeIntervals.lastIndex) SnoozeOptionDivider()
+                    }
+                    SnoozeOptionDivider()
+                    SnoozeRadioRow(
+                        label = if (snoozeMinutes in SnoozeIntervals) {
+                            "직접 설정"
+                        } else {
+                            "직접 설정 · ${snoozeMinutes}분"
+                        },
+                        selected = snoozeMinutes !in SnoozeIntervals,
+                        onClick = {
+                            customMinutesText = snoozeMinutes.toString()
+                            customIntervalDialogOpen = true
+                        },
+                    )
+                }
+
+                SnoozeOptionSection(title = "반복") {
+                    val repeatOptions = listOf(
+                        SnoozeRepeatLimits.THREE to "3회",
+                        SnoozeRepeatLimits.FIVE to "5회",
+                        SnoozeRepeatLimits.FOREVER to "계속 반복",
+                    )
+                    repeatOptions.forEachIndexed { index, (limit, label) ->
+                        SnoozeRadioRow(
+                            label = label,
+                            selected = snoozeRepeatLimit == limit,
+                            onClick = { onSnoozeRepeatLimitChange(limit) },
+                        )
+                        if (index != repeatOptions.lastIndex) SnoozeOptionDivider()
+                    }
+                }
+            }
+        }
+    }
+
+    if (customIntervalDialogOpen) {
+        val customMinutes = customMinutesText.toIntOrNull()
+        AlertDialog(
+            onDismissRequest = { customIntervalDialogOpen = false },
+            title = { Text("간격 직접 설정") },
+            text = {
+                OutlinedTextField(
+                    value = customMinutesText,
+                    onValueChange = { value ->
+                        customMinutesText = value.filter { it.isDigit() }.take(2)
+                    },
+                    label = { Text("분") },
+                    singleLine = true,
+                    isError = customMinutesText.isNotBlank() && customMinutes !in 1..60,
+                )
             },
             confirmButton = {
-                TextButton(onClick = { detailDialog = null }) {
-                    Text("완료")
+                TextButton(
+                    enabled = customMinutes in 1..60,
+                    onClick = {
+                        onSnoozeMinutesChange(requireNotNull(customMinutes))
+                        customIntervalDialogOpen = false
+                    },
+                ) {
+                    Text("적용")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { customIntervalDialogOpen = false }) {
+                    Text("취소")
                 }
             },
         )
     }
 }
 
-private fun alarmVolumeLabel(value: Int): String =
-    if (value <= 0) "무음" else "${value.coerceIn(0, 100)}%"
+@Composable
+private fun SnoozeOptionSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+        Surface(
+            shape = RoundedCornerShape(14.dp),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+private fun SnoozeRadioRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        color = Color.Transparent,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CompactSelectionDot(
+                selected = selected,
+            )
+            Spacer(Modifier.width(9.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompactSelectionDot(selected: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(18.dp)
+            .border(
+                width = 1.5.dp,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.outline
+                },
+                shape = CircleShape,
+            )
+            .background(
+                color = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                shape = CircleShape,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .background(MaterialTheme.colorScheme.onPrimary, CircleShape),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SnoozeOptionDivider() {
+    Box(
+        modifier = Modifier
+            .padding(start = 39.dp)
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant),
+    )
+}
 
 @Composable
 internal fun EditorActionButtons(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmTimePicker.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmTimePicker.kt
@@ -52,8 +52,8 @@ internal fun AlarmTimePickerCard(
     modifier: Modifier = Modifier,
 ) {
     val currentOnTimeChange by rememberUpdatedState(onTimeChange)
-    val itemHeight = 88.dp
-    val verticalWheelPadding = 44.dp
+    val itemHeight = 76.dp
+    val verticalWheelPadding = 26.dp
     var workingHour by remember { mutableIntStateOf(hour) }
     var workingMinute by remember { mutableIntStateOf(minute) }
     val wheelBackgroundColor = Color(0xFF050505)
@@ -78,10 +78,7 @@ internal fun AlarmTimePickerCard(
 
     fun applyMinuteSteps(steps: Int) {
         if (steps == 0) return
-        val totalMinutes = floorMod(workingHour * 60 + workingMinute + steps, 24 * 60)
-        val nextHour = totalMinutes / 60
-        val nextMinute = totalMinutes % 60
-        commitTime(nextHour, nextMinute)
+        commitTime(workingHour, floorMod(workingMinute + steps, 60))
     }
 
     Column(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AmPmWheelColumn.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AmPmWheelColumn.kt
@@ -1,8 +1,7 @@
 package com.voicealarm.nativeapp
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
@@ -44,6 +43,8 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+private val AmPmWheelEasing = CubicBezierEasing(0.16f, 1f, 0.3f, 1f)
+
 @Composable
 internal fun AmPmWheelColumn(
     hour: Int,
@@ -57,6 +58,8 @@ internal fun AmPmWheelColumn(
     val scope = rememberCoroutineScope()
     val itemHeightPx = with(LocalDensity.current) { itemHeight.toPx() }
     var dragOffsetPx by remember { mutableStateOf(0f) }
+    var previousAmPmIndex by remember { mutableIntStateOf(amPmIndex) }
+    var suppressNextAutoAnimation by remember { mutableStateOf(false) }
     val minOffset = if (isPm) -itemHeightPx * 0.22f else -itemHeightPx * 0.72f
     val maxOffset = if (isPm) itemHeightPx * 0.72f else itemHeightPx * 0.22f
     val rows = if (isPm) {
@@ -66,6 +69,24 @@ internal fun AmPmWheelColumn(
     }
     val draggableState = rememberDraggableState { delta ->
         dragOffsetPx = (dragOffsetPx + delta).coerceIn(minOffset, maxOffset)
+    }
+
+    LaunchedEffect(amPmIndex, itemHeightPx) {
+        if (previousAmPmIndex == amPmIndex) return@LaunchedEffect
+        previousAmPmIndex = amPmIndex
+        if (suppressNextAutoAnimation) {
+            suppressNextAutoAnimation = false
+            dragOffsetPx = 0f
+            return@LaunchedEffect
+        }
+        val startOffset = if (amPmIndex == 1) itemHeightPx else -itemHeightPx
+        Animatable(startOffset).animateTo(
+            targetValue = 0f,
+            animationSpec = tween(durationMillis = 155, easing = AmPmWheelEasing),
+        ) {
+            dragOffsetPx = value
+        }
+        dragOffsetPx = 0f
     }
 
     Box(
@@ -89,7 +110,10 @@ internal fun AmPmWheelColumn(
                             startOffsetPx = startOffset,
                             steps = requestedStep,
                             itemHeightPx = itemHeightPx,
-                            onStep = onStep,
+                            onStep = { step ->
+                                suppressNextAutoAnimation = true
+                                onStep(step)
+                            },
                             onOffsetChange = { dragOffsetPx = it },
                         )
                     }
@@ -111,7 +135,10 @@ internal fun AmPmWheelColumn(
                                     startOffsetPx = 0f,
                                     steps = step,
                                     itemHeightPx = itemHeightPx,
-                                    onStep = onStep,
+                                    onStep = { selectedStep ->
+                                        suppressNextAutoAnimation = true
+                                        onStep(selectedStep)
+                                    },
                                     onOffsetChange = { dragOffsetPx = it },
                                 )
                             }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/DraggableTimeWheelColumn.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/DraggableTimeWheelColumn.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -59,6 +60,7 @@ internal fun DraggableTimeWheelColumn(
     val itemHeightPx = with(LocalDensity.current) { itemHeight.toPx() }
     var dragOffsetPx by remember { mutableStateOf(0f) }
     var gestureSteps by remember { mutableIntStateOf(0) }
+    var settleJob by remember { mutableStateOf<Job?>(null) }
 
     fun remainingStepsFor(nextSteps: Int): Int {
         return if (nextSteps > 0) {
@@ -104,7 +106,10 @@ internal fun DraggableTimeWheelColumn(
             .draggable(
                 state = draggableState,
                 orientation = Orientation.Vertical,
-                onDragStarted = { gestureSteps = 0 },
+                onDragStarted = {
+                    settleJob?.cancel()
+                    gestureSteps = 0
+                },
                 onDragStopped = { velocity ->
                     val startOffset = dragOffsetPx
                     val snapStep = when {
@@ -115,7 +120,8 @@ internal fun DraggableTimeWheelColumn(
                     val velocitySteps = flingStepsFor(velocity)
                     val requestedSteps = if (velocitySteps != 0) velocitySteps else snapStep
                     val stepsToSettle = remainingStepsFor(requestedSteps)
-                    scope.launch {
+                    settleJob?.cancel()
+                    settleJob = scope.launch {
                         animateWheelSettle(
                             startOffsetPx = startOffset,
                             steps = stepsToSettle,
@@ -148,7 +154,8 @@ internal fun DraggableTimeWheelColumn(
                 Surface(
                     onClick = {
                         if (offset != 0) {
-                            scope.launch {
+                            settleJob?.cancel()
+                            settleJob = scope.launch {
                                 animateWheelSettle(
                                     startOffsetPx = 0f,
                                     steps = offset.coerceIn(-maxStepsPerGesture, maxStepsPerGesture),
@@ -204,19 +211,35 @@ internal suspend fun animateWheelSettle(
     }
 
     val direction = if (steps > 0) 1 else -1
-    var currentOffset = startOffsetPx
-    repeat(abs(steps)) {
-        val targetOffset = if (direction > 0) -itemHeightPx else itemHeightPx
-        Animatable(currentOffset).animateTo(
-            targetValue = targetOffset,
-            animationSpec = tween(durationMillis = 165, easing = TimeWheelEasing),
-        ) {
-            onOffsetChange(value)
+    var consumedSteps = 0
+    val totalSteps = abs(steps)
+    val targetOffset = -steps * itemHeightPx
+    val durationMillis = (190 + totalSteps * 42).coerceIn(230, 720)
+
+    Animatable(startOffsetPx).animateTo(
+        targetValue = targetOffset,
+        animationSpec = tween(durationMillis = durationMillis, easing = TimeWheelEasing),
+    ) {
+        while (direction > 0 && value <= -(consumedSteps + 1) * itemHeightPx) {
+            consumedSteps += 1
+            onStep(1)
         }
-        onStep(direction)
-        onOffsetChange(0f)
-        currentOffset = 0f
+        while (direction < 0 && value >= (consumedSteps + 1) * itemHeightPx) {
+            consumedSteps += 1
+            onStep(-1)
+        }
+        val residualOffset = if (direction > 0) {
+            value + consumedSteps * itemHeightPx
+        } else {
+            value - consumedSteps * itemHeightPx
+        }
+        onOffsetChange(residualOffset)
     }
+    while (consumedSteps < totalSteps) {
+        consumedSteps += 1
+        onStep(direction)
+    }
+    onOffsetChange(0f)
 }
 
 internal fun floorMod(value: Int, divisor: Int): Int = ((value % divisor) + divisor) % divisor

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/theme/VoiceAlarmTheme.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/theme/VoiceAlarmTheme.kt
@@ -1,11 +1,19 @@
 package com.voicealarm.nativeapp
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 @Composable
 internal fun VoiceAlarmTheme(
@@ -78,10 +86,35 @@ internal fun VoiceAlarmTheme(
         colorScheme = colorScheme,
         typography = VoiceAlarmTypography,
     ) {
+        AppSystemBars(isDark = isDark)
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,
             content = content,
         )
     }
+}
+
+@Composable
+private fun AppSystemBars(isDark: Boolean) {
+    val view = LocalView.current
+    val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
+    SideEffect {
+        val window = view.context.findActivity()?.window ?: return@SideEffect
+        window.statusBarColor = backgroundColor
+        window.navigationBarColor = backgroundColor
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.navigationBarDividerColor = backgroundColor
+        }
+        WindowCompat.getInsetsController(window, view).apply {
+            isAppearanceLightStatusBars = !isDark
+            isAppearanceLightNavigationBars = !isDark
+        }
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -142,9 +142,18 @@ internal fun snoozeListLabel(enabled: Boolean, minutes: Int, repeatLimit: Int): 
     }
 
 internal fun vibrationLabel(pattern: String): String = when (pattern) {
-    VibrationPatterns.STRONG -> "강한 진동"
-    VibrationPatterns.NONE -> "진동 꺼짐"
-    else -> "기본 진동"
+    VibrationPatterns.STRONG -> "Strong"
+    VibrationPatterns.SHORT -> "Short"
+    VibrationPatterns.MEDIUM -> "Medium"
+    VibrationPatterns.HEARTBEAT -> "Heartbeat"
+    VibrationPatterns.TICKTOCK -> "Ticktock"
+    VibrationPatterns.WALTZ -> "Waltz"
+    VibrationPatterns.ZIGZAG -> "Zig-zig-zig"
+    VibrationPatterns.OFF_BEAT -> "Off-beat"
+    VibrationPatterns.RIPPLE -> "Ripple"
+    VibrationPatterns.SIREN -> "Siren"
+    VibrationPatterns.NONE -> "Off"
+    else -> "Basic call"
 }
 
 internal fun playModeLabel(mode: String): String = when (mode) {

--- a/apps/android-native/app/src/main/res/values/colors.xml
+++ b/apps/android-native/app/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="voice_alarm_app_background">#171A1D</color>
     <color name="voice_alarm_status_bar">#111827</color>
 </resources>

--- a/apps/android-native/app/src/main/res/values/styles.xml
+++ b/apps/android-native/app/src/main/res/values/styles.xml
@@ -4,9 +4,13 @@
         <item name="android:fontFamily">sans</item>
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
-        <item name="android:navigationBarColor">@android:color/white</item>
-        <item name="android:statusBarColor">@android:color/white</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/voice_alarm_app_background</item>
+        <item name="android:navigationBarDividerColor">@color/voice_alarm_app_background</item>
+        <item name="android:statusBarColor">@color/voice_alarm_app_background</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
     <style name="Theme.VoiceAlarm.Ringing" parent="android:style/Theme.Material.NoActionBar">
@@ -15,6 +19,11 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:keepScreenOn">true</item>
         <item name="android:navigationBarColor">@color/voice_alarm_status_bar</item>
+        <item name="android:navigationBarDividerColor">@color/voice_alarm_status_bar</item>
         <item name="android:statusBarColor">@color/voice_alarm_status_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 </resources>

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/AlarmEditorScreenTest.kt
@@ -5,6 +5,7 @@ import com.voicealarm.nativeapp.network.FamilyAlarmQuietWindow
 import com.voicealarm.nativeapp.network.FamilyGroupMember
 import java.time.LocalDateTime
 import java.time.ZoneId
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -92,6 +93,22 @@ class AlarmEditorScreenTest {
                 holidayOff = false,
                 nowMillis = nowMillis,
             ),
+        )
+    }
+
+    @Test
+    fun repeatSummaryShowsNextOneShotDateOrWeeklyDays() {
+        val zoneId = ZoneId.of("UTC")
+        val nowMillis = LocalDateTime.of(2026, 5, 13, 8, 0)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+
+        assertEquals("오늘 - 5월 13일(수)", repeatSummaryLabel(8, 30, 0, nowMillis, zoneId))
+        assertEquals("내일 - 5월 14일(목)", repeatSummaryLabel(7, 30, 0, nowMillis, zoneId))
+        assertEquals(
+            "매주 월, 화, 수",
+            repeatSummaryLabel(7, 30, (1 shl 1) or (1 shl 2) or (1 shl 3), nowMillis, zoneId),
         )
     }
 

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/data/AlarmTimeCalculatorTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/data/AlarmTimeCalculatorTest.kt
@@ -72,6 +72,60 @@ class AlarmTimeCalculatorTest {
     }
 
     @Test
+    fun holidayOffSkipsKnownSubstituteHolidayForRepeatAlarm() {
+        val now = millis("2026-02-28T08:00:00")
+        val mondayMask = 1 shl 1
+        val holidays = setOf(LocalDate.of(2026, 3, 2))
+
+        val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
+            hour = 7,
+            minute = 0,
+            repeatDaysMask = mondayMask,
+            holidayOff = true,
+            nowMillis = now,
+            zoneId = zoneId,
+            isHoliday = { it in holidays },
+        )
+
+        assertEquals(millis("2026-03-09T07:00:00"), nextFireAt)
+    }
+
+    @Test
+    fun holidayOffSkipsKnownElectionHolidayForRepeatAlarm() {
+        val now = millis("2026-06-01T08:00:00")
+        val wednesdayMask = 1 shl 3
+        val holidays = setOf(LocalDate.of(2026, 6, 3))
+
+        val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
+            hour = 7,
+            minute = 0,
+            repeatDaysMask = wednesdayMask,
+            holidayOff = true,
+            nowMillis = now,
+            zoneId = zoneId,
+            isHoliday = { it in holidays },
+        )
+
+        assertEquals(millis("2026-06-10T07:00:00"), nextFireAt)
+    }
+
+    @Test
+    fun holidayOffDoesNotChangeOneShotAlarm() {
+        val now = millis("2026-05-05T06:00:00")
+
+        val nextFireAt = AlarmTimeCalculator.nextFireAtMillis(
+            hour = 7,
+            minute = 0,
+            repeatDaysMask = 0,
+            holidayOff = true,
+            nowMillis = now,
+            zoneId = zoneId,
+        )
+
+        assertEquals(millis("2026-05-05T07:00:00"), nextFireAt)
+    }
+
+    @Test
     fun dayBitsMapSundayToZeroAndSaturdayToSix() {
         val sunday = LocalDate.of(2026, 5, 3)
         val saturday = LocalDate.of(2026, 5, 9)


### PR DESCRIPTION
## 작업 내용
- 알람 시간 휠의 빠른 스와이프와 오전/오후 전환 움직임을 자연스럽게 조정했습니다.
- 반복 요일, 공휴일 제외, 알람 이름 순서를 정리하고 요일 선택 상태와 주말 색상을 보강했습니다.
- 공휴일 제외 계산을 로컬 휴일 캐시 기반으로 확장하고 반복 알람 재계산에 반영했습니다.
- 다시 울림, 진동, 알람음 설정을 전체 패널 디자인으로 통일하고 큰 화면 기기의 하단 네비게이션 표시 문제를 정리했습니다.

## 커밋 구성
- feat: 알람 시간 휠 조작감을 개선
- feat: 공휴일 제외 계산을 로컬 캐시로 확장
- feat: 알람 설정 옵션 화면을 정리

## 검증
- ./gradlew.bat :app:assembleDebug
- ./gradlew.bat :app:testDebugUnitTest
- 실제 Android 기기 2대에 디버그 APK 재설치 후 알람 설정, 다시 울림, 진동, 알람음 화면 확인

Closes #288