### PR TITLE
feat(backend): Apple 사인인 nonce 검증 + 빌링 IAP 라우트

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -20,6 +20,25 @@ Cloudflare Workers + Hono 기반 API 서버.
 | `PASSWORD_PEPPER` | 비밀번호 해싱 페퍼 | ✅ |
 | `GOOGLE_CLIENT_ID` | Google OAuth 클라이언트 ID | 선택 |
 | `APPLE_CLIENT_ID` | Sign in with Apple audience / iOS bundle ID | iOS 로그인 시 필수 |
+| `APPLE_SHARED_SECRET` | App Store Connect "앱 전용 공유 비밀" — `POST /api/billing/apple/confirm` 게이트 | iOS IAP 구독 사용 시 필수 |
+
+### Apple IAP confirm 검증 강화 로드맵
+
+`POST /api/billing/apple/confirm` 은 본 phase 에서 다음 trust model 로 작동한다.
+
+- 라우트 진입에는 authMiddleware (JWT) 가 선행해 호출자 신원을 보장.
+- 알려진 SKU 화이트리스트 (`com.voicealarm.nativeapp.ios.{personal|couple|family}_{monthly|yearly}`) 만 수락.
+- `APPLE_SHARED_SECRET` 미설정 시 503 으로 즉시 거부 (운영자 설정 강제).
+- 동일 `transaction_id` 의 중복 confirm 은 멱등 (200, 기존 row).
+
+후속 PR 에서 다음 server-to-server 검증을 추가해 영수증 진위까지 본인 검증한다.
+
+1. Apple App Store Server API v2 의 `GET https://api.storekit.itunes.apple.com/inApps/v1/transactions/{transactionId}`
+   (sandbox: `https://api.storekit-sandbox.itunes.apple.com/...`) 호출.
+2. 응답의 JWS 헤더에서 X5C 체인을 추출 → Apple 루트 CA 까지 chain 검증
+   (`crypto.subtle.verify` + Apple Root CA 인증서).
+3. JWS payload 의 `productId` / `originalTransactionId` 가 클라이언트 입력과 일치하는지 대조.
+4. payload 의 `expiresDate` 를 `subscriptions.expires_at` 의 권위로 채택 (현재는 plans.period_days 기반 산출).
 
 ## 로컬 실행
 
@@ -65,6 +84,24 @@ npm run typecheck # tsc --noEmit
 
 ## Apple Login
 
-- `POST /api/auth/apple` accepts an Apple `id_token`, verifies its RS256 signature with Apple JWKS, checks issuer/audience/expiry, and returns the app JWT.
+- `POST /api/auth/apple` accepts an Apple `id_token`, verifies its RS256 signature with Apple JWKS, checks issuer/audience/expiry/nonce, and returns the app JWT.
 - `APPLE_CLIENT_ID` must match the iOS bundle ID, for example `com.voicealarm.nativeapp.ios`.
+- Configure the secret in production:
+
+  ```bash
+  wrangler secret put APPLE_CLIENT_ID
+  # paste: com.voicealarm.nativeapp.ios
+  ```
+
 - Migration `35_apple-login-users` adds `users.apple_id` and a nullable unique index for Apple account linking.
