### PR TITLE
feat: 공유 음성 viewer 라벨 저장 직후 샘플 미리듣기

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/network/VoiceProfileApi.kt
@@ -86,6 +86,7 @@ data class FamilyVoiceProfile(
     @SerializedName("is_shared") val isShared: Boolean? = null,
     @SerializedName("relationship_label") val relationshipLabel: String? = null,
     @SerializedName("listener_title") val listenerTitle: String? = null,
+    @SerializedName("needs_viewer_info") val needsViewerInfo: Boolean? = null,
 )
 
 data class FamilyVoiceProfileListResponse(

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -603,6 +603,46 @@ internal fun VoiceProfileManagementPanel(
         }
     }
 
+    // 공유받은 음성에 viewer 라벨을 막 입력했을 때 그 음성을 한 번 들려준다.
+    // 같은 입력이면 백엔드 캐시 hit, 처음이면 새로 합성. 둘 다 MediaPlayer 로 재생.
+    suspend fun playSharedVoicePreview(profileId: String) {
+        runCatching {
+            val response = onGenerateTts(
+                TtsGenerateRequest(
+                    voiceProfileId = profileId,
+                    text = "[gentle] 이 목소리로 깨워드릴까요?",
+                    category = "custom",
+                    language = "ko",
+                    random = false,
+                ),
+            )
+            val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
+            val cached = withContext(Dispatchers.IO) {
+                audioStore.cacheGeneratedAudio(
+                    bytes = bytes,
+                    format = response.audioFormat,
+                    rawAudioUri = null,
+                    displayName = "shared_voice_preview_${profileId}",
+                    cacheKey = "shared_preview_${profileId}",
+                    messageId = response.messageId,
+                )
+            }
+            stopMediaPreview()
+            val player = MediaPlayer.create(context, Uri.parse(cached.localAudioUri))
+                ?: return@runCatching
+            mediaPlayer = player.apply {
+                setOnCompletionListener {
+                    it.release()
+                    if (mediaPlayer === it) mediaPlayer = null
+                }
+                start()
+            }
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to preview shared voice", error)
+            localMessage = userFacingError(error, "미리듣기를 재생하지 못했어요.")
+        }
+    }
+
     fun selectSpeakerDraft(speaker: VoiceSpeakerSegment) {
         val state = speakerDraftStates[speaker.id] ?: return
         val selectedDraftId = state.profileId ?: return
@@ -1215,6 +1255,7 @@ internal fun VoiceProfileManagementPanel(
             onConfirm = { relationship, listener ->
                 onUpdateSharedVoiceInfo(profile.id, relationship, listener)
                 sharedInfoTarget = null
+                scope.launch { playSharedVoicePreview(profile.id) }
             },
         )
     }


### PR DESCRIPTION
## 변경
- `FamilyVoiceProfile` 모델에 `needs_viewer_info: Boolean?` 필드 추가 (백엔드 #357 동반)
- `SharedVoiceViewerInfoDialog`의 onConfirm 직후 `"[gentle] 이 목소리로 깨워드릴까요?"` 샘플 TTS를 호출하고 자동 1회 재생
- 캐시 hit / miss 모두 대응: `/api/tts/generate` 캐시 키가 hit면 기존 음성 재사용, miss면 새로 합성
- 로컬 캐시 키 `shared_preview_{profileId}` 로 저장하여 다음 미리듣기 시 빠르게 재생

## 후속 작업
- 알람 편집기에서 공유 음성 선택 시 needs_viewer_info=true이면 모달 강제 트리거하는 변경은 별도 PR로 분리 (시그니처 변경 폭이 큼)

## 빌드 검증
- `./gradlew :app:compileDebugKotlin` 성공

## 의존
- 백엔드 PR #358 (needs_viewer_info 필드)이 머지된 develop 기준에서만 의미 있음

closes #359