### PR TITLE
fix(android): QA Critical/High 수정 (C3/C4 + race/NPE)

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/data/AlarmAudioStore.kt
@@ -17,6 +17,9 @@ import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.util.Locale
 import java.util.Properties
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.math.abs
 
 object AlarmAudioLimits {
@@ -89,6 +92,43 @@ class AlarmAudioStore(
             startMillis = resolvedStartMillis,
             maxDurationMillis = maxDurationMillis,
         )
+        // 동일 cacheKey 로 동시에 trim/copy 가 두 번 일어나면 중복 파일 쓰기와 망가진 캐시가 생긴다.
+        // cacheKey 별 lock 으로 첫 번째 호출이 끝날 때까지 두 번째 호출이 기다리도록 한다.
+        return cacheKeyLock(cacheKey).withLock {
+            try {
+                cacheFromUriLocked(
+                    sourceUri = sourceUri,
+                    maxDurationMillis = maxDurationMillis,
+                    durationMillis = durationMillis,
+                    displayName = displayName,
+                    extension = extension,
+                    sourceMimeType = sourceMimeType,
+                    trackMimeType = trackMimeType,
+                    forceExtractAudio = forceExtractAudio,
+                    trimAsMp3 = trimAsMp3,
+                    resolvedStartMillis = resolvedStartMillis,
+                    cacheKey = cacheKey,
+                )
+            } finally {
+                releaseCacheKeyLockIfUnused(cacheKey)
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun cacheFromUriLocked(
+        sourceUri: Uri,
+        maxDurationMillis: Long,
+        durationMillis: Long,
+        displayName: String,
+        extension: String,
+        sourceMimeType: String?,
+        trackMimeType: String?,
+        forceExtractAudio: Boolean,
+        trimAsMp3: Boolean,
+        resolvedStartMillis: Long,
+        cacheKey: String,
+    ): CachedAlarmAudio {
         findCachedFile(cacheKey)?.let { cached ->
             val cachedUri = cached.toUri()
             val rawDuration = readDurationMillis(cachedUri)
@@ -657,6 +697,24 @@ class AlarmAudioStore(
         private const val DECODE_TIMEOUT_US = 10_000L
         private const val MAX_IDLE_OUTPUT_DEQUEUE_COUNT = 20
         private const val PCM_16BIT_MAX_LEVEL = 32768.0
+
+        // cacheKey 별 in-flight 작업 중복 방지용 lock.
+        // 프로세스 전역으로 공유하지 않으면 같은 입력에 대해 두 번 호출 시 두 번째가 첫 번째와
+        // 동시에 trim/copy 를 수행해 캐시 파일을 덮어쓸 수 있다.
+        private val cacheKeyLocks = ConcurrentHashMap<String, ReentrantLock>()
+
+        private fun cacheKeyLock(cacheKey: String): ReentrantLock =
+            cacheKeyLocks.computeIfAbsent(cacheKey) { ReentrantLock() }
+
+        private fun releaseCacheKeyLockIfUnused(cacheKey: String) {
+            val lock = cacheKeyLocks[cacheKey] ?: return
+            // hold 중인 호출은 위 withLock 안에서 unlock 된 직후이며,
+            // 다른 호출이 lock 을 잡고 있다면 isLocked 가 true 이므로 그대로 둔다.
+            if (!lock.isLocked) {
+                // 동일 키로 새 호출이 막 들어왔을 가능성을 고려, atomic remove 만 시도.
+                cacheKeyLocks.remove(cacheKey, lock)
+            }
+        }
 
         fun ttsCacheKey(
             profileId: String,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/ApiErrors.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/ApiErrors.kt
@@ -1,0 +1,24 @@
+package com.voicealarm.nativeapp.network
+
+import org.json.JSONObject
+import retrofit2.HttpException
+
+/**
+ * 백엔드 에러 응답의 `error_code` 필드를 추출하는 공용 헬퍼.
+ *
+ * 백엔드는 4xx/5xx 에서 `{"error_code": "...", "message": "..."}` 형식 JSON 본문을 반환한다.
+ * 여러 호출 지점에서 동일한 로직을 중복으로 갖고 있던 것을 한곳에 모은다.
+ *
+ * @return error_code 값. HTTP 예외가 아니거나 본문이 비어있거나 JSON 파싱 실패 시 null.
+ */
+fun apiErrorCode(error: Throwable): String? {
+    val body = (error as? HttpException)
+        ?.response()
+        ?.errorBody()
+        ?.string()
+        ?.takeIf { it.isNotBlank() }
+        ?: return null
+    return runCatching {
+        JSONObject(body).optString("error_code").takeIf { it.isNotBlank() }
+    }.getOrNull()
+}

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceAlarmApiClient.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceAlarmApiClient.kt
@@ -2,13 +2,28 @@ package com.voicealarm.nativeapp.network
 
 import com.voicealarm.nativeapp.BuildConfig
 import java.util.concurrent.TimeUnit
+import okhttp3.Authenticator
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object VoiceAlarmApiClient {
-    fun create(baseUrl: String = BuildConfig.VOICE_ALARM_API_BASE_URL): VoiceAlarmApi {
+    /**
+     * 인증이 만료(401)되었을 때 호출되는 콜백.
+     * 현재는 백엔드 refresh 엔드포인트가 없어 세션을 클리어하고 재로그인을 유도한다.
+     */
+    interface UnauthorizedHandler {
+        fun onUnauthorized()
+    }
+
+    fun create(
+        baseUrl: String = BuildConfig.VOICE_ALARM_API_BASE_URL,
+        unauthorizedHandler: UnauthorizedHandler? = null,
+    ): VoiceAlarmApi {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
                 HttpLoggingInterceptor.Level.BASIC
@@ -16,12 +31,15 @@ object VoiceAlarmApiClient {
                 HttpLoggingInterceptor.Level.NONE
             }
         }
-        val client = OkHttpClient.Builder()
+        val builder = OkHttpClient.Builder()
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
             .addInterceptor(logging)
-            .build()
+        if (unauthorizedHandler != null) {
+            builder.authenticator(UnauthorizedAuthenticator(unauthorizedHandler))
+        }
+        val client = builder.build()
 
         return Retrofit.Builder()
             .baseUrl(normalizeBaseUrl(baseUrl))
@@ -35,4 +53,34 @@ object VoiceAlarmApiClient {
 
     private fun normalizeBaseUrl(baseUrl: String): String =
         if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+
+    /**
+     * 401 응답을 받으면 한 번만 콜백을 호출하고 재시도 없이 응답을 그대로 흘려보낸다.
+     * - 백엔드에 refresh 엔드포인트가 없으므로 같은 토큰으로 재시도해도 의미가 없다.
+     * - 재시도 시 같은 응답이 반복되며 무한루프가 될 수 있어 null 을 반환해 전파.
+     * - 동일 응답에 대해 콜백이 이미 호출되었는지(Authorization 헤더 동일성)를 확인해 중복 호출을 방지.
+     */
+    private class UnauthorizedAuthenticator(
+        private val handler: UnauthorizedHandler,
+    ) : Authenticator {
+        override fun authenticate(route: Route?, response: Response): Request? {
+            // okhttp 가 같은 요청을 두 번 이상 호출하지 않도록 priorResponse 체인 확인.
+            if (responseRetryCount(response) >= 1) {
+                return null
+            }
+            runCatching { handler.onUnauthorized() }
+            // 새 토큰을 발급할 방법이 없으므로 retry 하지 않는다.
+            return null
+        }
+
+        private fun responseRetryCount(response: Response): Int {
+            var current: Response? = response.priorResponse
+            var count = 0
+            while (current != null) {
+                count += 1
+                current = current.priorResponse
+            }
+            return count
+        }
+    }
 }

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
@@ -65,7 +65,9 @@ data class VoiceProfileRelationshipUpdateRequest(
 
 data class VoiceProfile(
     val id: String,
-    val name: String,
+    // Gson 은 JSON 에 name 이 누락되거나 null 이어도 기본값을 통하지 않고 그대로 null 을 주입할 수 있어
+    // 추후 NPE 를 막기 위해 기본값을 부여한다.
+    val name: String = "",
     val status: String? = null,
     @SerializedName("created_at") val createdAt: String? = null,
     @SerializedName("is_shared") val isShared: Boolean? = null,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/editor/AlarmEditorScreen.kt
@@ -119,6 +119,8 @@ internal fun AlarmEditorScreen(
     var audioMessage by remember { mutableStateOf<String?>(null) }
     var isRecording by remember { mutableStateOf(false) }
     var isSaving by remember { mutableStateOf(false) }
+    // 진행 중인 TTS 생성 Job 을 추적해, 사용자가 도중에 시각을 변경하면 취소한다.
+    var generationJob by remember { mutableStateOf<Job?>(null) }
     var localInputMode by remember { mutableStateOf(VoiceCaptureMode.Record) }
     var recordingElapsedMillis by remember { mutableStateOf(0L) }
     var recordingLevels by remember { mutableStateOf(List(18) { 0.08f }) }
@@ -504,7 +506,9 @@ internal fun AlarmEditorScreen(
             }
         }
 
-        scope.launch {
+        // 이전에 진행 중이던 generation 이 남아 있다면 취소.
+        generationJob?.cancel()
+        generationJob = scope.launch {
             isSaving = true
             audioMessage = "음성을 생성해서 저장하는 중..."
             showFamilyAlarmToast("음성을 생성하는 중...")
@@ -578,6 +582,7 @@ internal fun AlarmEditorScreen(
                 audioMessage = userFacingError(error, "음성 생성에 실패했어요.")
             }
             isSaving = false
+            generationJob = null
         }
     }
 
@@ -734,10 +739,19 @@ internal fun AlarmEditorScreen(
 
     // 랜덤 문구는 알람 시각이 프롬프트 컨텍스트로 들어가므로,
     // 시각이 바뀌면 기존 캐시 TTS 를 무효화해 저장 시 재생성하게 한다.
+    // 또한 진행 중인 generation 코루틴이 있으면 결과가 stale 한 시각으로 저장되지 않도록 취소한다.
     LaunchedEffect(editor.hour, editor.minute) {
         if (editor.voiceRandomPrompt && !editor.ttsMessageId.isNullOrBlank()) {
             editor.clearTtsMeta()
             editor.clearAudio()
+        }
+        generationJob?.let { current ->
+            if (current.isActive) {
+                current.cancel()
+                isSaving = false
+                audioMessage = "알람 시각이 바뀌어 음성 생성을 중단했어요."
+            }
+            generationJob = null
         }
     }
 

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModel.kt
@@ -53,8 +53,29 @@ import androidx.compose.runtime.setValue
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     internal val repository = AlarmAppContainer.repository(application)
-    internal val api = VoiceAlarmApiClient.create()
     internal val authSessionStore = AuthSessionStore(application)
+    internal val api = VoiceAlarmApiClient.create(
+        unauthorizedHandler = object : VoiceAlarmApiClient.UnauthorizedHandler {
+            override fun onUnauthorized() {
+                // 백엔드에 refresh 엔드포인트가 없어 같은 토큰으로 재시도해도 의미가 없다.
+                // 세션을 비우고 화면에 재로그인을 안내한다.
+                handleUnauthorized()
+            }
+        },
+    )
+
+    /**
+     * okhttp Authenticator 에서 호출되는 401 처리.
+     * 다른 스레드(non-main) 에서 호출될 수 있어 UI 스레드로 옮긴 뒤 세션을 클리어한다.
+     */
+    private fun handleUnauthorized() {
+        viewModelScope.launch {
+            if (authSession == null) return@launch
+            runCatching { authSessionStore.clear() }
+            authSession = null
+            message = "로그인이 만료되었어요. 다시 로그인해 주세요."
+        }
+    }
 
     val alarms: StateFlow<List<AlarmEntity>> = repository.observeAlarms()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelAlarmActions.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.core.net.toUri
 import com.voicealarm.nativeapp.core.VoiceAlarmLog.TAG
 import com.voicealarm.nativeapp.data.AlarmAppContainer
+import com.voicealarm.nativeapp.data.AlarmAudioStore
 import com.voicealarm.nativeapp.data.AlarmDraft
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.AlarmPlayModes
@@ -107,11 +109,14 @@ private suspend fun MainViewModel.createFamilyTargetAlarm(draft: AlarmDraft, onD
     runCatching {
         withContext(Dispatchers.IO) {
             if (draft.shouldUploadLocalVoiceForFamilyAlarm()) {
-                val localAudio = draft.toCachedLocalAudio()
+                val audioStore = AlarmAudioStore(getApplication<Application>())
+                val localAudio = draft.toCachedLocalAudio(audioStore)
+                val resolvedDurationMillis = localAudio.durationMillis
+                    ?: throw IllegalArgumentException("음성 길이를 확인하지 못했어요. 다시 녹음해 주세요.")
                 val upload = api.uploadVoiceAudio(
                     authorization = VoiceAlarmApiClient.bearer(session.token),
                     audio = voiceUploadPart(localAudio),
-                    durationMs = (localAudio.durationMillis ?: 0L).toString().toRequestBody("text/plain".toMediaType()),
+                    durationMs = resolvedDurationMillis.toString().toRequestBody("text/plain".toMediaType()),
                     originalName = localAudio.displayName.toRequestBody("text/plain".toMediaType()),
                 ).upload
                 api.createFamilyVoiceAlarm(
@@ -147,14 +152,21 @@ private fun AlarmDraft.shouldUploadLocalVoiceForFamilyAlarm(): Boolean =
         !localAudioUri.isNullOrBlank() &&
         rawAudioUri?.let(RemoteAlarmMapper::isRemoteAudioUrl) != true
 
-private fun AlarmDraft.toCachedLocalAudio(): CachedAlarmAudio =
-    CachedAlarmAudio(
-        localAudioUri = requireNotNull(localAudioUri),
+private fun AlarmDraft.toCachedLocalAudio(audioStore: AlarmAudioStore): CachedAlarmAudio {
+    val resolvedLocalAudioUri = requireNotNull(localAudioUri)
+    // 가족 음성 알람 업로드는 백엔드가 INVALID_DURATION 으로 0L 을 거부하므로
+    // 캐시된 로컬 파일에서 실제 길이를 읽어와 채워야 한다.
+    val durationMillis = runCatching {
+        audioStore.readDurationMillis(resolvedLocalAudioUri.toUri())
+    }.getOrNull()
+    return CachedAlarmAudio(
+        localAudioUri = resolvedLocalAudioUri,
         rawAudioUri = rawAudioUri,
-        displayName = localAudioUri?.let(::audioFileLabel) ?: "family_alarm_voice",
-        durationMillis = null,
+        displayName = audioFileLabel(resolvedLocalAudioUri),
+        durationMillis = durationMillis,
         cacheKey = audioCacheKey,
     )
+}
 
 private fun AlarmDraft.toRemoteAlarmWriteRequest(): RemoteAlarmWriteRequest {
     val rawAudioUrl = rawAudioUri?.takeIf(RemoteAlarmMapper::isRemoteAudioUrl)

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelGrowthBillingActions.kt
@@ -18,6 +18,7 @@ import com.voicealarm.nativeapp.data.AlarmDraft
 import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.CharacterEventEntity
+import com.voicealarm.nativeapp.network.apiErrorCode
 import com.voicealarm.nativeapp.network.AuthTokenResponse
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.AuthSessionStore
@@ -55,8 +56,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import org.json.JSONObject
-import retrofit2.HttpException
 
 
 internal fun MainViewModel.refreshCharacterAndBilling() {
@@ -144,18 +143,6 @@ private suspend fun MainViewModel.refreshCharacterBillingAfterMutation(
     }.onFailure { error ->
         Log.w(TAG, "Failed to refresh character or billing after $reason", error)
     }
-}
-
-private fun billingErrorCode(error: Throwable): String? {
-    val body = (error as? HttpException)
-        ?.response()
-        ?.errorBody()
-        ?.string()
-        ?.takeIf { it.isNotBlank() }
-        ?: return null
-    return runCatching {
-        JSONObject(body).optString("error_code").takeIf { it.isNotBlank() }
-    }.getOrNull()
 }
 
 private fun billingFailureMessage(errorCode: String?, fallback: String): String =
@@ -395,7 +382,7 @@ internal fun MainViewModel.checkoutPlan(planKey: String, gift: Boolean = false) 
         }.onFailure { error ->
             Log.e(TAG, "Failed to checkout plan key=$planKey gift=$gift", error)
             val fallback = if (gift) "선물하기에 실패했어요" else "이용권 적용에 실패했어요"
-            message = billingFailureMessage(billingErrorCode(error), userFacingError(error, fallback))
+            message = billingFailureMessage(apiErrorCode(error), userFacingError(error, fallback))
         }
         billingBusy = false
     }
@@ -420,7 +407,7 @@ internal fun MainViewModel.ensureFamilyShareCode() {
         }.onFailure { error ->
             Log.e(TAG, "Failed to ensure family share code", error)
             message = billingFailureMessage(
-                billingErrorCode(error),
+                apiErrorCode(error),
                 userFacingError(error, "$planLabel 공유 코드를 불러오지 못했어요"),
             )
         }
@@ -446,7 +433,7 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
             refreshSocial()
         }.onFailure { error ->
             Log.e(TAG, "Failed to cancel subscription mode=$mode", error)
-            message = billingFailureMessage(billingErrorCode(error), userFacingError(error, "해지에 실패했어요"))
+            message = billingFailureMessage(apiErrorCode(error), userFacingError(error, "해지에 실패했어요"))
         }
         billingBusy = false
     }
@@ -494,7 +481,7 @@ internal fun MainViewModel.changePlan(planKey: String, atPeriodEnd: Boolean) {
             refreshSocial()
         }.onFailure { error ->
             Log.e(TAG, "Failed to change plan key=$planKey mode=$mode", error)
-            val errorCode = billingErrorCode(error)
+            val errorCode = apiErrorCode(error)
             if (errorCode == "NO_ACTIVE_SUBSCRIPTION") {
                 message = billingFailureMessage(errorCode, "현재 적용된 이용권이 없어 새 이용권으로 적용할게요")
                 billingBusy = false

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/main/MainViewModelVoiceActions.kt
@@ -18,6 +18,7 @@ import com.voicealarm.nativeapp.data.AlarmEntity
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.CharacterEventEntity
 import com.voicealarm.nativeapp.data.VoiceProfileCreationDraft
+import com.voicealarm.nativeapp.network.apiErrorCode
 import com.voicealarm.nativeapp.network.AuthTokenResponse
 import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.AuthSessionStore
@@ -53,8 +54,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import org.json.JSONObject
-import retrofit2.HttpException
 
 
 internal fun MainViewModel.loadVoiceProfiles() {
@@ -182,7 +181,7 @@ internal fun MainViewModel.createVoiceProfiles(items: List<VoiceProfileCreationD
         }.onFailure { error ->
             voiceProfiles = voiceProfiles.filterNot { it.id in pendingIds }
             Log.e(TAG, "Failed to create voice profile", error)
-            message = when (voiceErrorCode(error)) {
+            message = when (apiErrorCode(error)) {
                 "VOICE_CLONE_AUDIO_TOO_SHORT" -> "학습 음성은 1분 이상이어야 해요."
                 "VOICE_CLONE_AUDIO_TOO_LONG" -> "학습 음성은 2분 이하로 준비해 주세요."
                 "INVALID_DURATION" -> "음성 길이를 확인하지 못했어요. 파일을 다시 선택해 주세요."
@@ -193,18 +192,6 @@ internal fun MainViewModel.createVoiceProfiles(items: List<VoiceProfileCreationD
         }
         voiceProfileBusy = false
     }
-}
-
-private fun voiceErrorCode(error: Throwable): String? {
-    val body = (error as? HttpException)
-        ?.response()
-        ?.errorBody()
-        ?.string()
-        ?.takeIf { it.isNotBlank() }
-        ?: return null
-    return runCatching {
-        JSONObject(body).optString("error_code").takeIf { it.isNotBlank() }
-    }.getOrNull()
 }
 
 internal suspend fun MainViewModel.separateVoiceSpeakers(audio: CachedAlarmAudio): List<VoiceSpeakerSegment> {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -72,6 +72,7 @@ import com.voicealarm.nativeapp.data.AlarmVoiceRecorder
 import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VoiceProfileAudioLimits
 import com.voicealarm.nativeapp.data.VoiceProfileCreationDraft
+import com.voicealarm.nativeapp.network.apiErrorCode
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyVoiceProfile
@@ -81,6 +82,7 @@ import com.voicealarm.nativeapp.network.VoiceProfile
 import com.voicealarm.nativeapp.network.VoiceSpeakerSegment
 import android.util.Base64
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -176,6 +178,9 @@ internal fun VoiceProfileManagementPanel(
     var fileWaveformLoading by remember { mutableStateOf(false) }
     var detectedSpeakers by remember { mutableStateOf<List<VoiceSpeakerSegment>>(emptyList()) }
     var speakerDraftStates by remember { mutableStateOf<Map<String, SpeakerDraftState>>(emptyMap()) }
+    // 진행 중인 prepareSpeakerDraft 코루틴을 화자 id 별로 추적해
+    // 선택/정리 시 다른 draft 작업이 cleanup 과 동시에 진행되지 않도록 한다.
+    val speakerDraftJobs = remember { mutableMapOf<String, Job>() }
     var activePlayingSpeakerId by remember { mutableStateOf<String?>(null) }
     var separatingBusy by remember { mutableStateOf(false) }
     var promotingBusy by remember { mutableStateOf(false) }
@@ -304,6 +309,20 @@ internal fun VoiceProfileManagementPanel(
         }
     }
 
+    /**
+     * 진행 중인 화자 draft 준비 Job 들을 취소하고, 인자로 받은 화자 id 는 제외한다.
+     * select 시점에 다른 draft 의 clone/synthesize 가 promote 와 동시에 진행되는 race 를 막는다.
+     */
+    fun cancelOtherSpeakerDraftJobs(keepSpeakerId: String?) {
+        val toCancel = speakerDraftJobs.entries
+            .filter { (id, _) -> id != keepSpeakerId }
+            .toList()
+        toCancel.forEach { (id, job) ->
+            runCatching { job.cancel() }
+            speakerDraftJobs.remove(id)
+        }
+    }
+
     fun closeCreateDialog() {
         if (recorder.isRecording) recorder.cancel()
         isRecording = false
@@ -318,6 +337,8 @@ internal fun VoiceProfileManagementPanel(
         cropEndMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS
         detectedSpeakers = emptyList()
         // 다이얼로그 닫힐 때 현재 화면에 남은 draft 가 있으면 모두 삭제 (선택되지 않은 채 닫힘)
+        // 진행 중인 prepare Job 도 취소해 닫힌 뒤 server 호출이 이어지지 않게 한다.
+        cancelOtherSpeakerDraftJobs(keepSpeakerId = null)
         cleanupDraftsAsync(speakerDraftStates.values.mapNotNull { it.profileId })
         speakerDraftStates = emptyMap()
         activePlayingSpeakerId = null
@@ -446,7 +467,7 @@ internal fun VoiceProfileManagementPanel(
             }
         }.onFailure { error ->
             Log.e(TAG, "Failed to prepare speaker draft id=${speaker.id}", error)
-            val code = speakerSeparationErrorCode(error)
+            val code = apiErrorCode(error)
             val cls = error.javaClass.simpleName
             val msg = error.message ?: "(no message)"
             val display = if (code != null) "미리듣기 실패 · $code" else "미리듣기 실패 · $cls: $msg"
@@ -493,12 +514,24 @@ internal fun VoiceProfileManagementPanel(
                 }
                 localMessage = if (visible.isEmpty()) "분리할 화자를 찾지 못했어요." else null
                 val baseName = profileName.trim()
+                // 기존 추적 중인 Job 이 있다면 새 separate 가 일어났으므로 모두 취소.
+                cancelOtherSpeakerDraftJobs(keepSpeakerId = null)
                 visible.forEachIndexed { index, speaker ->
-                    scope.launch { prepareSpeakerDraft(speaker, index, baseName, uri) }
+                    val job = scope.launch {
+                        try {
+                            prepareSpeakerDraft(speaker, index, baseName, uri)
+                        } finally {
+                            // 자신이 등록한 Job 만 정리.
+                            if (speakerDraftJobs[speaker.id] === coroutineContext[Job]) {
+                                speakerDraftJobs.remove(speaker.id)
+                            }
+                        }
+                    }
+                    speakerDraftJobs[speaker.id] = job
                 }
             }.onFailure { error ->
                 Log.e(TAG, "Failed to separate speakers", error)
-                val code = speakerSeparationErrorCode(error)
+                val code = apiErrorCode(error)
                 localMessage = when (code) {
                     "AUDIO_DURATION_TOO_SHORT" -> "분리할 구간은 1분 이상이어야 해요."
                     "AUDIO_DURATION_TOO_LONG" -> "분리할 구간은 2분 이하여야 해요."
@@ -519,6 +552,8 @@ internal fun VoiceProfileManagementPanel(
     }
 
     fun resetSpeakers() {
+        // cleanup 보다 먼저 진행 중인 draft Job 을 취소해 cleanup 과 동시 진행을 막는다.
+        cancelOtherSpeakerDraftJobs(keepSpeakerId = null)
         cleanupDraftsAsync(speakerDraftStates.values.mapNotNull { it.profileId })
         detectedSpeakers = emptyList()
         speakerDraftStates = emptyMap()
@@ -557,6 +592,11 @@ internal fun VoiceProfileManagementPanel(
     fun selectSpeakerDraft(speaker: VoiceSpeakerSegment) {
         val state = speakerDraftStates[speaker.id] ?: return
         val selectedDraftId = state.profileId ?: return
+        // 아직 ready 가 아닌 draft 는 promote 대상이 아니다.
+        // (prepareSpeakerDraft 가 진행 중에 사용자가 빠르게 탭하는 경우 가드)
+        if (state.status != SpeakerDraftStatus.Ready) return
+        // 선택한 화자를 제외한 다른 draft 의 prepare Job 을 cancel 해 cleanup 과 동시에 진행되지 않게 한다.
+        cancelOtherSpeakerDraftJobs(keepSpeakerId = speaker.id)
         scope.launch {
             promotingBusy = true
             stopMediaPreview()
@@ -1607,14 +1647,3 @@ private fun SharedVoiceViewerInfoDialog(
     )
 }
 
-private fun speakerSeparationErrorCode(error: Throwable): String? {
-    val body = (error as? retrofit2.HttpException)
-        ?.response()
-        ?.errorBody()
-        ?.string()
-        ?.takeIf { it.isNotBlank() }
-        ?: return null
-    return runCatching {
-        org.json.JSONObject(body).optString("error_code").takeIf { it.isNotBlank() }
-    }.getOrNull()
-}


### PR DESCRIPTION
QA 감사 보고 (Agent #3, #5) 의 Android 관련 Critical/High 7건 수정.

## Critical

- **C3 가족 음성 알람 항상 400** — \`AlarmDraft.toCachedLocalAudio()\` 가 \`AlarmAudioStore.readDurationMillis(uri)\` 로 실제 duration 측정. duration 못 읽으면 명확한 한글 오류.
- **C4 토큰 자동 갱신 부재** — \`VoiceAlarmApiClient.create(unauthorizedHandler)\` 에 OkHttp \`Authenticator\` 등록. 401 시 1회만 콜백 호출, 무한루프 방지. 콜백은 \`AuthSessionStore\` 클리어 + 재로그인 안내.

## High

- **VoiceProfile.name NPE 방어** — \`val name: String = \"\"\` 기본값 추가 (Gson 의 null 주입 위험 차단).
- **클로닝 race** — \`speakerDraftJobs: MutableMap<String, Job>\` + \`cancelOtherSpeakerDraftJobs(keepId)\`. select/reset/close/separate 시점에 다른 draft Job 취소, select 는 status != Ready 시 가드.
- **cacheFromUri Mutex** — companion \`cacheKeyLocks: ConcurrentHashMap<String, ReentrantLock>\`. 같은 cacheKey 동시 호출 시 두 번째가 잠금 대기.
- **시각 변경 race** — \`generationJob\` 보관, hour/minute 변경 LaunchedEffect 에서 cancel + isSaving=false + 안내.
- **error_code 헬퍼 통합** — \`network/ApiErrors.kt\` 의 \`apiErrorCode(error)\` 로 3중 복제 (panel/voice/billing) 일원화.

## 검증
- \`./gradlew :app:compileDebugKotlin\` BUILD SUCCESSFUL
- \`./gradlew :app:test\` BUILD SUCCESSFUL