### PR TITLE
fix: 오디오 캐시 폴백 및 한국어 어체 프롬프트 (#339)

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -91,19 +91,34 @@ class AlarmAudioStore(
         )
         findCachedFile(cacheKey)?.let { cached ->
             val cachedUri = cached.toUri()
-            val metadata = readMetadata(cacheKey)
-            val cachedDurationMillis = normalizeDurationWithinLimit(
-                durationMillis = readDurationMillis(cachedUri) ?: durationMillis,
-                maxDurationMillis = maxDurationMillis,
-            )
-            return CachedAlarmAudio(
-                localAudioUri = cachedUri.toString(),
-                rawAudioUri = metadata.rawAudioUri ?: sourceUri.toString(),
-                displayName = cached.name,
-                durationMillis = cachedDurationMillis,
-                cacheKey = cacheKey,
-                messageId = metadata.messageId,
-            )
+            val rawDuration = readDurationMillis(cachedUri)
+            // 과거 잘못 만들어진 캐시(.m4a 헤더만 있고 실제 오디오 없음) 를 걸러낸다.
+            //   - 파일 크기가 비정상적으로 작음 (헤더만 있는 수백 바이트)
+            //   - 또는 duration 을 읽지 못함
+            // 이런 캐시는 무효로 보고 삭제 후 다시 trim 한다.
+            val cachedSize = cached.length()
+            if (rawDuration == null || rawDuration <= 0L || cachedSize < 4 * 1024) {
+                Log.w(
+                    TAG,
+                    "Discarding corrupt voice audio cache path=${cached.absolutePath} size=$cachedSize duration=$rawDuration",
+                )
+                runCatching { cached.delete() }
+                runCatching { metadataFile(cacheKey).delete() }
+            } else {
+                val metadata = readMetadata(cacheKey)
+                val cachedDurationMillis = normalizeDurationWithinLimit(
+                    durationMillis = rawDuration,
+                    maxDurationMillis = maxDurationMillis,
+                )
+                return CachedAlarmAudio(
+                    localAudioUri = cachedUri.toString(),
+                    rawAudioUri = metadata.rawAudioUri ?: sourceUri.toString(),
+                    displayName = cached.name,
+                    durationMillis = cachedDurationMillis,
+                    cacheKey = cacheKey,
+                    messageId = metadata.messageId,
+                )
+            }
         }
         val target = if (forceExtractAudio || resolvedStartMillis > 0 || durationMillis > maxDurationMillis) {
             val trimExtension = if (trimAsMp3) "mp3" else "m4a"
@@ -125,7 +140,17 @@ class AlarmAudioStore(
             }
         }
 
-        val cachedDurationMillis = readDurationMillis(target.toUri()) ?: durationMillis
+        val trimmedDuration = readDurationMillis(target.toUri())
+        if (trimmedDuration == null || trimmedDuration <= 0L || target.length() < 4 * 1024) {
+            // trim/copy 가 사실상 빈 파일을 만들었음 (대부분 비호환 코덱). 캐시 남기지 않고 명확히 실패.
+            Log.e(
+                TAG,
+                "Trim produced empty audio path=${target.absolutePath} size=${target.length()} duration=$trimmedDuration",
+            )
+            runCatching { target.delete() }
+            throw IllegalArgumentException("선택한 파일에서 오디오를 추출하지 못했어요. m4a/mp3/wav 형식으로 다시 시도해 주세요.")
+        }
+        val cachedDurationMillis = trimmedDuration
         val normalizedDurationMillis = normalizeDurationWithinLimit(cachedDurationMillis, maxDurationMillis)
 
         Log.i(TAG, "Cached local voice audio path=${target.absolutePath} durationMillis=$normalizedDurationMillis")

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -120,35 +120,66 @@ class AlarmAudioStore(
                 )
             }
         }
