### PR TITLE
feat: 음성 등록 위저드 + 날씨 멘트 권유형 개편

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/ui/voices/VoiceProfileManagementPanel.kt
@@ -27,10 +27,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material3.AlertDialog
@@ -38,12 +40,18 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -165,8 +173,10 @@ internal fun VoiceProfileManagementPanel(
     val scope = rememberCoroutineScope()
     var profileName by remember { mutableStateOf("") }
     var profileRelationship by remember { mutableStateOf("") }
+    var relationshipSelection by remember { mutableStateOf(RelationshipSelection()) }
     var profileListenerTitle by remember { mutableStateOf("") }
     var shareVoice by remember { mutableStateOf(false) }
+    var currentStep by remember { mutableStateOf(VoiceRegistrationStep.Source) }
     var selectedAudio by remember { mutableStateOf<CachedAlarmAudio?>(null) }
     var localMessage by remember { mutableStateOf<String?>(null) }
     var inputMode by remember { mutableStateOf(VoiceCaptureMode.Record) }
@@ -353,8 +363,10 @@ internal fun VoiceProfileManagementPanel(
         createSubmitAttempted = false
         profileName = ""
         profileRelationship = ""
+        relationshipSelection = RelationshipSelection()
         profileListenerTitle = ""
         shareVoice = false
+        currentStep = VoiceRegistrationStep.Source
         selectedAudio = null
         mediaPlayer?.release()
         mediaPlayer = null
@@ -723,7 +735,7 @@ internal fun VoiceProfileManagementPanel(
     fun submitCreateProfile(name: String) {
         createSubmitAttempted = true
         val trimmedName = name.trim()
-        val trimmedRelationship = profileRelationship.trim()
+        val trimmedRelationship = relationshipSelection.resolved
         val trimmedListener = profileListenerTitle.trim()
         if (trimmedName.isBlank()) {
             localMessage = null
@@ -921,6 +933,13 @@ internal fun VoiceProfileManagementPanel(
                                 style = MaterialTheme.typography.titleLarge,
                                 fontWeight = FontWeight.Bold,
                             )
+                            val stepIndex = currentStep.ordinal + 1
+                            val stepTitle = when (currentStep) {
+                                VoiceRegistrationStep.Source -> "음성 준비"
+                                VoiceRegistrationStep.Identity -> "누구의 목소리인가요"
+                                VoiceRegistrationStep.Sharing -> "공유 설정"
+                            }
+                            MutedText("$stepIndex / 3 · $stepTitle")
                         }
                         IconButton(
                             onClick = ::closeCreateDialog,
@@ -938,183 +957,181 @@ internal fun VoiceProfileManagementPanel(
                             .padding(horizontal = 20.dp),
                         verticalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
-                        VoiceCaptureModeSelector(
-                            selected = inputMode,
-                            enabled = !isRecording && !createPreparing,
-                            onSelect = {
-                                if (inputMode != it) stopMediaPreview()
-                                inputMode = it
-                            },
-                        )
-
-                        if (inputMode == VoiceCaptureMode.Record) {
-                            VoiceRecordControls(
-                                isRecording = isRecording,
-                                elapsedMillis = recordingElapsedMillis,
-                                maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
-                                levels = recordingLevels,
-                                enabled = !voiceProfileBusy && !createPreparing,
-                                notice = "1분 이상 2분 이하로 녹음해 주세요. 1분 30초를 권장해요.",
-                                onRecordClick = {
-                                    if (isRecording) {
-                                        stopRecording()
-                                    } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
-                                        PackageManager.PERMISSION_GRANTED
-                                    ) {
-                                        startRecording()
-                                    } else {
-                                        recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                                    }
-                                },
-                            )
-                        } else {
-                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                FileSpeakerModeSelector(
-                                    selected = fileSpeakerMode,
-                                    enabled = !voiceProfileBusy && !isRecording && !createPreparing && !fileInputLocked,
-                                    onSelect = ::setFileSpeakerMode,
-                                )
-                                VoiceFileControls(
-                                    durationMillis = selectedFileDurationMillis,
-                                    cropStartMillis = cropStartMillis,
-                                    cropEndMillis = cropEndMillis,
-                                    minDurationMillis = VoiceProfileAudioLimits.MIN_DURATION_MILLIS,
-                                    maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
-                                    enabled = !voiceProfileBusy && !isRecording && !createPreparing && !fileInputLocked,
-                                    uploadLabel = "파일/영상 업로드",
-                                    notice = "1분 이상 2분 이하 구간을 선택해 주세요. 1분 30초를 권장해요.",
-                                    isPreviewActive = filePreviewPlaying,
-                                    isPreviewPreparing = filePreviewPreparing,
-                                    waveformLevels = fileWaveformLevels,
-                                    waveformLoading = fileWaveformLoading,
-                                    onPickFile = { pickAudioLauncher.launch(arrayOf("audio/*", "video/*")) },
-                                    onCropChange = { start, end ->
-                                        if (start != cropStartMillis || end != cropEndMillis) {
-                                            stopMediaPreview()
-                                            cropStartMillis = start
-                                            cropEndMillis = end
-                                            resetSpeakers()
-                                        }
+                        when (currentStep) {
+                            VoiceRegistrationStep.Source -> {
+                                VoiceCaptureModeSelector(
+                                    selected = inputMode,
+                                    enabled = !isRecording && !createPreparing,
+                                    onSelect = {
+                                        if (inputMode != it) stopMediaPreview()
+                                        inputMode = it
                                     },
-                                    onPreviewCrop = { playFileCropPreview() },
                                 )
-                                if (fileSpeakerMode == FileSpeakerMode.Multiple) {
-                                    selectedFileDurationMillis?.let {
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    ) {
-                                        Button(
-                                            onClick = { separateSpeakers() },
-                                            enabled = !separatingBusy && !promotingBusy && !createPreparing && !hasSeparatedSpeakers,
-                                            modifier = Modifier.weight(1f),
-                                            shape = WakerButtonShape,
-                                        ) {
-                                            Text(
-                                                when {
-                                                    separatingBusy -> "분리 중"
-                                                    hasSeparatedSpeakers -> "분리 완료"
-                                                    else -> "화자 분리"
-                                                },
-                                            )
-                                        }
-                                        OutlinedButton(
-                                            onClick = { resetSpeakers() },
-                                            enabled = hasSeparatedSpeakers && !promotingBusy && !createPreparing,
-                                            modifier = Modifier.weight(1f),
-                                            shape = WakerButtonShape,
-                                            border = wakerCardBorder(),
-                                            colors = wakerOutlinedButtonColors(),
-                                        ) {
-                                            Text("초기화")
-                                        }
-                                    }
-                                    detectedSpeakers.forEachIndexed { index, speaker ->
-                                        val draftState = speakerDraftStates[speaker.id] ?: SpeakerDraftState()
-                                        SpeakerDraftRow(
-                                            speaker = speaker,
-                                            index = index,
-                                            state = draftState,
-                                            isPlaying = activePlayingSpeakerId == speaker.id,
-                                            promotingBusy = promotingBusy,
-                                            onTogglePlay = { playSpeakerDraftPreview(speaker) },
-                                            onSelect = { selectSpeakerDraft(speaker) },
+
+                                if (inputMode == VoiceCaptureMode.Record) {
+                                    VoiceRecordControls(
+                                        isRecording = isRecording,
+                                        elapsedMillis = recordingElapsedMillis,
+                                        maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                                        levels = recordingLevels,
+                                        enabled = !voiceProfileBusy && !createPreparing,
+                                        notice = "1분 이상 2분 이하로 녹음해 주세요. 1분 30초를 권장해요.",
+                                        onRecordClick = {
+                                            if (isRecording) {
+                                                stopRecording()
+                                            } else if (context.checkSelfPermission(Manifest.permission.RECORD_AUDIO) ==
+                                                PackageManager.PERMISSION_GRANTED
+                                            ) {
+                                                startRecording()
+                                            } else {
+                                                recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                            }
+                                        },
+                                    )
+                                } else {
+                                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                        FileSpeakerModeSelector(
+                                            selected = fileSpeakerMode,
+                                            enabled = !voiceProfileBusy && !isRecording && !createPreparing && !fileInputLocked,
+                                            onSelect = ::setFileSpeakerMode,
                                         )
-                                    }
+                                        VoiceFileControls(
+                                            durationMillis = selectedFileDurationMillis,
+                                            cropStartMillis = cropStartMillis,
+                                            cropEndMillis = cropEndMillis,
+                                            minDurationMillis = VoiceProfileAudioLimits.MIN_DURATION_MILLIS,
+                                            maxDurationMillis = VoiceProfileAudioLimits.MAX_DURATION_MILLIS,
+                                            enabled = !voiceProfileBusy && !isRecording && !createPreparing && !fileInputLocked,
+                                            uploadLabel = "파일/영상 업로드",
+                                            notice = "1분 이상 2분 이하 구간을 선택해 주세요. 1분 30초를 권장해요.",
+                                            isPreviewActive = filePreviewPlaying,
+                                            isPreviewPreparing = filePreviewPreparing,
+                                            waveformLevels = fileWaveformLevels,
+                                            waveformLoading = fileWaveformLoading,
+                                            onPickFile = { pickAudioLauncher.launch(arrayOf("audio/*", "video/*")) },
+                                            onCropChange = { start, end ->
+                                                if (start != cropStartMillis || end != cropEndMillis) {
+                                                    stopMediaPreview()
+                                                    cropStartMillis = start
+                                                    cropEndMillis = end
+                                                    resetSpeakers()
+                                                }
+                                            },
+                                            onPreviewCrop = { playFileCropPreview() },
+                                        )
+                                        if (fileSpeakerMode == FileSpeakerMode.Multiple) {
+                                            selectedFileDurationMillis?.let {
+                                                Row(
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                ) {
+                                                    Button(
+                                                        onClick = { separateSpeakers() },
+                                                        enabled = !separatingBusy && !promotingBusy && !createPreparing && !hasSeparatedSpeakers,
+                                                        modifier = Modifier.weight(1f),
+                                                        shape = WakerButtonShape,
+                                                    ) {
+                                                        Text(
+                                                            when {
+                                                                separatingBusy -> "분리 중"
+                                                                hasSeparatedSpeakers -> "분리 완료"
+                                                                else -> "화자 분리"
+                                                            },
+                                                        )
+                                                    }
+                                                    OutlinedButton(
+                                                        onClick = { resetSpeakers() },
+                                                        enabled = hasSeparatedSpeakers && !promotingBusy && !createPreparing,
+                                                        modifier = Modifier.weight(1f),
+                                                        shape = WakerButtonShape,
+                                                        border = wakerCardBorder(),
+                                                        colors = wakerOutlinedButtonColors(),
+                                                    ) {
+                                                        Text("초기화")
+                                                    }
+                                                }
+                                                detectedSpeakers.forEachIndexed { index, speaker ->
+                                                    val draftState = speakerDraftStates[speaker.id] ?: SpeakerDraftState()
+                                                    SpeakerDraftRow(
+                                                        speaker = speaker,
+                                                        index = index,
+                                                        state = draftState,
+                                                        isPlaying = activePlayingSpeakerId == speaker.id,
+                                                        promotingBusy = promotingBusy,
+                                                        onTogglePlay = { playSpeakerDraftPreview(speaker) },
+                                                        onSelect = { selectSpeakerDraft(speaker) },
+                                                    )
+                                                }
+                                            }
+                                            MutedText("화자 분리는 선택과 동시에 등록돼요. 이름·관계·호칭은 등록 후 목록에서 정리할 수 있어요.")
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        val hasVoiceCapture = selectedAudio != null || selectedFileUri != null
-                        if (hasVoiceCapture) {
-                            OutlinedTextField(
-                                value = profileName,
-                                onValueChange = { profileName = it.take(50) },
-                                label = { Text("알람 음성 이름 (필수)") },
-                                placeholder = { Text("예: 지우 목소리") },
-                                singleLine = true,
-                                isError = nameRequiredError,
-                                supportingText = {
-                                    if (nameRequiredError) Text("필수 입력 값입니다.")
-                                },
-                                shape = WakerInputShape,
-                                colors = wakerOutlinedTextFieldColors(),
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                            OutlinedTextField(
-                                value = profileRelationship,
-                                onValueChange = { profileRelationship = it.take(30) },
-                                label = { Text("나와의 관계 (필수)") },
-                                placeholder = { Text("예: 손녀, 엄마, 연인") },
-                                singleLine = true,
-                                isError = relationshipRequiredError,
-                                supportingText = {
-                                    if (relationshipRequiredError) Text("필수 입력 값입니다.")
-                                },
-                                shape = WakerInputShape,
-                                colors = wakerOutlinedTextFieldColors(),
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                            OutlinedTextField(
-                                value = profileListenerTitle,
-                                onValueChange = { profileListenerTitle = it.take(30) },
-                                label = { Text("이 목소리가 나를 부를 호칭 (필수)") },
-                                placeholder = { Text("예: 민지야, 여보, 우리 손주") },
-                                singleLine = true,
-                                isError = listenerRequiredError,
-                                supportingText = {
-                                    if (listenerRequiredError) {
-                                        Text("필수 입력 값입니다.")
-                                    } else {
-                                        Text("랜덤 문구에서 이 호칭으로 나를 불러요.")
-                                    }
-                                },
-                                shape = WakerInputShape,
-                                colors = wakerOutlinedTextFieldColors(),
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                            if (canShareVoice) {
-                                Surface(
+                            VoiceRegistrationStep.Identity -> {
+                                OutlinedTextField(
+                                    value = profileName,
+                                    onValueChange = { profileName = it.take(50) },
+                                    label = { Text("알람 음성 이름 (필수)") },
+                                    placeholder = { Text("예: 엄마 목소리") },
+                                    singleLine = true,
+                                    isError = nameRequiredError,
+                                    supportingText = {
+                                        if (nameRequiredError) Text("필수 입력 값입니다.")
+                                    },
+                                    shape = WakerInputShape,
+                                    colors = wakerOutlinedTextFieldColors(),
                                     modifier = Modifier.fillMaxWidth(),
-                                    shape = RoundedCornerShape(18.dp),
-                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
-                                ) {
-                                    Row(
-                                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        Column(modifier = Modifier.weight(1f)) {
-                                            Text("알람 음성 공유", fontWeight = FontWeight.SemiBold)
-                                            MutedText(if (shareVoice) "상대가 선택할 수 있어요" else "나만 사용")
+                                )
+                                RelationshipDropdownField(
+                                    selection = relationshipSelection,
+                                    onSelectionChange = { relationshipSelection = it },
+                                    isError = relationshipRequiredError,
+                                )
+                                OutlinedTextField(
+                                    value = profileListenerTitle,
+                                    onValueChange = { profileListenerTitle = it.take(30) },
+                                    label = { Text("이 목소리가 나를 부를 호칭 (필수)") },
+                                    placeholder = { Text("예: 민지야, 여보, 우리 손주") },
+                                    singleLine = true,
+                                    isError = listenerRequiredError,
+                                    supportingText = {
+                                        if (listenerRequiredError) {
+                                            Text("필수 입력 값입니다.")
+                                        } else {
+                                            Text("랜덤 문구에서 이 호칭으로 나를 불러요.")
                                         }
-                                        VoiceAlarmSwitch(
-                                            checked = shareVoice,
-                                            onCheckedChange = { shareVoice = it },
-                                        )
-                                    }
-                                }
+                                    },
+                                    shape = WakerInputShape,
+                                    colors = wakerOutlinedTextFieldColors(),
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                ListenerTitlePreview(
+                                    listenerTitle = profileListenerTitle.trim(),
+                                    relationshipLabel = relationshipSelection.resolved,
+                                )
+                            }
+
+                            VoiceRegistrationStep.Sharing -> {
+                                SharingOptionCard(
+                                    enabled = true,
+                                    title = "나만 사용",
+                                    description = "이 알람 음성은 내 계정에서만 들려요.",
+                                    onClick = { shareVoice = false },
+                                    isChosen = !shareVoice,
+                                )
+                                SharingOptionCard(
+                                    enabled = canShareVoice,
+                                    title = "가족·친구와 공유",
+                                    description = if (canShareVoice) {
+                                        "등록 후 목록에서 공유 코드를 만들어 전달할 수 있어요."
+                                    } else {
+                                        "공유 기능은 가족 그룹이나 유료 요금제에서 사용할 수 있어요."
+                                    },
+                                    onClick = { if (canShareVoice) shareVoice = true },
+                                    isChosen = shareVoice && canShareVoice,
+                                )
                             }
                         }
 
@@ -1127,6 +1144,11 @@ internal fun VoiceProfileManagementPanel(
                         Spacer(modifier = Modifier.height(4.dp))
                     }
 
+                    val canAdvanceFromSource = !voiceProfileBusy && !isRecording && !createPreparing &&
+                        !promotingBusy && (canSubmitRecord || canSubmitSingleFile)
+                    val identityComplete = profileName.trim().isNotBlank() &&
+                        relationshipSelection.isComplete &&
+                        profileListenerTitle.trim().isNotBlank()
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -1139,21 +1161,76 @@ internal fun VoiceProfileManagementPanel(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Button(
-                            onClick = { submitCreateProfile(resolvedProfileName) },
-                            enabled = !voiceProfileBusy && !isRecording && !createPreparing && !promotingBusy &&
-                                (canSubmitRecord || canSubmitSingleFile),
-                            modifier = Modifier.fillMaxWidth(),
-                            shape = WakerButtonShape,
-                        ) {
-                            Text(
-                                when {
-                                    createPreparing -> "준비 중"
-                                    inputMode == VoiceCaptureMode.File &&
-                                        fileSpeakerMode == FileSpeakerMode.Multiple -> "화자 선택"
-                                    else -> "등록"
+                        if (currentStep != VoiceRegistrationStep.Source) {
+                            OutlinedButton(
+                                onClick = {
+                                    currentStep = when (currentStep) {
+                                        VoiceRegistrationStep.Sharing -> VoiceRegistrationStep.Identity
+                                        VoiceRegistrationStep.Identity -> VoiceRegistrationStep.Source
+                                        VoiceRegistrationStep.Source -> VoiceRegistrationStep.Source
+                                    }
+                                    createSubmitAttempted = false
+                                    localMessage = null
                                 },
-                            )
+                                enabled = !voiceProfileBusy && !createPreparing && !promotingBusy,
+                                modifier = Modifier.weight(1f),
+                                shape = WakerButtonShape,
+                                border = wakerCardBorder(),
+                                colors = wakerOutlinedButtonColors(),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text("이전")
+                            }
+                        }
+                        when (currentStep) {
+                            VoiceRegistrationStep.Source -> {
+                                Button(
+                                    onClick = {
+                                        localMessage = null
+                                        currentStep = VoiceRegistrationStep.Identity
+                                    },
+                                    enabled = canAdvanceFromSource,
+                                    modifier = Modifier.weight(1f),
+                                    shape = WakerButtonShape,
+                                ) {
+                                    Text(if (createPreparing) "준비 중" else "다음")
+                                }
+                            }
+
+                            VoiceRegistrationStep.Identity -> {
+                                Button(
+                                    onClick = {
+                                        createSubmitAttempted = true
+                                        if (identityComplete) {
+                                            localMessage = null
+                                            createSubmitAttempted = false
+                                            currentStep = VoiceRegistrationStep.Sharing
+                                        }
+                                    },
+                                    enabled = !voiceProfileBusy && !createPreparing && !promotingBusy,
+                                    modifier = Modifier.weight(1f),
+                                    shape = WakerButtonShape,
+                                ) {
+                                    Text("다음")
+                                }
+                            }
+
+                            VoiceRegistrationStep.Sharing -> {
+                                Button(
+                                    onClick = { submitCreateProfile(resolvedProfileName) },
+                                    enabled = !voiceProfileBusy && !isRecording && !createPreparing &&
+                                        !promotingBusy && (canSubmitRecord || canSubmitSingleFile),
+                                    modifier = Modifier.weight(1f),
+                                    shape = WakerButtonShape,
+                                ) {
+                                    Text(if (createPreparing) "준비 중" else "등록")
+                                }
+                            }
                         }
                     }
                 }
@@ -1474,6 +1551,204 @@ internal enum class FileSpeakerMode {
     Multiple,
 }
 
+internal enum class VoiceRegistrationStep {
+    Source,
+    Identity,
+    Sharing,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RelationshipDropdownField(
+    selection: RelationshipSelection,
+    onSelectionChange: (RelationshipSelection) -> Unit,
+    isError: Boolean,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val presetLabel = selection.preset?.label.orEmpty()
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            OutlinedTextField(
+                value = presetLabel,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("나와의 관계 (필수)") },
+                placeholder = { Text("관계를 선택해 주세요") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                isError = isError && !selection.isComplete,
+                supportingText = {
+                    if (isError && !selection.isComplete) Text("필수 입력 값입니다.")
+                },
+                shape = WakerInputShape,
+                colors = wakerOutlinedTextFieldColors(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(),
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
+                RelationshipPreset.entries.forEach { preset ->
+                    DropdownMenuItem(
+                        text = { Text(preset.label) },
+                        onClick = {
+                            expanded = false
+                            onSelectionChange(
+                                if (preset == RelationshipPreset.Custom) {
+                                    selection.copy(preset = preset)
+                                } else {
+                                    RelationshipSelection(preset = preset, customLabel = "")
+                                },
+                            )
+                        },
+                    )
+                }
+            }
+        }
+        if (selection.preset == RelationshipPreset.Custom) {
+            OutlinedTextField(
+                value = selection.customLabel,
+                onValueChange = {
+                    onSelectionChange(selection.copy(customLabel = it.take(30)))
+                },
+                label = { Text("관계 직접 입력") },
+                placeholder = { Text("예: 손녀, 연인, 동료") },
+                singleLine = true,
+                isError = isError && !selection.isComplete,
+                supportingText = {
+                    if (isError && !selection.isComplete) Text("필수 입력 값입니다.")
+                },
+                shape = WakerInputShape,
+                colors = wakerOutlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListenerTitlePreview(
+    listenerTitle: String,
+    relationshipLabel: String,
+) {
+    if (listenerTitle.isBlank()) return
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = WakerCardShape,
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = "이 목소리는 이렇게 불러줘요",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Text(
+                text = "\"$listenerTitle, 일어날 시간이에요\"",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            if (relationshipLabel.isNotBlank()) {
+                MutedText("관계 · $relationshipLabel")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SharingOptionCard(
+    enabled: Boolean,
+    title: String,
+    description: String,
+    isChosen: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor = if (isChosen) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    OutlinedCard(
+        shape = WakerCardShape,
+        border = wakerCardBorder(if (enabled) 1f else 0.4f),
+        colors = CardDefaults.outlinedCardColors(containerColor = containerColor),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            RadioButton(
+                selected = isChosen,
+                onClick = onClick,
+                enabled = enabled,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, fontWeight = FontWeight.SemiBold)
+                MutedText(description)
+            }
+        }
+    }
+}
+
+internal enum class RelationshipPreset(val label: String) {
+    Mom("엄마"),
+    Dad("아빠"),
+    Grandma("할머니"),
+    Grandpa("할아버지"),
+    Son("아들"),
+    Daughter("딸"),
+    Granddaughter("손녀"),
+    Grandson("손주"),
+    Sibling("형제·자매"),
+    Boyfriend("남자친구"),
+    Girlfriend("여자친구"),
+    Husband("남편"),
+    Wife("아내"),
+    Friend("친구"),
+    Celebrity("연예인"),
+    Custom("직접 입력"),
+}
+
+internal data class RelationshipSelection(
+    val preset: RelationshipPreset? = null,
+    val customLabel: String = "",
+) {
+    val resolved: String
+        get() = when (preset) {
+            null -> ""
+            RelationshipPreset.Custom -> customLabel.trim()
+            else -> preset.label
+        }
+
+    val isComplete: Boolean
+        get() = resolved.isNotBlank()
+}
+
+internal fun parseRelationshipLabel(raw: String?): RelationshipSelection {
+    val trimmed = raw?.trim().orEmpty()
+    if (trimmed.isEmpty()) return RelationshipSelection()
+    val match = RelationshipPreset.entries.firstOrNull {
+        it != RelationshipPreset.Custom && it.label == trimmed
+    }
+    return if (match != null) {
+        RelationshipSelection(preset = match)
+    } else {
+        RelationshipSelection(preset = RelationshipPreset.Custom, customLabel = trimmed)
+    }
+}
+
 internal enum class SpeakerDraftStatus {
     Cloning,
     Synthesizing,
@@ -1553,96 +1828,124 @@ internal fun VoiceProfileRow(
     val isProcessing = profile.status == "processing"
     val isDeleting = profile.status == "deleting"
     val rowEnabled = enabled && !isProcessing && !isDeleting
+    var menuExpanded by remember { mutableStateOf(false) }
+    val isShared = profile.isShared == true
     OutlinedCard(
         shape = WakerCardShape,
         border = wakerCardBorder(),
         colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surface),
     ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .background(
+                        if (isDeleting) {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        } else {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        },
+                        CircleShape,
+                    ),
+                contentAlignment = Alignment.Center,
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(42.dp)
-                        .background(
-                            if (isDeleting) {
-                                MaterialTheme.colorScheme.surfaceVariant
-                            } else {
-                                MaterialTheme.colorScheme.secondaryContainer
-                            },
-                            CircleShape,
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Mic,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                }
-                Column(
-                    modifier = Modifier.weight(1f),
+                Icon(
+                    imageVector = Icons.Outlined.Mic,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         text = profile.name,
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
-                    profile.relationshipLabel
-                        ?.takeIf { it.isNotBlank() }
-                        ?.let { MutedText("관계 · $it") }
-                }
-                when {
-                    isProcessing -> VoiceProgressMessage("생성 중")
-                    isDeleting -> VoiceProgressMessage("삭제 중")
-                    else -> {
-                        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-                            IconButton(onClick = onRename, enabled = rowEnabled) {
-                                Icon(Icons.Outlined.Edit, contentDescription = "수정")
-                            }
-                            IconButton(onClick = onDelete, enabled = rowEnabled) {
-                                Icon(Icons.Outlined.Delete, contentDescription = "삭제")
-                            }
-                        }
+                    if (canShareVoice && isShared && !isProcessing && !isDeleting) {
+                        VoiceSharedBadge()
                     }
                 }
+                val detail = buildList {
+                    profile.relationshipLabel?.takeIf { it.isNotBlank() }?.let { add("관계 $it") }
+                    profile.listenerTitle?.takeIf { it.isNotBlank() }?.let { add("호칭 $it") }
+                }.joinToString(" · ")
+                if (detail.isNotBlank()) MutedText(detail)
             }
-            if (canShareVoice && !isProcessing && !isDeleting) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text("공유 허용", fontWeight = FontWeight.SemiBold)
-                            MutedText(
-                                if (profile.isShared == true) {
-                                    "상대가 이 알람 음성을 선택할 수 있어요"
-                                } else {
-                                    "내 계정에서만 사용할게요"
+            when {
+                isProcessing -> VoiceProgressMessage("생성 중")
+                isDeleting -> VoiceProgressMessage("삭제 중")
+                else -> {
+                    Box {
+                        IconButton(
+                            onClick = { menuExpanded = true },
+                            enabled = rowEnabled,
+                        ) {
+                            Icon(Icons.Outlined.MoreVert, contentDescription = "더보기")
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("이름·관계·호칭 수정") },
+                                leadingIcon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onRename()
+                                },
+                            )
+                            if (canShareVoice) {
+                                DropdownMenuItem(
+                                    text = { Text(if (isShared) "공유 끄기" else "공유 켜기") },
+                                    onClick = {
+                                        menuExpanded = false
+                                        onShareChange(!isShared)
+                                    },
+                                )
+                            }
+                            DropdownMenuItem(
+                                text = { Text("삭제") },
+                                leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onDelete()
                                 },
                             )
                         }
-                        VoiceAlarmSwitch(
-                            checked = profile.isShared == true,
-                            onCheckedChange = onShareChange,
-                            enabled = rowEnabled,
-                        )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun VoiceSharedBadge() {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f),
+    ) {
+        Text(
+            text = "공유 중",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+        )
     }
 }
 

--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -494,7 +494,7 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
     : `No relationship label is available, so keep the line generally warm. ${listenerInstruction}`;
   const modeInstruction = (() => {
     if (context.mode === 'wake_weather') {
-      return `Create a wake-up message. Start naturally like "일어나실 시간이에요" or "좋은 아침이에요" rather than describing whose voice it is. Use only actionable weather facts from this context: ${context.weatherSummary || 'weather information is unavailable'}. Prioritize temperature, precipitation probability, umbrella advice when rain risk is high, and fine-dust/mask advice only when the context says it is bad. Do not mention location names, city/country names, the exact date, or weekday. Do not say vague weather labels like "the weather is rain" by themselves. Ending is optional; if you add one, keep it short like "오늘도 화이팅!"`;
+      return `Create a wake-up message. Start naturally like "일어나실 시간이에요" or "좋은 아침이에요" rather than describing whose voice it is. The weather context already comes as one or two short actionable suggestions, e.g. "비가 올 수 있어요. 우산 챙기세요", "미세먼지가 많아요. 외출할 땐 마스크 챙기세요", "날씨가 좋아요. 잠깐 산책 가기에도 딱이에요". Weave at most two of these suggestions into the line naturally. DO NOT recite raw numbers, temperatures, percentages, weather codes, or labels like "강수 확률 70%" or "최저 12도 최고 19도". DO NOT just describe the weather ("비가 와요" alone is not enough) — always pair it with a short action the listener can take (e.g. 우산 챙기기, 마스크 챙기기, 따뜻하게 입기, 산책 추천). Do not mention location names, city/country names, the exact date, or weekday. Ending is optional; if you add one, keep it short like "오늘도 화이팅!". Weather context: ${context.weatherSummary || 'weather information is unavailable'}.`;
     }
     if (context.mode === 'wake_fortune') {
       return `Create a wake-up message with a light, entertainment-only daily fortune. If fortune input is available, infer only a gentle mood from gender, birth date, and birth time. Fortune input is internal only: ${context.fortuneProfile || 'fortune profile is unavailable'}. Never mention the listener's birth date, birthday, birth time, zodiac details, "born on", "birth date", "생년월일", "태어난 시간", "몇 월 며칠생", or any specific month/day/year/time from the input. Do not sound like a real prediction or guarantee.`;
@@ -528,7 +528,7 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
       ? '한국어 어체 규칙: 가족·친구·연인 관계에서는 절대 "~합니다", "~하십시오" 같은 합니다체를 쓰지 말 것. 손녀→조부모, 자식→부모 등 손아랫사람이 손윗사람에게 말할 때는 친근한 해요체 ("~해요", "~예요"). 부모→자식, 형/누나→동생 등은 다정한 반말 또는 해요체 혼용. 친구·연인 사이는 반말. 뉴스 앵커처럼 들리지 않게 진짜 가족이 옆에서 말하는 톤으로.'
       : '',
     context.targetLanguage === 'ko'
-      ? '문장 구조 예시 (wake_weather): "일어나실 시간이에요. 최저 12도, 최고 19도고 강수확률이 70%예요. 우산 챙겨가세요. 오늘도 화이팅!" — 위치/날짜/관계 설명 없이 시작, 필요한 날씨 정보만 말하고 짧게 마무리. 이 패턴을 따르되 내용은 컨텍스트에 맞게 새로 작성.'
+      ? '문장 구조 예시 (wake_weather): "일어나실 시간이에요. 비가 올 수 있대요. 우산 꼭 챙기세요. 오늘도 화이팅!" / "좋은 아침이에요. 날씨가 좋대요. 잠깐 산책 가기에도 딱이에요." / "일어나실 시간이에요. 미세먼지가 많대요. 마스크 챙겨 나가세요." — 위치/날짜/관계/숫자 없이 시작해서, 날씨 상태와 그에 맞는 행동 권유를 한두 마디로 자연스럽게 묶고 짧게 마무리. 강수확률·기온 숫자를 그대로 읽는 패턴은 금지.'
       : '',
     'Make it feel meaningfully different from a prerecorded fixed alarm.',
     'Do not include any brackets, delivery tags, [tag] markers, or stage directions in your output. A single delivery tag will be added in a later step.',

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -257,6 +257,9 @@ async function findViewerListenerTitle(
   return normalizeRelationshipLabel(result.rows[0]?.listener_title);
 }
 
+const RAIN_WMO_CODES = [51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82, 95, 96, 99];
+const SNOW_WMO_CODES = [71, 73, 75, 77, 85, 86];
+
 async function loadWeatherSummary(args: {
   latitude?: unknown;
   longitude?: unknown;
@@ -294,27 +297,73 @@ async function loadWeatherSummary(args: {
     const minTemp = Number(json.daily.temperature_2m_min?.[0]);
     const rainProbability = Number(json.daily.precipitation_probability_max?.[0]);
     const precipitation = Number(json.daily.precipitation_sum?.[0]);
-    const temperatureText =
-      Number.isFinite(maxTemp) && Number.isFinite(minTemp)
-        ? `최저 ${Math.round(minTemp)}도, 최고 ${Math.round(maxTemp)}도`
-        : '';
-    const rainText = Number.isFinite(rainProbability)
-      ? `강수 확률 ${Math.round(rainProbability)}%`
-      : Number.isFinite(precipitation) && precipitation > 0
-        ? `예상 강수량 ${Math.round(precipitation)}mm`
-        : '';
-    const umbrella =
-      (Number.isFinite(rainProbability) && rainProbability >= 50) ||
-      (Number.isFinite(precipitation) && precipitation > 0.5) ||
-      [51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82, 95, 96, 99].includes(code)
-        ? '우산을 챙기면 좋아요'
-        : null;
-    const dustText = await loadAirQualitySummary(location);
-    const parts = [temperatureText, rainText, umbrella, dustText].filter(Boolean);
-    return parts.length > 0 ? parts.join(', ') : null;
+    const dustAdvice = await loadAirQualitySummary(location);
+    return buildWeatherAdvice({
+      code,
+      maxTemp,
+      minTemp,
+      rainProbability,
+      precipitation,
+      dustAdvice,
+    });
   } catch {
     return null;
   }
+}
+
+interface WeatherAdviceInput {
+  code: number;
+  maxTemp: number;
+  minTemp: number;
+  rainProbability: number;
+  precipitation: number;
+  dustAdvice: string | null;
+}
+
+function buildWeatherAdvice(input: WeatherAdviceInput): string | null {
+  const { code, maxTemp, minTemp, rainProbability, precipitation, dustAdvice } = input;
+  const heavyRain =
+    (Number.isFinite(rainProbability) && rainProbability >= 60) ||
+    (Number.isFinite(precipitation) && precipitation > 1) ||
+    RAIN_WMO_CODES.includes(code);
+  const lightRain =
+    !heavyRain &&
+    ((Number.isFinite(rainProbability) && rainProbability >= 30) ||
+      (Number.isFinite(precipitation) && precipitation > 0));
+  const snowy = SNOW_WMO_CODES.includes(code);
+
+  const advices: string[] = [];
+  if (snowy) {
+    advices.push('눈이 올 수 있어요. 미끄럽지 않게 조심하세요');
+  } else if (heavyRain) {
+    advices.push('비가 올 수 있어요. 우산 꼭 챙기세요');
+  } else if (lightRain) {
+    advices.push('비가 살짝 올 수 있어요. 우산을 챙기면 안심돼요');
+  }
+
+  if (dustAdvice) {
+    advices.push(dustAdvice);
+  }
+
+  if (advices.length === 0) {
+    if (Number.isFinite(maxTemp) && maxTemp >= 30) {
+      advices.push('낮에 무더울 거예요. 시원하게 입고 물도 자주 드세요');
+    } else if (Number.isFinite(maxTemp) && maxTemp >= 25) {
+      advices.push('낮엔 따뜻해요. 가볍게 입고 나가도 좋겠어요');
+    } else if (
+      (Number.isFinite(minTemp) && minTemp <= 0) ||
+      (Number.isFinite(maxTemp) && maxTemp <= 5)
+    ) {
+      advices.push('많이 쌀쌀해요. 따뜻하게 입고 나가세요');
+    } else if (Number.isFinite(maxTemp) && maxTemp <= 12) {
+      advices.push('쌀쌀해요. 겉옷 하나 챙기세요');
+    } else if (Number.isFinite(maxTemp) && maxTemp >= 15 && maxTemp <= 24) {
+      advices.push('날씨가 좋아요. 잠깐 산책 가기에도 딱이에요');
+    }
+  }
+
+  if (advices.length === 0) return null;
+  return advices.slice(0, 2).join(' ');
 }
 
 async function loadAirQualitySummary(location: {
@@ -341,8 +390,7 @@ async function loadAirQualitySummary(location: {
     const pm10Bad = pm10Max != null && pm10Max > 80;
     const pm25Bad = pm25Max != null && pm25Max > 35;
     if (!pm10Bad && !pm25Bad) return null;
-    const dustLevel = pm10Bad || pm25Bad ? '나쁨' : null;
-    return dustLevel ? `미세먼지 ${dustLevel}, 마스크를 챙기면 좋아요` : null;
+    return '미세먼지가 많아요. 외출할 땐 마스크 챙기세요';
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
두 가지 변경을 한 PR에 묶었습니다.

### 1. 음성 등록 3단계 위저드 (Android)
- `apps/android-native/.../VoiceProfileManagementPanel.kt`
- 기존 단일 모달(녹음/파일 + 메타데이터 + 공유 토글) → 3단계 위저드
  - Step 1 `음성 준비`: 녹음/파일/화자 분리
  - Step 2 `누구의 목소리`: 이름 + 관계 드롭다운(엄마/아빠/할머니/할아버지/아들/딸/손녀/손주/형제·자매/남자친구/여자친구/남편/아내/친구/연예인/직접 입력) + 호칭 + 호칭 프리뷰 카드
  - Step 3 `공유 설정`: 라디오 2개 (나만 사용 / 가족·친구 공유)
- 리스트 카드 우측 액션을 `···` 메뉴(이름·관계·호칭 수정 / 공유 켜·끄기 / 삭제)로 통합, 공유 상태는 `공유 중` 칩으로 표시
- 화자 분리(2명 이상) 모드는 기존 흐름 유지 + 안내 문구 추가

### 2. 랜덤 날씨 멘트 행동 권유형 개편 (Backend)
- `packages/backend/src/routes/tts.ts`, `packages/backend/src/lib/vertex-translate.ts`
- `loadWeatherSummary`: raw 정보 콤마 나열(`"최저 12도, 최고 19도, 강수 확률 70%..."`) → 권유 멘트 최대 2개
  - 비/눈 → `"비가 올 수 있어요. 우산 꼭 챙기세요"`, `"눈이 올 수 있어요. 미끄럽지 않게 조심하세요"`
  - 미세먼지 → `"미세먼지가 많아요. 외출할 땐 마스크 챙기세요"`
  - 온도 분기 → 무더위/따뜻함/쌀쌀/추움/쾌적(산책 추천)
- LLM 프롬프트(`wake_weather`)에 raw 숫자·퍼센트 금지 + 권유와 짝지어야 함 명시, 한국어 예시 문장 3개 교체

## Test plan
- [x] `gradlew assembleDebug` 빌드 성공 (Android)
- [x] `packages/backend` 전체 테스트 통과 (1341 passed / 62 skipped)