### PR TITLE
fix: iOS-Android 알람 정합성 강화

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/AuthApi.kt
@@ -19,6 +19,7 @@ data class AuthUser(
     val email: String,
     val name: String = "",
     val plan: String = "free",
+    @SerializedName("apple_user_id") val appleUserId: String? = null,
     @SerializedName("allow_family_alarms") val allowFamilyAlarms: Boolean = false,
     @SerializedName("family_alarm_quiet_days") val familyAlarmQuietDays: List<Int> = listOf(1, 2, 3, 4, 5),
     @SerializedName("family_alarm_quiet_start") val familyAlarmQuietStart: String = "09:00",

--- a/apps/ios-native/README.md
+++ b/apps/ios-native/README.md
@@ -131,7 +131,9 @@ xcodegen 후 Xcode 에서:
 
 ### 백엔드 요구 사항
 
-`SubscriptionManager` 는 결제 성공 후 즉시 `POST /api/billing/apple/confirm` 라우트를 호출해 백엔드 `subscriptions` 테이블의 entitlement 를 동기화한다. 백엔드는 Apple App Store Server API (`https://api.storekit.itunes.apple.com/inApps/v1/transactions/{transactionId}`) 를 사용해 transaction 의 진위와 만료일을 검증해야 한다.
+`SubscriptionManager` 는 결제 성공 후 즉시 `POST /api/billing/apple/confirm` 라우트를 호출해 백엔드 entitlement 동기화를 시도한다. 백엔드는 Apple App Store Server API (`https://api.storekit.itunes.apple.com/inApps/v1/transactions/{transactionId}`) 로 transaction 의 진위와 만료일을 검증한 뒤에만 `subscriptions` 테이블을 갱신해야 한다.
+
+현재 백엔드 라우트는 server-to-server 검증이 구현되기 전까지 fail-closed 로 동작한다. 유효한 SKU 여도 501 `APPLE_TRANSACTION_VERIFICATION_REQUIRED` 를 반환하며 DB entitlement 를 변경하지 않는다. iOS 클라이언트는 StoreKit `currentEntitlements` 를 로컬 권위로 사용하고, 서버 검증 구현 후 foreground 진입 시 `resyncEntitlements()` 로 catch-up 한다.
 
 **라우트가 아직 배포되지 않은 경우**: 클라이언트는 graceful degradation 한다. StoreKit `currentEntitlements` 가 권위이므로 `currentTier` 는 정확하게 계산되며, 백엔드 plan/subscription row 만 갱신되지 않을 뿐이다. 백엔드 라우트가 배포된 후 다음 foreground 진입 시 자동 catch-up 된다 (`VoiceAlarmApp.swift` 의 `.active` 분기에서 `resyncEntitlements()` 가 호출됨).
 
@@ -145,7 +147,7 @@ xcodegen 후 Xcode 에서:
 }
 ```
 
-응답 페이로드 (`ConfirmAppleSubscriptionResponse`):
+서버 검증 구현 후 응답 페이로드 (`ConfirmAppleSubscriptionResponse`):
 
 ```json
 {

--- a/apps/ios-native/VoiceAlarm/AlarmAppContext.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmAppContext.swift
@@ -19,13 +19,13 @@ import Foundation
 //   1. 컴파일 순서 독립성 — B2 가 B5 보다 먼저 머지될 수 있다.
 //   2. 테스트에서 mock 주입이 자명해진다 (`AlarmAppContextTests` 참고).
 //   3. clientNonce 멱등성 검증을 store 내부 책임으로 떠넘긴다.
-public enum CharacterEventKind: String, Sendable {
+enum CharacterEventKind: String, Sendable {
     case alarmCompleted = "alarm_completed"
     case alarmSnoozed = "alarm_snoozed"
 }
 
 @MainActor
-public protocol CharacterEventQueueing: AnyObject {
+protocol CharacterEventQueueing: AnyObject {
     func queueAlarmEvent(
         eventType: CharacterEventKind,
         occurredAtMillis: Int64,
@@ -50,11 +50,11 @@ public protocol CharacterEventQueueing: AnyObject {
 //     줄에서). 두 인스턴스가 동시에 존재할 수 없는 이유: VoiceAlarmApp 은
 //     `@main` 단일 진입점이고 `@StateObject` 는 Scene 당 1회 init.
 @MainActor
-public final class AlarmAppContext {
-    public static var shared: AlarmAppContext?
+final class AlarmAppContext {
+    static var shared: AlarmAppContext?
 
-    public weak var store: LocalAlarmStore?
-    public weak var characterEvents: AnyObject?
+    weak var store: LocalAlarmStore?
+    weak var characterEvents: AnyObject?
 
     /// CharacterEventQueueing 으로 cast 해서 사용. weak any-protocol 은 Swift 에서
     /// 직접 표현이 까다로워 AnyObject 로 보관 후 호출 시점에 cast.
@@ -63,9 +63,9 @@ public final class AlarmAppContext {
     }
 
     /// `now()` 를 주입 가능하게 만들어 테스트에서 clock 을 고정한다.
-    public var nowProvider: () -> Date = { Date() }
+    var nowProvider: () -> Date = { Date() }
 
-    public init(
+    init(
         store: LocalAlarmStore,
         characterEvents: (AnyObject & CharacterEventQueueing)?
     ) {
@@ -80,7 +80,7 @@ public final class AlarmAppContext {
     /// 멱등성: clientNonce 가 `"{record.id}-stop-{record.updatedAtMillis}"` 형태로
     /// 같은 알람의 같은 stop 시점에 항상 같은 값을 만들도록 한다 — 두 경로가
     /// 1초 내 같은 stop 을 emit 해도 store 측 멱등 검사에서 한 번만 처리된다.
-    public func handleAlarmStopped(alarmKitIDString: String) async {
+    func handleAlarmStopped(alarmKitIDString: String) async {
         guard let store else { return }
         let recordBeforeStop = store.recordByAlarmKitID(alarmKitIDString)
         // markStopped 는 alarmKitID 매칭이 안 되면 no-op 이므로 안전.
@@ -109,14 +109,20 @@ public final class AlarmAppContext {
 
     // MARK: - Snooze
 
+    func canSnooze(alarmKitIDString: String) -> Bool {
+        guard let record = store?.recordByAlarmKitID(alarmKitIDString) else { return false }
+        return record.canSnooze
+    }
+
     /// LiveActivity 의 Snooze 버튼이 눌렸을 때 호출.
     /// snoozeMinutesOverride 가 nil 이면 record.snoozeMinutes 사용.
-    public func handleAlarmSnoozed(
+    func handleAlarmSnoozed(
         alarmKitIDString: String,
         snoozeMinutesOverride: Int? = nil
     ) async {
         guard let store else { return }
         guard let record = store.recordByAlarmKitID(alarmKitIDString) else { return }
+        guard record.canSnooze else { return }
 
         let now = nowProvider()
         let minutes = snoozeMinutesOverride ?? record.snoozeMinutes
@@ -153,7 +159,7 @@ public final class AlarmAppContext {
 extension LocalAlarmStore {
     /// 명세에서 요구하는 alias. 기존 `record(alarmKitID:)` 와 동일하지만
     /// 호출 사이트에서 의도가 더 명시적이다.
-    public func recordByAlarmKitID(_ alarmKitID: String) -> LocalAlarmRecord? {
+    func recordByAlarmKitID(_ alarmKitID: String) -> LocalAlarmRecord? {
         record(alarmKitID: alarmKitID)
     }
 }

--- a/apps/ios-native/VoiceAlarm/AlarmEnums.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmEnums.swift
@@ -112,14 +112,12 @@ enum VibrationPattern: String, Codable, CaseIterable {
 
 // MARK: - Snooze Repeat Limit
 // Android: `AlarmEntity.kt:158-164` `SnoozeRepeatLimits` (3 / 5 / 0=무제한).
-// 사양 문서에서 "once = 1" 도 명시. 모두 보존.
 enum SnoozeRepeatLimit: Int, Codable, CaseIterable {
     case unlimited = 0
-    case once = 1
     case three = 3
     case five = 5
 
-    static var validValues: [Int] { allCases.map(\.rawValue) }
+    static var validValues: [Int] { [three.rawValue, five.rawValue, unlimited.rawValue] }
     static func isValid(_ value: Int) -> Bool { validValues.contains(value) }
 }
 

--- a/apps/ios-native/VoiceAlarm/AlarmIntents.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmIntents.swift
@@ -92,6 +92,10 @@ struct SnoozeAlarmIntent: LiveActivityIntent {
         guard let uuid = UUID(uuidString: alarmID) else {
             return .result()
         }
+        if let ctx = AlarmAppContext.shared,
+           !ctx.canSnooze(alarmKitIDString: uuid.uuidString) {
+            return .result()
+        }
         do {
             try AlarmManager.shared.countdown(id: uuid)
         } catch {

--- a/apps/ios-native/VoiceAlarm/AlarmKitViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmKitViewModel.swift
@@ -87,7 +87,6 @@ final class AlarmKitViewModel: ObservableObject {
             .subtracting(currentIDs)
         for kitID in disappearedIDs {
             let recordExisted = store.recordByAlarmKitID(kitID) != nil
-            store.markStopped(alarmKitID: kitID)
             // In-app voice fallback 재생 중이면 정지 (AlarmKit 자체 stop 과 별개).
             AlarmVoicePlayer.shared.stop()
             // CharacterEvent emit (LiveActivity 가 아닌 경로의 stop 도 포함).
@@ -95,6 +94,8 @@ final class AlarmKitViewModel: ObservableObject {
             // 가 이미 queue 했다면 store 측에서 중복 제거가 된다.
             if recordExisted, let ctx = AlarmAppContext.shared {
                 await ctx.handleAlarmStopped(alarmKitIDString: kitID)
+            } else {
+                store.markStopped(alarmKitID: kitID)
             }
         }
 
@@ -171,7 +172,8 @@ final class AlarmKitViewModel: ObservableObject {
         await schedule(record: record, store: store)
     }
 
-    func schedule(record: LocalAlarmRecord, store: LocalAlarmStore) async {
+    @discardableResult
+    func schedule(record: LocalAlarmRecord, store: LocalAlarmStore) async -> Bool {
         #if canImport(AlarmKit)
         do {
             if AlarmManager.shared.authorizationState != .authorized {
@@ -179,7 +181,7 @@ final class AlarmKitViewModel: ObservableObject {
                 authorizationLabel = String(describing: state)
                 guard state == .authorized else {
                     statusMessage = "AlarmKit permission is required before scheduling."
-                    return
+                    return false
                 }
             }
             let id = UUID()
@@ -198,31 +200,43 @@ final class AlarmKitViewModel: ObservableObject {
             _ = try await AlarmManager.shared.schedule(id: id, configuration: configuration)
             store.markScheduled(localID: record.id, alarmKitID: id.uuidString)
             statusMessage = describeScheduleStatus(record: record, resolution: resolution)
+            return true
         } catch {
             statusMessage = "Schedule failed: \(error.localizedDescription)"
+            return false
         }
         #else
         statusMessage = "AlarmKit is unavailable in this SDK."
+        return false
+        #endif
+    }
+
+    @discardableResult
+    func cancelScheduledAlarm(record: LocalAlarmRecord) async -> Bool {
+        #if canImport(AlarmKit)
+        guard let alarmKitUUID = record.alarmKitUUID else { return true }
+        do {
+            try AlarmManager.shared.cancel(id: alarmKitUUID)
+            statusMessage = "Canceled \(record.label)"
+            return true
+        } catch {
+            statusMessage = "Cancel failed: \(error.localizedDescription)"
+            return false
+        }
+        #else
+        statusMessage = "AlarmKit is unavailable in this SDK."
+        return false
         #endif
     }
 
     func cancel(record: LocalAlarmRecord, store: LocalAlarmStore) async {
-        #if canImport(AlarmKit)
-        guard let alarmKitUUID = record.alarmKitUUID else {
+        guard record.alarmKitUUID != nil else {
             store.delete(record)
             return
         }
-        do {
-            try AlarmManager.shared.cancel(id: alarmKitUUID)
+        if await cancelScheduledAlarm(record: record) {
             store.delete(record)
-            statusMessage = "Canceled \(record.label)"
-        } catch {
-            statusMessage = "Cancel failed: \(error.localizedDescription)"
         }
-        #else
-        store.delete(record)
-        statusMessage = "AlarmKit is unavailable in this SDK."
-        #endif
     }
 
     #if canImport(AlarmKit)

--- a/apps/ios-native/VoiceAlarm/AudioCacheStore.swift
+++ b/apps/ios-native/VoiceAlarm/AudioCacheStore.swift
@@ -7,6 +7,7 @@ struct CachedVoiceAudio: Equatable {
     var url: URL
     var fileName: String
     var format: String
+    var cacheKey: String
 }
 
 // MARK: - AudioCacheMetadata
@@ -85,7 +86,7 @@ final class AudioCacheStore {
             enforceMaxDuration: false  // tts 길이는 서버가 보장. 한도는 메타에만.
         )
 
-        return CachedVoiceAudio(url: url, fileName: fileName, format: format)
+        return CachedVoiceAudio(url: url, fileName: fileName, format: format, cacheKey: cacheKey)
     }
 
     /// Legacy URL 조회. messageId 기반 파일명용.

--- a/apps/ios-native/VoiceAlarm/CharacterEventEntity.swift
+++ b/apps/ios-native/VoiceAlarm/CharacterEventEntity.swift
@@ -22,22 +22,22 @@ import Foundation
 //                          도 body 에 context 를 싣지 않음).
 //   - attempts            : 재시도 횟수. 백오프/관측 용도.
 //   - updatedAtMillis     : 마지막 상태 변경 시점.
-public struct CharacterEventEntity: Codable, Identifiable, Equatable, Hashable {
-    public let id: String
-    public let eventType: String
-    public let occurredAtMillis: Int64
-    public let clientNonce: String
-    public let localDate: String
-    public let sourceAlarmId: String?
-    public let contextJson: String?
-    public var syncState: String
-    public var attempts: Int
-    public var lastError: String?
-    public let createdAtMillis: Int64
-    public var syncedAtMillis: Int64?
-    public var updatedAtMillis: Int64
+struct CharacterEventEntity: Codable, Identifiable, Equatable, Hashable {
+    let id: String
+    let eventType: String
+    let occurredAtMillis: Int64
+    let clientNonce: String
+    let localDate: String
+    let sourceAlarmId: String?
+    let contextJson: String?
+    var syncState: String
+    var attempts: Int
+    var lastError: String?
+    let createdAtMillis: Int64
+    var syncedAtMillis: Int64?
+    var updatedAtMillis: Int64
 
-    public init(
+    init(
         id: String,
         eventType: String,
         occurredAtMillis: Int64,
@@ -73,12 +73,12 @@ public struct CharacterEventEntity: Codable, Identifiable, Equatable, Hashable {
 // Android 의 `CharacterEventTypes` / `CharacterEventStates` (string const 객체) 를
 // Swift enum 으로 포팅. rawValue 는 서버 contract 와 동일하게 snake_case 유지.
 
-public enum CharacterEventType: String, Codable, CaseIterable, Sendable {
+enum CharacterEventType: String, Codable, CaseIterable, Sendable {
     case alarmCompleted = "alarm_completed"
     case alarmSnoozed = "alarm_snoozed"
 }
 
-public enum CharacterEventSyncState: String, Codable, Sendable {
+enum CharacterEventSyncState: String, Codable, Sendable {
     case pending
     case synced
     case failed

--- a/apps/ios-native/VoiceAlarm/CharacterEventStore.swift
+++ b/apps/ios-native/VoiceAlarm/CharacterEventStore.swift
@@ -7,14 +7,14 @@ import Foundation
 // 분단위 sync 가 아니라 앱 활성화/포그라운드 진입 시점 sync 라 JSON 으로 충분.
 //
 // `actor` 로 격리해 store mutation 과 디스크 I/O 가 직렬화되도록 한다.
-public actor CharacterEventPersistence {
-    public let url: URL
+actor CharacterEventPersistence {
+    let url: URL
 
-    public init(url: URL) {
+    init(url: URL) {
         self.url = url
     }
 
-    public init() {
+    init() {
         let dir = (try? FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,
@@ -24,16 +24,16 @@ public actor CharacterEventPersistence {
         self.url = dir.appendingPathComponent("character-events.json")
     }
 
-    public static var `default`: CharacterEventPersistence { CharacterEventPersistence() }
+    static var `default`: CharacterEventPersistence { CharacterEventPersistence() }
 
-    public func save(events: [CharacterEventEntity]) async {
+    func save(events: [CharacterEventEntity]) async {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         guard let data = try? encoder.encode(events) else { return }
         try? data.write(to: url, options: .atomic)
     }
 
-    public func load() async -> [CharacterEventEntity] {
+    func load() async -> [CharacterEventEntity] {
         guard let data = try? Data(contentsOf: url) else { return [] }
         let decoder = JSONDecoder()
         guard let events = try? decoder.decode([CharacterEventEntity].self, from: data) else {
@@ -50,7 +50,7 @@ public actor CharacterEventPersistence {
 //
 // API 의존성을 protocol 로 분리해 테스트 시 mock 주입을 자명하게 만든다.
 // 실제 구현은 `VoiceAlarmAPI` 의 extension 으로 conform.
-public protocol CharacterXPGranting: AnyObject {
+protocol CharacterXPGranting: AnyObject {
     func grantCharacterXP(
         event: String,
         clientNonce: String,
@@ -83,20 +83,20 @@ public protocol CharacterXPGranting: AnyObject {
 //     `buildClientNonce(alarmID:eventType:occurredAtMillis:timezone:)` 를 static 으로 노출.
 //     수동 grant 경로 또는 디버그 호출에서 사용.
 @MainActor
-public final class CharacterEventStore: ObservableObject {
-    @Published public private(set) var events: [CharacterEventEntity] = []
-    @Published public private(set) var isFlushing: Bool = false
-    @Published public private(set) var lastFlushSummary: FlushSummary?
+final class CharacterEventStore: ObservableObject {
+    @Published private(set) var events: [CharacterEventEntity] = []
+    @Published private(set) var isFlushing: Bool = false
+    @Published private(set) var lastFlushSummary: FlushSummary?
 
-    public struct FlushSummary: Equatable, Sendable {
-        public let total: Int
-        public let synced: Int
-        public let failed: Int
-        public let skipped: Int
-        public let finishedAtMillis: Int64
+    struct FlushSummary: Equatable, Sendable {
+        let total: Int
+        let synced: Int
+        let failed: Int
+        let skipped: Int
+        let finishedAtMillis: Int64
     }
 
-    public typealias TokenProvider = @MainActor () -> String?
+    typealias TokenProvider = @MainActor () -> String?
 
     private let api: CharacterXPGranting
     private let tokenProvider: TokenProvider
@@ -104,7 +104,7 @@ public final class CharacterEventStore: ObservableObject {
     private let calendarTimeZone: TimeZone
     private var nowProvider: () -> Date
 
-    public init(
+    init(
         api: CharacterXPGranting,
         tokenProvider: @escaping TokenProvider,
         persistence: CharacterEventPersistence = .default,
@@ -119,7 +119,7 @@ public final class CharacterEventStore: ObservableObject {
     }
 
     /// 초기 로드. `VoiceAlarmApp` `.task` 에서 1회 호출해 디스크 → 메모리 hydrate.
-    public func loadFromDisk() async {
+    func loadFromDisk() async {
         let loaded = await persistence.load()
         events = loaded
     }
@@ -129,7 +129,7 @@ public final class CharacterEventStore: ObservableObject {
     /// 멱등 큐 진입점. 동일 `clientNonce` 가 이미 있으면 (state 무관) skip 한다.
     /// SYNCED 인 nonce 가 다시 들어와도 무시 — 서버는 duplicated=true 를 반환할
     /// 뿐이지만, 굳이 또 호출할 이유가 없다.
-    public func queue(
+    func queue(
         eventType: CharacterEventType,
         occurredAtMillis: Int64,
         clientNonce: String,
@@ -168,7 +168,7 @@ public final class CharacterEventStore: ObservableObject {
     /// 백그라운드/포그라운드 재시도 진입점. token 이 없으면 즉시 return.
     /// 중복 호출은 isFlushing 가드로 한 번만 실행.
     @discardableResult
-    public func flushPending() async -> FlushSummary {
+    func flushPending() async -> FlushSummary {
         if isFlushing {
             return lastFlushSummary ?? FlushSummary(
                 total: 0,
@@ -247,7 +247,7 @@ public final class CharacterEventStore: ObservableObject {
     /// 알고리즘 (구분자만 `-` 로 통일 — AlarmAppContext 가 `record.id-stop-...` 형식을
     /// 쓰는 것과 시각적으로 호환). 멱등성 자체는 store 가 `events.contains(where:)`
     /// 로 보장하므로 구분자 차이는 무관.
-    public static func buildClientNonce(
+    static func buildClientNonce(
         alarmID: String,
         eventType: CharacterEventType,
         occurredAtMillis: Int64,
@@ -296,7 +296,7 @@ public final class CharacterEventStore: ObservableObject {
 // `AlarmAppContext` (Phase 2-B2) 가 사용하는 단일 진입점. 시그니처는 B2 의 protocol
 // 정의를 그대로 따른다 — 절대 변경 금지.
 extension CharacterEventStore: CharacterEventQueueing {
-    public func queueAlarmEvent(
+    func queueAlarmEvent(
         eventType: CharacterEventKind,
         occurredAtMillis: Int64,
         clientNonce: String,

--- a/apps/ios-native/VoiceAlarm/LocalAlarmStore.swift
+++ b/apps/ios-native/VoiceAlarm/LocalAlarmStore.swift
@@ -13,7 +13,7 @@ struct LocalAlarmRecord: Identifiable, Codable, Equatable, Hashable {
     var holidayOff: Bool
     var snoozeEnabled: Bool
     var snoozeMinutes: Int          // 1..30
-    var snoozeRepeatLimit: Int      // 0/1/3/5 (0 == 무제한)
+    var snoozeRepeatLimit: Int      // 0/3/5 (0 == 무제한)
     var snoozeCount: Int
     var vibrationPattern: String    // VibrationPattern.rawValue
     var playMode: String            // AlarmPlayMode.rawValue (alarm_only / voice_only / sound_then_voice)
@@ -56,6 +56,12 @@ struct LocalAlarmRecord: Identifiable, Codable, Equatable, Hashable {
 
     var hasVoiceAudio: Bool {
         ttsMessageId != nil || rawAudioUri != nil || localAudioUri != nil
+    }
+
+    var canSnooze: Bool {
+        snoozeEnabled &&
+            (snoozeRepeatLimit == SnoozeRepeatLimit.unlimited.rawValue ||
+                snoozeCount < snoozeRepeatLimit)
     }
 
     var timeString: String {
@@ -547,9 +553,24 @@ final class LocalAlarmStore: ObservableObject {
     /// AlarmKit alarmUpdates 에서 알람이 사라졌을 때 호출.
     func markStopped(alarmKitID: String) {
         guard let index = alarms.firstIndex(where: { $0.alarmKitID == alarmKitID }) else { return }
-        alarms[index].state = AlarmRuntimeState.dismissed.rawValue
-        alarms[index].enabled = false
-        alarms[index].updatedAtMillis = Int64(Date().timeIntervalSince1970 * 1000)
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        if alarms[index].repeatDaysMask != 0,
+           let nextFireAt = try? AlarmTimeCalculator.nextFireAtMillis(
+            hour: alarms[index].hour,
+            minute: alarms[index].minute,
+            repeatDaysMask: alarms[index].repeatDaysMask,
+            holidayOff: alarms[index].holidayOff,
+            nowMillis: now
+           ) {
+            alarms[index].fireAtMillis = nextFireAt
+            alarms[index].state = AlarmRuntimeState.armed.rawValue
+            alarms[index].enabled = true
+            alarms[index].snoozeCount = 0
+        } else {
+            alarms[index].state = AlarmRuntimeState.dismissed.rawValue
+            alarms[index].enabled = false
+        }
+        alarms[index].updatedAtMillis = now
         persist()
     }
 

--- a/apps/ios-native/VoiceAlarm/RemoteAlarmPullSync.swift
+++ b/apps/ios-native/VoiceAlarm/RemoteAlarmPullSync.swift
@@ -83,10 +83,13 @@ final class RemoteAlarmPullSync: @unchecked Sendable {
     // MARK: Merge
 
     /// 단일 remote 알람을 로컬 store 와 머지한다.
-    private func mergeRemote(remote: RemoteAlarm, mapped: LocalAlarmRecord, token: String) async {
+    private func mergeRemote(remote: RemoteAlarm, mapped initialMapped: LocalAlarmRecord, token: String) async {
+        var mapped = initialMapped
         if let existing = store.alarms.first(where: { $0.remoteAlarmId == remote.id }) {
             // 충돌 정책 + last write wins.
             guard Self.shouldApplyRemote(existing: existing, mapped: mapped) else { return }
+
+            mapped = await recordWithCachedTTSIfNeeded(mapped, token: token)
 
             // 기존 로컬 ID/alarmKitID/snoozeCount/state 는 보존해서 머지.
             let merged = Self.merge(existing: existing, mapped: mapped)
@@ -97,6 +100,8 @@ final class RemoteAlarmPullSync: @unchecked Sendable {
                 await rescheduleReceivedRemote(record: merged, existing: existing)
             }
         } else {
+            mapped = await recordWithCachedTTSIfNeeded(mapped, token: token)
+
             // 신규 import.
             store.upsert(mapped)
 
@@ -104,14 +109,6 @@ final class RemoteAlarmPullSync: @unchecked Sendable {
             if mapped.originEnum == .receivedRemote && mapped.enabled {
                 await alarmKit.schedule(record: mapped, store: store)
             }
-        }
-
-        // 3. TTS 음원 캐싱. cacheKey 가 있고 아직 디스크에 없으면 백그라운드로 다운로드.
-        if let cacheKey = mapped.audioCacheKey,
-           audioCache.cachedURL(for: cacheKey) == nil,
-           let messageId = mapped.ttsMessageId,
-           !messageId.isEmpty {
-            await fetchAndCacheTTS(messageId: messageId, cacheKey: cacheKey, token: token)
         }
     }
 
@@ -150,11 +147,12 @@ final class RemoteAlarmPullSync: @unchecked Sendable {
     }
 
     private func rescheduleReceivedRemote(record: LocalAlarmRecord, existing: LocalAlarmRecord) async {
-        // alarmKitID 가 있으면 먼저 cancel. cancel 이 실패해도 schedule 은 시도.
-        if existing.alarmKitID != nil {
-            await alarmKit.cancel(record: existing, store: store)
+        // 새 예약을 먼저 성공시킨 뒤 기존 AlarmKit ID 를 해제해 로컬 레코드가
+        // 삭제되거나 무예약 상태로 남는 일을 막는다.
+        let scheduled = await alarmKit.schedule(record: record, store: store)
+        if scheduled, existing.alarmKitID != nil {
+            await alarmKit.cancelScheduledAlarm(record: existing)
         }
-        await alarmKit.schedule(record: record, store: store)
     }
 
     // MARK: Cascade delete
@@ -190,5 +188,20 @@ final class RemoteAlarmPullSync: @unchecked Sendable {
         } catch {
             // 캐싱 실패는 sync 전체를 실패시키지 않는다. 다음 사이클에서 재시도.
         }
+    }
+
+    private func recordWithCachedTTSIfNeeded(_ record: LocalAlarmRecord, token: String) async -> LocalAlarmRecord {
+        var copy = record
+        guard let cacheKey = copy.audioCacheKey,
+              let messageId = copy.ttsMessageId,
+              !messageId.isEmpty else { return copy }
+
+        if audioCache.cachedURL(for: cacheKey) == nil {
+            await fetchAndCacheTTS(messageId: messageId, cacheKey: cacheKey, token: token)
+        }
+        if let cached = audioCache.cachedURL(for: cacheKey) {
+            copy.localAudioUri = cached.lastPathComponent
+        }
+        return copy
     }
 }

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
@@ -231,11 +231,6 @@ struct AlarmEditorSheet: View {
             store.alarms.first { $0.id == id }
         }
 
-        // 기존 record 가 있으면 우선 cancel — alarmKit ID 가 stale 해지지 않게.
-        if let existing {
-            await alarmKit.cancel(record: existing, store: store)
-        }
-
         let fireAt: Int64 = (try? AlarmTimeCalculator.nextFireAtMillis(
             hour: draft.hour,
             minute: draft.minute,
@@ -255,6 +250,7 @@ struct AlarmEditorSheet: View {
         if let prepared = voiceStudio.preparedAlarm, draft.playMode != .alarmOnly {
             merged.voiceSource = VoiceSource.serverTts.rawValue
             merged.localAudioUri = prepared.localAudioFileName
+            merged.audioCacheKey = prepared.audioCacheKey
             merged.rawAudioUri = prepared.rawAudioURL ?? merged.rawAudioUri
             merged.voiceProfileId = prepared.voiceProfileID
             merged.voiceText = prepared.text
@@ -263,7 +259,22 @@ struct AlarmEditorSheet: View {
         }
 
         store.upsert(merged)
-        await alarmKit.schedule(record: merged, store: store)
+        let scheduled = await alarmKit.schedule(record: merged, store: store)
+        guard scheduled else {
+            if let existing {
+                store.upsert(existing)
+            } else {
+                store.deleteByID(merged.id)
+            }
+            validationAlert = ValidationAlertContent(
+                title: "예약할 수 없어요",
+                message: alarmKit.statusMessage ?? "AlarmKit 예약에 실패했어요."
+            )
+            return
+        }
+        if let existing {
+            await alarmKit.cancelScheduledAlarm(record: existing)
+        }
         onSchedulingDidFinish()
     }
 

--- a/apps/ios-native/VoiceAlarm/Views/Editor/SnoozeRepeatLimitPicker.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/SnoozeRepeatLimitPicker.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
-/// 스누즈 반복 횟수(1 / 3 / 5 / 무제한) segmented selector.
+/// 스누즈 반복 횟수(3 / 5 / 무제한) segmented selector.
 ///
-/// Android `AlarmSettingsCard.kt` 의 `snoozeRepeatLabel` 4종을 칩 행으로
-/// 재현. `SnoozeRepeatLimit` 의 raw value(`0/1/3/5`) 와 양방향 바인딩한다.
+/// Android `AlarmSettingsCard.kt` 의 `snoozeRepeatLabel` 3종을 칩 행으로
+/// 재현. `SnoozeRepeatLimit` 의 raw value(`0/3/5`) 와 양방향 바인딩한다.
 struct SnoozeRepeatLimitPicker: View {
     @Binding var limit: SnoozeRepeatLimit
 
     @Environment(\.voiceAlarmTheme) private var theme
 
-    private let options: [SnoozeRepeatLimit] = [.once, .three, .five, .unlimited]
+    private let options: [SnoozeRepeatLimit] = [.three, .five, .unlimited]
 
     var body: some View {
         HStack(spacing: 8) {
@@ -63,7 +63,6 @@ struct SnoozeRepeatLimitPicker: View {
 extension SnoozeRepeatLimit {
     var shortLabel: String {
         switch self {
-        case .once: return "1회"
         case .three: return "3회"
         case .five: return "5회"
         case .unlimited: return "무제한"
@@ -72,7 +71,6 @@ extension SnoozeRepeatLimit {
 
     var fullLabel: String {
         switch self {
-        case .once: return "1회"
         case .three: return "3회"
         case .five: return "5회"
         case .unlimited: return "무제한"

--- a/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
@@ -500,7 +500,7 @@ struct EmailRegisterRequest: Encodable {
     var email: String
     var password: String
     var name: String
-    var verificationCode: String
+    var emailVerificationCode: String
 }
 
 struct EmailLoginRequest: Encodable {
@@ -1004,7 +1004,7 @@ final class VoiceAlarmAPI {
     /// 이메일 인증 코드 발송 요청. Android `AuthApi.requestEmailVerification` 와 동일.
     func requestEmailVerification(email: String) async throws -> RequestEmailVerificationResponse {
         try await request(
-            "auth/email/verify/request",
+            "auth/email-code",
             method: "POST",
             body: RequestEmailVerificationRequest(email: email)
         )
@@ -1013,7 +1013,7 @@ final class VoiceAlarmAPI {
     /// 이메일 인증 코드 검증.
     func verifyEmailCode(email: String, code: String) async throws -> VerifyEmailCodeResponse {
         try await request(
-            "auth/email/verify/confirm",
+            "auth/email-code/verify",
             method: "POST",
             body: VerifyEmailCodeRequest(email: email, code: code)
         )
@@ -1022,13 +1022,13 @@ final class VoiceAlarmAPI {
     /// 이메일/비밀번호 회원가입. 인증코드 검증 이후 호출되어야 한다.
     func register(email: String, password: String, name: String, verificationCode: String) async throws -> AuthSession {
         try await request(
-            "auth/email/register",
+            "auth/register",
             method: "POST",
             body: EmailRegisterRequest(
                 email: email,
                 password: password,
                 name: name,
-                verificationCode: verificationCode
+                emailVerificationCode: verificationCode
             )
         )
     }
@@ -1036,7 +1036,7 @@ final class VoiceAlarmAPI {
     /// 이메일/비밀번호 로그인.
     func loginWithEmail(email: String, password: String) async throws -> AuthSession {
         try await request(
-            "auth/email/login",
+            "auth/login",
             method: "POST",
             body: EmailLoginRequest(email: email, password: password)
         )
@@ -1046,23 +1046,21 @@ final class VoiceAlarmAPI {
 
     /// 가족 그룹에서 다른 멤버를 내보낸다. 소유자 전용. Android `FamilyApi.removeMember`.
     func removeFamilyMember(groupId: String, userId: String, token: String) async throws -> EmptyResponse {
-        struct Body: Encodable { var userId: String }
         return try await request(
-            "family/groups/\(groupId)/remove",
-            method: "POST",
-            token: token,
-            body: Body(userId: userId)
+            "family/groups/\(groupId)/members/\(userId)",
+            method: "DELETE",
+            token: token
         )
     }
 
     /// 소유권 이양. 새 소유자는 동일 그룹 멤버여야 한다.
     func transferFamilyOwnership(groupId: String, newOwnerId: String, token: String) async throws -> EmptyResponse {
-        struct Body: Encodable { var newOwnerId: String }
+        struct Body: Encodable { var targetUserId: String }
         return try await request(
-            "family/groups/\(groupId)/transfer",
+            "family/groups/\(groupId)/transfer-ownership",
             method: "POST",
             token: token,
-            body: Body(newOwnerId: newOwnerId)
+            body: Body(targetUserId: newOwnerId)
         )
     }
 
@@ -1082,7 +1080,7 @@ final class VoiceAlarmAPI {
     /// `createFamilyVoiceAlarm`. targetUserId 가 수신자.
     func createFamilyVoiceAlarm(_ requestBody: FamilyVoiceAlarmRequest, token: String) async throws -> FamilyVoiceAlarmResponse {
         try await request(
-            "family/alarms",
+            "family/alarms/voice",
             method: "POST",
             token: token,
             body: requestBody
@@ -1094,7 +1092,7 @@ final class VoiceAlarmAPI {
     func redeemVoucher(code: String, token: String) async throws -> VoucherRedemptionResponse {
         struct Body: Encodable { var code: String }
         return try await request(
-            "billing/vouchers/redeem",
+            "billing/redeem",
             method: "POST",
             token: token,
             body: Body(code: code)

--- a/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
@@ -5,6 +5,7 @@ struct PreparedVoiceAlarm {
     var messageID: String
     var voiceProfileID: String
     var localAudioFileName: String
+    var audioCacheKey: String
     var rawAudioURL: String?
     var text: String
     var language: String
@@ -329,6 +330,7 @@ final class VoiceStudioViewModel: ObservableObject {
                 messageID: response.messageId,
                 voiceProfileID: response.voiceProfileId,
                 localAudioFileName: cached.fileName,
+                audioCacheKey: cached.cacheKey,
                 rawAudioURL: response.audioUrl,
                 text: response.text,
                 language: ttsLanguage

--- a/apps/ios-native/VoiceAlarmTests/AlarmAppContextTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/AlarmAppContextTests.swift
@@ -81,6 +81,20 @@ final class AlarmAppContextTests: XCTestCase {
         XCTAssertEqual(mockQueue.events.count, 0)
     }
 
+    func test_handleAlarmStopped_repeatingAlarmRemainsArmed() async throws {
+        let kitID = UUID().uuidString
+        var record = makeArmedRecord(alarmKitID: kitID)
+        record.repeatDaysMask = RepeatDay.monday.mask
+        store.upsert(record)
+
+        await ctx.handleAlarmStopped(alarmKitIDString: kitID)
+
+        let updated = try XCTUnwrap(store.record(id: record.id))
+        XCTAssertEqual(updated.state, AlarmRuntimeState.armed.rawValue)
+        XCTAssertTrue(updated.enabled)
+        XCTAssertEqual(updated.snoozeCount, 0)
+    }
+
     // MARK: - Snooze
 
     func test_handleAlarmSnoozed_advancesFireAndIncrementsCount() async throws {
@@ -123,6 +137,35 @@ final class AlarmAppContextTests: XCTestCase {
     func test_handleAlarmSnoozed_unknownKitID_noMutation_noQueue() async {
         let unknown = UUID().uuidString
         await ctx.handleAlarmSnoozed(alarmKitIDString: unknown, snoozeMinutesOverride: 5)
+        XCTAssertEqual(mockQueue.events.count, 0)
+    }
+
+    func test_handleAlarmSnoozed_disabledNoOps() async throws {
+        let kitID = UUID().uuidString
+        var record = makeArmedRecord(alarmKitID: kitID)
+        record.snoozeEnabled = false
+        store.upsert(record)
+
+        await ctx.handleAlarmSnoozed(alarmKitIDString: kitID, snoozeMinutesOverride: nil)
+
+        let updated = try XCTUnwrap(store.record(id: record.id))
+        XCTAssertEqual(updated.snoozeCount, record.snoozeCount)
+        XCTAssertEqual(updated.state, record.state)
+        XCTAssertEqual(mockQueue.events.count, 0)
+    }
+
+    func test_handleAlarmSnoozed_limitReachedNoOps() async throws {
+        let kitID = UUID().uuidString
+        var record = makeArmedRecord(alarmKitID: kitID)
+        record.snoozeRepeatLimit = SnoozeRepeatLimit.three.rawValue
+        record.snoozeCount = 3
+        store.upsert(record)
+
+        await ctx.handleAlarmSnoozed(alarmKitIDString: kitID, snoozeMinutesOverride: nil)
+
+        let updated = try XCTUnwrap(store.record(id: record.id))
+        XCTAssertEqual(updated.snoozeCount, 3)
+        XCTAssertEqual(updated.state, record.state)
         XCTAssertEqual(mockQueue.events.count, 0)
     }
 

--- a/apps/ios-native/VoiceAlarmTests/AlarmEnumsTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/AlarmEnumsTests.swift
@@ -53,9 +53,9 @@ final class AlarmEnumsTests: XCTestCase {
 
     func test_snoozeRepeatLimitValidValues() {
         XCTAssertTrue(SnoozeRepeatLimit.isValid(0))
-        XCTAssertTrue(SnoozeRepeatLimit.isValid(1))
         XCTAssertTrue(SnoozeRepeatLimit.isValid(3))
         XCTAssertTrue(SnoozeRepeatLimit.isValid(5))
+        XCTAssertFalse(SnoozeRepeatLimit.isValid(1))
         XCTAssertFalse(SnoozeRepeatLimit.isValid(2))
         XCTAssertFalse(SnoozeRepeatLimit.isValid(99))
     }

--- a/apps/ios-native/VoiceAlarmTests/AudioCacheStoreTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/AudioCacheStoreTests.swift
@@ -43,6 +43,26 @@ final class AudioCacheStoreTests: XCTestCase {
         XCTAssertEqual(e3, "")
     }
 
+    func test_legacyTtsCacheReturnsCacheKeyForAlarmScheduling() throws {
+        let response = TtsGenerateResponse(
+            messageId: "msg-cache-key",
+            audioBase64: Data("fake-audio".utf8).base64EncodedString(),
+            audioFormat: "mp3",
+            audioUrl: "r2://tts/msg-cache-key.mp3",
+            audioObjectKey: nil,
+            text: "wake up",
+            voiceProfileId: "voice-1",
+            cacheKey: "server-cache-key",
+            cacheHit: false,
+            provider: "test"
+        )
+
+        let cached = try AudioCacheStore.cache(tts: response)
+
+        XCTAssertEqual(cached.cacheKey, "server-cache-key")
+        XCTAssertNotNil(AudioCacheStore.shared.cachedURL(for: cached.cacheKey))
+    }
+
     func test_cacheBytes_writesFileAndMetadata_andCascadeCleanupRespectsActiveKeys() throws {
         let store = AudioCacheStore()
         let payload = Data([0x49, 0x44, 0x33] + Array(repeating: UInt8(0x20), count: 64)) // ID3 흉내

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -24,12 +24,13 @@ Cloudflare Workers + Hono 기반 API 서버.
 
 ### Apple IAP confirm 검증 강화 로드맵
 
-`POST /api/billing/apple/confirm` 은 본 phase 에서 다음 trust model 로 작동한다.
+`POST /api/billing/apple/confirm` 은 서버가 Apple transaction 을 직접 검증하기 전까지 fail-closed 로 작동한다.
 
 - 라우트 진입에는 authMiddleware (JWT) 가 선행해 호출자 신원을 보장.
 - 알려진 SKU 화이트리스트 (`com.voicealarm.nativeapp.ios.{personal|couple|family}_{monthly|yearly}`) 만 수락.
 - `APPLE_SHARED_SECRET` 미설정 시 503 으로 즉시 거부 (운영자 설정 강제).
-- 동일 `transaction_id` 의 중복 confirm 은 멱등 (200, 기존 row).
+- secret 과 SKU 가 유효해도 클라이언트가 보낸 transaction_id/product_id 만으로 entitlement 를 갱신하지 않는다.
+- 현재는 501 `APPLE_TRANSACTION_VERIFICATION_REQUIRED` 를 반환하고 DB 를 변경하지 않는다.
 
 후속 PR 에서 다음 server-to-server 검증을 추가해 영수증 진위까지 본인 검증한다.
 

--- a/packages/backend/src/routes/billing-apple.ts
+++ b/packages/backend/src/routes/billing-apple.ts
@@ -1,33 +1,16 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
-import { getDB } from '../lib/db';
-import { withWriteTransaction } from '../lib/transactions';
-import {
-  applePlanKeyFromProductId,
-  planTypeToUserPlan,
-  resolveUserPk,
-} from './billing-helpers';
+import { applePlanKeyFromProductId } from './billing-helpers';
 
 // MARK: - POST /billing/apple/confirm
 //
 // iOS `SubscriptionManager.syncWithBackend` 가 호출하는 라우트.
 // App Store 영수증 확인 후 백엔드 entitlement 를 동기화한다.
 //
-// 본 phase 의 trust model (Apple App Store Server API v2 JWS 검증은 후속 PR 에서 강화):
-//   1. 클라이언트는 인증된 사용자 세션에서만 호출 가능 (authMiddleware 통과 필수).
-//   2. 알려진 SKU (`com.voicealarm.nativeapp.ios.{personal|couple|family}_{monthly|yearly}`)
-//      만 수락. 임의 product_id 는 400 UNKNOWN_PRODUCT 로 거절.
-//   3. APPLE_SHARED_SECRET 환경변수가 설정되어 있어야 한다. 미설정 시 503 — 운영자가
-//      `wrangler secret put APPLE_SHARED_SECRET` 으로 주입.
-//   4. 동일 transaction_id 의 중복 confirm 은 멱등 (200, 기존 row 반환).
-//
-// 후속 강화 (README/PR-NOTES 에 명시):
-//   - Apple App Store Server API v2 의 `Get Transaction Info`
-//     (`https://api.storekit.itunes.apple.com/inApps/v1/transactions/{transactionId}`,
-//     sandbox: `https://api.storekit-sandbox.itunes.apple.com/...`) 로 JWS 를 받아
-//     X5C 체인을 Apple 루트 CA 까지 검증하고 payload 의 productId/originalTransactionId
-//     와 클라이언트 입력을 대조하는 server-to-server 검증을 추가.
-//   - JWS 의 `expiresDate` 를 expires_at 의 권위 (authoritative) 로 채택.
+// 이 라우트는 인증된 앱 세션에서만 호출되지만, 클라이언트가 보낸
+// transaction_id/product_id 는 권위가 아니다. App Store Server API/JWS 검증이
+// 붙기 전까지는 fail-closed 로 유지한다. 그렇지 않으면 iOS 호출 하나로
+// 공유 users.plan/subscriptions 상태가 변해 Android 유료 기능까지 열릴 수 있다.
 
 interface ConfirmRequest {
   transaction_id: string;
@@ -51,22 +34,6 @@ function parseConfirmRequest(value: unknown): ConfirmRequest | { error: string }
     transaction_id: transactionId,
     original_transaction_id: originalTransactionId,
     product_id: productId,
-  };
-}
-
-interface PlanRow {
-  id: string;
-  key: string;
-  plan_type: string;
-  period_days: number;
-}
-
-function normalizePlanRow(row: Record<string, unknown>): PlanRow {
-  return {
-    id: String(row.id),
-    key: String(row.key),
-    plan_type: String(row.plan_type),
-    period_days: Number(row.period_days) || 30,
   };
 }
 
@@ -104,100 +71,17 @@ billingApple.post('/apple/confirm', async (c) => {
     );
   }
 
-  const userPk = await resolveUserPk(c);
-  if (!userPk) {
-    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
-  }
-
-  const db = getDB(c.env);
-
-  // 멱등 lookup: 같은 transaction_id 가 이미 처리됐다면 그대로 echo.
-  const existingRes = await db.execute({
-    sql: `SELECT s.id AS sub_id, s.expires_at, p.key AS plan_key
-          FROM subscriptions s
-          JOIN plans p ON p.id = s.plan_id
-          WHERE s.apple_transaction_id = ? AND s.user_id = ?
-          LIMIT 1`,
-    args: [transaction_id, userPk],
-  });
-  if (existingRes.rows.length > 0) {
-    const row = existingRes.rows[0]!;
-    return c.json({
-      subscription_id: String(row.sub_id),
-      plan: String(row.plan_key),
-      expires_at: String(row.expires_at),
-    });
-  }
-
-  // plan_key 로 plans 행 조회.
-  const planRes = await db.execute({
-    sql: `SELECT id, key, plan_type, period_days FROM plans WHERE key = ? AND is_active = 1`,
-    args: [planKey],
-  });
-  if (planRes.rows.length === 0) {
-    return c.json(
-      { error: `Plan not found for key=${planKey}`, error_code: 'PLAN_NOT_FOUND' },
-      400,
-    );
-  }
-  const plan = normalizePlanRow(planRes.rows[0]!);
-
-  // expires_at: 본 phase 에서는 period_days 기반으로 산출. 후속 PR 에서 Apple JWS expiresDate 로 교체.
-  const startsAt = new Date();
-  const expiresAt = new Date(startsAt.getTime() + plan.period_days * 24 * 60 * 60 * 1000);
-  const subscriptionId = crypto.randomUUID();
-  const startsAtIso = startsAt.toISOString();
-  const expiresAtIso = expiresAt.toISOString();
-
-  try {
-    await withWriteTransaction(db, async (tx) => {
-      // 기존 active 구독을 expired 로 정리 (단일 active 유지). 즉시 만료 처리는
-      // billing-cancel 의 cancel 흐름과 달리 voice data 등을 건드리지 않는다.
-      await tx.execute({
-        sql: `UPDATE subscriptions
-              SET status = 'expired', updated_at = datetime('now')
-              WHERE user_id = ? AND status = 'active'`,
-        args: [userPk],
-      });
-
-      await tx.execute({
-        sql: `INSERT INTO subscriptions (
-                id, user_id, plan_id, plan_group_id, status,
-                starts_at, expires_at,
-                apple_transaction_id, apple_original_transaction_id, apple_product_id
-              ) VALUES (?, ?, ?, NULL, 'active', ?, ?, ?, ?, ?)`,
-        args: [
-          subscriptionId,
-          userPk,
-          plan.id,
-          startsAtIso,
-          expiresAtIso,
-          transaction_id,
-          original_transaction_id,
-          product_id,
-        ],
-      });
-
-      await tx.execute({
-        sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
-        args: [planTypeToUserPlan(plan.plan_type), userPk],
-      });
-    });
-  } catch (err) {
-    // DB 미초기화 / unique 충돌 / 트랜잭션 실패 등 — 클라이언트는 StoreKit 권위에 의지하고
-    // 다음 사이클에서 재시도하므로 5xx 로 graceful degradation.
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return c.json(
-      { error: 'Failed to persist Apple subscription', error_code: 'APPLE_PERSIST_FAILED', detail: message },
-      500,
-    );
-  }
-
-  return c.json({
-    subscription_id: subscriptionId,
-    plan: plan.key,
-    expires_at: expiresAtIso,
-  });
+  return c.json(
+    {
+      error: 'Apple transaction verification is required before entitlement mutation',
+      error_code: 'APPLE_TRANSACTION_VERIFICATION_REQUIRED',
+      plan_key: planKey,
+      transaction_id,
+      original_transaction_id,
+      product_id,
+    },
+    501,
+  );
 });
 
 export default billingApple;

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -6,9 +6,9 @@ export interface Env {
   GOOGLE_CLIENT_ID: string;
   APPLE_CLIENT_ID?: string;
   /**
-   * App Store Connect 의 "Apple shared secret" — 본 phase 에서는 클라이언트가 보낸
-   * transaction 데이터가 신뢰 가능한 서버 환경에서 전달됐는지 표시하기 위한 게이트로 사용.
-   * 후속 PR 에서 Apple App Store Server API v2 의 JWS 검증으로 강화 예정. README 참조.
+   * App Store Connect 의 "Apple shared secret".
+   * 현재 /billing/apple/confirm 은 이 secret 이 있어도 fail-closed 로 동작하며,
+   * 후속 PR 에서 Apple App Store Server API v2 의 JWS 검증으로 entitlement 갱신을 열 예정.
    */
   APPLE_SHARED_SECRET?: string;
   GOOGLE_VERTEX_CREDENTIALS_JSON?: string;

--- a/packages/backend/test/billing-apple.test.ts
+++ b/packages/backend/test/billing-apple.test.ts
@@ -11,14 +11,6 @@ vi.mock('../src/lib/db', () => ({
 
 import billingApple from '../src/routes/billing-apple';
 
-const PLAN_PERSONAL = {
-  id: '70000000-0000-4000-8000-000000000002',
-  key: 'personal',
-  plan_type: 'personal',
-  period_days: 30,
-  is_active: 1,
-};
-
 const ENV: Env = {
   PERSO_API_KEY: 'x',
   ELEVENLABS_API_KEY: 'x',
@@ -51,37 +43,18 @@ beforeEach(() => {
 });
 
 describe('POST /billing/apple/confirm', () => {
-  it('정상 confirm 시 200, plan/expires_at/subscription_id 반환', async () => {
-    // 호출 순서: resolveUserPk → 멱등 lookup → plan lookup → UPDATE old → INSERT → UPDATE users.
-    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
-    mockDB.pushResult([]); // idempotent lookup empty
-    mockDB.pushResult([PLAN_PERSONAL]); // plan lookup
-    mockDB.pushResult([], 1); // UPDATE old subs → expired
-    mockDB.pushResult([], 1); // INSERT subscriptions
-    mockDB.pushResult([], 1); // UPDATE users SET plan
-
+  it('검증되지 않은 transaction confirm 은 501 로 fail-closed 하고 DB 를 변경하지 않는다', async () => {
     const res = await buildApp().request(
       jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
       undefined,
       ENV,
     );
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(501);
     const body = await res.json();
-    expect(body.plan).toBe('personal');
-    expect(typeof body.subscription_id).toBe('string');
-    expect(typeof body.expires_at).toBe('string');
-
-    // INSERT subscriptions 호출에 apple_* 컬럼이 채워져야 함.
-    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO subscriptions'));
-    expect(insert).toBeDefined();
-    expect(insert!.args).toContain('apple-tx-1');
-    expect(insert!.args).toContain('apple-orig-1');
-    expect(insert!.args).toContain('com.voicealarm.nativeapp.ios.personal_monthly');
-
-    // users.plan 이 'plus' (personal → plus) 로 업데이트.
-    const userUpdate = mockDB.calls.find((c) => c.sql.includes('UPDATE users SET plan'));
-    expect(userUpdate?.args[0]).toBe('plus');
+    expect(body.error_code).toBe('APPLE_TRANSACTION_VERIFICATION_REQUIRED');
+    expect(body.plan_key).toBe('personal');
+    expect(mockDB.calls).toHaveLength(0);
   });
 
   it('알 수 없는 product_id 시 400 UNKNOWN_PRODUCT', async () => {
@@ -98,20 +71,6 @@ describe('POST /billing/apple/confirm', () => {
     expect(body.error_code).toBe('UNKNOWN_PRODUCT');
   });
 
-  it('인증된 사용자가 DB 에 없으면 404 USER_NOT_FOUND', async () => {
-    // billingApple 자체에 auth 가 없으므로 resolveUserPk 가 fakeAuth 의 userId 로 DB 조회 → 미일치.
-    mockDB.pushResult([]); // resolveUserPk: users row 없음
-
-    const res = await buildApp('unknown-user').request(
-      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
-      undefined,
-      ENV,
-    );
-    expect(res.status).toBe(404);
-    const body = await res.json();
-    expect(body.error_code).toBe('USER_NOT_FOUND');
-  });
-
   it('APPLE_SHARED_SECRET 미설정 시 503', async () => {
     const res = await buildApp().request(
       jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
@@ -123,58 +82,18 @@ describe('POST /billing/apple/confirm', () => {
     expect(body.error_code).toBe('APPLE_BILLING_UNCONFIGURED');
   });
 
-  it('동일 transaction_id 재호출 시 멱등 (200, 같은 응답)', async () => {
-    // 1차: 정상 confirm.
-    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
-    mockDB.pushResult([]); // idempotent lookup empty
-    mockDB.pushResult([PLAN_PERSONAL]); // plan lookup
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-
-    const first = await buildApp().request(
-      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
-      undefined,
-      ENV,
-    );
-    const firstBody = await first.json();
-    expect(first.status).toBe(200);
-
-    // 2차: 같은 transaction_id 가 이미 존재한다고 mock.
-    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
-    mockDB.pushResult([
-      {
-        sub_id: firstBody.subscription_id,
-        expires_at: firstBody.expires_at,
-        plan_key: 'personal',
-      },
-    ]); // idempotent lookup → 기존 row
-
-    const second = await buildApp().request(
-      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
-      undefined,
-      ENV,
-    );
-    expect(second.status).toBe(200);
-    const secondBody = await second.json();
-    expect(secondBody.subscription_id).toBe(firstBody.subscription_id);
-    expect(secondBody.plan).toBe('personal');
-    expect(secondBody.expires_at).toBe(firstBody.expires_at);
-  });
-
-  it('DB 미초기화 등 plan 조회 실패 시 graceful 에러 응답', async () => {
-    // plan 시드가 빠진 환경에선 PLAN_NOT_FOUND 400 으로 graceful 거부.
-    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
-    mockDB.pushResult([]); // idempotent lookup empty
-    mockDB.pushResult([]); // plan lookup empty (DB 시드 미적용)
-
+  it('필수 body 필드 누락 시 400 INVALID_REQUEST', async () => {
     const res = await buildApp().request(
-      jsonReq('POST', '/billing/apple/confirm', VALID_BODY),
+      jsonReq('POST', '/billing/apple/confirm', {
+        transaction_id: '',
+        original_transaction_id: 'apple-orig-1',
+        product_id: 'com.voicealarm.nativeapp.ios.personal_monthly',
+      }),
       undefined,
       ENV,
     );
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error_code).toBe('PLAN_NOT_FOUND');
+    expect(body.error_code).toBe('INVALID_REQUEST');
   });
 });

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -28,8 +28,9 @@ crons = ["*/5 * * * *"]
 # GOOGLE_CLIENT_ID = ""    # Google Sign In OAuth audience (web client ID)
 # APPLE_CLIENT_ID = "com.voicealarm.nativeapp.ios"  # Apple Sign In bundle ID (run: wrangler secret put APPLE_CLIENT_ID)
 # APPLE_SHARED_SECRET = ""  # App Store Connect → 앱 → "앱 전용 공유 비밀(App-Specific Shared Secret)".
-#                             POST /api/billing/apple/confirm 게이트로 사용. 미설정 시 503. 후속 PR 에서
-#                             Apple App Store Server API v2 JWS 검증 시 동일 secret 을 재사용.
+#                             미설정 시 POST /api/billing/apple/confirm 은 503. 설정돼도 현재는
+#                             fail-closed(501) 이며, 후속 PR 의 App Store Server API/JWS 검증 뒤
+#                             entitlement 갱신을 열어야 한다.
 # RESEND_API_KEY = ""      # 회원가입 이메일 인증 코드 발송용
 # AUTH_EMAIL_FROM = ""     # 예: Voice Alarm <no-reply@your-domain.com>
 # AUTH_EMAIL_REPLY_TO = ""

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -56,6 +56,7 @@ export const AuthResponseSchema = z.object({
     email: z.string().email(),
     name: z.string(),
     plan: z.enum(['free', 'plus', 'family']),
+    apple_user_id: z.string().nullable().optional(),
   }),
 });
 export type AuthResponse = z.infer<typeof AuthResponseSchema>;


### PR DESCRIPTION
﻿## 변경 내용
- Apple IAP 확인 API가 서버 검증 없이 구독 상태를 바꾸지 못하도록 안전하게 차단했습니다.
- iOS 네이티브 API 호출 계약을 Android와 백엔드 기준에 맞게 정리했습니다.
- iOS 음성 알람 스케줄링에서 TTS 캐시와 AlarmKit 실패 롤백을 보강했습니다.
- iOS 다시 울림과 반복 알람 동작을 Android 쪽 동작에 더 가깝게 맞췄습니다.

## 이유
기존 iOS 포팅 코드에는 Android 기준과 다른 API 계약, 알람 스케줄링 실패 처리, 반복 알람 유지 처리, Apple 결제 확인 안전성 문제가 섞여 있었습니다. 특히 검증되지 않은 Apple 거래 ID로 공유 구독 상태가 바뀔 수 있는 경로는 반드시 막아야 했습니다.

## 검증
- `npm run typecheck --workspace=backend`
- `npm test --workspace=backend`
- `npm run typecheck --workspace=@voice-alarm/shared`
- `npm test --workspace=@voice-alarm/shared`
- `./gradlew.bat :app:testDebugUnitTest`
- `git diff --check HEAD`

## 참고
브랜치명 규칙을 맞추기 위해 이 PR은 새 `fix/ios-android-alarm-parity` 브랜치 PR로 대체합니다.
