### PR TITLE
feat: 보이스 클로닝 시 배경음 자동 제거

### DIFF
--- a/packages/backend/src/lib/elevenlabs.ts
+++ b/packages/backend/src/lib/elevenlabs.ts
@@ -22,10 +22,17 @@ export class ElevenLabsClient {
   }
 
   /** Instant Voice Clone - 짧은 샘플로 즉시 음성 클론 */
-  async createInstantClone(audioData: ArrayBuffer, name: string): Promise<{ voice_id: string }> {
+  async createInstantClone(
+    audioData: ArrayBuffer,
+    name: string,
+    options?: { removeBackgroundNoise?: boolean },
+  ): Promise<{ voice_id: string }> {
     const formData = new FormData();
     formData.append('files', new Blob([audioData], { type: 'audio/wav' }), 'sample.wav');
     formData.append('name', name);
+    if (options?.removeBackgroundNoise) {
+      formData.append('remove_background_noise', 'true');
+    }
 
     const res = await fetch(`${ELEVENLABS_BASE_URL}/v1/voices/add`, {
       method: 'POST',

--- a/packages/backend/src/lib/voice-provider.ts
+++ b/packages/backend/src/lib/voice-provider.ts
@@ -72,7 +72,9 @@ export function createEnrollmentAttempts(params: {
       provider: 'elevenlabs',
       enroll: async () => {
         const client = new ElevenLabsClient(params.env.ELEVENLABS_API_KEY);
-        const result = await client.createInstantClone(params.audioData, params.name);
+        const result = await client.createInstantClone(params.audioData, params.name, {
+          removeBackgroundNoise: true,
+        });
         return {
           provider: 'elevenlabs',
           providerVoiceId: result.voice_id,

--- a/packages/backend/test/elevenlabs.test.ts
+++ b/packages/backend/test/elevenlabs.test.ts
@@ -113,6 +113,20 @@ describe('ElevenLabsClient', () => {
       expect(result.voice_id).toBe('new-voice-id');
     });
 
+    it('기본 옵션에서는 remove_background_noise 미전송', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ voice_id: 'v' }));
+      await client.createInstantClone(new ArrayBuffer(10), 'n');
+      const body = mockFetch.mock.calls[0][1].body as FormData;
+      expect(body.get('remove_background_noise')).toBeNull();
+    });
+
+    it('removeBackgroundNoise=true 시 FormData 에 remove_background_noise=true 첨부', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ voice_id: 'v' }));
+      await client.createInstantClone(new ArrayBuffer(10), 'n', { removeBackgroundNoise: true });
+      const body = mockFetch.mock.calls[0][1].body as FormData;
+      expect(body.get('remove_background_noise')).toBe('true');
+    });
+
     it('API 에러 시 예외', async () => {
       mockFetch.mockResolvedValueOnce(errorResponse(400, 'Bad audio'));
 


### PR DESCRIPTION
## Summary
ElevenLabs Instant Voice Clone 호출 시 `remove_background_noise=true` 옵션 활성화. 사용자가 시끄러운 환경에서 녹음/업로드해도 클로닝 품질 안정화.

### Changes
- `ElevenLabsClient.createInstantClone` 에 `options?: { removeBackgroundNoise?: boolean }` 인자 추가
- `voice-provider.ts` enroll attempt 에서 `removeBackgroundNoise: true` 전달
- 테스트 2건 추가 (기본 미전송 / 옵션 전송 검증)

### 비용 영향
- ElevenLabs character credits 차감: 약 1,000 chars / 1분 오디오
- 현 등록 샘플 30-60초 → 회당 500-1,000 chars
- IVC 등록 자체는 무과금이지만 isolation 추가분 발생

### 결정 컨텍스트
- Lazy enrollment 방향(PR #304) 은 close — eager enrollment 유지하기로 결정
- 음성 프로필 삭제 → ElevenLabs voice 삭제는 PR #301 에서 이미 처리됨
- raw 학습 자료 R2 보관은 하지 않음 (현 상태 유지)

## Test plan
- [x] `test/elevenlabs.test.ts` — 기본 / 옵션 / 에러 케이스 통과
- [x] `voice-profile.test.ts` / `voice.test.ts` 회귀 통과
- [ ] 실 호출: 시끄러운 환경 녹음 샘플 클로닝 후 TTS 품질 비교