### PR TITLE
fix: 음성 프로필 삭제 시 서버 음원 정리와 404 무사 통과

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -245,8 +245,13 @@ internal fun MainViewModel.deleteVoiceProfile(profileId: String) {
             voiceProfiles = voiceProfiles.filterNot { it.id == profileId }
             message = "음성 프로필을 삭제했어요"
         }.onFailure { error ->
-            Log.e(TAG, "Failed to delete voice profile id=$profileId", error)
-            message = userFacingError(error, "음성 프로필 삭제에 실패했어요")
+            if (error is retrofit2.HttpException && error.code() == 404) {
+                voiceProfiles = voiceProfiles.filterNot { it.id == profileId }
+                message = "이미 삭제된 음성 프로필이에요"
+            } else {
+                Log.e(TAG, "Failed to delete voice profile id=$profileId", error)
+                message = userFacingError(error, "음성 프로필 삭제에 실패했어요")
+            }
         }
         voiceProfileBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -769,7 +769,7 @@ private fun VoiceProfileDeleteDialog(
                         Icon(Icons.Outlined.Close, contentDescription = "닫기")
                     }
                 }
-                MutedText("삭제 후에는 이 프로필로 새 음성을 만들거나 문구를 수정할 수 없어요. 이미 저장된 알람의 로컬 음성은 그대로 남아요.")
+                MutedText("삭제하면 이 프로필로 만든 서버 저장 음원이 모두 함께 지워져요. 이미 기기에 받아둔 알람 음성은 그대로 남지만, 새로 음성을 만들거나 문구를 수정할 수 없어요.")
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -5,6 +5,7 @@ import { getDB } from '../lib/db';
 import { typedRow, getFormFile } from '../lib/db-types';
 import { UUID_RE } from '../lib/validate';
 import { logRouteError } from '../lib/logger';
+import { R2VoiceStorage } from '../lib/r2-storage';
 import { createEnrollmentAttempts, UnsupportedVoiceProviderError } from '../lib/voice-provider';
 
 const voiceProfile = new Hono<AppEnv>();
