### PR TITLE
fix: 홈 인사말 두 줄 자동 줄바꿈 방지

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/home/HomeComponents.kt
@@ -45,20 +45,23 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun HomeHeader() {
     val hour = java.time.LocalTime.now().hour
-    val greeting = when {
-        hour < 6 -> "좋아하는 목소리로\n깨워드릴게요"
-        hour < 12 -> "오늘 아침,\n어떤 목소리로 깨어났나요?"
-        hour < 17 -> "내일의 목소리 알람을\n준비해요"
-        hour < 21 -> "서로의 목소리로\n아침을 예약해요"
-        else -> "좋아하는 목소리로\n깨워드릴게요"
+    val (greetingTop, greetingBottom) = when {
+        hour < 6 -> "좋아하는 목소리로" to "깨워드릴게요"
+        hour < 12 -> "오늘 아침," to "어떤 목소리로 깨어났나요?"
+        hour < 17 -> "내일의 목소리 알람을" to "준비해요"
+        hour < 21 -> "서로의 목소리로" to "아침을 예약해요"
+        else -> "좋아하는 목소리로" to "깨워드릴게요"
     }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(end = 72.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         Text(
-            text = greeting,
+            text = greetingTop,
+            modifier = Modifier.padding(end = 72.dp),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = greetingBottom,
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,


### PR DESCRIPTION
## Summary
- HomeHeader 인사말을 단일 `Text(\n)` 에서 위/아래 두 개 Text 컴포저블로 분리
- 위 행에만 `padding(end = 72.dp)` 적용 → 프로필 메뉴 버튼 영역 회피 유지
- 아래 행은 전체 폭 사용 → 긴 문구(예: "어떤 목소리로 깨어났나요?")의 자동 줄바꿈 3행 분해 방지

## Test plan
- [ ] 홈 화면에서 시간대별 인사말이 모두 정확히 2행으로 표시되는지 확인
- [ ] 우측 프로필 메뉴 버튼과 1행 텍스트가 겹치지 않는지 확인
- [ ] 좁은 화면 디바이스에서 2행 텍스트가 안 잘리는지 확인