### PR TITLE
feat: 알람 삭제 시 마지막 참조면 서버 음원 cascade 정리

### DIFF
--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -1,7 +1,10 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
+import { typedRow } from '../lib/db-types';
 import { UUID_RE } from '../lib/validate';
+import { logRouteError } from '../lib/logger';
+import { R2VoiceStorage } from '../lib/r2-storage';
 import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import {
   familyAlarmSettingsFromRow,
@@ -351,6 +354,14 @@ alarmMutation.delete('/:id', async (c) => {
     return c.json({ error: 'Invalid alarm ID format', error_code: 'INVALID_ALARM_ID' }, 400);
   }
 
+  const targetRes = await db.execute({
+    sql: 'SELECT message_id FROM alarms WHERE id = ? AND user_id = ? LIMIT 1',
+    args: [id, userId],
+  });
+  const messageId = targetRes.rows.length > 0
+    ? (typedRow<{ message_id: string | null }>(targetRes.rows[0]!).message_id ?? null)
+    : null;
+
   const result = await db.execute({
     sql: 'DELETE FROM alarms WHERE id = ? AND user_id = ?',
     args: [id, userId],
@@ -358,6 +369,38 @@ alarmMutation.delete('/:id', async (c) => {
 
   if (result.rowsAffected === 0) {
     return c.json({ error: 'Alarm not found', error_code: 'ALARM_NOT_FOUND' }, 404);
+  }
+
+  if (messageId) {
+    const refRes = await db.execute({
+      sql: 'SELECT COUNT(*) AS cnt FROM alarms WHERE message_id = ?',
+      args: [messageId],
+    });
+    const cnt = Number(typedRow<{ cnt: number }>(refRes.rows[0]!).cnt ?? 0);
+    if (cnt === 0) {
+      const assetsRes = await db.execute({
+        sql: `SELECT audio_object_key FROM generated_audio_assets
+              WHERE message_id = ? AND audio_object_key IS NOT NULL`,
+        args: [messageId],
+      });
+      const bucket = c.env?.VOICE_BUCKET;
+      if (bucket && assetsRes.rows.length > 0) {
+        const storage = new R2VoiceStorage(bucket);
+        for (const row of assetsRes.rows) {
+          const key = typedRow<{ audio_object_key: string | null }>(row).audio_object_key;
+          if (!key) continue;
+          try {
+            await storage.delete(key);
+          } catch (err) {
+            logRouteError(c, err);
+          }
+        }
+      }
+      await db.execute({
+        sql: 'DELETE FROM generated_audio_assets WHERE message_id = ?',
+        args: [messageId],
+      });
+    }
   }
 
   return c.json({ success: true });

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -803,6 +803,7 @@ describe('DELETE /alarms/:id', () => {
   });
 
   it('존재하지 않는 알람 → 404', async () => {
+    mockDB.pushResult([]);
     mockDB.pushResult([], 0);
     const res = await buildApp().request(
       new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
@@ -811,21 +812,56 @@ describe('DELETE /alarms/:id', () => {
     expect((await res.json()).error_code).toBe('ALARM_NOT_FOUND');
   });
 
-  it('성공 삭제 → 200 success', async () => {
+  it('성공 삭제 (message_id 없음) → 200 success, cascade 미발생', async () => {
+    mockDB.pushResult([{ message_id: null }]);
     mockDB.pushResult([], 1);
     const res = await buildApp().request(
       new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
     );
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
+    expect(
+      mockDB.calls.some((c) => c.sql.startsWith('DELETE FROM generated_audio_assets')),
+    ).toBe(false);
+  });
+
+  it('마지막 참조 알람 삭제 시 generated_audio_assets 정리', async () => {
+    mockDB.pushResult([{ message_id: ID.message }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([{ cnt: 0 }]);
+    mockDB.pushResult([]);
+    const res = await buildApp().request(
+      new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    const cascadeDelete = mockDB.calls.find((c) =>
+      c.sql.startsWith('DELETE FROM generated_audio_assets'),
+    );
+    expect(cascadeDelete).toBeDefined();
+    expect(cascadeDelete!.args).toContain(ID.message);
+  });
+
+  it('다른 알람이 같은 message_id 쓰면 generated_audio_assets 보존', async () => {
+    mockDB.pushResult([{ message_id: ID.message }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([{ cnt: 1 }]);
+    const res = await buildApp().request(
+      new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    expect(
+      mockDB.calls.some((c) => c.sql.startsWith('DELETE FROM generated_audio_assets')),
+    ).toBe(false);
   });
 
   it('DELETE SQL에 userId 바인딩 (다른 사용자 알람 삭제 방지)', async () => {
+    mockDB.pushResult([{ message_id: null }]);
     mockDB.pushResult([], 1);
     await buildApp('user-A').request(
       new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
     );
-    const deleteCall = mockDB.calls[0];
+    const deleteCall = mockDB.calls.find((c) => c.sql.startsWith('DELETE FROM alarms'));
+    expect(deleteCall).toBeDefined();
     expect(deleteCall!.sql).toContain('user_id');
     expect(deleteCall!.args).toContain('user-A');
   });

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -480,6 +480,7 @@ describe('GET /alarm/tick — 발화 대상 조회', () => {
 
 describe('DELETE /alarm/:id — 알람 삭제', () => {
   it('존재하지 않으면 404 + ALARM_NOT_FOUND', async () => {
+    mockDB.pushResult([]);
     mockDB.pushResult([], 0);
     const app = buildApp();
     const res = await app.request(jsonReq('DELETE', `/alarm/${ID.alarm404}`));
@@ -489,6 +490,7 @@ describe('DELETE /alarm/:id — 알람 삭제', () => {
   });
 
   it('정상 삭제', async () => {
+    mockDB.pushResult([{ message_id: null }]);
     mockDB.pushResult([], 1);
     const app = buildApp();
     const res = await app.request(jsonReq('DELETE', `/alarm/${ID.alarm}`));


### PR DESCRIPTION
## Summary
Phase 2 #2: 백엔드 알람 DELETE 시 같은 `message_id`를 참조하는 다른 알람이 없으면, 해당 메시지의 R2 캐시 음원과 `generated_audio_assets` 행을 함께 정리.

### Backend (`packages/backend/src/routes/alarm-mutation.ts`)
DELETE `/alarms/:id` 흐름:
1. SELECT alarm의 `message_id` 미리 조회
2. `DELETE FROM alarms`
3. 위에서 받은 `message_id`가 있고:
   - 다른 알람이 같은 `message_id`를 참조하지 않으면 (`COUNT(*) FROM alarms WHERE message_id = ?` == 0)
     - `generated_audio_assets`의 `audio_object_key`들 조회
     - R2(`VOICE_BUCKET`) 객체 best-effort 삭제
     - `DELETE FROM generated_audio_assets WHERE message_id = ?`

### 의도적으로 보존
- `messages` 행은 그대로 유지 (`message_library`에 저장되었거나 가족 공유 사용처 보호)
- 다른 알람이 같은 메시지를 쓰면 cascade 발생 X
- ELEVENLABS / 외부 API 호출 없음 (모바일에서 voice_profile 단위 정리는 PR #301이 담당)

## Test plan
- [x] backend test suite 1282 통과 (alarm-mutation, alarm 테스트 케이스 4건 추가/갱신)
- [ ] 실기기: 알람 1개 삭제 → 서버 generated_audio_assets 행과 R2 객체 정리 확인
- [ ] 실기기: 동일 message_id를 쓰는 알람 2개 중 1개 삭제 → 행 보존 확인
- [ ] 실기기: 메시지가 message_library에 있어도 알람만 삭제 시 메시지 행 유지 확인

## Phase 2 후속
- #3 lazy enrollment — 별도 설계 문서 작성 후 진행