### PR TITLE
fix: ElevenLabs 보이스 설정 기본값 조정

### DIFF
--- a/packages/backend/src/lib/elevenlabs.ts
+++ b/packages/backend/src/lib/elevenlabs.ts
@@ -51,6 +51,8 @@ export class ElevenLabsClient {
       stability?: number;
       similarity_boost?: number;
       style?: number;
+      speed?: number;
+      use_speaker_boost?: boolean;
       model_id?: string;
     },
   ): Promise<ArrayBuffer> {
@@ -64,10 +66,11 @@ export class ElevenLabsClient {
         text,
         model_id: options?.model_id ?? 'eleven_multilingual_v2',
         voice_settings: {
-          stability: options?.stability ?? 0.5,
+          stability: options?.stability ?? 1,
           similarity_boost: options?.similarity_boost ?? 0.75,
-          style: options?.style ?? 0.5,
-          use_speaker_boost: true,
+          style: options?.style ?? 0,
+          speed: options?.speed ?? 1,
+          use_speaker_boost: options?.use_speaker_boost ?? true,
         },
       }),
     });

--- a/packages/backend/test/elevenlabs.test.ts
+++ b/packages/backend/test/elevenlabs.test.ts
@@ -61,8 +61,10 @@ describe('ElevenLabsClient', () => {
       const body = JSON.parse(opts.body);
       expect(body.text).toBe('안녕하세요');
       expect(body.model_id).toBe('eleven_multilingual_v2');
-      expect(body.voice_settings.stability).toBe(0.5);
+      expect(body.voice_settings.stability).toBe(1);
       expect(body.voice_settings.similarity_boost).toBe(0.75);
+      expect(body.voice_settings.style).toBe(0);
+      expect(body.voice_settings.speed).toBe(1);
       expect(body.voice_settings.use_speaker_boost).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- `ElevenLabsClient.textToSpeech` 기본값 조정: stability 0.5→1, style 0.5→0
- 옵션 타입에 `speed` (기본 1) 와 `use_speaker_boost` (기본 true) 추가하여 호출부 override 가능
- similarity_boost 0.75 / use_speaker_boost true 는 기존 유지

## Test plan
- [x] `test/elevenlabs.test.ts` 12개 모두 통과 (기본값/커스텀 옵션 케이스 포함)
- [ ] 실제 TTS 합성 결과에서 발화 안정성이 향상되고 노이즈/표현 변동이 줄었는지 확인
- [ ] 알람 음원 캐시(`generated_audio_assets`)는 모델/세팅 변경 시 재생성되므로 기존 캐시 재사용 여부 확인