### PR TITLE
feat: 공유 음성에 viewer 라벨 미설정 플래그 노출

### DIFF
--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -262,6 +262,8 @@ voiceProfile.get('/family', async (c) => {
     sql: `SELECT vp.id, vp.name, vp.status, vp.created_at, vp.user_id, vp.is_shared,
                  COALESCE(NULLIF(vpr.relationship_label, ''), vp.relationship_label) AS relationship_label,
                  COALESCE(NULLIF(vpr.listener_title, ''), vp.listener_title) AS listener_title,
+                 vpr.relationship_label AS viewer_relationship_raw,
+                 vpr.listener_title AS viewer_listener_raw,
                  u.name as owner_name
           FROM voice_profiles vp
           LEFT JOIN users u ON vp.user_id = u.google_id OR vp.user_id = u.id
@@ -277,10 +279,26 @@ voiceProfile.get('/family', async (c) => {
   });
 
   return c.json({
-    profiles: voicesRes.rows.map((row) => ({
-      ...row,
-      is_shared: Boolean(Number(row.is_shared ?? 0)),
-    })),
+    profiles: voicesRes.rows.map((row) => {
+      const viewerRelationshipRaw = row.viewer_relationship_raw;
+      const viewerListenerRaw = row.viewer_listener_raw;
+      const needsViewerInfo =
+        typeof viewerRelationshipRaw !== 'string' ||
+        viewerRelationshipRaw.trim() === '' ||
+        typeof viewerListenerRaw !== 'string' ||
+        viewerListenerRaw.trim() === '';
+      // viewer raw 필드는 응답에서 제외
+      const {
+        viewer_relationship_raw: _r,
+        viewer_listener_raw: _l,
+        ...rest
+      } = row as Record<string, unknown>;
+      return {
+        ...rest,
+        is_shared: Boolean(Number(row.is_shared ?? 0)),
+        needs_viewer_info: needsViewerInfo,
+      };
+    }),
   });
 });
 

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -652,6 +652,51 @@ describe('GET /voice/family — 가족 음성 프로필', () => {
     expect(body.profiles[0].owner_name).toBe('엄마');
   });
 
+  it('viewer 라벨 미설정 시 needs_viewer_info=true', async () => {
+    mockDB.pushResult([{ user_id: 'user-2' }]);
+    mockDB.pushResult([
+      {
+        id: V1,
+        name: '엄마 목소리',
+        status: 'ready',
+        user_id: 'user-2',
+        owner_name: '엄마',
+        relationship_label: '엄마',
+        listener_title: '딸',
+        viewer_relationship_raw: null,
+        viewer_listener_raw: null,
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/voice/family'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profiles[0].needs_viewer_info).toBe(true);
+    expect(body.profiles[0].viewer_relationship_raw).toBeUndefined();
+  });
+
+  it('viewer 라벨 설정 시 needs_viewer_info=false', async () => {
+    mockDB.pushResult([{ user_id: 'user-2' }]);
+    mockDB.pushResult([
+      {
+        id: V1,
+        name: '엄마 목소리',
+        status: 'ready',
+        user_id: 'user-2',
+        owner_name: '엄마',
+        relationship_label: '엄마',
+        listener_title: '아들',
+        viewer_relationship_raw: '엄마',
+        viewer_listener_raw: '아들',
+      },
+    ]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('GET', '/voice/family'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profiles[0].needs_viewer_info).toBe(false);
+  });
+
   it('가족 멤버는 있지만 음성 없으면 빈 배열', async () => {
     mockDB.pushResult([{ user_id: 'user-2' }]);
     mockDB.pushResult([]);


### PR DESCRIPTION
## 변경
- `GET /api/voice/family` 응답 각 항목에 `needs_viewer_info: boolean` 필드 추가
- viewer 본인의 `voice_profile_relationships` row가 없거나 `relationship_label`/`listener_title`이 빈 문자열이면 `true`
- 기존 `relationship_label`/`listener_title`은 owner fallback 그대로 유지 (호환성)
- viewer raw 컬럼은 응답에서 제외

## 영향
- 클라이언트는 이 플래그로 viewer 라벨 입력 모달을 띄울지 결정 가능
- 기존 응답은 추가 필드만 도입, 기존 키 변경 없음

## 테스트
- 57개 vitest 통과
- viewer 라벨 미설정 / 설정 케이스 각각 테스트 추가

closes #357