### PR TITLE
feat: 음성 추가 UI 단계화 및 화자 미리듣기 멘트 정리

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/alarms/AlarmListScreen.kt
@@ -168,6 +168,7 @@ internal fun AlarmListScreen(
                         voiceProfileBusy = voiceProfileBusy,
                         subscriptionResponse = subscriptionResponse,
                         familyGroup = familyGroup,
+                        authSession = authSession,
                         onCreateVoiceProfile = onCreateVoiceProfile,
                         onCreateVoiceProfiles = onCreateVoiceProfiles,
                         onSeparateVoiceSpeakers = onSeparateVoiceSpeakers,

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/util/PlatformAndLabelUtils.kt
@@ -187,6 +187,26 @@ internal fun hasCoupleOrFamilyAccess(
         plan?.planType == "couple"
 }
 
+// 음성 공유 토글을 노출할지 판단한다. 개인 플랜이고 가족·커플 그룹에 본인 외 멤버가
+// 0명이면 공유 대상이 없으므로 토글을 숨긴다. family/couple 플랜이거나 그룹에
+// 다른 멤버가 1명이라도 있으면 노출한다.
+internal fun canShareVoiceWithOthers(
+    subscriptionResponse: BillingSubscriptionResponse?,
+    familyGroup: FamilyGroupCurrentResponse?,
+    authSession: AuthSession?,
+): Boolean {
+    val plan = subscriptionResponse?.plan
+    val isFamilyOrCouplePlan = plan?.key == "family" || plan?.key == "couple" ||
+        plan?.planType == "family" || plan?.planType == "couple"
+    if (isFamilyOrCouplePlan) return true
+    val currentUserId = authSession?.user?.id
+    val currentEmail = authSession?.user?.email
+    val membersExceptSelf = familyGroup?.members.orEmpty().count { member ->
+        member.userId != currentUserId && member.email != currentEmail
+    }
+    return membersExceptSelf > 0
+}
+
 internal fun hasPaidVoiceAccess(subscriptionResponse: BillingSubscriptionResponse?): Boolean {
     val subscription = subscriptionResponse?.subscription ?: return false
     if (subscription.status != "active") return false

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -73,6 +73,7 @@ import com.voicealarm.nativeapp.data.CachedAlarmAudio
 import com.voicealarm.nativeapp.data.VoiceProfileAudioLimits
 import com.voicealarm.nativeapp.data.VoiceProfileCreationDraft
 import com.voicealarm.nativeapp.network.apiErrorCode
+import com.voicealarm.nativeapp.network.AuthSession
 import com.voicealarm.nativeapp.network.BillingSubscriptionResponse
 import com.voicealarm.nativeapp.network.FamilyGroupCurrentResponse
 import com.voicealarm.nativeapp.network.FamilyVoiceProfile
@@ -143,6 +144,7 @@ internal fun VoiceProfileManagementPanel(
     voiceProfileBusy: Boolean,
     subscriptionResponse: BillingSubscriptionResponse?,
     familyGroup: FamilyGroupCurrentResponse?,
+    authSession: AuthSession?,
     onCreateVoiceProfile: (String, CachedAlarmAudio, Boolean, String, String) -> Unit,
     onCreateVoiceProfiles: (List<VoiceProfileCreationDraft>) -> Unit,
     onSeparateVoiceSpeakers: suspend (CachedAlarmAudio) -> List<VoiceSpeakerSegment>,
@@ -202,7 +204,7 @@ internal fun VoiceProfileManagementPanel(
     var filePreviewPlaying by remember { mutableStateOf(false) }
     val isLimitReached = voiceProfiles.size >= MAX_VOICE_PROFILES
     val canCreateVoice = hasPaidVoiceAccess(subscriptionResponse)
-    val canShareVoice = hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
+    val canShareVoice = canShareVoiceWithOthers(subscriptionResponse, familyGroup, authSession)
     val paidVoiceRequiredMessage = "유료 요금제를 사용해야 목소리를 만들 수 있어요."
 
     fun stopMediaPreview() {
@@ -447,7 +449,7 @@ internal fun VoiceProfileManagementPanel(
             val ttsResponse = onGenerateTts(
                 TtsGenerateRequest(
                     voiceProfileId = profile.id,
-                    text = "제 목소리를 선택하시는건가요?",
+                    text = "[gentle] 이 목소리로 깨워드릴까요?",
                     category = "custom",
                     language = "ko",
                     random = false,
@@ -896,74 +898,6 @@ internal fun VoiceProfileManagementPanel(
                             .padding(horizontal = 20.dp),
                         verticalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
-                        OutlinedTextField(
-                            value = profileName,
-                            onValueChange = { profileName = it.take(50) },
-                            label = { Text("알람 음성 이름 (필수)") },
-                            placeholder = { Text("예: 지우 목소리") },
-                            singleLine = true,
-                            isError = nameRequiredError,
-                            supportingText = {
-                                if (nameRequiredError) Text("필수 입력 값입니다.")
-                            },
-                            shape = VocaWakeInputShape,
-                            colors = vocaWakeOutlinedTextFieldColors(),
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        OutlinedTextField(
-                            value = profileRelationship,
-                            onValueChange = { profileRelationship = it.take(30) },
-                            label = { Text("나와의 관계 (필수)") },
-                            placeholder = { Text("예: 손녀, 엄마, 연인") },
-                            singleLine = true,
-                            isError = relationshipRequiredError,
-                            supportingText = {
-                                if (relationshipRequiredError) Text("필수 입력 값입니다.")
-                            },
-                            shape = VocaWakeInputShape,
-                            colors = vocaWakeOutlinedTextFieldColors(),
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        OutlinedTextField(
-                            value = profileListenerTitle,
-                            onValueChange = { profileListenerTitle = it.take(30) },
-                            label = { Text("이 목소리가 나를 부를 호칭 (필수)") },
-                            placeholder = { Text("예: 민지야, 여보, 우리 손주") },
-                            singleLine = true,
-                            isError = listenerRequiredError,
-                            supportingText = {
-                                if (listenerRequiredError) {
-                                    Text("필수 입력 값입니다.")
-                                } else {
-                                    Text("랜덤 문구에서 이 호칭으로 나를 불러요.")
-                                }
-                            },
-                            shape = VocaWakeInputShape,
-                            colors = vocaWakeOutlinedTextFieldColors(),
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        if (canShareVoice) {
-                            Surface(
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(18.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Column(modifier = Modifier.weight(1f)) {
-                                        Text("알람 음성 공유", fontWeight = FontWeight.SemiBold)
-                                        MutedText(if (shareVoice) "상대가 선택할 수 있어요" else "나만 사용")
-                                    }
-                                    VoiceAlarmSwitch(
-                                        checked = shareVoice,
-                                        onCheckedChange = { shareVoice = it },
-                                    )
-                                }
-                            }
-                        }
                         VoiceCaptureModeSelector(
                             selected = inputMode,
                             enabled = !isRecording && !createPreparing,
@@ -1067,6 +1001,78 @@ internal fun VoiceProfileManagementPanel(
                                             onSelect = { selectSpeakerDraft(speaker) },
                                         )
                                     }
+                                    }
+                                }
+                            }
+                        }
+
+                        val hasVoiceCapture = selectedAudio != null || selectedFileUri != null
+                        if (hasVoiceCapture) {
+                            OutlinedTextField(
+                                value = profileName,
+                                onValueChange = { profileName = it.take(50) },
+                                label = { Text("알람 음성 이름 (필수)") },
+                                placeholder = { Text("예: 지우 목소리") },
+                                singleLine = true,
+                                isError = nameRequiredError,
+                                supportingText = {
+                                    if (nameRequiredError) Text("필수 입력 값입니다.")
+                                },
+                                shape = VocaWakeInputShape,
+                                colors = vocaWakeOutlinedTextFieldColors(),
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            OutlinedTextField(
+                                value = profileRelationship,
+                                onValueChange = { profileRelationship = it.take(30) },
+                                label = { Text("나와의 관계 (필수)") },
+                                placeholder = { Text("예: 손녀, 엄마, 연인") },
+                                singleLine = true,
+                                isError = relationshipRequiredError,
+                                supportingText = {
+                                    if (relationshipRequiredError) Text("필수 입력 값입니다.")
+                                },
+                                shape = VocaWakeInputShape,
+                                colors = vocaWakeOutlinedTextFieldColors(),
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            OutlinedTextField(
+                                value = profileListenerTitle,
+                                onValueChange = { profileListenerTitle = it.take(30) },
+                                label = { Text("이 목소리가 나를 부를 호칭 (필수)") },
+                                placeholder = { Text("예: 민지야, 여보, 우리 손주") },
+                                singleLine = true,
+                                isError = listenerRequiredError,
+                                supportingText = {
+                                    if (listenerRequiredError) {
+                                        Text("필수 입력 값입니다.")
+                                    } else {
+                                        Text("랜덤 문구에서 이 호칭으로 나를 불러요.")
+                                    }
+                                },
+                                shape = VocaWakeInputShape,
+                                colors = vocaWakeOutlinedTextFieldColors(),
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            if (canShareVoice) {
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(18.dp),
+                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text("알람 음성 공유", fontWeight = FontWeight.SemiBold)
+                                            MutedText(if (shareVoice) "상대가 선택할 수 있어요" else "나만 사용")
+                                        }
+                                        VoiceAlarmSwitch(
+                                            checked = shareVoice,
+                                            onCheckedChange = { shareVoice = it },
+                                        )
                                     }
                                 }
                             }


### PR DESCRIPTION
## 변경 요약

### 1. 화자 후보 미리듣기 멘트 변경
- `VoiceProfileManagementPanel.kt` `prepareSpeakerDraft()`의 미리듣기 멘트를 `"제 목소리를 선택하시는건가요?"` → `"[gentle] 이 목소리로 깨워드릴까요?"`로 변경
- 기본 톤 태그(`[gentle]`)를 텍스트에 포함시켜 Gemini/태깅 단계가 비어 있어도 안정적인 톤 보장

### 2. 음성 추가 다이얼로그 단계화
- 진입 직후엔 `VoiceCaptureModeSelector` + 녹음/파일 컨트롤만 노출
- `selectedAudio != null || selectedFileUri != null` 인 시점부터 이름·관계·호칭 입력 필드 노출
- 그 다음 단계에 공유 토글 노출 (조건 충족 시)
- 내부 디자인·스타일·필드 자체는 그대로 유지, 표시 시점과 순서만 조정

### 3. 공유 토글 노출 조건 강화
- `canShareVoiceWithOthers(subscriptionResponse, familyGroup, authSession)` 헬퍼 신설
- 개인 플랜 + 가족 본인 외 0명 + 커플 본인 외 0명 → 토글 숨김
- family/couple 플랜이거나 그룹에 다른 멤버가 1명 이상 → 토글 노출

## 영향
- 백엔드 변경 없음
- iOS 변경 없음
- 기존 음성 생성 흐름의 데이터/타입 호환

## 빌드 검증
- `./gradlew :app:compileDebugKotlin` 성공

closes #355