### PR TITLE
fix: TTS 원문과 합성 문구 저장 분리

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -749,6 +749,16 @@ export const migrations: Migration[] = [
       ...TTS_PRESET_SEED_STATEMENTS,
     ],
   },
+  {
+    id: 34,
+    name: 'tts-prepared-text-fields',
+    statements: [
+      `ALTER TABLE messages ADD COLUMN synthesis_text TEXT`,
+      `ALTER TABLE messages ADD COLUMN delivery_tags_json TEXT NOT NULL DEFAULT '[]'`,
+      `ALTER TABLE generated_audio_assets ADD COLUMN original_text TEXT`,
+      `ALTER TABLE generated_audio_assets ADD COLUMN delivery_tags_json TEXT NOT NULL DEFAULT '[]'`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -37,6 +37,13 @@ export class AlarmTextTranslationUnavailableError extends Error {
   }
 }
 
+export class AlarmTextPreparationInvalidError extends Error {
+  constructor() {
+    super('Alarm text preparation returned invalid content.');
+    this.name = 'AlarmTextPreparationInvalidError';
+  }
+}
+
 const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const DEFAULT_TOKEN_URI = 'https://oauth2.googleapis.com/token';
 const DEFAULT_VERTEX_LOCATION = 'global';
@@ -118,7 +125,16 @@ export async function prepareAlarmTextWithVertex(
     maxOutputTokens: 256,
   });
   const parsed = parseAlarmTextPreparation(raw);
