### PR TITLE
feat(ios): Android 대비 부족 기능 보강 (Top 1~5)

### DIFF
--- a/apps/ios-native/VoiceAlarm/AlarmEnums.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmEnums.swift
@@ -175,6 +175,34 @@ enum VoiceProfileAudioLimits {
     static let maxDurationMillis: Int64 = 120_000
 }
 
+// MARK: - Random Prompt Context
+// Android: `TtsApi.kt:17` `randomContext`. 랜덤 깨움말 생성 시 함께 보내는
+// 컨텍스트 키. 백엔드가 컨텍스트별 프롬프트 템플릿/추가 입력값 (날씨/운세 등) 을
+// 결정한다. 추가 컨텍스트는 백엔드 합의 후 enum case 만 늘리면 된다.
+enum RandomPromptContext: String, CaseIterable, Identifiable {
+    case preset
+    case wakeWeather = "wake_weather"
+    case wakeFortune = "wake_fortune"
+    case meal
+    case sleep
+    case exercise
+    case love
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .preset: return "기본"
+        case .wakeWeather: return "날씨"
+        case .wakeFortune: return "운세"
+        case .meal: return "식사"
+        case .sleep: return "수면"
+        case .exercise: return "운동"
+        case .love: return "사랑"
+        }
+    }
+}
+
 // MARK: - Default Alarm Sound IDs
 // Android: `AlarmEntity.kt:174-176` `DefaultAlarmSounds`
 enum DefaultAlarmSounds {

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
@@ -86,6 +86,24 @@ struct AlarmEditorSheet: View {
                         }
                         .buttonStyle(.bordered)
                     }
