### PR TITLE
feat: 수동 입력 TTS에도 Gemini 자동 태깅 적용

### DIFF
--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -442,7 +442,7 @@ function alarmTextPrompt(args: {
     ? `Translate the user's alarm message from ${sourceName} to ${targetName}.`
     : `Keep the user's alarm message in ${sourceName}.`;
   const tagInstruction = args.shouldTag
-    ? `Add exactly one ElevenLabs v3 delivery tag from this allowlist: ${APPROVED_TAGS.map((tag) => `[${tag}]`).join(', ')}. Put the single tag at the beginning of the text. Do not rewrite, add, remove, or reorder any words unless translation is requested.`
+    ? `Add exactly one ElevenLabs v3 delivery tag from this allowlist: ${APPROVED_TAGS.map((tag) => `[${tag}]`).join(', ')}. Put the single tag at the very beginning of the text. Pick the tag that best matches the meaning and intended mood of the user text — use [warmly]/[encouraging]/[gentle]/[comforting] for affectionate or soft lines, [calmly]/[softly]/[sleepily] for night or quiet lines, [happily]/[brightly]/[proudly] for cheerful or celebratory lines. Do not rewrite, add, remove, or reorder any words unless translation is requested.`
     : 'Do not add or remove delivery tags.';
 
   return [
@@ -531,6 +531,7 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
       ? '문장 구조 예시 (wake_weather): "일어나실 시간이에요. 최저 12도, 최고 19도고 강수확률이 70%예요. 우산 챙겨가세요. 오늘도 화이팅!" — 위치/날짜/관계 설명 없이 시작, 필요한 날씨 정보만 말하고 짧게 마무리. 이 패턴을 따르되 내용은 컨텍스트에 맞게 새로 작성.'
       : '',
     'Make it feel meaningfully different from a prerecorded fixed alarm.',
+    'Do not include any brackets, delivery tags, [tag] markers, or stage directions in your output. A single delivery tag will be added in a later step.',
     'No markdown, no emojis, no quotes, no explanations, no extra fields.',
     'Keep the final text spoken, kind, and 200 characters or fewer.',
     'Return strict JSON: {"text":"final alarm line"}.',

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -652,7 +652,7 @@ tts.post('/generate', async (c) => {
       targetLanguage: shouldTranslate ? requestedLanguage : sourceLanguage,
       sourceLanguage,
       translate: shouldTranslate,
-      autoTag: randomRequested,
+      autoTag: true,
     });
     const synthesisText = prepared.text;
     const messageText = requestText;

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -521,8 +521,9 @@ describe('POST /tts/generate — edge cases', () => {
     expect(insertSql!.args[6]).toBe('morning');
   });
 
-  it('수동 입력 문구는 delivery tag를 자동 삽입하지 않는다', async () => {
+  it('수동 입력 문구에도 delivery tag가 자동 삽입된다', async () => {
     const text = '좋은 아침이에요! 일어나세요! 오늘 하루도 힘내봐요!';
+    const taggedText = `[encouraging] ${text}`;
     mockDB.pushResult([{ plan: 'free', daily_tts_count: 0, daily_tts_reset_at: today() }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
     mockTextToSpeech.mockResolvedValue(new Uint8Array([2]).buffer);
@@ -539,15 +540,15 @@ describe('POST /tts/generate — edge cases', () => {
     const body = await res.json();
     expect(body.text).toBe(text);
     expect(body.original_text).toBe(text);
-    expect(body.synthesis_text).toBe(text);
-    expect(body.tags).toEqual([]);
+    expect(body.synthesis_text).toBe(taggedText);
+    expect(body.tags).toEqual(['encouraging']);
     const inserted = mockDB.calls.find((c) => c.sql.includes('INSERT INTO messages'));
     expect(inserted!.args[3]).toBe(text);
-    expect(inserted!.args[4]).toBe(text);
-    expect(inserted!.args[5]).toBe('[]');
+    expect(inserted!.args[4]).toBe(taggedText);
+    expect(inserted!.args[5]).toBe(JSON.stringify(['encouraging']));
     expect(mockTextToSpeech).toHaveBeenCalledWith(
       'el-voice-1',
-      text,
+      taggedText,
       expect.objectContaining({
         model_id: 'eleven_v3',
         language_code: 'ko',
@@ -562,6 +563,7 @@ describe('POST /tts/generate — edge cases', () => {
 
   it('영어 직접 입력은 번역 없이 language_code=en 으로 합성한다', async () => {
     const text = 'Good morning! Wake up! I hope you have a great day!';
+    const taggedText = `[warmly] ${text}`;
     mockDB.pushResult([{ plan: 'free', daily_tts_count: 0, daily_tts_reset_at: today() }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
     mockTextToSpeech.mockResolvedValue(new Uint8Array([3]).buffer);
@@ -583,11 +585,11 @@ describe('POST /tts/generate — edge cases', () => {
     const body = await res.json();
     expect(body.text).toBe(text);
     expect(body.original_text).toBe(text);
-    expect(body.synthesis_text).toBe(text);
+    expect(body.synthesis_text).toBe(taggedText);
     expect(body.language).toBe('en');
     expect(mockTextToSpeech).toHaveBeenCalledWith(
       'el-voice-1',
-      text,
+      taggedText,
       expect.objectContaining({
         language_code: 'en',
       }),

--- a/packages/backend/test/vertex-translate.test.ts
+++ b/packages/backend/test/vertex-translate.test.ts
@@ -126,6 +126,54 @@ describe('prepareAlarmTextWithVertex', () => {
       }),
     ).rejects.toBeInstanceOf(AlarmTextPreparationInvalidError);
   });
+
+  it('tags plain user-typed Korean text when autoTag is true', async () => {
+    mockFetch.mockResolvedValueOnce(
+      geminiText('{"text":"[gentle] 오늘도 화이팅","tags":["gentle"]}'),
+    );
+
+    const prepared = await prepareAlarmTextWithVertex(ENV, '오늘도 화이팅', {
+      targetLanguage: 'ko',
+      sourceLanguage: 'ko',
+      translate: false,
+      autoTag: true,
+    });
+
+    expect(prepared.text).toBe('[gentle] 오늘도 화이팅');
+    expect(prepared.tags).toEqual(['gentle']);
+    expect(prepared.provider).not.toBe('local');
+  });
+
+  it('skips Gemini when user already typed a delivery tag', async () => {
+    const prepared = await prepareAlarmTextWithVertex(ENV, '[warmly] 좋은 아침', {
+      targetLanguage: 'ko',
+      sourceLanguage: 'ko',
+      translate: false,
+      autoTag: true,
+    });
+
+    expect(prepared.text).toBe('[warmly] 좋은 아침');
+    expect(prepared.tags).toEqual(['warmly']);
+    expect(prepared.provider).toBe('local');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('tags translated output when both translate and autoTag are true', async () => {
+    mockFetch.mockResolvedValueOnce(
+      geminiText('{"text":"[brightly] Good morning!","tags":["brightly"]}'),
+    );
+
+    const prepared = await prepareAlarmTextWithVertex(ENV, '좋은 아침이에요', {
+      targetLanguage: 'en',
+      sourceLanguage: 'ko',
+      translate: true,
+      autoTag: true,
+    });
+
+    expect(prepared.text).toBe('[brightly] Good morning!');
+    expect(prepared.translated).toBe(true);
+    expect(prepared.tags).toEqual(['brightly']);
+  });
 });
 
 describe('generateDynamicAlarmTextWithVertex', () => {


### PR DESCRIPTION
## 배경
현재 `POST /api/tts/generate`는 랜덤 분기에서만 Gemini가 ElevenLabs v3 delivery tag를 부착한다. 사용자가 직접 타이핑한 멘트와 번역 케이스는 태깅 없이 원문 그대로 합성되어 톤이 흔들렸다.

## 변경
- `packages/backend/src/routes/tts.ts` — `prepareAlarmTextWithVertex` 호출 시 `autoTag: randomRequested` → `autoTag: true`
- `packages/backend/src/lib/vertex-translate.ts`
  - `alarmTextPrompt`의 `tagInstruction`을 "**정확히 1개** 태그를 맨 앞에" 로 강화 + 의미 기반 톤 선택 가이드 추가 (관계/호칭 비주입, AI 의미 판단만)
  - `dynamicAlarmTextPrompt`에 "brackets / delivery tag / stage direction 출력 금지" 명시 → 동적 분기 멘트가 항상 평문으로 나와 후속 태깅 단계가 정확히 1개 부착
- `packages/backend/test/vertex-translate.test.ts` — 평문 한국어 / 사용자 직접 태그 포함 / 번역+태깅 동시 케이스 테스트 3개 추가

## 영향
- 수동 입력 / 번역 / 랜덤 모든 분기에 태그 1개 보장
- 사용자가 직접 `[warmly]` 등을 친 경우 `TAG_RE` 가드가 보존 (Gemini 미호출, provider='local')
- 캐시 키(`request_hash`)는 `synthesisText` 기반 — 태그 부착 후에도 동일 입력은 캐시 히트
- Gemini 1회 호출 추가 (수동 입력당, p50 ~300-700ms 추정, gemini-2.5-flash)

## 테스트
- vitest 8개 모두 통과
- 백엔드 tsc 클린

closes #353