-        val target = if (forceExtractAudio || resolvedStartMillis > 0 || durationMillis > maxDurationMillis) {
+        val needsTrim = forceExtractAudio || resolvedStartMillis > 0 || durationMillis > maxDurationMillis
+        Log.i(
+            TAG,
+            "cacheFromUri source=$sourceUri sourceMime=$sourceMimeType trackMime=$trackMimeType ext=$extension duration=$durationMillis max=$maxDurationMillis start=$resolvedStartMillis needsTrim=$needsTrim trimAsMp3=$trimAsMp3",
+        )
+        val target = if (needsTrim) {
             val trimExtension = if (trimAsMp3) "mp3" else "m4a"
-            File(audioDir, "${safeCacheKey(cacheKey)}.$trimExtension").also {
+            val trimTarget = File(audioDir, "${safeCacheKey(cacheKey)}.$trimExtension")
+            runCatching {
                 trimToMaxDuration(
                     sourceUri = sourceUri,
-                    target = it,
+                    target = trimTarget,
                     maxDurationMillis = maxDurationMillis,
                     startMillis = resolvedStartMillis,
                     forceMp3 = trimAsMp3,
                 )
+            }.onFailure { error ->
+                Log.w(TAG, "trimToMaxDuration threw, will try direct copy as fallback", error)
+                runCatching { trimTarget.delete() }
+            }
+            // trim 이 성공했어도 결과가 빈 파일이면 직접 복사로 폴백.
+            val trimDuration = if (trimTarget.exists()) readDurationMillis(trimTarget.toUri()) else null
+            if (trimTarget.exists() && trimTarget.length() >= 4 * 1024 && trimDuration != null && trimDuration > 0L) {
+                trimTarget
+            } else {
+                Log.w(
+                    TAG,
+                    "trim output empty (size=${trimTarget.length()} duration=$trimDuration), falling back to direct copy",
+                )
+                runCatching { trimTarget.delete() }
+                // 원본을 그대로 캐시 디렉토리에 복사. duration 이 maxDuration 보다 길면 이후 단계에서 거부됨.
+                File(audioDir, "${safeCacheKey(cacheKey)}.$extension").also { file ->
+                    context.contentResolver.openInputStream(sourceUri).use { input ->
+                        requireNotNull(input) { "선택한 오디오 파일을 열 수 없어요." }
+                        file.outputStream().use { output -> input.copyTo(output) }
+                    }
+                }
             }
         } else {
             File(audioDir, "${safeCacheKey(cacheKey)}.$extension").also { file ->
                 context.contentResolver.openInputStream(sourceUri).use { input ->
-                    requireNotNull(input) { "Unable to open selected audio." }
+                    requireNotNull(input) { "선택한 오디오 파일을 열 수 없어요." }
                     file.outputStream().use { output -> input.copyTo(output) }
                 }
             }
         }
 
         val trimmedDuration = readDurationMillis(target.toUri())
+        Log.i(
+            TAG,
+            "cacheFromUri result path=${target.absolutePath} size=${target.length()} duration=$trimmedDuration",
+        )
         if (trimmedDuration == null || trimmedDuration <= 0L || target.length() < 4 * 1024) {
-            // trim/copy 가 사실상 빈 파일을 만들었음 (대부분 비호환 코덱). 캐시 남기지 않고 명확히 실패.
+            // trim/copy 가 사실상 빈 파일을 만들었음. 캐시 남기지 않고 명확히 실패.
             Log.e(
                 TAG,
-                "Trim produced empty audio path=${target.absolutePath} size=${target.length()} duration=$trimmedDuration",
+                "Cached audio empty path=${target.absolutePath} size=${target.length()} duration=$trimmedDuration",
             )
             runCatching { target.delete() }
-            throw IllegalArgumentException("선택한 파일에서 오디오를 추출하지 못했어요. m4a/mp3/wav 형식으로 다시 시도해 주세요.")
+            throw IllegalArgumentException("선택한 파일에서 오디오를 추출하지 못했어요. 다른 파일로 시도해 주세요.")
         }
         val cachedDurationMillis = trimmedDuration
         val normalizedDurationMillis = normalizeDurationWithinLimit(cachedDurationMillis, maxDurationMillis)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -446,10 +446,14 @@ internal fun VoiceProfileManagementPanel(
             }
         }.onFailure { error ->
             Log.e(TAG, "Failed to prepare speaker draft id=${speaker.id}", error)
+            val code = speakerSeparationErrorCode(error)
+            val cls = error.javaClass.simpleName
+            val msg = error.message ?: "(no message)"
+            val display = if (code != null) "미리듣기 실패 · $code" else "미리듣기 실패 · $cls: $msg"
             speakerDraftStates = speakerDraftStates.toMutableMap().also {
                 it[speaker.id] = (it[speaker.id] ?: SpeakerDraftState()).copy(
                     status = SpeakerDraftStatus.Failed,
-                    errorMessage = userFacingError(error, "화자 미리듣기 준비에 실패했어요."),
+                    errorMessage = display,
                 )
             }
         }
@@ -494,14 +498,20 @@ internal fun VoiceProfileManagementPanel(
                 }
             }.onFailure { error ->
                 Log.e(TAG, "Failed to separate speakers", error)
-                localMessage = when (speakerSeparationErrorCode(error)) {
+                val code = speakerSeparationErrorCode(error)
+                localMessage = when (code) {
                     "AUDIO_DURATION_TOO_SHORT" -> "분리할 구간은 1분 이상이어야 해요."
                     "AUDIO_DURATION_TOO_LONG" -> "분리할 구간은 2분 이하여야 해요."
                     "AUDIO_FILE_EMPTY" -> "선택한 음성 파일이 비어 있어요."
                     "INVALID_DURATION" -> "음성 길이를 확인하지 못했어요. 파일을 다시 선택해 주세요."
                     "INVALID_AUDIO_MIME_TYPE" -> "지원하지 않는 오디오 형식이에요."
                     "VOICE_FEATURE_REQUIRES_PAID_PLAN" -> "유료 요금제를 사용해야 화자 분리를 할 수 있어요."
-                    else -> userFacingError(error, "화자 분리에 실패했어요.")
+                    else -> {
+                        // 진단용: 어떤 예외가 어디서 났는지 화면에 그대로 보여준다.
+                        val cls = error.javaClass.simpleName
+                        val msg = error.message ?: "(no message)"
+                        "화자 분리 실패 · $cls: $msg"
+                    }
                 }
             }
             separatingBusy = false

--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -451,14 +451,40 @@ function alarmTextPrompt(args: {
   ].join('\n');
 }
 
+// 한국어일 때 관계 라벨에 맞는 어체(반말/해요체/합니다체) 가이드를 추가한다.
+// 알람 청자는 보통 부모/조부모 (어른) 이라는 가정을 기본으로 깔고, speaker(말하는 사람)
+// 가 어떤 관계냐에 따라 자연스러운 한국어 화법을 매핑한다.
+function koreanRegisterGuidance(relationshipLabel: string | null | undefined): string {
+  if (!relationshipLabel) return '';
+  const label = relationshipLabel.trim();
+  if (!label) return '';
+  const youngerToElder = ['손녀', '손자', '손주', '딸', '아들', '자식', '며느리', '사위', '조카'];
+  const elderToYounger = ['할머니', '할아버지', '엄마', '어머니', '아빠', '아버지', '부모', '이모', '고모', '삼촌', '외할머니', '외할아버지'];
+  const peerOrIntimate = ['친구', '연인', '여자친구', '남자친구', '애인', '여보', '자기', '동생'];
+
+  if (youngerToElder.some((k) => label.includes(k))) {
+    return ' Speaker is younger than the listener: write in warm 해요체 (e.g. "할머니, 일어나셨어요?", "오늘은 ~해요"). Do NOT use stiff 합니다체 like "~합니다", "~하십시오". Sound like family talking, not a TV news anchor.';
+  }
+  if (elderToYounger.some((k) => label.includes(k))) {
+    return ' Speaker is older than the listener: write in caring 반말 or 해요체 mixed style (e.g. "우리 딸, 잘 잤어?", "오늘도 화이팅이야"). Avoid 합니다체.';
+  }
+  if (peerOrIntimate.some((k) => label.includes(k))) {
+    return ' Speaker and listener are peers/intimate: write in 반말 (e.g. "일어났어?", "오늘 뭐 입을까?"). Never use 합니다체.';
+  }
+  return ' Use a warm conversational tone — prefer 해요체 over 합니다체. Sound like a real person, not an announcement.';
+}
+
 function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
   const targetName = LANGUAGE_NAMES[context.targetLanguage] || context.targetLanguage;
   const listenerTitle = context.listenerTitle?.trim();
   const listenerInstruction = listenerTitle
     ? `When addressing the listener, call them "${listenerTitle}" exactly (use this label naturally, do not translate it, and never replace it with grandmother, grandfather, mom, dad, son, daughter, grandson, or granddaughter).`
     : 'Do not address the listener by guessed family titles such as grandmother, grandfather, mom, dad, son, daughter, grandson, or granddaughter. Use a neutral greeting instead.';
+  const koreanRegisterInstruction = context.targetLanguage === 'ko'
+    ? koreanRegisterGuidance(context.relationshipLabel?.trim())
+    : '';
   const relationship = context.relationshipLabel?.trim()
-    ? `The selected voice belongs to the user's "${context.relationshipLabel}" relationship. This label describes the speaker's relationship to the user, not the listener's title. Use it only to shape warmth and tone. ${listenerInstruction} Do not invent names or private facts.`
+    ? `The selected voice belongs to the user's "${context.relationshipLabel}" relationship. This label describes the speaker's relationship to the user, not the listener's title. Use it to shape both warmth AND the speaker's natural speech register (반말 / 해요체 / 합니다체 in Korean). ${listenerInstruction} Do not invent names or private facts.${koreanRegisterInstruction}`
     : `No relationship label is available, so keep the line generally warm. ${listenerInstruction}`;
   const modeInstruction = (() => {
     if (context.mode === 'wake_weather') {
@@ -490,6 +516,12 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
     listenerTitle
       ? `Address the listener as "${listenerTitle}" rather than guessing a family title.`
       : 'For example, if the relationship label is "손녀", do not write "할머니" or "할아버지"; use a neutral greeting instead.',
+    context.targetLanguage === 'ko'
+      ? '한국어 어체 규칙: 가족·친구·연인 관계에서는 절대 "~합니다", "~하십시오" 같은 합니다체를 쓰지 말 것. 손녀→조부모, 자식→부모 등 손아랫사람이 손윗사람에게 말할 때는 친근한 해요체 ("~해요", "~예요"). 부모→자식, 형/누나→동생 등은 다정한 반말 또는 해요체 혼용. 친구·연인 사이는 반말. 뉴스 앵커처럼 들리지 않게 진짜 가족이 옆에서 말하는 톤으로.'
+      : '',
+    context.targetLanguage === 'ko'
+      ? '문장 구조 예시 (손녀가 할아버지에게 비 오는 날 깨우는 wake_weather): "할아버지, 일어나세요! 오늘 서울에는 비가 와요. 나가실 때 우산 챙기시고, 건강하세요!" — 호칭으로 시작, 짧은 문장 3~4개, 마지막에 안부/응원으로 마무리. 이 패턴을 따르되 내용은 컨텍스트에 맞게 새로 작성.'
+      : '',
     'Make it feel meaningfully different from a prerecorded fixed alarm.',
     'No markdown, no emojis, no quotes, no explanations, no extra fields.',
     'Keep the final text spoken, kind, and 200 characters or fewer.',

--- a/packages/backend/src/routes/voice-upload.ts
+++ b/packages/backend/src/routes/voice-upload.ts
@@ -50,22 +50,33 @@ voiceUpload.post('/upload', async (c) => {
   let formData: FormData;
   try {
     formData = await c.req.formData();
-  } catch {
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] formData parse failed', err);
     return c.json({ error: 'multipart/form-data body required', error_code: 'MULTIPART_BODY_REQUIRED' }, 400);
   }
 
   const audioFile = getFormFile(formData, 'audio');
+  // eslint-disable-next-line no-console
+  console.log('[voice/upload] keys', Array.from(formData.keys()).join(','), 'audio?', !!audioFile, 'type=', (audioFile as File | null)?.type, 'name=', (audioFile as File | null)?.name, 'size=', (audioFile as File | null)?.size, 'durationMs=', formData.get('durationMs'));
+
   if (!audioFile || typeof audioFile === 'string') {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] AUDIO_FILE_REQUIRED');
     return c.json({ error: 'audio file is required', error_code: 'AUDIO_FILE_REQUIRED' }, 400);
   }
 
   const mimeType = audioFile.type || 'application/octet-stream';
   if (!mimeType.startsWith('audio/')) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] INVALID_AUDIO_MIME_TYPE', mimeType);
     return c.json({ error: 'audio/* MIME type required', error_code: 'INVALID_AUDIO_MIME_TYPE' }, 415);
   }
 
   const buffer = await audioFile.arrayBuffer();
   if (buffer.byteLength === 0) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] AUDIO_FILE_EMPTY');
     return c.json({ error: 'audio file is empty', error_code: 'AUDIO_FILE_EMPTY' }, 400);
   }
   if (buffer.byteLength > MAX_UPLOAD_BYTES) {
@@ -77,13 +88,19 @@ voiceUpload.post('/upload', async (c) => {
 
   const durationRaw = formData.get('durationMs');
   if (typeof durationRaw !== 'string' || durationRaw.length === 0) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] INVALID_DURATION raw=', durationRaw);
     return c.json({ error: 'durationMs must be a positive integer', error_code: 'INVALID_DURATION' }, 400);
   }
   const durationMs = Number.parseInt(durationRaw, 10);
   if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] INVALID_DURATION parsed=', durationMs);
     return c.json({ error: 'durationMs must be a positive integer', error_code: 'INVALID_DURATION' }, 400);
   }
   if (durationMs < MIN_UPLOAD_DURATION_MS) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] AUDIO_DURATION_TOO_SHORT', durationMs);
     return c.json(
       {
         error: `audio file must be at least ${MIN_UPLOAD_DURATION_MS / 1000} seconds`,
@@ -93,6 +110,8 @@ voiceUpload.post('/upload', async (c) => {
     );
   }
   if (durationMs > MAX_UPLOAD_DURATION_MS) {
+    // eslint-disable-next-line no-console
+    console.error('[voice/upload] AUDIO_DURATION_TOO_LONG', durationMs);
     return c.json(
       {
         error: `audio file exceeds ${MAX_UPLOAD_DURATION_MS / 1000} seconds`,


### PR DESCRIPTION
## 변경 사항

### AlarmAudioStore — 손상된 캐시 폐기 + trim 폴백
- 4KB 미만이거나 duration 을 읽지 못하는 .m4a 캐시는 무효로 보고 삭제 후 다시 trim.
- trim 자체가 빈 파일을 만들면 (`MediaMuxer` 가 일부 m4a 변종을 못 다루는 경우) 원본을 그대로 캐시 디렉토리에 복사하는 폴백 추가.
- 두 경로 모두 빈 파일이면 명확한 한국어 에러로 던짐.
- 진단 로그 강화 (\`cacheFromUri source=... needsTrim=... size=... duration=...\`).

### VoiceProfileManagementPanel — 진단용 에러 표시
- 화자 분리 / 미리듣기 단계 실패 시 화면에 예외 클래스명·메시지를 그대로 표시 (`화자 분리 실패 · IllegalArgumentException: ...`). logcat 없이도 원인 파악.

### vertex-translate — 한국어 어체 가이드
- 관계 라벨에 맞춰 어체(반말 / 해요체 / 합니다체) 가이드를 프롬프트에 주입.
  - 손녀·손자·딸·아들·조카·며느리·사위 → 친근한 해요체, 합니다체 금지
  - 할머니·할아버지·엄마·아빠·이모·고모·삼촌 → 다정한 반말·해요체 혼용
  - 친구·연인·여보·동생·애인 → 반말
- 사용자가 준 예시 문장(`"할아버지, 일어나세요! 오늘 서울에는 비가 와요. ..."`)을 few-shot 으로 포함.

## 배포 노트
- 백엔드는 이미 \`wrangler deploy\` 로 즉시 반영됨.
- 마이그레이션 #38, #39 는 직전에 별도로 적용 완료.
- Android 변경은 머지 후 새 APK 배포 필요.

## 진단 로그
backend 의 \`voice/upload\` 400 분기마다 \`console.error\` 가 남아 있음. 안정화 확인 후 제거 PR 별도로 올릴 것.