+
+                    // Android `TtsApi.randomContext` 와 매칭되는 랜덤 프롬프트 토글.
+                    // 토글 ON 이면 카테고리 picker 가 노출되며, generateTTS 호출 시
+                    // VoiceStudioViewModel 의 randomPrompt/randomContext 가 함께 전달된다.
+                    // 날씨/운세 컨텍스트의 추가 입력(country/city/birthday 등) 은 추후 PR.
+                    Toggle("랜덤 깨움말 생성", isOn: $voiceStudio.randomPrompt)
+                        .tint(theme.palette.primary)
+                    if voiceStudio.randomPrompt {
+                        Picker("랜덤 컨텍스트", selection: $voiceStudio.randomContext) {
+                            ForEach(RandomPromptContext.allCases, id: \.rawValue) { context in
+                                Text(context.label).tag(context.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        Text("선택한 컨텍스트에 어울리는 깨움말이 자동 생성돼요.")
+                            .font(theme.typography.bodySmall)
+                            .foregroundStyle(theme.palette.onSurfaceVariant)
+                    }
                 }
             }
 

--- a/apps/ios-native/VoiceAlarm/Views/Settings/FamilyAlarmQuietTimeDialog.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Settings/FamilyAlarmQuietTimeDialog.swift
@@ -1,0 +1,399 @@
+import SwiftUI
+
+/// 가족 알람 "설정 불가 시간" 편집 모달.
+///
+/// Android `FamilyAlarmQuietTimeDialog` (`SettingsScreen.kt:387-559`) 의 SwiftUI
+/// 포팅. 시간대 목록(최대 8개)을 관리하며, 각 시간대마다 요일 선택과 시작/종료
+/// 시각을 편집한다. 저장 시 `[FamilyAlarmQuietWindow]` 를 콜백으로 돌려준다.
+///
+/// 요일 인덱스 컨벤션: Android 와 동일하게 0=일요일, 1=월요일 ... 6=토요일.
+/// 시간 문자열은 "HH:mm" 두 자리.
+struct FamilyAlarmQuietTimeDialog: View {
+    let initialWindows: [FamilyAlarmQuietWindow]
+    let onCancel: () -> Void
+    let onConfirm: ([FamilyAlarmQuietWindow]) -> Void
+
+    /// 편집 중인 시간대 목록. 한 행이 빠지지 않도록 최소 1행을 유지.
+    @State private var drafts: [QuietWindowDraft] = []
+    @State private var pickerTarget: QuietTimePickerTarget?
+
+    private static let maxWindows = 8
+
+    /// 한 행의 0..6 일 인덱스 → 한글 1글자.
+    private static let dayLabels: [String] = ["일", "월", "화", "수", "목", "금", "토"]
+
+    private var isValid: Bool {
+        !drafts.isEmpty && drafts.allSatisfy { $0.isValid }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(Array(drafts.enumerated()), id: \.offset) { index, draft in
+                        QuietWindowCard(
+                            index: index,
+                            draft: draft,
+                            removable: drafts.count > 1,
+                            onToggleDay: { day in toggleDay(index: index, day: day) },
+                            onPickStart: {
+                                pickerTarget = QuietTimePickerTarget(index: index, isStart: true)
+                            },
+                            onPickEnd: {
+                                pickerTarget = QuietTimePickerTarget(index: index, isStart: false)
+                            },
+                            onRemove: {
+                                drafts.remove(at: index)
+                            }
+                        )
+                    }
+                    Button {
+                        if drafts.count < Self.maxWindows {
+                            drafts.append(QuietWindowDraft.defaultEvening)
+                        }
+                    } label: {
+                        Text("+ 시간 추가")
+                            .font(.subheadline.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(drafts.count >= Self.maxWindows)
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 16)
+            }
+            footer
+        }
+        .background(VoiceAlarmTheme.background)
+        .onAppear {
+            // initialWindows 가 비어 있어도 최소 한 행을 채워 사용자가 입력을 시작할 수 있게 한다.
+            let seeds = initialWindows.isEmpty
+                ? [FamilyAlarmQuietWindow(days: [1, 2, 3, 4, 5], start: "22:00", end: "07:00")]
+                : initialWindows
+            drafts = seeds.map(QuietWindowDraft.init(window:))
+        }
+        .sheet(item: $pickerTarget) { target in
+            QuietTimePicker(
+                title: target.isStart ? "시작 시간" : "종료 시간",
+                initialHour: hour(forTarget: target),
+                initialMinute: minute(forTarget: target),
+                onCancel: { pickerTarget = nil },
+                onConfirm: { hh, mm in
+                    apply(hour: hh, minute: mm, target: target)
+                    pickerTarget = nil
+                }
+            )
+            .presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("설정 불가 시간")
+                    .font(.title3.weight(.bold))
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            Text("선택한 시간대에는 다른 사람이 내게 알람을 만들 수 없어요.")
+                .font(.footnote)
+                .foregroundStyle(VoiceAlarmTheme.textSecondary)
+        }
+        .padding(20)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Button("취소", action: onCancel)
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+            Button("저장") {
+                onConfirm(drafts.map { $0.toWindow() })
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(VoiceAlarmTheme.primary)
+            .frame(maxWidth: .infinity)
+            .disabled(!isValid)
+        }
+        .padding(20)
+        .background(VoiceAlarmTheme.surface)
+        .overlay(
+            Rectangle()
+                .fill(VoiceAlarmTheme.outline.opacity(0.5))
+                .frame(height: 1),
+            alignment: .top
+        )
+    }
+
+    // MARK: - Edits
+
+    private func toggleDay(index: Int, day: Int) {
+        guard drafts.indices.contains(index) else { return }
+        var draft = drafts[index]
+        if draft.days.contains(day) {
+            draft.days.remove(day)
+        } else {
+            draft.days.insert(day)
+        }
+        drafts[index] = draft
+    }
+
+    private func hour(forTarget target: QuietTimePickerTarget) -> Int {
+        guard drafts.indices.contains(target.index) else { return 9 }
+        let draft = drafts[target.index]
+        return target.isStart ? draft.startHour : draft.endHour
+    }
+
+    private func minute(forTarget target: QuietTimePickerTarget) -> Int {
+        guard drafts.indices.contains(target.index) else { return 0 }
+        let draft = drafts[target.index]
+        return target.isStart ? draft.startMinute : draft.endMinute
+    }
+
+    private func apply(hour: Int, minute: Int, target: QuietTimePickerTarget) {
+        guard drafts.indices.contains(target.index) else { return }
+        var draft = drafts[target.index]
+        if target.isStart {
+            draft.startHour = hour
+            draft.startMinute = minute
+        } else {
+            draft.endHour = hour
+            draft.endMinute = minute
+        }
+        drafts[target.index] = draft
+    }
+}
+
+// MARK: - Draft model
+
+private struct QuietWindowDraft: Equatable {
+    var days: Set<Int>           // 0..6
+    var startHour: Int           // 0..23
+    var startMinute: Int         // 0..59
+    var endHour: Int             // 0..23
+    var endMinute: Int           // 0..59
+
+    static let defaultEvening = QuietWindowDraft(
+        days: [1, 2, 3, 4, 5],
+        startHour: 22,
+        startMinute: 0,
+        endHour: 7,
+        endMinute: 0
+    )
+
+    init(days: Set<Int>, startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
+        self.days = days
+        self.startHour = startHour
+        self.startMinute = startMinute
+        self.endHour = endHour
+        self.endMinute = endMinute
+    }
+
+    init(window: FamilyAlarmQuietWindow) {
+        let cleanedDays = window.days.filter { (0...6).contains($0) }
+        days = Set(cleanedDays.isEmpty ? [1, 2, 3, 4, 5] : cleanedDays)
+        let start = QuietWindowDraft.parse(window.start, fallbackHour: 9, fallbackMinute: 0)
+        let end = QuietWindowDraft.parse(window.end, fallbackHour: 18, fallbackMinute: 30)
+        startHour = start.hour
+        startMinute = start.minute
+        endHour = end.hour
+        endMinute = end.minute
+    }
+
+    var isValid: Bool {
+        !days.isEmpty &&
+            (0...23).contains(startHour) &&
+            (0...59).contains(startMinute) &&
+            (0...23).contains(endHour) &&
+            (0...59).contains(endMinute)
+    }
+
+    func toWindow() -> FamilyAlarmQuietWindow {
+        FamilyAlarmQuietWindow(
+            days: days.sorted(),
+            start: QuietWindowDraft.timeString(hour: startHour, minute: startMinute),
+            end: QuietWindowDraft.timeString(hour: endHour, minute: endMinute)
+        )
+    }
+
+    private static func parse(_ raw: String, fallbackHour: Int, fallbackMinute: Int) -> (hour: Int, minute: Int) {
+        let parts = raw.split(separator: ":")
+        let h = parts.first.flatMap { Int($0) } ?? fallbackHour
+        let m = parts.dropFirst().first.flatMap { Int($0) } ?? fallbackMinute
+        return (max(0, min(23, h)), max(0, min(59, m)))
+    }
+
+    private static func timeString(hour: Int, minute: Int) -> String {
+        String(format: "%02d:%02d", max(0, min(23, hour)), max(0, min(59, minute)))
+    }
+}
+
+// MARK: - Picker target
+
+private struct QuietTimePickerTarget: Identifiable {
+    let index: Int
+    let isStart: Bool
+    var id: String { "\(index)-\(isStart)" }
+}
+
+// MARK: - Card
+
+private struct QuietWindowCard: View {
+    let index: Int
+    let draft: QuietWindowDraft
+    let removable: Bool
+    let onToggleDay: (Int) -> Void
+    let onPickStart: () -> Void
+    let onPickEnd: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("시간대 \(index + 1)")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                if removable {
+                    Button(role: .destructive, action: onRemove) {
+                        Image(systemName: "trash")
+                            .foregroundStyle(VoiceAlarmTheme.error)
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("이 시간대 삭제")
+                }
+            }
+            HStack(spacing: 6) {
+                ForEach(0..<7, id: \.self) { day in
+                    let selected = draft.days.contains(day)
+                    Button {
+                        onToggleDay(day)
+                    } label: {
+                        Text(dayLabel(day))
+                            .font(.footnote.weight(.semibold))
+                            .frame(maxWidth: .infinity, minHeight: 36)
+                            .background(
+                                selected ? VoiceAlarmTheme.primary : VoiceAlarmTheme.surfaceVariant,
+                                in: Capsule()
+                            )
+                            .foregroundStyle(selected ? Color.white : VoiceAlarmTheme.text)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            HStack(spacing: 8) {
+                timeChip(label: timeLabel(hour: draft.startHour, minute: draft.startMinute), action: onPickStart)
+                Text("~")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                timeChip(label: timeLabel(hour: draft.endHour, minute: draft.endMinute), action: onPickEnd)
+            }
+        }
+        .padding(14)
+        .background(VoiceAlarmTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14).stroke(VoiceAlarmTheme.outline, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func timeChip(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(VoiceAlarmTheme.primaryDark)
+                .frame(maxWidth: .infinity, minHeight: 48)
+                .background(VoiceAlarmTheme.primary.opacity(0.15), in: RoundedRectangle(cornerRadius: 14))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(VoiceAlarmTheme.primary.opacity(0.5), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func dayLabel(_ day: Int) -> String {
+        let labels = ["일", "월", "화", "수", "목", "금", "토"]
+        return labels[max(0, min(6, day))]
+    }
+
+    private func timeLabel(hour: Int, minute: Int) -> String {
+        String(format: "%d:%02d", hour, minute)
+    }
+}
+
+// MARK: - Time picker
+
+/// 단순 시:분 픽커. SwiftUI `DatePicker(.wheel)` 의 hour/minute 만 사용.
+private struct QuietTimePicker: View {
+    let title: String
+    let initialHour: Int
+    let initialMinute: Int
+    let onCancel: () -> Void
+    let onConfirm: (Int, Int) -> Void
+
+    @State private var selection: Date = Date()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text(title)
+                    .font(.title3.weight(.bold))
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            DatePicker(
+                "",
+                selection: $selection,
+                displayedComponents: [.hourAndMinute]
+            )
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+            HStack(spacing: 10) {
+                Button("취소", action: onCancel)
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity)
+                Button("확인") {
+                    let cal = Calendar(identifier: .gregorian)
+                    let parts = cal.dateComponents([.hour, .minute], from: selection)
+                    onConfirm(parts.hour ?? 0, parts.minute ?? 0)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(VoiceAlarmTheme.primary)
+                .frame(maxWidth: .infinity)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .onAppear {
+            var comps = DateComponents()
+            comps.hour = initialHour
+            comps.minute = initialMinute
+            selection = Calendar(identifier: .gregorian).date(from: comps) ?? Date()
+        }
+    }
+}
+
+#if DEBUG
+#Preview("FamilyAlarmQuietTimeDialog") {
+    FamilyAlarmQuietTimeDialog(
+        initialWindows: [
+            FamilyAlarmQuietWindow(days: [1, 2, 3, 4, 5], start: "22:00", end: "07:00"),
+            FamilyAlarmQuietWindow(days: [0, 6], start: "00:00", end: "10:00"),
+        ],
+        onCancel: {},
+        onConfirm: { _ in }
+    )
+}
+#endif

--- a/apps/ios-native/VoiceAlarm/Views/Settings/SettingsView.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Settings/SettingsView.swift
@@ -11,6 +11,8 @@ struct SettingsView: View {
     @EnvironmentObject private var socialFeatures: SocialFeatureViewModel
 
     @State private var nicknameDraft: String = ""
+    /// "설정 불가 시간" 편집 모달 표시 플래그.
+    @State private var quietDialogOpen: Bool = false
 
     /// 보조 화면 요청 — 부모가 settingsPresented 를 false 로 만들고,
     /// 시트 dismiss 후 auxiliaryScreen 을 세팅한다.
@@ -66,7 +68,27 @@ struct SettingsView: View {
                             }
                         }
                         Divider()
-                        SettingsRow(label: "설정 불가 시간", value: HelperFormatters.quietScheduleLabel(user.familyAlarmQuietWindows))
+                        // Android `FamilyAlarmQuietTimeDialog` 와 동등 — 라벨 부분은 현재 값을
+                        // 그대로 보여주고, 탭 시 편집 모달을 띄운다.
+                        Button {
+                            quietDialogOpen = true
+                        } label: {
+                            HStack {
+                                Text("설정 불가 시간")
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(VoiceAlarmTheme.text)
+                                Spacer()
+                                Text(HelperFormatters.quietScheduleLabel(user.familyAlarmQuietWindows))
+                                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                                    .lineLimit(1)
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
                     }
                     .settingsCard(title: "공유 알람")
 
@@ -84,6 +106,20 @@ struct SettingsView: View {
         .background(VoiceAlarmTheme.background)
         .onAppear {
             nicknameDraft = auth.session?.user.name ?? ""
+        }
+        .sheet(isPresented: $quietDialogOpen) {
+            FamilyAlarmQuietTimeDialog(
+                initialWindows: auth.session?.user.familyAlarmQuietWindows ?? [],
+                onCancel: { quietDialogOpen = false },
+                onConfirm: { windows in
+                    quietDialogOpen = false
+                    Task {
+                        await auth.updateProfile(quietWindows: windows)
+                        await socialFeatures.refreshAll(session: auth.session)
+                    }
+                }
+            )
+            .presentationDetents([.large])
         }
     }
 }

--- a/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
@@ -16,6 +16,9 @@ struct VoiceCloneUploadFlow: View {
     @State private var profileName: String = ""
     @State private var noiseRemovalEnabled: Bool = false
     @State private var isShared: Bool = false
+    /// 공유된 음성을 받는 사람이 자신을 부를 호칭. Android `VoiceProfileApi.kt:74`.
+    /// 본인이 사용할 때는 비어 있어도 무방하나, 가족·커플에게 공유할 거라면 미리 채워둔다.
+    @State private var listenerTitle: String = ""
     @State private var animatedLevel: CGFloat = 0.0
     @State private var levelTimer: Timer?
 
@@ -73,6 +76,15 @@ struct VoiceCloneUploadFlow: View {
                 .onChange(of: profileName) { _, newValue in
                     voice.cloneName = newValue
                 }
+            Text("이 목소리가 부를 호칭")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                .padding(.top, 4)
+            TextField("예: 지호야, 우리 강아지", text: $listenerTitle)
+                .textFieldStyle(.roundedBorder)
+            Text("공유 받은 사람이 듣게 될 호칭이에요. 공유하지 않으면 비워둬도 돼요.")
+                .font(.caption2)
+                .foregroundStyle(VoiceAlarmTheme.textSecondary)
             HStack(spacing: 10) {
                 Toggle(isOn: $isShared) {
                     Text("가족·커플과 공유")
@@ -266,17 +278,24 @@ struct VoiceCloneUploadFlow: View {
         }
         let trimmedName = profileName.trimmingCharacters(in: .whitespacesAndNewlines)
         let effectiveName = trimmedName.isEmpty ? "내 목소리" : trimmedName
+        let trimmedListener = listenerTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveListener = trimmedListener.isEmpty ? nil : trimmedListener
         if noiseRemovalEnabled {
             let _ = await voice.cloneWithNoiseRemoval(
                 audioFileURL: url,
                 name: effectiveName,
                 durationMs: durationMs,
                 isShared: isShared,
-                session: auth.session
+                session: auth.session,
+                listenerTitle: effectiveListener
             )
         } else {
             voice.cloneName = effectiveName
-            await voice.uploadRecordingForClone(session: auth.session)
+            await voice.uploadRecordingForClone(
+                session: auth.session,
+                isShared: isShared,
+                listenerTitle: effectiveListener
+            )
         }
         // 성공 시 management 로 복귀.
         if voice.statusMessage?.contains("등록") == true || voice.statusMessage?.contains("완료") == true {

--- a/apps/ios-native/VoiceAlarm/Views/Voices/VoiceProfileManagementPanel.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/VoiceProfileManagementPanel.swift
@@ -31,6 +31,10 @@ struct VoiceProfileManagementPanel: View {
     /// 슬롯 가득 시 노출하는 플랜 안내 시트.
     @State private var planGateOpen: Bool = false
 
+    /// 공유받은 음성에 viewer 가 자신의 관계/호칭을 등록할 때 사용하는 다이얼로그 타깃.
+    /// Android `SharedVoiceViewerInfoDialog` (VoiceProfileManagementPanel.kt:1543) 와 동일한 의도.
+    @State private var sharedViewerInfoTarget: FamilyVoiceProfile?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             ScreenHeader(title: "음성", subtitle: nil)
@@ -107,6 +111,27 @@ struct VoiceProfileManagementPanel: View {
                     onRequestBilling?()
                 },
                 onClose: { planGateOpen = false }
+            )
+            .presentationDetents([.medium])
+        }
+        .sheet(item: $sharedViewerInfoTarget) { profile in
+            SharedVoiceViewerInfoDialog(
+                profileName: profile.name,
+                initialRelationship: profile.relationshipLabel ?? "",
+                initialListenerTitle: profile.listenerTitle ?? "",
+                onCancel: { sharedViewerInfoTarget = nil },
+                onConfirm: { relation, listener in
+                    let target = profile
+                    sharedViewerInfoTarget = nil
+                    Task {
+                        await voice.updateSharedVoiceViewerInfo(
+                            profileId: target.id,
+                            relationshipLabel: relation,
+                            listenerTitle: listener,
+                            session: auth.session
+                        )
+                    }
+                }
             )
             .presentationDetents([.medium])
         }
@@ -225,7 +250,10 @@ struct VoiceProfileManagementPanel: View {
                 Text("공유받은 보이스")
                     .font(.subheadline.weight(.semibold))
                 ForEach(voice.familyVoices) { family in
-                    FamilyVoiceProfileRow(profile: family)
+                    FamilyVoiceProfileRow(
+                        profile: family,
+                        onEdit: { sharedViewerInfoTarget = family }
+                    )
                 }
             }
         }
@@ -389,22 +417,49 @@ private extension ISO8601DateFormatter {
 
 private struct FamilyVoiceProfileRow: View {
     let profile: FamilyVoiceProfile
+    let onEdit: () -> Void
+
+    /// Android `SharedVoiceProfileRow.needsViewerInfo` (VoiceProfileManagementPanel.kt:1477) 와 동일.
+    /// 관계/호칭 중 하나라도 비어 있으면 "설정하기" CTA 버튼을 노출.
+    private var needsViewerInfo: Bool {
+        (profile.relationshipLabel?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) ||
+            (profile.listenerTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+    }
 
     var body: some View {
-        HStack(spacing: 12) {
-            ZStack {
-                Circle().fill(VoiceAlarmTheme.secondary.opacity(0.18))
-                Image(systemName: "person.wave.2")
-                    .foregroundStyle(VoiceAlarmTheme.secondary)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle().fill(VoiceAlarmTheme.secondary.opacity(0.18))
+                    Image(systemName: "person.wave.2")
+                        .foregroundStyle(VoiceAlarmTheme.secondary)
+                }
+                .frame(width: 40, height: 40)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(profile.name).font(.subheadline.weight(.semibold))
+                    Text(detailLine)
+                        .font(.caption)
+                        .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                }
+                Spacer()
+                Button(action: onEdit) {
+                    Image(systemName: "pencil")
+                        .font(.callout)
+                        .foregroundStyle(VoiceAlarmTheme.primary)
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("내 정보 수정")
             }
-            .frame(width: 40, height: 40)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(profile.name).font(.subheadline.weight(.semibold))
-                Text(profile.ownerName?.isEmpty == false ? "\(profile.ownerName!) 님의 보이스" : "공유받은 보이스")
-                    .font(.caption)
-                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+            if needsViewerInfo {
+                Button(action: onEdit) {
+                    Text("이 음성이 나를 부를 호칭 설정하기")
+                        .font(.footnote.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(VoiceAlarmTheme.primary)
             }
-            Spacer()
         }
         .padding(12)
         .background(VoiceAlarmTheme.surface)
@@ -412,6 +467,23 @@ private struct FamilyVoiceProfileRow: View {
             RoundedRectangle(cornerRadius: 12).stroke(VoiceAlarmTheme.outline, lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// 소유자명 + (관계, 호칭) 정보를 한 줄로 조립.
+    private var detailLine: String {
+        var parts: [String] = []
+        if let owner = profile.ownerName, !owner.isEmpty {
+            parts.append("\(owner) 님의 보이스")
+        } else {
+            parts.append("공유받은 보이스")
+        }
+        if let relation = profile.relationshipLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !relation.isEmpty {
+            parts.append("관계 \(relation)")
+        }
+        if let listener = profile.listenerTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !listener.isEmpty {
+            parts.append("호칭 \(listener)")
+        }
+        return parts.joined(separator: " · ")
     }
 }
 
@@ -521,6 +593,109 @@ private struct VoiceProfileDeleteDialog: View {
             Spacer(minLength: 0)
         }
         .padding(20)
+    }
+}
+
+// MARK: - Shared voice viewer info dialog
+
+/// 공유받은 음성에 대해 viewer 가 자신과의 관계와 호칭을 설정하는 다이얼로그.
+///
+/// Android `SharedVoiceViewerInfoDialog`
+/// (`VoiceProfileManagementPanel.kt:1543`) 와 1:1 대응. 둘 다 필수이며, 비어 있으면
+/// 인라인 오류 메시지를 띄우고 저장을 막는다.
+private struct SharedVoiceViewerInfoDialog: View {
+    let profileName: String
+    let initialRelationship: String
+    let initialListenerTitle: String
+    let onCancel: () -> Void
+    let onConfirm: (String, String) -> Void
+
+    @State private var relationship: String = ""
+    @State private var listenerTitle: String = ""
+    @State private var submitted: Bool = false
+
+    private var trimmedRelationship: String {
+        relationship.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var trimmedListener: String {
+        listenerTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var relationshipError: Bool { submitted && trimmedRelationship.isEmpty }
+    private var listenerError: Bool { submitted && trimmedListener.isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                Text("공유 음성 설정")
+                    .font(.title3.weight(.bold))
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            Text("'\(profileName)' 가 내게 어떻게 말할지 알려주세요.")
+                .font(.subheadline)
+                .foregroundStyle(VoiceAlarmTheme.textSecondary)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("나와의 관계")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                TextField("예: 손주, 자식, 형제", text: $relationship)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: relationship) { _, newValue in
+                        if newValue.count > 30 {
+                            relationship = String(newValue.prefix(30))
+                        }
+                    }
+                if relationshipError {
+                    Text("필수 입력 값입니다.")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(VoiceAlarmTheme.error)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("이 목소리가 나를 부를 호칭")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(VoiceAlarmTheme.textSecondary)
+                TextField("예: 지호야, 우리 강아지", text: $listenerTitle)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: listenerTitle) { _, newValue in
+                        if newValue.count > 30 {
+                            listenerTitle = String(newValue.prefix(30))
+                        }
+                    }
+                if listenerError {
+                    Text("필수 입력 값입니다.")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(VoiceAlarmTheme.error)
+                }
+            }
+
+            HStack {
+                Button("취소", action: onCancel)
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity)
+                Button("저장") {
+                    submitted = true
+                    if !trimmedRelationship.isEmpty && !trimmedListener.isEmpty {
+                        onConfirm(trimmedRelationship, trimmedListener)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(VoiceAlarmTheme.primary)
+                .frame(maxWidth: .infinity)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .onAppear {
+            relationship = initialRelationship
+            listenerTitle = initialListenerTitle
+        }
     }
 }
 

--- a/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
@@ -90,11 +90,46 @@ struct VoiceProfile: Decodable, Identifiable, Equatable {
     var status: String?
     var createdAt: String?
     var isShared: Bool?
+    /// 작성 중 임시 프로필 여부. promote 하기 전엔 알람 선택에 노출하지 않는다.
+    /// Android `VoiceProfileApi.kt:72`.
+    var isDraft: Bool?
+    /// 공유 음성을 받은 사람이 음성 주인과의 관계를 기록한 라벨.
+    /// (예: "엄마", "할머니"). Android `VoiceProfileApi.kt:73`.
+    var relationshipLabel: String?
+    /// 공유 음성이 viewer 를 부를 때 쓰는 호칭(예: "지호야").
+    /// Android `VoiceProfileApi.kt:74`.
+    var listenerTitle: String?
 }
 
 struct VoiceProfileUpdateRequest: Encodable {
     var name: String?
     var isShared: Bool?
+    /// promote 시 false 로 명시 전송.
+    var isDraft: Bool?
+    var relationshipLabel: String?
+    var listenerTitle: String?
+
+    init(
+        name: String? = nil,
+        isShared: Bool? = nil,
+        isDraft: Bool? = nil,
+        relationshipLabel: String? = nil,
+        listenerTitle: String? = nil
+    ) {
+        self.name = name
+        self.isShared = isShared
+        self.isDraft = isDraft
+        self.relationshipLabel = relationshipLabel
+        self.listenerTitle = listenerTitle
+    }
+}
+
+/// `PATCH /voice/:id/relationship` 의 body. 공유받은 음성 viewer 가 자신의
+/// 관계/호칭을 등록할 때 사용. 두 값 모두 필수.
+/// Android `VoiceProfileApi.kt:61-64`.
+struct VoiceProfileRelationshipUpdateRequest: Encodable {
+    var relationshipLabel: String
+    var listenerTitle: String
 }
 
 struct VoiceUploadResponse: Decodable {
@@ -148,6 +183,55 @@ struct TtsGenerateRequest: Encodable {
     var language: String
     var translate: Bool
     var random: Bool
+    /// 랜덤 프롬프트 컨텍스트 (preset / wake_weather / wake_fortune / meal /
+    /// sleep / exercise / love). Android `TtsApi.kt:17` 참고.
+    var randomContext: String?
+    /// 알람이 울릴 시각 (랜덤 프롬프트에 시간 컨텍스트 제공).
+    var alarmHour: Int?
+    var alarmMinute: Int?
+    /// 날씨 랜덤 프롬프트용 위치.
+    var weatherCountry: String?
+    var weatherCity: String?
+    /// 운세 랜덤 프롬프트용 사주.
+    var fortuneGender: String?
+    var fortuneBirthDate: String?
+    var fortuneBirthTime: String?
+    /// 공유 음성 viewer 가 자신을 부를 호칭.
+    var listenerTitle: String?
+
+    init(
+        voiceProfileId: String,
+        text: String,
+        category: String,
+        language: String,
+        translate: Bool,
+        random: Bool,
+        randomContext: String? = nil,
+        alarmHour: Int? = nil,
+        alarmMinute: Int? = nil,
+        weatherCountry: String? = nil,
+        weatherCity: String? = nil,
+        fortuneGender: String? = nil,
+        fortuneBirthDate: String? = nil,
+        fortuneBirthTime: String? = nil,
+        listenerTitle: String? = nil
+    ) {
+        self.voiceProfileId = voiceProfileId
+        self.text = text
+        self.category = category
+        self.language = language
+        self.translate = translate
+        self.random = random
+        self.randomContext = randomContext
+        self.alarmHour = alarmHour
+        self.alarmMinute = alarmMinute
+        self.weatherCountry = weatherCountry
+        self.weatherCity = weatherCity
+        self.fortuneGender = fortuneGender
+        self.fortuneBirthDate = fortuneBirthDate
+        self.fortuneBirthTime = fortuneBirthTime
+        self.listenerTitle = listenerTitle
+    }
 }
 
 struct TtsGenerateResponse: Decodable, Equatable {
@@ -161,6 +245,9 @@ struct TtsGenerateResponse: Decodable, Equatable {
     var cacheKey: String?
     var cacheHit: Bool?
     var provider: String?
+    /// 랜덤 프롬프트가 사용된 경우, 백엔드가 선택한 실제 컨텍스트(다양화/감사 용).
+    /// Android `TtsApi.kt:39`.
+    var randomContext: String?
 }
 
 struct TtsMessageListResponse: Decodable {
@@ -230,6 +317,10 @@ struct FamilyVoiceProfile: Decodable, Identifiable, Equatable {
     var userId: String?
     var ownerName: String?
     var isShared: Bool?
+    /// 받은 사람이 음성 주인과의 관계로 등록한 라벨.
+    var relationshipLabel: String?
+    /// 받은 사람을 음성이 부를 호칭.
+    var listenerTitle: String?
 }
 
 struct CodeRegisterRequest: Encodable {
@@ -653,7 +744,10 @@ final class VoiceAlarmAPI {
         isShared: Bool,
         durationMs: Int,
         token: String,
-        noiseRemoval: Bool = false
+        noiseRemoval: Bool = false,
+        relationshipLabel: String? = nil,
+        listenerTitle: String? = nil,
+        isDraft: Bool? = nil
     ) async throws -> VoiceProfile {
         var fields: [String: String] = [
             "name": name,
@@ -665,6 +759,17 @@ final class VoiceAlarmAPI {
         if noiseRemoval {
             fields["noiseRemoval"] = "true"
             fields["noise_removal"] = "true"
+        }
+        // Android `VoiceProfileApi.kt:97-108` 와 동일하게 multipart 필드로 전송.
+        // 비어 있으면 보내지 않아 백엔드 누락 검증을 피한다.
+        if let trimmed = relationshipLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+            fields["relationshipLabel"] = trimmed
+        }
+        if let trimmed = listenerTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+            fields["listenerTitle"] = trimmed
+        }
+        if let isDraft {
+            fields["isDraft"] = isDraft ? "true" : "false"
         }
         let response: VoiceProfileResponse = try await multipartRequest(
             "voice/clone",
@@ -766,13 +871,22 @@ final class VoiceAlarmAPI {
         id: String,
         name: String? = nil,
         isShared: Bool? = nil,
+        isDraft: Bool? = nil,
+        relationshipLabel: String? = nil,
+        listenerTitle: String? = nil,
         token: String
     ) async throws -> VoiceProfile {
         let response: VoiceProfileResponse = try await request(
             "voice/\(id)",
             method: "PATCH",
             token: token,
-            body: VoiceProfileUpdateRequest(name: name.nilIfBlank, isShared: isShared)
+            body: VoiceProfileUpdateRequest(
+                name: name.nilIfBlank,
+                isShared: isShared,
+                isDraft: isDraft,
+                relationshipLabel: relationshipLabel?.nilIfBlank,
+                listenerTitle: listenerTitle?.nilIfBlank
+            )
         )
         return response.profile
     }
@@ -782,6 +896,45 @@ final class VoiceAlarmAPI {
         // 보내 향후 백엔드가 "사용 중일 때 거부" 모드를 도입해도 호환되도록 한다.
         let path = force ? "voice/\(id)?force=true" : "voice/\(id)"
         let _: EmptyResponse = try await request(path, method: "DELETE", token: token)
+    }
+
+    /// 임시(draft) 음성을 정식 프로필로 승격. `PATCH /voice/:id` body 에
+    /// `is_draft: false` 만 보내는 변형. Android `MainViewModelVoiceActions` 의 promote 흐름.
+    func promoteDraftVoice(profileId: String, token: String) async throws -> VoiceProfile {
+        let response: VoiceProfileResponse = try await request(
+            "voice/\(profileId)",
+            method: "PATCH",
+            token: token,
+            body: VoiceProfileUpdateRequest(isDraft: false)
+        )
+        return response.profile
+    }
+
+    /// 임시(draft) 음성을 영구 삭제. `DELETE /voice/:id?force=true`.
+    /// promote 하지 않고 시트를 닫은 경우 호출.
+    func deleteDraftVoice(profileId: String, token: String) async throws {
+        try await deleteVoiceProfile(id: profileId, token: token, force: true)
+    }
+
+    /// 공유받은 음성에 대한 viewer 의 관계/호칭 갱신.
+    /// `PATCH /voice/:id/relationship`. body 의 두 필드는 모두 필수.
+    /// Android `VoiceProfileApi.kt:132-137`.
+    func updateVoiceProfileRelationship(
+        profileId: String,
+        relationshipLabel: String,
+        listenerTitle: String,
+        token: String
+    ) async throws -> VoiceProfile {
+        let response: VoiceProfileResponse = try await request(
+            "voice/\(profileId)/relationship",
+            method: "PATCH",
+            token: token,
+            body: VoiceProfileRelationshipUpdateRequest(
+                relationshipLabel: relationshipLabel.trimmingCharacters(in: .whitespacesAndNewlines),
+                listenerTitle: listenerTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        )
+        return response.profile
     }
 
     func listFamilyVoiceProfiles(token: String) async throws -> [FamilyVoiceProfile] {

--- a/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
@@ -36,6 +36,10 @@ final class VoiceStudioViewModel: ObservableObject {
     @Published var ttsLanguage = "ko"
     @Published var translateText = false
     @Published var randomPrompt = false
+    /// 랜덤 프롬프트 컨텍스트. Android `TtsApi.kt` randomContext 와 동일.
+    /// 허용 값: preset / wake_weather / wake_fortune / meal / sleep / exercise / love.
+    /// randomPrompt 가 true 일 때만 의미가 있다.
+    @Published var randomContext: String = "preset"
     @Published var cloneName = "내 목소리"
     @Published var isBusy = false
     @Published var statusMessage: String?
@@ -357,7 +361,8 @@ final class VoiceStudioViewModel: ObservableObject {
                     category: ttsCategory,
                     language: ttsLanguage,
                     translate: translateText,
-                    random: randomPrompt
+                    random: randomPrompt,
+                    randomContext: randomPrompt ? randomContext : nil
                 ),
                 token: token
             )

--- a/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
@@ -122,7 +122,11 @@ final class VoiceStudioViewModel: ObservableObject {
         statusMessage = "녹음을 저장했어요. \(recordingDurationLabel)"
     }
 
-    func uploadRecordingForClone(session: AuthSession?) async {
+    func uploadRecordingForClone(
+        session: AuthSession?,
+        isShared: Bool = false,
+        listenerTitle: String? = nil
+    ) async {
         guard let token = session?.token else {
             statusMessage = "로그인이 필요해요."
             return
@@ -145,9 +149,10 @@ final class VoiceStudioViewModel: ObservableObject {
             let profile = try await api.cloneVoice(
                 audioFileURL: url,
                 name: cloneName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "내 목소리" : cloneName,
-                isShared: false,
+                isShared: isShared,
                 durationMs: durationMs,
-                token: token
+                token: token,
+                listenerTitle: listenerTitle
             )
             selectedProfileID = profile.id
             statusMessage = "목소리 학습을 등록했어요."
@@ -163,7 +168,8 @@ final class VoiceStudioViewModel: ObservableObject {
         name: String,
         durationMs: Int,
         isShared: Bool,
-        session: AuthSession?
+        session: AuthSession?,
+        listenerTitle: String? = nil
     ) async -> VoiceProfile? {
         guard let token = session?.token else {
             statusMessage = "로그인이 필요해요."
@@ -179,7 +185,8 @@ final class VoiceStudioViewModel: ObservableObject {
                 isShared: isShared,
                 durationMs: durationMs,
                 token: token,
-                noiseRemoval: true
+                noiseRemoval: true,
+                listenerTitle: listenerTitle
             )
             selectedProfileID = profile.id
             statusMessage = "배경음 제거 학습이 완료됐어요."
@@ -188,6 +195,35 @@ final class VoiceStudioViewModel: ObservableObject {
         } catch {
             statusMessage = mapVoiceError(error)
             return nil
+        }
+    }
+
+    /// 공유받은 음성에 viewer 의 관계·호칭을 등록한다.
+    /// `VoiceProfileManagementPanel` 의 SharedVoiceViewerInfoDialog 가 호출.
+    func updateSharedVoiceViewerInfo(
+        profileId: String,
+        relationshipLabel: String,
+        listenerTitle: String,
+        session: AuthSession?
+    ) async {
+        guard let token = session?.token else {
+            statusMessage = "로그인이 필요해요."
+            return
+        }
+        guard !isBusy else { return }
+        isBusy = true
+        defer { isBusy = false }
+        do {
+            _ = try await api.updateVoiceProfileRelationship(
+                profileId: profileId,
+                relationshipLabel: relationshipLabel,
+                listenerTitle: listenerTitle,
+                token: token
+            )
+            statusMessage = "공유 음성 정보를 저장했어요."
+            await refresh(session: session)
+        } catch {
+            statusMessage = mapVoiceError(error)
         }
     }
 


### PR DESCRIPTION
QA 감사 보고 (Agent #4) 의 iOS 기능 격차 우선순위 Top 1~5 보강.

## Top 1+2 — API 정합 (\`54b3885\`)
- \`TtsGenerateRequest\` 에 randomContext / alarmHour / alarmMinute / weather*  / fortune* / listenerTitle 8필드 추가 (Android 14필드와 일치)
- \`TtsGenerateResponse.randomContext\` 디코딩 추가
- \`VoiceProfile\`, \`FamilyVoiceProfile\` 에 isDraft / relationshipLabel / listenerTitle 추가
- \`VoiceProfileUpdateRequest\` 확장 + 신규 \`VoiceProfileRelationshipUpdateRequest\`
- \`cloneVoice\` 멀티파트에 relationshipLabel / listenerTitle / isDraft 파트 추가
- 신규 API 메서드: \`promoteDraftVoice\`, \`deleteDraftVoice\`, \`updateVoiceProfileRelationship\`
- \`VoiceCloneUploadFlow.nameSection\` 에 호칭 입력 칸 추가

## Top 4 — 공유 음성 viewer info 다이얼로그 (\`90fd664\`)
\`FamilyVoiceProfileRow\` pencil 버튼 + \`needsViewerInfo\` 시 \"호칭 설정하기\" CTA + 신규 \`SharedVoiceViewerInfoDialog\` 시트 (관계+호칭 필수, 30자 cap).

## Top 5 — 블랙아웃 시간 편집 모달 (\`5ea63b1\`)
\`FamilyAlarmQuietTimeDialog.swift\` 신규 — 최대 8개 시간대, 요일 7-칩, 시작/종료 시각 (.wheel DatePicker), + 추가 / trash 제거. 저장 시 \`AuthViewModel.updateProfile(quietWindows:)\` 호출.

## Top 3 (부분) — 랜덤 깨움말 UI (\`b77102e\`)
\`RandomPromptContext\` enum 7-case + \`VoiceStudioViewModel.randomContext\` + \`AlarmEditorSheet\` 토글·picker 노출. 단, wake_weather / wake_fortune 의 추가 입력(country/city, fortune_*) UI 는 후속 PR 로 분리.

## 검증 한계
Windows 환경이라 \`xcodebuild\` 실행 불가. iOS 빌드는 macOS 에서 \`./scripts/build-debug.sh\` 로 확인 필요. SwiftUI Preview 로 신규 시트 시각 확인 권장.