### PR TITLE
fix: Wrangler 배포 CI Node 22 적용

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 22+
 - npm 9+
 - Git
 - JDK/Android SDK for native Android work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
## 변경 사항

- backend 배포 워크플로의 GitHub Actions Node 버전을 22로 올렸습니다.
- 루트 CI의 lint/typecheck/test 잡도 Node 22로 통일했습니다.
- 기여 문서의 Node.js prerequisite을 22+로 갱신했습니다.

## 원인

`wrangler 4.90.0`은 `node >=22.0.0`을 요구하지만, 기존 워크플로는 Node 20을 사용해 `cloudflare/wrangler-action@v4`의 Wrangler 버전 확인 단계에서 실패했습니다.

## 검증

- `npm ci`
- `npx --no-install wrangler --version` → `4.90.0`
- `npm run typecheck --workspace=backend`
- `npm test --workspace=backend`

Closes #309