### PR TITLE
fix: 알람 삭제 시 캐시 오디오 파일 정리

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -187,6 +187,19 @@ class AlarmAudioStore(
         )
     }
 
+    fun deleteCachedAudio(cacheKey: String) {
+        val safeKey = safeCacheKey(cacheKey)
+        audioDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.nameWithoutExtension == safeKey) {
+                if (file.delete()) {
+                    Log.i(TAG, "Deleted cached alarm audio path=${file.absolutePath}")
+                } else {
+                    Log.w(TAG, "Failed to delete cached alarm audio path=${file.absolutePath}")
+                }
+            }
+        }
+    }
+
     fun readDurationMillis(uri: Uri): Long? {
         val retriever = MediaMetadataRetriever()
         return runCatching {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmDao.kt
@@ -39,6 +39,9 @@ interface AlarmDao {
     )
     suspend fun countAtTime(hour: Int, minute: Int, excludeId: String? = null): Int
 
+    @Query("SELECT COUNT(*) FROM alarms WHERE audioCacheKey = :cacheKey")
+    suspend fun countByAudioCacheKey(cacheKey: String): Int
+
     @Upsert
     suspend fun upsert(alarm: AlarmEntity)
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmRepository.kt
@@ -249,7 +249,11 @@ class AlarmRepository(
             return
         }
         alarmScheduler.cancel(alarmId)
+        val cacheKey = current.audioCacheKey
         alarmDao.delete(current)
+        if (!cacheKey.isNullOrBlank() && alarmDao.countByAudioCacheKey(cacheKey) == 0) {
+            alarmAudioStore.deleteCachedAudio(cacheKey)
+        }
         Log.i(TAG, "Deleted alarm id=$alarmId")
     }
 


### PR DESCRIPTION
## Summary
Phase 2 #1: 알람 삭제 시 같은 cacheKey를 쓰는 다른 알람이 없으면 기기에 캐시된 오디오 파일도 함께 정리.

### Mobile (`apps/android-native`)
- `AlarmDao` 에 `countByAudioCacheKey(cacheKey)` 쿼리 추가
- `AlarmAudioStore.deleteCachedAudio(cacheKey)` 추가 — `${safeKey}.*` 패턴 매칭으로 오디오 파일과 `.meta` 동반 삭제
- `AlarmRepository.deleteAlarm` cascade: 삭제 후 cacheKey 참조 수 확인, 0이면 파일 정리

### 동작 보존
- 같은 cacheKey가 다른 알람에서도 쓰이면 파일은 유지 (공유 캐시 깨뜨리지 않음)
- localAudioUri/audioCacheKey 가 null인 알람은 기존 동작 그대로

## Test plan
- [x] `assembleDebug` 빌드 성공
- [ ] 실기기: 같은 음성 알람 1개만 삭제 → 캐시 파일 제거 확인 (`filesDir/alarm-audio`)
- [ ] 실기기: 동일 음성 알람 2개 중 1개 삭제 → 파일 유지 확인
- [ ] 실기기: 모두 삭제 후 → 파일 완전 정리 확인

## Phase 2 후속
- #2 백엔드 R2 reference counting 청소 (선택)
- #3 lazy enrollment 본격 작업 (별도 설계 후 진행)