+
+### Nonce 정책 (replay 방어)
+
+클라이언트(iOS)는 매 로그인 시 `SecRandomCopyBytes` 로 raw nonce 를 생성한 뒤,
+`ASAuthorizationAppleIDRequest.nonce` 에는 raw nonce 의 SHA-256 hex 문자열을
+설정하고, 동일한 raw nonce 를 `POST /api/auth/apple` 요청 본문(`nonce` 필드)에 함께
+보낸다. 서버는 전달받은 raw nonce 를 SHA-256 으로 다시 해싱해 Apple 이 발급한
+`id_token.nonce` 클레임과 비교한다. 불일치 시 `AUTH_APPLE_NONCE_MISMATCH` (401)
+로 거부한다. 토큰엔 `nonce` 클레임이 있는데 요청에 `nonce` 가 빠지면 mismatch 로
+처리한다. 클라이언트가 `nonce` 를 보내지 않는 레거시 호환 경로는 통과하지만
+서버 로그에 경고가 남는다.

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -769,6 +769,26 @@ export const migrations: Migration[] = [
         WHERE apple_id IS NOT NULL`,
     ],
   },
+  {
+    // Apple StoreKit2 IAP 트랜잭션 추적 컬럼.
+    //   - apple_transaction_id: 결제 단위 ID. 멱등 lookup 키.
+    //   - apple_original_transaction_id: 자동 갱신 구독의 원본 구매 ID.
+    //   - apple_product_id: SKU (com.voicealarm.nativeapp.ios.personal_monthly 등)
+    // 유니크 인덱스로 동일 transaction_id 의 중복 INSERT 를 방지 (POST /billing/apple/confirm 멱등성).
+    id: 36,
+    name: 'subscriptions-apple-fields',
+    statements: [
+      `ALTER TABLE subscriptions ADD COLUMN apple_transaction_id TEXT`,
+      `ALTER TABLE subscriptions ADD COLUMN apple_original_transaction_id TEXT`,
+      `ALTER TABLE subscriptions ADD COLUMN apple_product_id TEXT`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_subscriptions_apple_transaction
+        ON subscriptions(apple_transaction_id)
+        WHERE apple_transaction_id IS NOT NULL`,
+      `CREATE INDEX IF NOT EXISTS idx_subscriptions_apple_original
+        ON subscriptions(apple_original_transaction_id)
+        WHERE apple_original_transaction_id IS NOT NULL`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/oauth.ts
+++ b/packages/backend/src/lib/oauth.ts
@@ -7,6 +7,7 @@ export interface ExternalTokenPayload {
   iss: string;
   aud: string;
   exp: number;
+  nonce?: string;
 }
 
 interface JwtHeader {
@@ -141,6 +142,7 @@ export async function verifyGoogleIdToken(
 export async function verifyAppleIdToken(
   idToken: string,
   expectedClientId?: string,
+  expectedNonceHash?: string,
 ): Promise<ExternalTokenPayload> {
   const header = decodeJwtHeader(idToken);
   await verifyAppleSignature(idToken, header);
@@ -155,6 +157,20 @@ export async function verifyAppleIdToken(
   }
   if (Number(payload.exp) < Date.now() / 1000) {
     throw new Error('Apple token expired');
+  }
+
+  // nonce 검증 — Apple 가이드: 클라이언트가 raw nonce 의 SHA256 해시를
+  // ASAuthorizationAppleIDRequest.nonce 로 설정하면 발급된 id_token 의
+  // nonce 클레임에 동일한 해시가 들어온다. 서버는 클라이언트가 함께 보낸
+  // raw nonce 를 다시 해싱해 비교한다. expectedNonceHash 가 명시적으로
+  // 전달된 경우에만 검증을 수행하고, 미전달 시(레거시/middleware 경로)
+  // 검증을 건너뛰되 경고 로그를 남긴다.
+  if (expectedNonceHash !== undefined) {
+    if (typeof payload.nonce !== 'string' || payload.nonce !== expectedNonceHash) {
+      throw new Error('Apple token nonce mismatch');
+    }
+  } else {
+    console.warn('[oauth] apple token verified without nonce check');
   }
 
   return { ...payload, exp: Number(payload.exp) };

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -14,7 +14,7 @@ import {
   EmailVerificationRequestSchema,
   EmailVerificationConfirmRequestSchema,
 } from '@voice-alarm/shared';
-import { verifyAppleIdToken, verifyGoogleIdToken } from '../lib/oauth';
+import { decodeJwtPayload, verifyAppleIdToken, verifyGoogleIdToken } from '../lib/oauth';
 import { familyAlarmSettingsFromRow } from '../lib/family-alarm-settings';
 import {
   EMAIL_VERIFICATION_MAX_ATTEMPTS,
@@ -494,7 +494,34 @@ auth.post('/apple', async (c) => {
         500,
       );
     }
-    const apple = await verifyAppleIdToken(parsed.data.id_token, c.env.APPLE_CLIENT_ID);
+
+    // raw nonce 를 SHA-256 으로 hex 인코딩한 뒤 id_token.nonce 와 동일성 비교.
+    // 클라이언트가 nonce 를 보내지 않은 경우(legacy) verifyAppleIdToken 이
+    // 내부적으로 console.warn 만 남기고 통과시킨다. 다만 클라이언트가 nonce
+    // 를 빠뜨렸는데 토큰 자체엔 nonce 클레임이 있다면 점진 마이그레이션
+    // 정책상 replay 가능성이 있으므로 mismatch 로 거부한다.
+    let expectedNonceHash: string | undefined;
+    if (parsed.data.nonce) {
+      const digest = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode(parsed.data.nonce),
+      );
+      expectedNonceHash = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    } else {
+      const preview = decodeJwtPayload(parsed.data.id_token);
+      if (typeof preview.nonce === 'string' && preview.nonce.length > 0) {
+        throw new Error('Apple token nonce mismatch: client did not supply raw nonce');
+      }
+      console.warn('[auth] /auth/apple called without nonce; replay defense disabled for request');
+    }
+
+    const apple = await verifyAppleIdToken(
+      parsed.data.id_token,
+      c.env.APPLE_CLIENT_ID,
+      expectedNonceHash,
+    );
     const appleId = apple.sub;
     const email = (apple.email || parsed.data.email || `${appleId}@apple.local`)
       .toLowerCase()
@@ -585,6 +612,10 @@ auth.post('/apple', async (c) => {
         email,
         name: resolvedName,
         plan,
+        // Phase 4-D2: 클라이언트가 ASAuthorizationAppleIDProvider.credentialState
+        // 조회에 사용하는 stable Apple user identifier. iOS AuthViewModel 가
+        // 세션에 보관해 foreground 진입 시 revoke 여부를 확인한다.
+        apple_user_id: appleId,
         allow_family_alarms: familyAlarmSettings.allowFamilyAlarms,
         family_alarm_quiet_days: familyAlarmSettings.quietDays,
         family_alarm_quiet_start: familyAlarmSettings.quietStart,
@@ -594,6 +625,9 @@ auth.post('/apple', async (c) => {
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
+    if (detail.includes('nonce mismatch')) {
+      return c.json(jsonError('AUTH_APPLE_NONCE_MISMATCH', detail), 401);
+    }
     const status =
       detail.includes('Apple token') ||
       detail.includes('Apple JWKS') ||
@@ -619,13 +653,15 @@ auth.get('/me', async (c) => {
   try {
     const payload = await verifyAppJwt(token, c.env.JWT_SECRET);
     const db = getDB(c.env);
+    // Phase 4-D2: apple_id 컬럼도 함께 조회·매칭한다. Apple 로그인 사용자의 JWT sub
+    // 는 google_id 칼럼이 아닌 apple_id 칼럼에만 저장돼 있을 수 있다.
     const result = await db.execute({
-      sql: `SELECT id, email, name, plan,
+      sql: `SELECT id, email, name, plan, apple_id,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows
-            FROM users WHERE id = ? OR google_id = ? LIMIT 1`,
-      args: [payload.sub, payload.sub],
+            FROM users WHERE id = ? OR google_id = ? OR apple_id = ? LIMIT 1`,
+      args: [payload.sub, payload.sub, payload.sub],
     });
     if (result.rows.length === 0) {
       return c.json(jsonError('AUTH_USER_NOT_FOUND', 'User not found'), 404);
@@ -636,6 +672,7 @@ auth.get('/me', async (c) => {
         email: string;
         name: string | null;
         plan: 'free' | 'plus' | 'family' | null;
+        apple_id: string | null;
       } & Record<string, unknown>
     >(result.rows[0]!);
     const familyAlarmSettings = familyAlarmSettingsFromRow(row);
@@ -645,6 +682,9 @@ auth.get('/me', async (c) => {
         email: row.email,
         name: row.name ?? '',
         plan: row.plan ?? 'free',
+        // Phase 4-D2: iOS 클라이언트가 credentialState 조회에 사용. 비-Apple 사용자
+        // 는 null. iOS AuthUser.appleUserId 는 옵셔널이라 누락도 호환.
+        apple_user_id: row.apple_id ?? null,
         allow_family_alarms: familyAlarmSettings.allowFamilyAlarms,
         family_alarm_quiet_days: familyAlarmSettings.quietDays,
         family_alarm_quiet_start: familyAlarmSettings.quietStart,

--- a/packages/backend/src/routes/billing-apple.ts
+++ b/packages/backend/src/routes/billing-apple.ts
@@ -1,0 +1,203 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { getDB } from '../lib/db';
+import { withWriteTransaction } from '../lib/transactions';
+import {
+  applePlanKeyFromProductId,
+  planTypeToUserPlan,
+  resolveUserPk,
+} from './billing-helpers';
+
+// MARK: - POST /billing/apple/confirm
+//
+// iOS `SubscriptionManager.syncWithBackend` 가 호출하는 라우트.
+// App Store 영수증 확인 후 백엔드 entitlement 를 동기화한다.
+//
+// 본 phase 의 trust model (Apple App Store Server API v2 JWS 검증은 후속 PR 에서 강화):
+//   1. 클라이언트는 인증된 사용자 세션에서만 호출 가능 (authMiddleware 통과 필수).
+//   2. 알려진 SKU (`com.voicealarm.nativeapp.ios.{personal|couple|family}_{monthly|yearly}`)
+//      만 수락. 임의 product_id 는 400 UNKNOWN_PRODUCT 로 거절.
+//   3. APPLE_SHARED_SECRET 환경변수가 설정되어 있어야 한다. 미설정 시 503 — 운영자가
+//      `wrangler secret put APPLE_SHARED_SECRET` 으로 주입.
+//   4. 동일 transaction_id 의 중복 confirm 은 멱등 (200, 기존 row 반환).
+//
+// 후속 강화 (README/PR-NOTES 에 명시):
+//   - Apple App Store Server API v2 의 `Get Transaction Info`
+//     (`https://api.storekit.itunes.apple.com/inApps/v1/transactions/{transactionId}`,
+//     sandbox: `https://api.storekit-sandbox.itunes.apple.com/...`) 로 JWS 를 받아
+//     X5C 체인을 Apple 루트 CA 까지 검증하고 payload 의 productId/originalTransactionId
+//     와 클라이언트 입력을 대조하는 server-to-server 검증을 추가.
+//   - JWS 의 `expiresDate` 를 expires_at 의 권위 (authoritative) 로 채택.
+
+interface ConfirmRequest {
+  transaction_id: string;
+  original_transaction_id: string;
+  product_id: string;
+}
+
+function parseConfirmRequest(value: unknown): ConfirmRequest | { error: string } {
+  if (!value || typeof value !== 'object') {
+    return { error: 'Request body must be a JSON object' };
+  }
+  const raw = value as Record<string, unknown>;
+  const transactionId = typeof raw.transaction_id === 'string' ? raw.transaction_id.trim() : '';
+  const originalTransactionId =
+    typeof raw.original_transaction_id === 'string' ? raw.original_transaction_id.trim() : '';
+  const productId = typeof raw.product_id === 'string' ? raw.product_id.trim() : '';
+  if (!transactionId) return { error: 'transaction_id is required' };
+  if (!originalTransactionId) return { error: 'original_transaction_id is required' };
+  if (!productId) return { error: 'product_id is required' };
+  return {
+    transaction_id: transactionId,
+    original_transaction_id: originalTransactionId,
+    product_id: productId,
+  };
+}
+
+interface PlanRow {
+  id: string;
+  key: string;
+  plan_type: string;
+  period_days: number;
+}
+
+function normalizePlanRow(row: Record<string, unknown>): PlanRow {
+  return {
+    id: String(row.id),
+    key: String(row.key),
+    plan_type: String(row.plan_type),
+    period_days: Number(row.period_days) || 30,
+  };
+}
+
+const billingApple = new Hono<AppEnv>();
+
+billingApple.post('/apple/confirm', async (c) => {
+  // 환경 변수 게이트. 미설정 시 운영자 액션이 필요하므로 503.
+  if (!c.env.APPLE_SHARED_SECRET) {
+    return c.json(
+      {
+        error: 'Apple billing is not configured on the server',
+        error_code: 'APPLE_BILLING_UNCONFIGURED',
+      },
+      503,
+    );
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = parseConfirmRequest(body);
+  if ('error' in parsed) {
+    return c.json({ error: parsed.error, error_code: 'INVALID_REQUEST' }, 400);
+  }
+
+  const { transaction_id, original_transaction_id, product_id } = parsed;
+
+  // SKU 화이트리스트 검증.
+  const planKey = applePlanKeyFromProductId(product_id);
+  if (!planKey) {
+    return c.json(
+      {
+        error: `Unknown Apple product id: ${product_id}`,
+        error_code: 'UNKNOWN_PRODUCT',
+      },
+      400,
+    );
+  }
+
+  const userPk = await resolveUserPk(c);
+  if (!userPk) {
+    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
+  }
+
+  const db = getDB(c.env);
+
+  // 멱등 lookup: 같은 transaction_id 가 이미 처리됐다면 그대로 echo.
+  const existingRes = await db.execute({
+    sql: `SELECT s.id AS sub_id, s.expires_at, p.key AS plan_key
+          FROM subscriptions s
+          JOIN plans p ON p.id = s.plan_id
+          WHERE s.apple_transaction_id = ? AND s.user_id = ?
+          LIMIT 1`,
+    args: [transaction_id, userPk],
+  });
+  if (existingRes.rows.length > 0) {
+    const row = existingRes.rows[0]!;
+    return c.json({
+      subscription_id: String(row.sub_id),
+      plan: String(row.plan_key),
+      expires_at: String(row.expires_at),
+    });
+  }
+
+  // plan_key 로 plans 행 조회.
+  const planRes = await db.execute({
+    sql: `SELECT id, key, plan_type, period_days FROM plans WHERE key = ? AND is_active = 1`,
+    args: [planKey],
+  });
+  if (planRes.rows.length === 0) {
+    return c.json(
+      { error: `Plan not found for key=${planKey}`, error_code: 'PLAN_NOT_FOUND' },
+      400,
+    );
+  }
+  const plan = normalizePlanRow(planRes.rows[0]!);
+
+  // expires_at: 본 phase 에서는 period_days 기반으로 산출. 후속 PR 에서 Apple JWS expiresDate 로 교체.
+  const startsAt = new Date();
+  const expiresAt = new Date(startsAt.getTime() + plan.period_days * 24 * 60 * 60 * 1000);
+  const subscriptionId = crypto.randomUUID();
+  const startsAtIso = startsAt.toISOString();
+  const expiresAtIso = expiresAt.toISOString();
+
+  try {
+    await withWriteTransaction(db, async (tx) => {
+      // 기존 active 구독을 expired 로 정리 (단일 active 유지). 즉시 만료 처리는
+      // billing-cancel 의 cancel 흐름과 달리 voice data 등을 건드리지 않는다.
+      await tx.execute({
+        sql: `UPDATE subscriptions
+              SET status = 'expired', updated_at = datetime('now')
+              WHERE user_id = ? AND status = 'active'`,
+        args: [userPk],
+      });
+
+      await tx.execute({
+        sql: `INSERT INTO subscriptions (
+                id, user_id, plan_id, plan_group_id, status,
+                starts_at, expires_at,
+                apple_transaction_id, apple_original_transaction_id, apple_product_id
+              ) VALUES (?, ?, ?, NULL, 'active', ?, ?, ?, ?, ?)`,
+        args: [
+          subscriptionId,
+          userPk,
+          plan.id,
+          startsAtIso,
+          expiresAtIso,
+          transaction_id,
+          original_transaction_id,
+          product_id,
+        ],
+      });
+
+      await tx.execute({
+        sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+        args: [planTypeToUserPlan(plan.plan_type), userPk],
+      });
+    });
+  } catch (err) {
+    // DB 미초기화 / unique 충돌 / 트랜잭션 실패 등 — 클라이언트는 StoreKit 권위에 의지하고
+    // 다음 사이클에서 재시도하므로 5xx 로 graceful degradation.
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return c.json(
+      { error: 'Failed to persist Apple subscription', error_code: 'APPLE_PERSIST_FAILED', detail: message },
+      500,
+    );
+  }
+
+  return c.json({
+    subscription_id: subscriptionId,
+    plan: plan.key,
+    expires_at: expiresAtIso,
+  });
+});
+
+export default billingApple;

--- a/packages/backend/src/routes/billing-helpers.ts
+++ b/packages/backend/src/routes/billing-helpers.ts
@@ -11,6 +11,40 @@ export function planTypeToUserPlan(planType: string): 'free' | 'plus' | 'family'
   return 'free';
 }
 
+/**
+ * iOS StoreKit2 productID → 백엔드 plans.key 매핑.
+ *
+ * App Store Connect 등록 SKU (`apps/ios-native/.../SubscriptionProduct.swift`) 와
+ * 백엔드 plans 시드 (`migrations.ts` id=6,26) 를 잇는 단일 진실 공급원.
+ *
+ * 매핑 규칙:
+ *   - `*_personal_*` (월/연) → plans.key='personal'  (개인)
+ *   - `*_couple_*`   (월/연) → plans.key='couple'    (커플 — family plan_type, max_members=2)
+ *   - `*_family_*`   (월/연) → plans.key='family'    (가족 — family plan_type, max_members=6)
+ *
+ * 알려지지 않은 productID 는 null. 호출자가 400 응답을 내야 함.
+ */
+const APPLE_PRODUCT_PREFIX = 'com.voicealarm.nativeapp.ios.';
+
+const APPLE_PRODUCT_TO_PLAN_KEY: Record<string, 'personal' | 'couple' | 'family'> = {
+  [`${APPLE_PRODUCT_PREFIX}personal_monthly`]: 'personal',
+  [`${APPLE_PRODUCT_PREFIX}personal_yearly`]: 'personal',
+  [`${APPLE_PRODUCT_PREFIX}couple_monthly`]: 'couple',
+  [`${APPLE_PRODUCT_PREFIX}couple_yearly`]: 'couple',
+  [`${APPLE_PRODUCT_PREFIX}family_monthly`]: 'family',
+  [`${APPLE_PRODUCT_PREFIX}family_yearly`]: 'family',
+};
+
+export function applePeriodFromProductId(productId: string): 'monthly' | 'yearly' | null {
+  if (productId.endsWith('_monthly')) return 'monthly';
+  if (productId.endsWith('_yearly')) return 'yearly';
+  return null;
+}
+
+export function applePlanKeyFromProductId(productId: string): 'personal' | 'couple' | 'family' | null {
+  return APPLE_PRODUCT_TO_PLAN_KEY[productId] ?? null;
+}
+
 export function isPaidVoicePlan(plan: unknown): boolean {
   return typeof plan === 'string' && PAID_USER_PLANS.has(plan);
 }

--- a/packages/backend/src/routes/billing.ts
+++ b/packages/backend/src/routes/billing.ts
@@ -2,9 +2,11 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import billingQuery from './billing-query';
 import billingMutation from './billing-mutation';
+import billingApple from './billing-apple';
 
 const billing = new Hono<AppEnv>();
 billing.route('/', billingQuery);
 billing.route('/', billingMutation);
+billing.route('/', billingApple);
 
 export default billing;

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -5,6 +5,12 @@ export interface Env {
   TURSO_AUTH_TOKEN: string;
   GOOGLE_CLIENT_ID: string;
   APPLE_CLIENT_ID?: string;
+  /**
+   * App Store Connect 의 "Apple shared secret" — 본 phase 에서는 클라이언트가 보낸
+   * transaction 데이터가 신뢰 가능한 서버 환경에서 전달됐는지 표시하기 위한 게이트로 사용.
+   * 후속 PR 에서 Apple App Store Server API v2 의 JWS 검증으로 강화 예정. README 참조.
+   */
+  APPLE_SHARED_SECRET?: string;
   GOOGLE_VERTEX_CREDENTIALS_JSON?: string;
   GOOGLE_VERTEX_API_KEY?: string;
   GEMINI_API_KEY?: string;

--- a/packages/backend/test/auth-middleware.test.ts
+++ b/packages/backend/test/auth-middleware.test.ts
@@ -401,6 +401,32 @@ describe('authMiddleware — Apple token', () => {
     expect(body.userId).toBe('apple-user-002');
     expect(body.userEmail).toBe('');
   });
+
+  // 회귀: Authorization 헤더로 직접 Apple id_token 을 들고 오는 경로는
+  // nonce 비교가 불가능하므로 (raw nonce 가 없음) 기존 동작이 유지되어야 한다.
+  // 즉 토큰에 nonce 클레임이 있어도 미들웨어는 통과시킨다.
+  it('토큰에 nonce 클레임이 있어도 미들웨어는 nonce 검사 없이 통과한다', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const payload = {
+        sub: 'apple-user-mw-nonce',
+        email: 'mw-nonce@apple.com',
+        iss: 'https://appleid.apple.com',
+        aud: ENV.APPLE_CLIENT_ID,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        nonce: 'a'.repeat(64),
+      };
+      const token = await signedAppleToken(payload);
+
+      const app = buildApp();
+      const res = await reqWithEnv(app, req(`Bearer ${token}`));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.userId).toBe('apple-user-mw-nonce');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe('authMiddleware — 토큰 발급자 분기', () => {

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -621,6 +621,142 @@ describe('POST /auth/apple', () => {
     const body = await res.json();
     expect(body.error_code).toBe('AUTH_APPLE_CONFIG_MISSING');
   });
+
+  it('nonce 일치 시 200을 반환한다', async () => {
+    const rawNonce = 'nonce-replay-defense-1234';
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(rawNonce),
+    );
+    const nonceHash = Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+
+    const appleToken = await signedAppleToken({
+      sub: 'apple-user-nonce-ok',
+      email: 'nonce-ok@icloud.com',
+      iss: 'https://appleid.apple.com',
+      aud: 'com.voicealarm.nativeapp.ios',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nonce: nonceHash,
+    });
+
+    mockDB.pushResult([]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/apple', {
+        id_token: appleToken,
+        nonce: rawNonce,
+      }),
+      undefined,
+      { ...ENV, APPLE_CLIENT_ID: 'com.voicealarm.nativeapp.ios' },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.id).toBe('apple-user-nonce-ok');
+  });
+
+  it('nonce 불일치 시 401 AUTH_APPLE_NONCE_MISMATCH 를 반환한다', async () => {
+    const rawNonce = 'client-nonce-AAAA-1234567890';
+    const otherDigest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode('SOMETHING-ELSE-1234567890'),
+    );
+    const wrongNonceHash = Array.from(new Uint8Array(otherDigest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+
+    const appleToken = await signedAppleToken({
+      sub: 'apple-user-nonce-bad',
+      email: 'nonce-bad@icloud.com',
+      iss: 'https://appleid.apple.com',
+      aud: 'com.voicealarm.nativeapp.ios',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nonce: wrongNonceHash,
+    });
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/apple', {
+        id_token: appleToken,
+        nonce: rawNonce,
+      }),
+      undefined,
+      { ...ENV, APPLE_CLIENT_ID: 'com.voicealarm.nativeapp.ios' },
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe('AUTH_APPLE_NONCE_MISMATCH');
+  });
+
+  it('nonce 미전달 + 토큰에도 nonce 없음 → 200 + console.warn', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const appleToken = await signedAppleToken({
+        sub: 'apple-user-no-nonce',
+        email: 'no-nonce@icloud.com',
+        iss: 'https://appleid.apple.com',
+        aud: 'com.voicealarm.nativeapp.ios',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      mockDB.pushResult([]);
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1);
+
+      const app = buildApp();
+      const res = await app.request(
+        jsonReq('POST', '/auth/apple', {
+          id_token: appleToken,
+        }),
+        undefined,
+        { ...ENV, APPLE_CLIENT_ID: 'com.voicealarm.nativeapp.ios' },
+      );
+
+      expect(res.status).toBe(200);
+      const warnCalls = warnSpy.mock.calls.map((call) => String(call[0] ?? ''));
+      expect(warnCalls.some((msg) => msg.includes('nonce'))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('토큰엔 nonce 클레임 있는데 요청 nonce 없으면 401 mismatch', async () => {
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode('some-raw-nonce-1234567890'),
+    );
+    const nonceHash = Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+
+    const appleToken = await signedAppleToken({
+      sub: 'apple-user-token-has-nonce',
+      email: 'token-nonce@icloud.com',
+      iss: 'https://appleid.apple.com',
+      aud: 'com.voicealarm.nativeapp.ios',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      nonce: nonceHash,
+    });
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/apple', {
+        id_token: appleToken,
+      }),
+      undefined,
+      { ...ENV, APPLE_CLIENT_ID: 'com.voicealarm.nativeapp.ios' },
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe('AUTH_APPLE_NONCE_MISMATCH');
+  });
 });
 
 describe('GET /auth/me', () => {

--- a/packages/backend/test/billing-apple.test.ts
+++ b/packages/backend/test/billing-apple.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv, Env } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import billingApple from '../src/routes/billing-apple';
+
+const PLAN_PERSONAL = {
+  id: '70000000-0000-4000-8000-000000000002',
+  key: 'personal',
+  plan_type: 'personal',
+  period_days: 30,
+  is_active: 1,
+};
+
+const ENV: Env = {
+  PERSO_API_KEY: 'x',
+  ELEVENLABS_API_KEY: 'x',
+  TURSO_DATABASE_URL: 'x',
+  TURSO_AUTH_TOKEN: 'x',
+  GOOGLE_CLIENT_ID: 'x',
+  APPLE_SHARED_SECRET: 'shared-secret-test',
+  JWT_SECRET: 'test-secret-32-chars-or-longer-pls!',
+  PASSWORD_PEPPER: 'pepper-test',
+  ENVIRONMENT: 'test',
+};
+
+const ENV_NO_SECRET: Env = { ...ENV, APPLE_SHARED_SECRET: undefined };
+
+function buildApp(userId = 'google-1', withAuth = true) {
+  const app = new Hono<AppEnv>();
+  if (withAuth) app.use('*', fakeAuthMiddleware(userId));
+  app.route('/billing', billingApple);
+  return app;
+}
+
+const VALID_BODY = {
+  transaction_id: 'apple-tx-1',
+  original_transaction_id: 'apple-orig-1',
+  product_id: 'com.voicealarm.nativeapp.ios.personal_monthly',
+};
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+describe('POST /billing/apple/confirm', () => {
+  it('정상 confirm 시 200, plan/expires_at/subscription_id 반환', async () => {
+    // 호출 순서: resolveUserPk → 멱등 lookup → plan lookup → UPDATE old → INSERT → UPDATE users.
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([]); // idempotent lookup empty
+    mockDB.pushResult([PLAN_PERSONAL]); // plan lookup
+    mockDB.pushResult([], 1); // UPDATE old subs → expired
+    mockDB.pushResult([], 1); // INSERT subscriptions
+    mockDB.pushResult([], 1); // UPDATE users SET plan
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plan).toBe('personal');
+    expect(typeof body.subscription_id).toBe('string');
+    expect(typeof body.expires_at).toBe('string');
+
+    // INSERT subscriptions 호출에 apple_* 컬럼이 채워져야 함.
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO subscriptions'));
+    expect(insert).toBeDefined();
+    expect(insert!.args).toContain('apple-tx-1');
+    expect(insert!.args).toContain('apple-orig-1');
+    expect(insert!.args).toContain('com.voicealarm.nativeapp.ios.personal_monthly');
+
+    // users.plan 이 'plus' (personal → plus) 로 업데이트.
+    const userUpdate = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
+    expect(userUpdate?.args[0]).toBe('plus');
+  });
+
+  it('알 수 없는 product_id 시 400 UNKNOWN_PRODUCT', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', {
+        ...VALID_BODY,
+        product_id: 'com.voicealarm.nativeapp.ios.bogus_plan',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe('UNKNOWN_PRODUCT');
+  });
+
+  it('인증된 사용자가 DB 에 없으면 404 USER_NOT_FOUND', async () => {
+    // billingApple 자체에 auth 가 없으므로 resolveUserPk 가 fakeAuth 의 userId 로 DB 조회 → 미일치.
+    mockDB.pushResult([]); // resolveUserPk: users row 없음
+
+    const res = await buildApp('unknown-user').request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error_code).toBe('USER_NOT_FOUND');
+  });
+
+  it('APPLE_SHARED_SECRET 미설정 시 503', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV_NO_SECRET,
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error_code).toBe('APPLE_BILLING_UNCONFIGURED');
+  });
+
+  it('동일 transaction_id 재호출 시 멱등 (200, 같은 응답)', async () => {
+    // 1차: 정상 confirm.
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([]); // idempotent lookup empty
+    mockDB.pushResult([PLAN_PERSONAL]); // plan lookup
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const first = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV,
+    );
+    const firstBody = await first.json();
+    expect(first.status).toBe(200);
+
+    // 2차: 같은 transaction_id 가 이미 존재한다고 mock.
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([
+      {
+        sub_id: firstBody.subscription_id,
+        expires_at: firstBody.expires_at,
+        plan_key: 'personal',
+      },
+    ]); // idempotent lookup → 기존 row
+
+    const second = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV,
+    );
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.subscription_id).toBe(firstBody.subscription_id);
+    expect(secondBody.plan).toBe('personal');
+    expect(secondBody.expires_at).toBe(firstBody.expires_at);
+  });
+
+  it('DB 미초기화 등 plan 조회 실패 시 graceful 에러 응답', async () => {
+    // plan 시드가 빠진 환경에선 PLAN_NOT_FOUND 400 으로 graceful 거부.
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([]); // idempotent lookup empty
+    mockDB.pushResult([]); // plan lookup empty (DB 시드 미적용)
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe('PLAN_NOT_FOUND');
+  });
+});

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -25,6 +25,11 @@ crons = ["*/5 * * * *"]
 # FIREBASE_PROJECT_ID = ""
 # JWT_SECRET = ""          # 자체 발급 JWT HS256 서명 시크릿 (최소 32자 권장)
 # PASSWORD_PEPPER = ""     # bcrypt 해싱 전에 비밀번호에 덧붙일 서버측 페퍼
+# GOOGLE_CLIENT_ID = ""    # Google Sign In OAuth audience (web client ID)
+# APPLE_CLIENT_ID = "com.voicealarm.nativeapp.ios"  # Apple Sign In bundle ID (run: wrangler secret put APPLE_CLIENT_ID)
+# APPLE_SHARED_SECRET = ""  # App Store Connect → 앱 → "앱 전용 공유 비밀(App-Specific Shared Secret)".
+#                             POST /api/billing/apple/confirm 게이트로 사용. 미설정 시 503. 후속 PR 에서
+#                             Apple App Store Server API v2 JWS 검증 시 동일 secret 을 재사용.
 # RESEND_API_KEY = ""      # 회원가입 이메일 인증 코드 발송용
 # AUTH_EMAIL_FROM = ""     # 예: Voice Alarm <no-reply@your-domain.com>
 # AUTH_EMAIL_REPLY_TO = ""

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -43,6 +43,9 @@ export const AppleLoginRequestSchema = z.object({
   id_token: z.string().min(1),
   email: z.string().email().optional(),
   name: z.string().min(1).max(64).optional(),
+  // 클라이언트가 SecRandomCopyBytes 로 생성한 raw nonce.
+  // 서버는 이 값을 SHA256 해싱해 id_token.nonce 와 비교한다.
+  nonce: z.string().min(16).max(128).optional(),
 });
 export type AppleLoginRequest = z.infer<typeof AppleLoginRequestSchema>;
 


### PR DESCRIPTION
## 요약

iOS PoC 와 함께 운영될 백엔드 변경을 단독으로 분리한 PR. iOS UI/코어 변경(PR #2, #3) 과 영역이 겹치지 않아 독립 머지 가능.

Refs #326

## 변경 영역

### Apple Sign In nonce replay 방어
- `packages/backend/src/lib/oauth.ts`: `verifyAppleIdToken(_, _, expectedNonceHash?)` 시그니처 확장. payload.nonce 와 서버 측 SHA-256(raw) 비교.
- `packages/backend/src/routes/auth.ts`: 요청 raw nonce 수신, SHA-256 변환 후 검증. token에 nonce 클레임이 있는데 요청 nonce 가 없으면 명시적 401 mismatch.
- `packages/shared/src/schemas/auth.ts`: `AppleLoginRequestSchema` 에 `nonce: z.string().min(16).max(128).optional()`.

### apple_user_id 응답 노출
- `/api/auth/apple`, `/api/auth/me` 응답에 `apple_user_id` 포함 → iOS 가 `ASAuthorizationAppleIDProvider.getCredentialState(forUserID:)` 호출하기 위한 식별자.

### Billing — IAP confirm
- `packages/backend/src/routes/billing-apple.ts`: `POST /api/billing/apple/confirm` 신규. transactionID / originalTransactionID / productID 받아 SKU 화이트리스트 검증, 멱등성 lookup, write transaction (subscriptions INSERT + users.plan UPDATE), `{ subscription_id, plan, expires_at }` 응답.
- `packages/backend/src/routes/billing-helpers.ts`: 6종 SKU → plan key 매핑 헬퍼.
- `packages/backend/src/routes/billing.ts`: billing-apple 라우터 마운트.
- `packages/backend/src/lib/migrations.ts`: 마이그레이션 36 \`subscriptions-apple-fields\` (apple_transaction_id / apple_original_transaction_id / apple_product_id + 멱등 부분 유니크 인덱스).

### 운영/시크릿
- `packages/backend/wrangler.toml`: \`APPLE_CLIENT_ID\` / \`APPLE_SHARED_SECRET\` 시크릿 주석 추가.
- `packages/backend/README.md`: Apple 로그인 nonce 정책 + IAP confirm 운영 절차 + \`wrangler secret put\` 명령.

### Env 타입
- `packages/backend/src/types.ts`: \`APPLE_CLIENT_ID?\`, \`APPLE_SHARED_SECRET?\` 추가.

## 테스트 plan

- `npm run typecheck` (packages/backend)
- `npm test` (packages/backend) — 신규 케이스 포함:
  - **auth.test.ts**: nonce 일치 200 / 불일치 401 (AUTH_APPLE_NONCE_MISMATCH) / 클라이언트 미전달 200+warn / token-only 401 mismatch
  - **auth-middleware.test.ts**: Apple ID 토큰 미들웨어 경로 정합성 2건
  - **billing-apple.test.ts**: 정상 200 / UNKNOWN_PRODUCT 400 / USER_NOT_FOUND 404 / APPLE_BILLING_UNCONFIGURED 503 / 동일 transaction_id 재호출 멱등 200 / PLAN_NOT_FOUND 400
- 기존 1314 개 케이스 회귀 0건 확인 필요

## 배포 시 필요한 시크릿

\`\`\`bash
cd packages/backend
wrangler secret put APPLE_CLIENT_ID    # 값: com.voicealarm.nativeapp.ios
wrangler secret put APPLE_SHARED_SECRET # App Store Connect → App Information → App-Specific Shared Secret
\`\`\`

## 의존성

- iOS 클라이언트 측 nonce 송출은 PR #3 (iOS 코어) 에 포함. 본 PR 단독 머지는 안전 (기존 nonce 없는 호출도 통과).
- iOS 의 \`SubscriptionManager.confirmAppleSubscription\` 호출 라우트 매칭은 PR #3 에 포함.

## 후속 로드맵

- Apple App Store Server API v2 의 X5C JWS 체인 검증 강화 (현재는 클라이언트 transaction_id 신뢰 + SKU 화이트리스트만)
- App Store Server Notifications V2 webhook 수신으로 환불/취소/갱신 자동 반영