### PR TITLE
Fix Android alarm permission gate and voice clone edge cases

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -91,11 +91,15 @@ class AlarmAudioStore(
         findCachedFile(cacheKey)?.let { cached ->
             val cachedUri = cached.toUri()
             val metadata = readMetadata(cacheKey)
+            val cachedDurationMillis = normalizeDurationWithinLimit(
+                durationMillis = readDurationMillis(cachedUri) ?: durationMillis,
+                maxDurationMillis = maxDurationMillis,
+            )
             return CachedAlarmAudio(
                 localAudioUri = cachedUri.toString(),
                 rawAudioUri = metadata.rawAudioUri ?: sourceUri.toString(),
                 displayName = cached.name,
-                durationMillis = readDurationMillis(cachedUri) ?: durationMillis,
+                durationMillis = cachedDurationMillis,
                 cacheKey = cacheKey,
                 messageId = metadata.messageId,
             )
@@ -121,14 +125,14 @@ class AlarmAudioStore(
         }
 
         val cachedDurationMillis = readDurationMillis(target.toUri()) ?: durationMillis
-        requireWithinLimit(cachedDurationMillis, maxDurationMillis)
+        val normalizedDurationMillis = normalizeDurationWithinLimit(cachedDurationMillis, maxDurationMillis)
 
-        Log.i(TAG, "Cached local voice audio path=${target.absolutePath} durationMillis=$cachedDurationMillis")
+        Log.i(TAG, "Cached local voice audio path=${target.absolutePath} durationMillis=$normalizedDurationMillis")
         return CachedAlarmAudio(
             localAudioUri = target.toUri().toString(),
             rawAudioUri = sourceUri.toString(),
             displayName = displayName,
-            durationMillis = cachedDurationMillis,
+            durationMillis = normalizedDurationMillis,
             cacheKey = cacheKey,
             messageId = null,
         )
@@ -215,11 +219,20 @@ class AlarmAudioStore(
         }
     }
 
+    private fun normalizeDurationWithinLimit(
+        durationMillis: Long?,
+        maxDurationMillis: Long,
+    ): Long? {
+        requireWithinLimit(durationMillis, maxDurationMillis)
+        return durationMillis?.coerceAtMost(maxDurationMillis)
+    }
+
     private fun requireWithinLimit(
         durationMillis: Long?,
         maxDurationMillis: Long = AlarmAudioLimits.MAX_DURATION_MILLIS,
     ) {
-        require(durationMillis == null || durationMillis <= maxDurationMillis) {
+        val toleratedLimit = maxDurationMillis + DURATION_METADATA_TOLERANCE_MILLIS
+        require(durationMillis == null || durationMillis <= toleratedLimit) {
             "Voice audio must be ${maxDurationMillis / 1000} seconds or shorter."
         }
     }
@@ -264,7 +277,7 @@ class AlarmAudioStore(
 
                 while (true) {
                     val sampleTimeUs = extractor.sampleTime
-                    if (sampleTimeUs < 0 || sampleTimeUs > endUs) break
+                    if (sampleTimeUs < 0 || sampleTimeUs >= endUs) break
                     buffer.clear()
                     val sampleSize = extractor.readSampleData(buffer, 0)
                     if (sampleSize < 0) break
@@ -321,7 +334,7 @@ class AlarmAudioStore(
                 target.outputStream().use { output ->
                     while (true) {
                         val sampleTimeUs = extractor.sampleTime
-                        if (sampleTimeUs < 0 || sampleTimeUs > endUs) break
+                        if (sampleTimeUs < 0 || sampleTimeUs >= endUs) break
                         buffer.clear()
                         val sampleSize = extractor.readSampleData(buffer, 0)
                         if (sampleSize < 0) break
@@ -421,6 +434,7 @@ class AlarmAudioStore(
     companion object {
         private const val AUDIO_DIR = "alarm-audio"
         private const val META_EXTENSION = "meta"
+        private const val DURATION_METADATA_TOLERANCE_MILLIS = 750L
 
         fun ttsCacheKey(
             profileId: String,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/app/VoiceAlarmApp.kt
@@ -172,7 +172,9 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     }
 
     fun requestFirstMissingAlarmPermission() {
-        permissions.firstMissingAlarmTarget()?.let(viewModel::requestPermissionGate)
+        val target = PermissionSnapshot.read(context).firstMissingAlarmTarget() ?: return
+        viewModel.message = alarmPermissionRequiredMessage(target)
+        requestPermission(target)
     }
 
     LaunchedEffect(permissionState.refreshTick, bulkPermissionFlowActive) {
@@ -574,7 +576,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
                           },
                           onEditAlarm = { navController.navigate(AppRoute.alarmEdit(it.id)) },
                           onDeleteAlarm = viewModel::deleteAlarm,
-                          onRequestPermissionGate = viewModel::requestPermissionGate,
+                          onRequestPermissionGate = ::requestPermission,
                           onRequestAllPermissions = ::requestAllMissingPermissions,
                           profileMenu = if (tab == NativeTab.Alarms) {
                               {
@@ -753,6 +755,13 @@ private val NativeTab.route: String
 
 private fun String?.toNativeTab(): NativeTab? =
     NativeTab.values().firstOrNull { it.route == this }
+
+private fun alarmPermissionRequiredMessage(target: PermissionTarget): String = when (target) {
+    PermissionTarget.Notifications -> "알람 화면과 종료 버튼을 표시하려면 알림 권한이 필요해요."
+    PermissionTarget.ExactAlarms -> "정해진 시간에 울리려면 정확한 알람 권한이 필요해요."
+    PermissionTarget.FullScreenIntent -> "잠금화면 위에 알람 화면을 띄우려면 전체 화면 알람 권한을 켜 주세요."
+    PermissionTarget.RecordAudio -> "음성을 녹음하려면 마이크 권한이 필요해요."
+}
 
 private fun NavHostController.navigateTopLevelTab(tab: NativeTab) {
     navigate(tab.route) {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/VoiceAudioCard.kt
@@ -126,13 +126,17 @@ internal fun VoiceAudioCard(
                             detail = sharedVoiceDetail(profile),
                         )
                     }
-                LaunchedEffect(visibleVoiceSource, profileOptions) {
+                LaunchedEffect(visibleVoiceSource, voiceProfileBusy, profileOptions, editor.voiceProfileId) {
                     if (
                         visibleVoiceSource == VoiceSources.TTS_PROFILE &&
-                        editor.voiceProfileId.isNullOrBlank() &&
+                        !voiceProfileBusy &&
                         profileOptions.isNotEmpty()
                     ) {
-                        editor.voiceProfileId = profileOptions.first().id
+                        val selectedProfileAvailable = profileOptions.any { it.id == editor.voiceProfileId }
+                        if (editor.voiceProfileId.isNullOrBlank() || !selectedProfileAvailable) {
+                            editor.voiceProfileId = profileOptions.first().id
+                            editor.clearTtsMeta()
+                        }
                     }
                 }
                 val selectedProfileUnavailable = !voiceProfileBusy &&

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
@@ -56,11 +56,27 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 
 
+private fun MainViewModel.requireAlarmPermissionsForMutation(): Boolean {
+    val snapshot = PermissionSnapshot.read(getApplication<Application>())
+    val missingTarget = snapshot.firstMissingAlarmTarget() ?: return true
+    requestPermissionGate(missingTarget)
+    message = alarmPermissionBlockedMessage(missingTarget)
+    return false
+}
+
+private fun alarmPermissionBlockedMessage(target: PermissionTarget): String = when (target) {
+    PermissionTarget.Notifications -> "알람 화면과 종료 버튼을 표시하려면 알림 권한이 필요해요."
+    PermissionTarget.ExactAlarms -> "정해진 시간에 울리려면 정확한 알람 권한이 필요해요."
+    PermissionTarget.FullScreenIntent -> "잠금화면 위에 알람 화면을 띄우려면 전체 화면 알람 권한을 켜 주세요."
+    PermissionTarget.RecordAudio -> "음성을 녹음하려면 마이크 권한이 필요해요."
+}
+
 internal fun MainViewModel.createAlarm(draft: AlarmDraft, onDone: () -> Unit) {
     if (draft.playMode != AlarmPlayModes.ALARM_ONLY && !hasPaidVoiceAccess(subscriptionResponse)) {
         message = "유료 요금제를 사용해야 목소리 알람을 만들 수 있어요."
         return
     }
+    if (!requireAlarmPermissionsForMutation()) return
     viewModelScope.launch {
         if (!draft.targetUserId.isNullOrBlank()) {
             createFamilyTargetAlarm(draft, onDone)
@@ -168,6 +184,7 @@ internal fun MainViewModel.updateAlarm(alarmId: String, draft: AlarmDraft, onDon
         message = "유료 요금제를 사용해야 목소리 알람을 만들 수 있어요."
         return
     }
+    if (!requireAlarmPermissionsForMutation()) return
     viewModelScope.launch {
         runCatching {
             repository.updateAlarm(alarmId, draft)
@@ -182,6 +199,7 @@ internal fun MainViewModel.updateAlarm(alarmId: String, draft: AlarmDraft, onDon
 }
 
 internal fun MainViewModel.setAlarmEnabled(alarmId: String, enabled: Boolean) {
+    if (enabled && !requireAlarmPermissionsForMutation()) return
     viewModelScope.launch {
         runCatching {
             repository.setEnabled(alarmId, enabled)
@@ -208,6 +226,7 @@ internal fun MainViewModel.deleteAlarm(alarmId: String) {
 }
 
 internal fun MainViewModel.copyAlarm(alarmId: String) {
+    if (!requireAlarmPermissionsForMutation()) return
     viewModelScope.launch {
         runCatching {
             repository.copyAlarm(alarmId)
@@ -221,6 +240,7 @@ internal fun MainViewModel.copyAlarm(alarmId: String) {
 }
 
 internal fun MainViewModel.createTestAlarm(delayMinutes: Int) {
+    if (!requireAlarmPermissionsForMutation()) return
     viewModelScope.launch {
         runCatching {
             repository.createTestAlarm(delayMinutes)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -134,6 +134,9 @@ internal fun MainViewModel.createVoiceProfiles(items: List<Triple<String, Cached
         }.onFailure { error ->
             Log.e(TAG, "Failed to create voice profile", error)
             message = when (voiceErrorCode(error)) {
+                "VOICE_CLONE_AUDIO_TOO_SHORT" -> "학습 음성은 1분 이상이어야 해요."
+                "VOICE_CLONE_AUDIO_TOO_LONG" -> "학습 음성은 2분 이하로 준비해 주세요."
+                "INVALID_DURATION" -> "음성 길이를 확인하지 못했어요. 파일을 다시 선택해 주세요."
                 "VOICE_SLOT_EXHAUSTED" -> "서비스가 확장중이에요. 잠시만 기다려주세요!"
                 "VOICE_FEATURE_REQUIRES_PAID_PLAN" -> "유료 요금제를 사용해야 목소리를 만들 수 있어요."
                 else -> userFacingError(error, "알람 음성 생성에 실패했어요")


### PR DESCRIPTION
## Summary
- require notification, exact alarm, and full-screen intent permissions before alarm creation, enabling, copying, and test scheduling
- open the relevant Android permission/settings screen when an alarm-critical permission is missing
- tolerate small Android audio metadata drift at the 120s voice clone limit and normalize duration sent to the backend
- auto-select an available voice profile when the editor was holding a deleted profile ID
- show clearer voice clone duration errors

## Root Cause
Android 14+ can reject full-screen alarm UI unless the full-screen intent special access is allowed. Voice clone audio trimmed to exactly 120s can still be reported by Android metadata as slightly over 120s, which caused local/server duration validation failures.

## Validation
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:installDebug`
- confirmed connected device app ops: `SCHEDULE_EXACT_ALARM: allow`, `USE_FULL_SCREEN_INTENT: allow`

Closes #321