@@ -472,6 +473,35 @@ voiceProfile.delete('/:id', async (c) => {
   } catch {
     // 외부 API 삭제 실패해도 로컬은 삭제 진행
   }
+
+  const assetsRes = await db.execute({
+    sql: `SELECT audio_object_key FROM generated_audio_assets
+          WHERE voice_profile_id = ? AND audio_object_key IS NOT NULL`,
+    args: [id],
+  });
+  if (c.env.VOICE_BUCKET && assetsRes.rows.length > 0) {
+    const storage = new R2VoiceStorage(c.env.VOICE_BUCKET);
+    for (const row of assetsRes.rows) {
+      const key = typedRow<{ audio_object_key: string | null }>(row).audio_object_key;
+      if (!key) continue;
+      try {
+        await storage.delete(key);
+      } catch (err) {
+        // R2 객체 삭제 실패해도 DB 정리는 진행
+        logRouteError(c, err);
+      }
+    }
+  }
+
+  await db.execute({
+    sql: 'DELETE FROM generated_audio_assets WHERE voice_profile_id = ?',
+    args: [id],
+  });
+
+  await db.execute({
+    sql: `UPDATE messages SET audio_url = NULL WHERE voice_profile_id = ?`,
+    args: [id],
+  });
 
   await db.execute({
     sql: `UPDATE voice_profiles

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -479,8 +479,9 @@ voiceProfile.delete('/:id', async (c) => {
           WHERE voice_profile_id = ? AND audio_object_key IS NOT NULL`,
     args: [id],
   });
-  if (c.env.VOICE_BUCKET && assetsRes.rows.length > 0) {
-    const storage = new R2VoiceStorage(c.env.VOICE_BUCKET);
+  const bucket = c.env?.VOICE_BUCKET;
+  if (bucket && assetsRes.rows.length > 0) {
+    const storage = new R2VoiceStorage(bucket);
     for (const row of assetsRes.rows) {
       const key = typedRow<{ audio_object_key: string | null }>(row).audio_object_key;
       if (!key) continue;

--- a/packages/backend/test/voice-profile.test.ts
+++ b/packages/backend/test/voice-profile.test.ts
@@ -404,7 +404,7 @@ describe('DELETE /:id — 프로필 삭제 (voice-profile)', () => {
     expect(res.status).toBe(404);
   });
 
-  it('연관 메시지가 있어도 프로필만 숨김 처리', async () => {
+  it('생성된 음원은 정리하되 메시지와 알람 자체는 보존', async () => {
     mockDB.pushResult([{ id: V1, elevenlabs_voice_id: null }]);
     mockDB.pushResult([], 1);
     const res = await req(
@@ -415,13 +415,25 @@ describe('DELETE /:id — 프로필 삭제 (voice-profile)', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.deleted).toBe(true);
-    expect(mockDB.calls.some((c) => c.sql.startsWith('DELETE'))).toBe(false);
+    expect(
+      mockDB.calls.some(
+        (c) => c.sql.startsWith('DELETE FROM messages') || c.sql.startsWith('DELETE FROM alarms'),
+      ),
+    ).toBe(false);
+    const assetsDelete = mockDB.calls.find((c) =>
+      c.sql.startsWith('DELETE FROM generated_audio_assets'),
+    );
+    expect(assetsDelete).toBeDefined();
+    const messagesUpdate = mockDB.calls.find((c) =>
+      c.sql.startsWith('UPDATE messages SET audio_url'),
+    );
+    expect(messagesUpdate).toBeDefined();
     const update = mockDB.calls.find((c) => c.sql.startsWith('UPDATE voice_profiles'));
     expect(update?.sql).toContain('deleted_at');
     expect(update?.sql).toContain('is_shared = 0');
   });
 
-  it('force=true 여도 메시지와 알람은 삭제하지 않음', async () => {
+  it('force=true 여도 메시지와 알람 행은 삭제하지 않음', async () => {
     mockDB.pushResult([{ id: V1, elevenlabs_voice_id: null }]);
     mockDB.pushResult([], 1);
     const res = await req(
@@ -432,7 +444,11 @@ describe('DELETE /:id — 프로필 삭제 (voice-profile)', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.deleted).toBe(true);
-    expect(mockDB.calls.some((c) => c.sql.startsWith('DELETE'))).toBe(false);
+    expect(
+      mockDB.calls.some(
+        (c) => c.sql.startsWith('DELETE FROM messages') || c.sql.startsWith('DELETE FROM alarms'),
+      ),
+    ).toBe(false);
   });
 
   it('프로필은 삭제 시 목록에서만 숨김 처리', async () => {
@@ -636,7 +652,11 @@ describe('DELETE /:id — force edge cases (voice-profile)', () => {
     );
     expect(res.status).toBe(200);
     expect((await res.json()).deleted).toBe(true);
-    expect(mockDB.calls.some((c) => c.sql.startsWith('DELETE'))).toBe(false);
+    expect(
+      mockDB.calls.some(
+        (c) => c.sql.startsWith('DELETE FROM messages') || c.sql.startsWith('DELETE FROM alarms'),
+      ),
+    ).toBe(false);
   });
 
   it('force=TRUE 여도 소프트 삭제', async () => {
@@ -660,6 +680,10 @@ describe('DELETE /:id — force edge cases (voice-profile)', () => {
     expect(res.status).toBe(200);
     expect(mockDeleteVoice).toHaveBeenCalledWith('elv-abc');
     expect((await res.json()).deleted).toBe(true);
-    expect(mockDB.calls.some((c) => c.sql.startsWith('DELETE'))).toBe(false);
+    expect(
+      mockDB.calls.some(
+        (c) => c.sql.startsWith('DELETE FROM messages') || c.sql.startsWith('DELETE FROM alarms'),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Phase 1: 음성 프로필 삭제 시 관련 R2 음원과 캐시 행을 함께 정리. 이미 삭제된 프로필을 모바일에서 재삭제 시도해도 안전하게 마무리.

### Backend (`packages/backend/src/routes/voice-profile.ts`)
DELETE `/voice/:id` 핸들러에 다음 단계 추가:
1. `generated_audio_assets`에서 해당 `voice_profile_id`의 `audio_object_key` 조회
2. R2(`VOICE_BUCKET`)에서 각 객체 best-effort 삭제 (실패는 로그 후 계속 진행)
3. `generated_audio_assets` 행 일괄 삭제
4. `messages.audio_url` NULL 처리 (행 자체는 알람 참조 보존을 위해 유지)
5. 기존 voice_profiles soft-delete

### Mobile
- `MainViewModelVoiceActions.kt`: deleteVoiceProfile 실패 시 HTTP 404면 성공으로 간주, 리스트에서 제거 + "이미 삭제된 음성 프로필이에요" 안내
- `VoiceProfileManagementPanel.kt`: 삭제 다이얼로그 본문을 "삭제하면 이 프로필로 만든 서버 저장 음원이 모두 함께 지워져요"로 갱신

### 의도적으로 유지한 부분
- `messages`, `alarms` 행 자체는 삭제하지 않음 — 알람이 voice_profile_id를 참조해도 깨지지 않게 (기기에 캐시된 오디오로 재생됨)
- 캐시된 로컬 오디오 정리는 Phase 2 (알람 삭제 시 cascade)에서 다룰 예정

## Test plan
- [x] `packages/backend` 60개 voice-profile 테스트 통과
- [x] `compileDebugKotlin` 빌드 성공
- [ ] 실기기: 음성 프로필 삭제 → 서버 R2에서 관련 generated_audio 객체 정리 확인
- [ ] 실기기: 이미 삭제된 프로필을 다른 기기/세션에서 재삭제 시도 → "이미 삭제됨" 메시지 및 리스트 정리 확인