-  const preparedText = parsed.text || (shouldTag ? tagAlarmTextLocally(trimmed) : trimmed);
+  const fallbackText = shouldTag ? tagAlarmTextLocally(trimmed) : trimmed;
+  let preparedText = parsed.text;
+
+  if (!preparedText || isMetaJsonResponse(preparedText) || (!parsed.parsedJson && isMetaJsonResponse(raw))) {
+    if (shouldTranslate) {
+      throw new AlarmTextPreparationInvalidError();
+    }
+    preparedText = fallbackText;
+  }
+
   const tags = extractTags(preparedText);
 
   return {
@@ -359,7 +375,7 @@ function alarmTextPrompt(args: {
   ].join('\n');
 }
 
-function parseAlarmTextPreparation(raw: string): { text: string; tags: string[] } {
+function parseAlarmTextPreparation(raw: string): { text: string; tags: string[]; parsedJson: boolean } {
   const cleaned = raw
     .trim()
     .replace(/^```(?:json)?/i, '')
@@ -377,13 +393,26 @@ function parseAlarmTextPreparation(raw: string): { text: string; tags: string[] 
     return {
       text: stripWrappingQuotes(text),
       tags: tags.filter(Boolean),
+      parsedJson: true,
     };
   } catch {
     return {
       text: stripWrappingQuotes(cleaned),
       tags: extractTags(cleaned),
+      parsedJson: false,
     };
   }
+}
+
+function isMetaJsonResponse(text: string): boolean {
+  const normalized = text.trim().toLowerCase().replace(/\s+/g, ' ');
+  return (
+    normalized === 'here is the json requested:' ||
+    normalized === 'here is the json requested' ||
+    normalized === 'here is the requested json:' ||
+    normalized === 'here is the requested json' ||
+    normalized.includes('json requested')
+  );
 }
 
 function hasGeminiConfiguration(env: Env): boolean {

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -15,6 +15,7 @@ import {
   UnsupportedVoiceProviderError,
 } from '../lib/voice-provider';
 import {
+  AlarmTextPreparationInvalidError,
   AlarmTextTranslationUnavailableError,
   prepareAlarmTextWithVertex,
 } from '../lib/vertex-translate';
@@ -233,6 +234,8 @@ tts.post('/generate', async (c) => {
       autoTag: randomRequested,
     });
     const synthesisText = prepared.text;
+    const messageText = requestText;
+    const deliveryTagsJson = JSON.stringify(prepared.tags);
     const synthesisLanguage = prepared.translated
       ? requestedLanguage
       : inferSynthesisLanguage(synthesisText, sourceLanguage);
@@ -289,8 +292,9 @@ tts.post('/generate', async (c) => {
             audio_format: cached.audioFormat,
             audio_url: cached.audioUrl,
             audio_object_key: cached.audioObjectKey,
-            text: cached.text,
-            original_text: requestText,
+            text: messageText,
+            original_text: messageText,
+            synthesis_text: cached.synthesisText,
             translated: prepared.translated,
             tags: prepared.tags,
             voice_profile_id: body.voice_profile_id,
@@ -336,13 +340,16 @@ tts.post('/generate', async (c) => {
 
         const messageId = crypto.randomUUID();
         await db.execute({
-          sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, category, audio_url)
-                VALUES (?, ?, ?, ?, ?, ?)`,
+          sql: `INSERT INTO messages
+                (id, user_id, voice_profile_id, text, synthesis_text, delivery_tags_json, category, audio_url)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           args: [
             messageId,
             userPk,
             body.voice_profile_id,
+            messageText,
             synthesisText,
+            deliveryTagsJson,
             category,
             audioUrl,
           ],
@@ -352,9 +359,9 @@ tts.post('/generate', async (c) => {
           await db.execute({
             sql: `INSERT OR IGNORE INTO generated_audio_assets
                   (id, user_id, voice_profile_id, message_id, provider, provider_voice_id,
-                   model_id, language, request_hash, text, category, audio_url,
+                   model_id, language, request_hash, text, original_text, delivery_tags_json, category, audio_url,
                    audio_object_key, audio_format, mime_type, size_bytes)
-                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             args: [
               crypto.randomUUID(),
               userPk,
@@ -366,6 +373,8 @@ tts.post('/generate', async (c) => {
               synthesisLanguage,
               cacheKey,
               synthesisText,
+              messageText,
+              deliveryTagsJson,
               category,
               audioUrl,
               audioObjectKey,
@@ -393,8 +402,9 @@ tts.post('/generate', async (c) => {
             audio_format: generated.outputFormat,
             audio_url: audioUrl,
             audio_object_key: audioObjectKey,
-            text: synthesisText,
-            original_text: requestText,
+            text: messageText,
+            original_text: messageText,
+            synthesis_text: synthesisText,
             translated: prepared.translated,
             tags: prepared.tags,
             voice_profile_id: body.voice_profile_id,
@@ -421,6 +431,15 @@ tts.post('/generate', async (c) => {
           error_code: 'TRANSLATION_NOT_CONFIGURED',
         },
         503,
+      );
+    }
+    if (err instanceof AlarmTextPreparationInvalidError) {
+      return c.json(
+        {
+          error: 'Alarm text preparation returned invalid content.',
+          error_code: 'TEXT_PREPARATION_FAILED',
+        },
+        502,
       );
     }
     return c.json(
@@ -495,7 +514,8 @@ tts.get('/messages/:id/audio', async (c) => {
   }
 
   const result = await db.execute({
-    sql: `SELECT id, user_id, voice_profile_id, text, audio_url, category
+    sql: `SELECT id, user_id, voice_profile_id, text, synthesis_text,
+                 delivery_tags_json, audio_url, category
           FROM messages
           WHERE id = ?
             AND (
@@ -517,6 +537,8 @@ tts.get('/messages/:id/audio', async (c) => {
     id: string;
     voice_profile_id: string;
     text: string | null;
+    synthesis_text: string | null;
+    delivery_tags_json: string | null;
     audio_url: string | null;
     category: string | null;
   }>(result.rows[0]!);
@@ -542,6 +564,8 @@ tts.get('/messages/:id/audio', async (c) => {
     audio_format: loaded.format,
     audio_url: audioUrl,
     text: message.text ?? '',
+    synthesis_text: message.synthesis_text ?? message.text ?? '',
+    tags: parseDeliveryTags(message.delivery_tags_json),
     category: message.category ?? 'custom',
     voice_profile_id: message.voice_profile_id,
   });
@@ -609,7 +633,7 @@ async function findCachedGeneratedAudio(
 ): Promise<{
   messageId: string;
   provider: string;
-  text: string;
+  synthesisText: string;
   audioUrl: string;
   audioObjectKey: string | null;
   audioFormat: string;
@@ -617,8 +641,9 @@ async function findCachedGeneratedAudio(
 } | null> {
   const db = getDB(c.env);
   const result = await db.execute({
-    sql: `SELECT ga.message_id, ga.provider, ga.text, ga.audio_url, ga.audio_object_key,
-                 ga.audio_format, ga.mime_type
+    sql: `SELECT ga.message_id, ga.provider,
+                 COALESCE(ga.text, m.synthesis_text, m.text) AS synthesis_text,
+                 ga.audio_url, ga.audio_object_key, ga.audio_format, ga.mime_type
           FROM generated_audio_assets ga
           JOIN messages m ON m.id = ga.message_id
           WHERE ga.user_id IN (?, ?) AND ga.request_hash = ?
@@ -630,7 +655,7 @@ async function findCachedGeneratedAudio(
   const cached = typedRow<{
     message_id: string;
     provider: string;
-    text: string;
+    synthesis_text: string | null;
     audio_url: string | null;
     audio_object_key: string | null;
     audio_format: string | null;
@@ -643,12 +668,24 @@ async function findCachedGeneratedAudio(
   return {
     messageId: cached.message_id,
     provider: cached.provider,
-    text: cached.text,
+    synthesisText: cached.synthesis_text ?? '',
     audioUrl: cached.audio_url,
     audioObjectKey: cached.audio_object_key,
     audioFormat: cached.audio_format ?? loaded.format,
     bytes: loaded.bytes,
   };
+}
+
+function parseDeliveryTags(value: unknown): string[] {
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 export default tts;

--- a/packages/backend/test/migrations.test.ts
+++ b/packages/backend/test/migrations.test.ts
@@ -217,4 +217,14 @@ describe('migrations', () => {
     expect(all).toContain("'morning'");
     expect(all).toContain("'love'");
   });
+
+  it('migration #34 separates TTS display text from synthesis text and tags', () => {
+    const m = migrations.find((x) => x.id === 34);
+    expect(m).toBeDefined();
+    const all = m!.statements.join('\n');
+    expect(all).toContain('ALTER TABLE messages ADD COLUMN synthesis_text TEXT');
+    expect(all).toContain("ALTER TABLE messages ADD COLUMN delivery_tags_json TEXT NOT NULL DEFAULT '[]'");
+    expect(all).toContain('ALTER TABLE generated_audio_assets ADD COLUMN original_text TEXT');
+    expect(all).toContain("ALTER TABLE generated_audio_assets ADD COLUMN delivery_tags_json TEXT NOT NULL DEFAULT '[]'");
+  });
 });

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -383,7 +383,7 @@ describe('POST /tts/generate — edge cases', () => {
     expect(body.voice_profile_id).toBe(V1);
     // category defaults to 'custom'
     const insertSql = mockDB.calls.find(c => c.sql.includes('INSERT INTO messages'));
-    expect(insertSql!.args[4]).toBe('custom');
+    expect(insertSql!.args[6]).toBe('custom');
   });
 
   it('R2 bucket configured: stores generated TTS under a deterministic cache object key', async () => {
@@ -490,7 +490,7 @@ describe('POST /tts/generate — edge cases', () => {
     );
     expect(res.status).toBe(201);
     const insertSql = mockDB.calls.find(c => c.sql.includes('INSERT INTO messages'));
-    expect(insertSql!.args[4]).toBe('morning');
+    expect(insertSql!.args[6]).toBe('morning');
   });
 
   it('수동 입력 문구는 delivery tag를 자동 삽입하지 않는다', async () => {
@@ -509,7 +509,13 @@ describe('POST /tts/generate — edge cases', () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.text).toBe(text);
+    expect(body.original_text).toBe(text);
+    expect(body.synthesis_text).toBe(text);
     expect(body.tags).toEqual([]);
+    const inserted = mockDB.calls.find(c => c.sql.includes('INSERT INTO messages'));
+    expect(inserted!.args[3]).toBe(text);
+    expect(inserted!.args[4]).toBe(text);
+    expect(inserted!.args[5]).toBe('[]');
     expect(mockTextToSpeech).toHaveBeenCalledWith('el-voice-1', text, expect.objectContaining({
       language_code: 'ko',
       stability: 0.45,
@@ -540,6 +546,8 @@ describe('POST /tts/generate — edge cases', () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.text).toBe(text);
+    expect(body.original_text).toBe(text);
+    expect(body.synthesis_text).toBe(text);
     expect(body.language).toBe('en');
     expect(mockTextToSpeech).toHaveBeenCalledWith('el-voice-1', text, expect.objectContaining({
       language_code: 'en',
@@ -592,12 +600,15 @@ describe('POST /tts/generate — edge cases', () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.original_text).toBe('서버가 고른 아침 문구');
-    expect(body.text).toContain(body.original_text);
+    expect(body.text).toBe(body.original_text);
+    expect(body.synthesis_text).toContain(body.original_text);
     expect(body.tags).toContain('warmly');
-    expect(mockTextToSpeech).toHaveBeenCalledWith('el-voice-1', body.text, expect.any(Object));
+    expect(mockTextToSpeech).toHaveBeenCalledWith('el-voice-1', body.synthesis_text, expect.any(Object));
     const inserted = mockDB.calls.find(c => c.sql.includes('INSERT INTO messages'));
-    expect(inserted!.args[3]).toBe(body.text);
-    expect(inserted!.args[4]).toBe('morning');
+    expect(inserted!.args[3]).toBe(body.original_text);
+    expect(inserted!.args[4]).toBe(body.synthesis_text);
+    expect(inserted!.args[5]).toBe(JSON.stringify(body.tags));
+    expect(inserted!.args[6]).toBe('morning');
   });
 
   it('random=true 에 custom category 면 400', async () => {

--- a/packages/backend/test/vertex-translate.test.ts
+++ b/packages/backend/test/vertex-translate.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+import {
+  AlarmTextPreparationInvalidError,
+  prepareAlarmTextWithVertex,
+} from '../src/lib/vertex-translate';
+
+const mockFetch = vi.fn();
+
+const ENV: Env = {
+  PERSO_API_KEY: 'x',
+  ELEVENLABS_API_KEY: 'x',
+  TURSO_DATABASE_URL: 'x',
+  TURSO_AUTH_TOKEN: 'x',
+  GOOGLE_CLIENT_ID: 'x',
+  GOOGLE_VERTEX_API_KEY: 'gemini-key',
+  JWT_SECRET: 'test-secret-32-chars-or-longer!',
+  PASSWORD_PEPPER: 'pepper',
+  ENVIRONMENT: 'test',
+};
+
+function okJson(data: unknown) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function geminiText(text: string) {
+  return okJson({
+    candidates: [
+      {
+        content: {
+          parts: [{ text }],
+        },
+      },
+    ],
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+describe('prepareAlarmTextWithVertex', () => {
+  it('falls back to local tagging when Gemini returns only JSON helper text', async () => {
+    mockFetch.mockResolvedValueOnce(geminiText('Here Is the json requested:'));
+
+    const prepared = await prepareAlarmTextWithVertex(ENV, 'Good morning. Wake up.', {
+      targetLanguage: 'en',
+      sourceLanguage: 'en',
+      translate: false,
+      autoTag: true,
+    });
+
+    expect(prepared.text).toContain('Good morning. Wake up.');
+    expect(prepared.text).not.toContain('json requested');
+    expect(prepared.tags).toEqual(['warmly']);
+  });
+
+  it('parses JSON even when Gemini adds a short preamble', async () => {
+    mockFetch.mockResolvedValueOnce(
+      geminiText('Here is the JSON requested:\n{"text":"[warmly] Hello","tags":["warmly"]}'),
+    );
+
+    const prepared = await prepareAlarmTextWithVertex(ENV, 'Hello', {
+      targetLanguage: 'en',
+      sourceLanguage: 'en',
+      translate: false,
+      autoTag: true,
+    });
+
+    expect(prepared.text).toBe('[warmly] Hello');
+    expect(prepared.tags).toEqual(['warmly']);
+  });
+
+  it('does not synthesize malformed translation output', async () => {
+    mockFetch.mockResolvedValueOnce(geminiText('Here Is the json requested:'));
+
+    await expect(
+      prepareAlarmTextWithVertex(ENV, '좋은 아침이에요', {
+        targetLanguage: 'en',
+        sourceLanguage: 'ko',
+        translate: true,
+        autoTag: true,
+      }),
+    ).rejects.toBeInstanceOf(AlarmTextPreparationInvalidError);
+  });
+});


### PR DESCRIPTION
## Summary
- keep `messages.text` as the original user/preset text and store generated delivery-tag text in `synthesis_text`
- add `delivery_tags_json` and generated audio original-text metadata via migration #34
- prevent Gemini helper prose like `Here Is the json requested:` from being synthesized
- add regression coverage for malformed Gemini output, message storage separation, and migration fields

## Verification
- `npm run typecheck` (packages/backend)
- `npm test -- tts.test.ts vertex-translate.test.ts migrations.test.ts` (packages/backend)
- `npm test` (packages/backend)
- `npx eslint packages/backend/src/lib/migrations.ts packages/backend/src/lib/vertex-translate.ts packages/backend/src/routes/tts.ts packages/backend/test/migrations.test.ts packages/backend/test/tts.test.ts packages/backend/test/vertex-translate.test.ts`

Closes #319