### PR TITLE
fix: 음성 알람 반복 재생과 한국어 프롬프트 안정화

### DIFF
--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
@@ -11,6 +11,7 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.RingtoneManager
+import android.media.audiofx.LoudnessEnhancer
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
@@ -52,7 +53,9 @@ class RingingService : Service() {
     private var voiceLoopActive = false
     private var voiceRepeatJob: Job? = null
     private var voiceFadeJob: Job? = null
+    private var voiceRepeatLoudness: LoudnessEnhancer? = null
     private var currentAlarm: AlarmEntity? = null
+    private var ringingAlarmId: String? = null
     private var voiceAfterAlarmStarted = false
     private var voiceHasPlayedThisRing = false
 
@@ -115,8 +118,20 @@ class RingingService : Service() {
             startForeground(RINGING_NOTIFICATION_ID, notification)
         }
 
+        if (ringingAlarmId == alarmId) {
+            openRingingActivity(alarmId)
+            Log.i(TAG, "Ringing already active id=$alarmId; ignoring duplicate start")
+            return
+        }
+
+        if (ringingAlarmId != null) {
+            stopMediaAndVibration()
+        }
+        ringingAlarmId = alarmId
+
         serviceScope.launch {
             val alarm = AlarmAppContainer.repository(applicationContext).getAlarm(alarmId)
+            if (ringingAlarmId != alarmId) return@launch
             currentAlarm = alarm
             voiceAfterAlarmStarted = false
             voiceHasPlayedThisRing = false
@@ -147,7 +162,7 @@ class RingingService : Service() {
         )
         when {
             playMode == AlarmPlayModes.VOICE_ONLY && voiceUri != null && voiceVolumePercent > 0 -> {
-                startVoiceLoop(voiceUri, alarm)
+                startVoiceLoop(voiceUri, alarm, fadeIn = true)
             }
 
             playMode == AlarmPlayModes.VOICE_ONLY && voiceUri != null -> {
@@ -160,7 +175,7 @@ class RingingService : Service() {
                     startAlarmToneLoop(alarm)
                 } else if (voiceVolumePercent > 0) {
                     voiceAfterAlarmStarted = true
-                    startVoiceLoop(voiceUri, alarm)
+                    startVoiceLoop(voiceUri, alarm, fadeIn = true)
                 } else {
                     stopMediaOnly()
                     Log.i(TAG, "Alarm+voice audio muted by per-alarm settings id=${alarm?.id}")
@@ -198,26 +213,33 @@ class RingingService : Service() {
         }
     }
 
-    private fun startVoiceLoop(voiceUri: Uri, alarm: AlarmEntity?) {
+    private fun startVoiceLoop(voiceUri: Uri, alarm: AlarmEntity?, fadeIn: Boolean) {
         audioSequenceActive = false
         voiceLoopActive = true
         cancelVoiceRepeatJob()
         cancelVoiceFadeJob()
+        releaseVoiceRepeatLoudness()
         mediaPlayer?.release()
         val repeatVoice = alarm?.voiceRepeat != false
-        val shouldFadeIn = !voiceHasPlayedThisRing
+        val shouldFadeIn = fadeIn && !voiceHasPlayedThisRing
         mediaPlayer = createVoicePlayer(voiceUri)?.apply {
             voiceHasPlayedThisRing = true
             applyVoiceVolume(this, alarm, fadeIn = shouldFadeIn)
             isLooping = false
             setOnCompletionListener { completed ->
-                completed.release()
-                if (mediaPlayer === completed) {
-                    cancelVoiceFadeJob()
-                    mediaPlayer = null
-                }
                 if (repeatVoice && voiceLoopActive) {
-                    scheduleVoiceRepeat(voiceUri, alarm)
+                    if (mediaPlayer === completed) {
+                        cancelVoiceFadeJob()
+                        scheduleVoiceRepeat(completed, alarm)
+                    } else {
+                        completed.release()
+                    }
+                } else {
+                    completed.release()
+                    if (mediaPlayer === completed) {
+                        cancelVoiceFadeJob()
+                        mediaPlayer = null
+                    }
                 }
             }
             start()
@@ -228,15 +250,26 @@ class RingingService : Service() {
         }
     }
 
-    private fun scheduleVoiceRepeat(voiceUri: Uri, alarm: AlarmEntity?) {
+    private fun scheduleVoiceRepeat(player: MediaPlayer, alarm: AlarmEntity?) {
         cancelVoiceRepeatJob()
         voiceRepeatJob = serviceScope.launch {
             delay(VOICE_REPEAT_GAP_MS)
             voiceRepeatJob = null
-            if (!voiceLoopActive) return@launch
+            if (!voiceLoopActive || mediaPlayer !== player) return@launch
             val alarmId = alarm?.id
             if (alarmId != null && currentAlarm?.id != alarmId) return@launch
-            startVoiceLoop(voiceUri, alarm)
+            val targetVolume = VoiceVolumeRamp.targetVolume(alarm?.voiceVolumePercent ?: 100)
+            runCatching {
+                Log.i(TAG, "Repeating voice playback on existing player volume=$targetVolume")
+                enableVoiceRepeatLoudness(player)
+                player.setVolume(targetVolume, targetVolume)
+                player.seekTo(0)
+                player.start()
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to repeat voice playback on existing player", error)
+                stopMediaOnly()
+                startRingingAudio(alarm)
+            }
         }
     }
 
@@ -248,6 +281,28 @@ class RingingService : Service() {
     private fun cancelVoiceFadeJob() {
         voiceFadeJob?.cancel()
         voiceFadeJob = null
+    }
+
+    private fun enableVoiceRepeatLoudness(player: MediaPlayer) {
+        if (voiceRepeatLoudness != null) return
+        runCatching {
+            LoudnessEnhancer(player.audioSessionId).apply {
+                setTargetGain(VOICE_REPEAT_LOUDNESS_GAIN_MB)
+                enabled = true
+                voiceRepeatLoudness = this
+                Log.i(TAG, "Enabled repeat voice loudness enhancer gainMb=$VOICE_REPEAT_LOUDNESS_GAIN_MB")
+            }
+        }.onFailure { error ->
+            Log.w(TAG, "Unable to enable repeat voice loudness enhancer", error)
+        }
+    }
+
+    private fun releaseVoiceRepeatLoudness() {
+        voiceRepeatLoudness?.run {
+            runCatching { enabled = false }
+            release()
+        }
+        voiceRepeatLoudness = null
     }
 
     private fun startAlarmVoiceSequence(voiceUri: Uri, alarm: AlarmEntity?) {
@@ -350,6 +405,10 @@ class RingingService : Service() {
         val plan = VoiceVolumeRamp.plan(
             volumePercent = alarm?.voiceVolumePercent ?: 100,
             fadeIn = fadeIn,
+        )
+        Log.i(
+            TAG,
+            "Applying voice volume fadeIn=$fadeIn start=${plan.startVolume} target=${VoiceVolumeRamp.targetVolume(alarm?.voiceVolumePercent ?: 100)} steps=${plan.stepVolumes.size}",
         )
         player.setVolume(plan.startVolume, plan.startVolume)
         if (plan.stepVolumes.isEmpty()) {
@@ -474,6 +533,10 @@ class RingingService : Service() {
         runCatching {
             stopForeground(STOP_FOREGROUND_REMOVE)
         }
+        ringingAlarmId = null
+        currentAlarm = null
+        voiceAfterAlarmStarted = false
+        voiceHasPlayedThisRing = false
         abandonAlarmAudioFocus()
     }
 
@@ -487,6 +550,7 @@ class RingingService : Service() {
         voiceLoopActive = false
         cancelVoiceRepeatJob()
         cancelVoiceFadeJob()
+        releaseVoiceRepeatLoudness()
         mediaPlayer?.run {
             runCatching {
                 if (isPlaying) stop()
@@ -537,6 +601,7 @@ class RingingService : Service() {
     companion object {
         private const val RINGING_NOTIFICATION_ID = 1001
         private const val VOICE_REPEAT_GAP_MS = 900L
+        private const val VOICE_REPEAT_LOUDNESS_GAIN_MB = 600
 
         fun start(context: Context, alarmId: String) {
             val intent = Intent(context, RingingService::class.java).apply {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/RingingService.kt
@@ -347,23 +347,19 @@ class RingingService : Service() {
     }
 
     private fun applyVoiceVolume(player: MediaPlayer, alarm: AlarmEntity?, fadeIn: Boolean) {
-        val targetVolume = ((alarm?.voiceVolumePercent ?: 100).coerceIn(0, 100)) / 100f
-        if (!fadeIn || targetVolume <= VOICE_FADE_MIN_START_VOLUME) {
-            player.setVolume(targetVolume, targetVolume)
+        val plan = VoiceVolumeRamp.plan(
+            volumePercent = alarm?.voiceVolumePercent ?: 100,
+            fadeIn = fadeIn,
+        )
+        player.setVolume(plan.startVolume, plan.startVolume)
+        if (plan.stepVolumes.isEmpty()) {
             return
         }
 
-        val startVolume = maxOf(
-            VOICE_FADE_MIN_START_VOLUME,
-            targetVolume * VOICE_FADE_START_RATIO,
-        ).coerceAtMost(targetVolume)
-        player.setVolume(startVolume, startVolume)
         voiceFadeJob = serviceScope.launch {
-            repeat(VOICE_FADE_STEPS) { index ->
-                delay(VOICE_FADE_IN_MS / VOICE_FADE_STEPS)
+            plan.stepVolumes.forEach { volume ->
+                delay(VoiceVolumeRamp.FADE_IN_MS / VoiceVolumeRamp.FADE_STEPS)
                 if (mediaPlayer !== player) return@launch
-                val progress = (index + 1).toFloat() / VOICE_FADE_STEPS
-                val volume = startVolume + ((targetVolume - startVolume) * progress)
                 runCatching { player.setVolume(volume, volume) }
             }
             if (mediaPlayer === player) voiceFadeJob = null
@@ -541,10 +537,6 @@ class RingingService : Service() {
     companion object {
         private const val RINGING_NOTIFICATION_ID = 1001
         private const val VOICE_REPEAT_GAP_MS = 900L
-        private const val VOICE_FADE_IN_MS = 6_000L
-        private const val VOICE_FADE_STEPS = 12
-        private const val VOICE_FADE_START_RATIO = 0.45f
-        private const val VOICE_FADE_MIN_START_VOLUME = 0.35f
 
         fun start(context: Context, alarmId: String) {
             val intent = Intent(context, RingingService::class.java).apply {

--- a/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/VoiceVolumeRamp.kt
+++ b/apps/android-native/app/src/main/java/com/voicealarm/nativeapp/alarm/VoiceVolumeRamp.kt
@@ -1,0 +1,47 @@
+package com.voicealarm.nativeapp.alarm
+
+internal object VoiceVolumeRamp {
+    const val FADE_IN_MS = 6_000L
+    const val FADE_STEPS = 12
+
+    private const val START_RATIO = 0.15f
+    private const val MIN_START_VOLUME = 0.10f
+
+    fun targetVolume(volumePercent: Int): Float =
+        volumePercent.coerceIn(0, 100) / 100f
+
+    fun plan(volumePercent: Int, fadeIn: Boolean): VoiceVolumeRampPlan {
+        val target = targetVolume(volumePercent)
+        if (!fadeIn || target <= 0f) {
+            return VoiceVolumeRampPlan(
+                startVolume = target,
+                stepVolumes = emptyList(),
+            )
+        }
+
+        val start = maxOf(
+            MIN_START_VOLUME,
+            target * START_RATIO,
+        ).coerceAtMost(target)
+        if (start >= target) {
+            return VoiceVolumeRampPlan(
+                startVolume = target,
+                stepVolumes = emptyList(),
+            )
+        }
+
+        val stepVolumes = (1..FADE_STEPS).map { step ->
+            val progress = step.toFloat() / FADE_STEPS
+            start + ((target - start) * progress)
+        }
+        return VoiceVolumeRampPlan(
+            startVolume = start,
+            stepVolumes = stepVolumes,
+        )
+    }
+}
+
+internal data class VoiceVolumeRampPlan(
+    val startVolume: Float,
+    val stepVolumes: List<Float>,
+)

--- a/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/alarm/VoiceVolumeRampTest.kt
+++ b/apps/android-native/app/src/test/java/com/voicealarm/nativeapp/alarm/VoiceVolumeRampTest.kt
@@ -1,0 +1,42 @@
+package com.voicealarm.nativeapp.alarm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceVolumeRampTest {
+    @Test
+    fun firstPlaybackStartsQuietAndReachesTargetVolume() {
+        val plan = VoiceVolumeRamp.plan(volumePercent = 100, fadeIn = true)
+
+        assertEquals(0.15f, plan.startVolume, 0.001f)
+        assertEquals(VoiceVolumeRamp.FADE_STEPS, plan.stepVolumes.size)
+        assertEquals(1f, plan.stepVolumes.last(), 0.001f)
+        assertTrue(plan.stepVolumes.zipWithNext().all { (left, right) -> right > left })
+    }
+
+    @Test
+    fun repeatedPlaybackStartsAtTargetVolume() {
+        val plan = VoiceVolumeRamp.plan(volumePercent = 100, fadeIn = false)
+
+        assertEquals(1f, plan.startVolume, 0.001f)
+        assertTrue(plan.stepVolumes.isEmpty())
+    }
+
+    @Test
+    fun lowConfiguredVoiceVolumeStillFadesWhenThereIsRoom() {
+        val plan = VoiceVolumeRamp.plan(volumePercent = 30, fadeIn = true)
+
+        assertTrue(plan.startVolume < 0.30f)
+        assertEquals(VoiceVolumeRamp.FADE_STEPS, plan.stepVolumes.size)
+        assertEquals(0.30f, plan.stepVolumes.last(), 0.001f)
+    }
+
+    @Test
+    fun mutedVoiceStaysMuted() {
+        val plan = VoiceVolumeRamp.plan(volumePercent = 0, fadeIn = true)
+
+        assertEquals(0f, plan.startVolume, 0.001f)
+        assertTrue(plan.stepVolumes.isEmpty())
+    }
+}

--- a/apps/ios-native/VoiceAlarm/AlarmVoicePlayer.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmVoicePlayer.swift
@@ -32,10 +32,6 @@ final class AlarmVoicePlayer: NSObject, AVAudioPlayerDelegate {
     static let shared = AlarmVoicePlayer()
 
     private static let voiceRepeatGapNanos: UInt64 = 900_000_000
-    private static let voiceFadeInNanos: UInt64 = 6_000_000_000
-    private static let voiceFadeSteps = 12
-    private static let voiceFadeStartRatio: Float = 0.45
-    private static let voiceFadeMinStartVolume: Float = 0.35
 
     private var player: AVAudioPlayer?
     private var activePlayerID: ObjectIdentifier?
@@ -113,24 +109,22 @@ final class AlarmVoicePlayer: NSObject, AVAudioPlayerDelegate {
         fadeTask?.cancel()
         fadeTask = nil
 
-        guard Self.shouldFadeInVoice(targetVolume: targetVolume, fadeIn: fadeIn) else {
-            player.volume = targetVolume
+        let plan = Self.voiceVolumeRampPlan(targetVolume: targetVolume, fadeIn: fadeIn)
+        player.volume = plan.startVolume
+        guard !plan.stepVolumes.isEmpty else {
             return
         }
 
-        let startVolume = Self.voiceFadeStartVolume(targetVolume: targetVolume)
-        player.volume = startVolume
         let generation = playbackGeneration + 1
         fadeTask = Task { @MainActor [weak self] in
-            for index in 1...Self.voiceFadeSteps {
+            for volume in plan.stepVolumes {
                 try? await Task.sleep(nanoseconds: Self.voiceFadeInNanos / UInt64(Self.voiceFadeSteps))
                 guard let self,
                       self.playbackGeneration == generation,
                       let player = self.player else {
                     return
                 }
-                let progress = Float(index) / Float(Self.voiceFadeSteps)
-                player.volume = startVolume + ((targetVolume - startVolume) * progress)
+                player.volume = volume
             }
             if self?.playbackGeneration == generation {
                 self?.fadeTask = nil
@@ -199,12 +193,29 @@ final class AlarmVoicePlayer: NSObject, AVAudioPlayerDelegate {
         max(0.0, min(1.0, Float(percent) / 100.0))
     }
 
-    static func shouldFadeInVoice(targetVolume: Float, fadeIn: Bool) -> Bool {
-        fadeIn && targetVolume > voiceFadeMinStartVolume
+    static let voiceFadeInNanos: UInt64 = 6_000_000_000
+    static let voiceFadeSteps = 12
+
+    static func voiceVolumeRampPlan(targetVolume: Float, fadeIn: Bool) -> VoiceVolumeRampPlan {
+        let target = max(0.0, min(1.0, targetVolume))
+        guard fadeIn, target > 0 else {
+            return VoiceVolumeRampPlan(startVolume: target, stepVolumes: [])
+        }
+
+        let start = min(max(VoiceVolumeRampPlan.minimumStartVolume, target * VoiceVolumeRampPlan.startRatio), target)
+        guard start < target else {
+            return VoiceVolumeRampPlan(startVolume: target, stepVolumes: [])
+        }
+
+        let stepVolumes = (1...voiceFadeSteps).map { step in
+            let progress = Float(step) / Float(voiceFadeSteps)
+            return start + ((target - start) * progress)
+        }
+        return VoiceVolumeRampPlan(startVolume: start, stepVolumes: stepVolumes)
     }
 
     static func voiceFadeStartVolume(targetVolume: Float) -> Float {
-        min(max(voiceFadeMinStartVolume, targetVolume * voiceFadeStartRatio), targetVolume)
+        voiceVolumeRampPlan(targetVolume: targetVolume, fadeIn: true).startVolume
     }
 
     // MARK: AVAudioPlayerDelegate
@@ -223,5 +234,13 @@ final class AlarmVoicePlayer: NSObject, AVAudioPlayerDelegate {
             self.stop()
         }
     }
+}
+
+struct VoiceVolumeRampPlan: Equatable {
+    static let startRatio: Float = 0.15
+    static let minimumStartVolume: Float = 0.10
+
+    let startVolume: Float
+    let stepVolumes: [Float]
 }
 #endif

--- a/apps/ios-native/VoiceAlarmTests/AlarmVoicePlayerTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/AlarmVoicePlayerTests.swift
@@ -11,12 +11,35 @@ final class AlarmVoicePlayerTests: XCTestCase {
         XCTAssertEqual(AlarmVoicePlayer.voiceVolume(forPercent: 120), 1)
     }
 
-    func test_voiceFadeStartVolume_matchesAndroidConstants() {
-        XCTAssertTrue(AlarmVoicePlayer.shouldFadeInVoice(targetVolume: 1.0, fadeIn: true))
-        XCTAssertEqual(AlarmVoicePlayer.voiceFadeStartVolume(targetVolume: 1.0), 0.45, accuracy: 0.001)
-        XCTAssertEqual(AlarmVoicePlayer.voiceFadeStartVolume(targetVolume: 0.5), 0.35, accuracy: 0.001)
-        XCTAssertFalse(AlarmVoicePlayer.shouldFadeInVoice(targetVolume: 0.35, fadeIn: true))
-        XCTAssertFalse(AlarmVoicePlayer.shouldFadeInVoice(targetVolume: 1.0, fadeIn: false))
+    func test_voiceVolumeRampPlan_firstPlaybackStartsQuietAndReachesTargetVolume() {
+        let plan = AlarmVoicePlayer.voiceVolumeRampPlan(targetVolume: 1.0, fadeIn: true)
+
+        XCTAssertEqual(plan.startVolume, 0.15, accuracy: 0.001)
+        XCTAssertEqual(plan.stepVolumes.count, AlarmVoicePlayer.voiceFadeSteps)
+        XCTAssertEqual(plan.stepVolumes.last ?? -1, 1.0, accuracy: 0.001)
+        XCTAssertTrue(zip(plan.stepVolumes, plan.stepVolumes.dropFirst()).allSatisfy { pair in pair.1 > pair.0 })
+    }
+
+    func test_voiceVolumeRampPlan_repeatedPlaybackStartsAtTargetVolume() {
+        let plan = AlarmVoicePlayer.voiceVolumeRampPlan(targetVolume: 1.0, fadeIn: false)
+
+        XCTAssertEqual(plan.startVolume, 1.0, accuracy: 0.001)
+        XCTAssertTrue(plan.stepVolumes.isEmpty)
+    }
+
+    func test_voiceVolumeRampPlan_lowConfiguredVoiceVolumeStillFadesWhenThereIsRoom() {
+        let plan = AlarmVoicePlayer.voiceVolumeRampPlan(targetVolume: 0.30, fadeIn: true)
+
+        XCTAssertLessThan(plan.startVolume, 0.30)
+        XCTAssertEqual(plan.stepVolumes.count, AlarmVoicePlayer.voiceFadeSteps)
+        XCTAssertEqual(plan.stepVolumes.last ?? -1, 0.30, accuracy: 0.001)
+    }
+
+    func test_voiceVolumeRampPlan_mutedVoiceStaysMuted() {
+        let plan = AlarmVoicePlayer.voiceVolumeRampPlan(targetVolume: 0, fadeIn: true)
+
+        XCTAssertEqual(plan.startVolume, 0, accuracy: 0.001)
+        XCTAssertTrue(plan.stepVolumes.isEmpty)
     }
 }
 #endif

--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -218,7 +218,7 @@ export async function generateDynamicAlarmTextWithVertex(
     return fallback;
   }
   const parsed = parseAlarmTextPreparation(raw);
-  const text = parsed.text.trim();
+  const text = polishDynamicAlarmText(parsed.text.trim(), context);
 
   if (
     !text ||
@@ -479,25 +479,31 @@ function alarmTextPrompt(args: {
 // 한국어일 때 관계 라벨에 맞는 어체(반말/해요체/합니다체) 가이드를 추가한다.
 // 알람 청자는 보통 부모/조부모 (어른) 이라는 가정을 기본으로 깔고, speaker(말하는 사람)
 // 가 어떤 관계냐에 따라 자연스러운 한국어 화법을 매핑한다.
+const YOUNGER_TO_ELDER_RELATIONSHIPS = ['손녀', '손자', '손주', '딸', '아들', '자식', '며느리', '사위', '조카'];
+const ELDER_TO_YOUNGER_RELATIONSHIPS = ['할머니', '할아버지', '엄마', '어머니', '아빠', '아버지', '부모', '이모', '고모', '삼촌', '외할머니', '외할아버지'];
+const GRANDCHILD_RELATIONSHIPS = ['손녀', '손자', '손주'];
+const SIBLING_RELATIONSHIPS = ['형제', '자매', '남매', '동생', '누나', '언니', '오빠', '형'];
+
 function koreanRegisterGuidance(relationshipLabel: string | null | undefined): string {
   if (!relationshipLabel) return '';
   const label = relationshipLabel.trim();
   if (!label) return '';
-  const youngerToElder = ['손녀', '손자', '손주', '딸', '아들', '자식', '며느리', '사위', '조카'];
-  const elderToYounger = ['할머니', '할아버지', '엄마', '어머니', '아빠', '아버지', '부모', '이모', '고모', '삼촌', '외할머니', '외할아버지'];
-  const peerOrIntimate = ['친구', '동생'];
+  const peerOrIntimate = ['친구', ...SIBLING_RELATIONSHIPS];
 
-  if (youngerToElder.some((k) => label.includes(k))) {
-    return ' Speaker is younger than the listener: write in warm 해요체 (e.g. "할머니, 일어나셨어요?", "오늘은 ~해요"). Do NOT use stiff 합니다체 like "~합니다", "~하십시오". Sound like family talking, not a TV news anchor.';
+  if (isGrandchildRelationship(label)) {
+    return ' Speaker is a grandchild speaking to a grandparent: write in warm, familiar 해요체 with respectful verb forms. Prefer "할머니, 일어나실 시간이에요" or "할아버지, 좋은 아침이에요"; never write casual elder-address phrases like "할머니, 일어날 시간이에요". It should sound like an actual grandchild speaking beside the listener, not a scripted announcement. Use small caring phrases when natural, such as "조심히 다녀오세요" or "감기 조심하세요". Do NOT use stiff 합니다체 like "~합니다", "~하십시오".';
   }
-  if (elderToYounger.some((k) => label.includes(k))) {
+  if (isYoungerToElderRelationship(label)) {
+    return ' Speaker is younger than the listener: write in warm, familiar 해요체 that still shows respect (e.g. "할아버지, 일어나실 시간이에요", "나가실 때 우산 꼭 챙기세요"). It should sound like an actual granddaughter/grandson or child speaking beside the listener, not a scripted announcement. Use small caring phrases when natural, such as "조심히 다녀오세요" or "감기 조심하세요". Do NOT use stiff 합니다체 like "~합니다", "~하십시오".';
+  }
+  if (ELDER_TO_YOUNGER_RELATIONSHIPS.some((k) => label.includes(k))) {
     return ' Speaker is older than the listener: write in caring 반말 or 해요체 mixed style (e.g. "우리 딸, 잘 잤어?", "오늘도 화이팅이야"). Avoid 합니다체.';
   }
   if (isRomanticRelationship(label)) {
     return ' Speaker is a romantic partner or spouse: write in intimate 반말 that feels warm and a little heart-fluttering when heard from a boyfriend, girlfriend, wife, or husband. Use soft caring phrases like "자기야", "내 생각도 조금 해", "감기 걸리면 안 돼", or "오늘도 네 편이야" only when they fit. Avoid stiff 해요체/합니다체, childish baby talk, melodrama, or generic slogans as the main emotion.';
   }
   if (peerOrIntimate.some((k) => label.includes(k))) {
-    return ' Speaker and listener are peers/intimate: write in 반말 (e.g. "일어났어?", "오늘 뭐 입을까?"). Never use 합니다체.';
+    return ' Speaker and listener are peers/intimate: write in natural 반말 (e.g. "일어났어?", "오늘 뭐 입을까?"). For sibling labels such as 형제·자매, 누나, 언니, 오빠, 형, or 동생, avoid 존댓말/해요체 and sound like a real sibling; for bedtime, prefer a line like "누나, 잘 시간이야. 휴대폰 내려놓고 얼른 자." Never use 합니다체.';
   }
   return ' Use a warm conversational tone — prefer 해요체 over 합니다체. Sound like a real person, not an announcement.';
 }
@@ -508,6 +514,24 @@ function isRomanticRelationship(relationshipLabel: string | null | undefined): b
   return ['연인', '여자친구', '남자친구', '애인', '여보', '자기', '아내', '남편', '배우자', '와이프', '신랑', '신부'].some((keyword) =>
     label.includes(keyword),
   );
+}
+
+function isYoungerToElderRelationship(relationshipLabel: string | null | undefined): boolean {
+  const label = relationshipLabel?.trim();
+  if (!label) return false;
+  return YOUNGER_TO_ELDER_RELATIONSHIPS.some((keyword) => label.includes(keyword));
+}
+
+function isGrandchildRelationship(relationshipLabel: string | null | undefined): boolean {
+  const label = relationshipLabel?.trim();
+  if (!label) return false;
+  return GRANDCHILD_RELATIONSHIPS.some((keyword) => label.includes(keyword));
+}
+
+function isSiblingRelationship(relationshipLabel: string | null | undefined): boolean {
+  const label = relationshipLabel?.trim();
+  if (!label) return false;
+  return SIBLING_RELATIONSHIPS.some((keyword) => label.includes(keyword));
 }
 
 function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
@@ -528,7 +552,7 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
       : '';
   const modeInstruction = (() => {
     if (context.mode === 'wake_weather') {
-      return `Create a wake-up message. Start naturally like "일어나실 시간이에요" or "좋은 아침이에요" rather than describing whose voice it is. The weather context already comes as one or two short actionable suggestions, e.g. "비가 올 수 있어요. 우산 챙기세요", "미세먼지가 많아요. 외출할 땐 마스크 챙기세요", "날씨가 좋아요. 잠깐 산책 가기에도 딱이에요". Weave at most two of these suggestions into the line naturally. DO NOT recite raw numbers, temperatures, percentages, weather codes, or labels like "강수 확률 70%" or "최저 12도 최고 19도". DO NOT just describe the weather ("비가 와요" alone is not enough) — always pair it with a short action the listener can take (e.g. 우산 챙기기, 마스크 챙기기, 따뜻하게 입기, 산책 추천). For Korean, weather can sound like softly relayed information using endings such as "~대", "~대요", "~다네요", "~것 같아", or "~면 좋겠다" when natural, but do not force a lead-in like "예보 보니까" or repeat an explicit source phrase every time. Do not mention location names, city/country names, the exact date, or weekday. Ending is optional; if you add one, keep it short and relationship-appropriate. Weather context: ${context.weatherSummary || 'weather information is unavailable'}.`;
+      return `Create a wake-up message that sounds like one real person gently waking another person up. Start with the listener's title if one is provided, then a natural wake-up phrase like "일어나실 시간이에요" or "좋은 아침이에요"; do not describe whose voice it is. The weather context already comes as one or two short actionable suggestions, e.g. "비가 올 수 있어요. 우산 챙기세요", "미세먼지가 많아요. 외출할 땐 마스크 챙기세요", "날씨가 좋아요. 잠깐 산책 가기에도 딱이에요". Convert that context into conversational speech and weave at most two suggestions into the line naturally. DO NOT recite raw numbers, temperatures, percentages, weather codes, or labels like "강수 확률 70%" or "최저 12도 최고 19도". DO NOT just describe the weather ("비가 와요" alone is not enough) — always pair it with a short action the listener can take (e.g. 우산 챙기기, 마스크 챙기기, 따뜻하게 입기, 산책 추천). For Korean, prefer soft relayed phrasing such as "~대요", "~있대요", "~다네요", or "~면 좋겠어요" when natural. In respectful family speech, keep natural particles and spacing: prefer "비가 올 수 있대요" or "오늘은 비가 올 수 있대요"; avoid clipped wording like "비 올 수 있대요". Avoid robotic connector phrases like "예보 보니까" unless it truly sounds spoken. Do not mention location names, city/country names, the exact date, or weekday. End with a tiny human care phrase only when it fits the relationship. Weather context: ${context.weatherSummary || 'weather information is unavailable'}.`;
     }
     if (context.mode === 'wake_fortune') {
       return `Create a wake-up message with a light, entertainment-only daily fortune. If fortune input is available, infer only a gentle mood from gender, birth date, and birth time. Fortune input is internal only: ${context.fortuneProfile || 'fortune profile is unavailable'}. Never mention the listener's birth date, birthday, birth time, zodiac details, "born on", "birth date", "생년월일", "태어난 시간", "몇 월 며칠생", or any specific month/day/year/time from the input. Do not sound like a real prediction or guarantee. For Korean, make the fortune feel like a soft, playful reading rather than something the speaker personally knows for certain; endings like "~래", "~라네요", "~것 같아", or "~면 좋겠다" are good when they sound natural. If the speaker is a romantic partner or spouse, do not mention new relationships, romantic opportunities, attraction from others, flirting, jealousy, or dating luck; keep the fortune about mood, small luck, confidence, health, work, study, or daily energy.`;
@@ -537,7 +561,9 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
       return `Create a ${context.mealLabel || 'meal'} reminder. Ask naturally whether they have eaten and recommend one menu idea. Consider this weather if available, using soft relayed weather phrasing in Korean when natural without forcing a source lead-in: ${context.weatherSummary || 'weather information is unavailable'}.`;
     }
     if (context.mode === 'sleep') {
-      return 'Create a bedtime message that helps the listener wind down, put the phone away, and rest without sounding like a generic notification.';
+      return isSiblingRelationship(context.relationshipLabel)
+        ? 'Create a sibling-style bedtime message in natural 반말. Make it sound like a real brother or sister, not a polite notification. Good Korean example: "누나, 잘 시간이야. 휴대폰 내려놓고 얼른 자." Avoid 해요체 like "잘 시간이에요", "쉬어요", or "주무세요" for sibling cases.'
+        : 'Create a bedtime message that helps the listener wind down, put the phone away, and rest without sounding like a generic notification.';
     }
     if (context.mode === 'exercise') {
       return `Create an exercise reminder. Make it energetic but not childish. If the weather suggests it, choose indoor strength training or outdoor cardio naturally. In Korean, weather can use soft reported phrasing when natural, but do not force an explicit source phrase. Weather context: ${context.weatherSummary || 'weather information is unavailable'}.`;
@@ -562,10 +588,10 @@ function dynamicAlarmTextPrompt(context: DynamicAlarmTextContext): string {
     'Do not announce the relationship or source of the voice. Avoid phrases like "손녀 목소리로 전해요"; the alarm should sound like a natural alarm line.',
     'Do not mention the exact date, weekday, alarm time, country, city, district, or saved location label unless the user explicitly wrote it as part of the alarm text.',
     context.targetLanguage === 'ko'
-      ? '한국어 어체 규칙: 가족·친구·연인·배우자 관계에서는 절대 "~합니다", "~하십시오" 같은 합니다체를 쓰지 말 것. 손녀→조부모, 자식→부모 등 손아랫사람이 손윗사람에게 말할 때는 친근한 해요체 ("~해요", "~예요"). 부모→자식, 형/누나→동생 등은 다정한 반말 또는 해요체 혼용. 친구 사이는 반말. 연인·남자친구·여자친구·아내·남편·배우자는 사적인 반말과 따뜻하고 살짝 설레는 톤. 뉴스 앵커처럼 들리지 않게 진짜 사람이 옆에서 말하는 톤으로.'
+      ? '한국어 어체 규칙: 가족·친구·연인·배우자 관계에서는 절대 "~합니다", "~하십시오" 같은 합니다체를 쓰지 말 것. 손녀·손자·손주→조부모는 친근하지만 공손한 해요체와 존대 동사를 써서 "할머니, 일어나실 시간이에요"처럼 말하고, "할머니, 일어날 시간이에요"처럼 낮춰 들리는 표현은 피한다. 자식→부모는 친근한 해요체 ("~해요", "~예요"). 부모→자식은 다정한 반말 또는 해요체 혼용. 형제·자매·친구 사이는 반말. 연인·남자친구·여자친구·아내·남편·배우자는 사적인 반말과 따뜻하고 살짝 설레는 톤. 뉴스 앵커처럼 들리지 않게 진짜 사람이 옆에서 말하는 톤으로.'
       : '',
     context.targetLanguage === 'ko'
-      ? '문장 구조 예시 (wake_weather): "일어나실 시간이에요. 비가 올 수 있대요. 우산 꼭 챙기세요. 오늘도 화이팅!" / "좋은 아침이에요. 날씨가 좋대요. 잠깐 산책 가기에도 딱이에요." / "자기야, 일어나자. 비 온대. 나가기 전에 우산 챙겨, 감기 걸리면 안 돼." / "일어나실 시간이에요. 미세먼지가 많대요. 마스크 챙겨 나가세요." — 위치/날짜/관계/숫자 없이 시작해서, 날씨 상태와 그에 맞는 행동 권유를 한두 마디로 자연스럽게 묶고 짧게 마무리. "예보 보니까" 같은 출처 도입은 선택 사항이며, 강수확률·기온 숫자를 그대로 읽는 패턴은 금지.'
+      ? '문장 구조 예시 (wake_weather): "할아버지, 일어나실 시간이에요. 오늘은 비가 올 수 있대요. 나가실 때 우산 꼭 챙기세요." / "할머니, 좋은 아침이에요. 미세먼지가 많대요. 외출하실 때 마스크 챙기세요." / "자기야, 일어나자. 비 온대. 나가기 전에 우산 챙겨, 감기 걸리면 안 돼." / "일어나실 시간이에요. 날씨가 좋대요. 잠깐 산책 가기에도 딱이에요." — 위치/날짜/관계/숫자 없이 시작해서, 날씨 상태와 그에 맞는 행동 권유를 한두 마디로 자연스럽게 묶고 짧게 마무리. "예보 보니까" 같은 출처 도입은 선택 사항이며, 강수확률·기온 숫자를 그대로 읽는 패턴은 금지. 손녀→할아버지처럼 손아랫사람이 손윗사람에게 말할 때는 "오늘은 비가 올 수 있대요", "나가실 때 우산 꼭 챙기세요"처럼 조사와 띄어쓰기가 살아 있는 다정한 말투를 우선한다.'
       : '',
     'Make it feel meaningfully different from a prerecorded fixed alarm.',
     'Do not include any brackets, delivery tags, [tag] markers, or stage directions in your output. A single delivery tag will be added in a later step.',
@@ -588,7 +614,11 @@ function dynamicAlarmTextReadableFallback(context: DynamicAlarmTextContext): str
         .slice(0, 200)
         .trim();
     }
-    return `${wakeOpener} ${stripTrailingPunctuation(context.weatherSummary)}. 오늘도 화이팅!`
+    const weatherTip = weatherSummaryForFallback(context.weatherSummary, false);
+    const careClosing = context.targetLanguage === 'ko' && isYoungerToElderRelationship(context.relationshipLabel)
+      ? ' 조심히 다녀오세요.'
+      : ' 오늘도 화이팅!';
+    return `${wakeOpener} ${weatherTip}.${careClosing}`
       .slice(0, 200)
       .trim();
   }
@@ -651,11 +681,50 @@ function dynamicAlarmTextReadableFallback(context: DynamicAlarmTextContext): str
     .trim();
 }
 
+function polishDynamicAlarmText(text: string, context: DynamicAlarmTextContext): string {
+  if (context.targetLanguage !== 'ko') return text;
+  let polished = text.trim();
+
+  if (isGrandchildRelationship(context.relationshipLabel)) {
+    const listener = context.listenerTitle?.trim();
+    const titlePattern = listener
+      ? escapeRegExp(listener)
+      : '할머니|할머님|할아버지|할아버님';
+    polished = polished.replace(
+      new RegExp(`(${titlePattern}),\\s*일어날\\s+시간(?:이에요|예요)`, 'g'),
+      '$1, 일어나실 시간이에요',
+    );
+  }
+
+  if (context.mode === 'sleep' && isSiblingRelationship(context.relationshipLabel)) {
+    const listener = context.listenerTitle?.trim();
+    if (listener && /(잘\s+시간(?:이에요|예요)|쉬어요|주무세요)/.test(polished)) {
+      return `${listener}, 잘 시간이야. 휴대폰 내려놓고 얼른 자.`;
+    }
+  }
+
+  if (context.mode !== 'wake_weather') return polished;
+  const respectful = !isRomanticRelationship(context.relationshipLabel);
+  if (!respectful) return polished;
+
+  return polished
+    .replace(/오늘\s+비\s+올\s+수\s+있대요/g, '오늘은 비가 올 수 있대요')
+    .replace(/오늘\s+비\s+올\s+수\s+있다네요/g, '오늘은 비가 올 수 있다네요')
+    .replace(/오늘\s+비\s+온대요/g, '오늘은 비가 온대요')
+    .replace(/비\s+올\s+수\s+있대요/g, '비가 올 수 있대요')
+    .replace(/비\s+올\s+수\s+있다네요/g, '비가 올 수 있다네요')
+    .replace(/비\s+온대요/g, '비가 온대요')
+    .trim();
+}
+
 function stripTrailingPunctuation(text: string): string {
   return text.trim().replace(/[.!?。]+$/g, '');
 }
 
 function weatherSummaryForFallback(summary: string, intimate: boolean): string {
+  const naturalSummary = naturalizeRawWeatherSummary(summary, intimate);
+  if (naturalSummary) return naturalSummary;
+
   const replacements: Array<[RegExp, string]> = intimate
     ? [
         [/비가 살짝 올 수 있어요/g, '비가 살짝 올 수 있대'],
@@ -685,11 +754,37 @@ function weatherSummaryForFallback(summary: string, intimate: boolean): string {
         [/낮엔 따뜻해요/g, '낮엔 따뜻하대요'],
         [/많이 쌀쌀해요/g, '많이 쌀쌀하대요'],
         [/쌀쌀해요/g, '쌀쌀하대요'],
+        [/우산을 챙기면 (?:좋아요|안심돼요)/g, '우산 꼭 챙기세요'],
       ];
   return replacements.reduce(
     (value, [pattern, replacement]) => value.replace(pattern, replacement),
     stripTrailingPunctuation(summary),
   );
+}
+
+function naturalizeRawWeatherSummary(summary: string, intimate: boolean): string | null {
+  const text = stripTrailingPunctuation(summary);
+  const hasRain = /(비|강수|우산|precipitation|rain)/i.test(text);
+  const hasSnow = /(눈|미끄럽|snow)/i.test(text);
+  const hasDust = /(미세먼지|초미세먼지|마스크|pm10|pm2\.?5)/i.test(text);
+  const hasCold = /(쌀쌀|추|최저|영하|겉옷|따뜻하게)/i.test(text);
+  const hasHeat = /(무더|더울|최고|물도|시원하게)/i.test(text);
+
+  if (intimate) {
+    if (hasSnow) return '눈 올 수 있대. 미끄럽지 않게 조심해';
+    if (hasRain) return '비 올 수 있대. 나가기 전에 우산 꼭 챙겨';
+    if (hasDust) return '미세먼지 많대. 나갈 땐 마스크 챙겨';
+    if (hasCold) return '쌀쌀하대. 겉옷 하나 챙겨';
+    if (hasHeat) return '낮에 많이 덥대. 물도 자주 마셔';
+    return null;
+  }
+
+  if (hasSnow) return '눈이 올 수 있대요. 미끄럽지 않게 조심하세요';
+  if (hasRain) return '비가 올 수 있대요. 나가실 때 우산 꼭 챙기세요';
+  if (hasDust) return '미세먼지가 많대요. 외출하실 때 마스크 챙기세요';
+  if (hasCold) return '쌀쌀하대요. 겉옷 하나 챙기세요';
+  if (hasHeat) return '낮에 많이 덥대요. 물도 자주 드세요';
+  return null;
 }
 
 function dynamicAlarmTextPreparationFallback(

--- a/packages/backend/test/vertex-translate.test.ts
+++ b/packages/backend/test/vertex-translate.test.ts
@@ -190,8 +190,9 @@ describe('generateDynamicAlarmTextWithVertex', () => {
     });
 
     expect(generated.text).toContain('일어나실 시간');
-    expect(generated.text).toContain('강수 확률 70%');
-    expect(generated.text).toContain('오늘도 화이팅');
+    expect(generated.text).toContain('비가 올 수 있대요');
+    expect(generated.text).toContain('우산 꼭 챙기세요');
+    expect(generated.text).not.toContain('강수 확률 70%');
     expect(generated.text).not.toContain('손녀 목소리');
     expect(generated.text).not.toContain('5월 20일');
     expect(generated.text).not.toContain('서울');
@@ -214,7 +215,9 @@ describe('generateDynamicAlarmTextWithVertex', () => {
 
     expect(generated.provider).toBe('local');
     expect(generated.text).toContain('일어나실 시간');
-    expect(generated.text).toContain('강수 확률 70%');
+    expect(generated.text).toContain('비가 올 수 있대요');
+    expect(generated.text).toContain('우산 꼭 챙기세요');
+    expect(generated.text).not.toContain('강수 확률 70%');
     expect(generated.text).not.toContain('손녀 목소리');
     expect(generated.text).not.toContain('5월 20일');
     expect(generated.text).not.toContain('서울');
@@ -223,7 +226,7 @@ describe('generateDynamicAlarmTextWithVertex', () => {
 
   it('accepts an explicit listener title even when it is a family title', async () => {
     mockFetch.mockResolvedValueOnce(
-      geminiText('{"text":"할머니, 일어나실 시간이에요. 비가 올 수 있대요. 우산 꼭 챙기세요."}'),
+      geminiText('{"text":"할아버지, 일어나실 시간이에요. 오늘 비 올 수 있대요. 나가실 때 우산 꼭 챙기세요."}'),
     );
 
     const generated = await generateDynamicAlarmTextWithVertex(ENV, {
@@ -233,13 +236,68 @@ describe('generateDynamicAlarmTextWithVertex', () => {
       dateLabel: '5월 20일 수요일',
       alarmTimeLabel: '07:30',
       relationshipLabel: '손녀',
-      listenerTitle: '할머니',
+      listenerTitle: '할아버지',
       weatherSummary: '비가 올 수 있어요. 우산 꼭 챙기세요',
     });
 
+    const requestBody = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body));
+    const prompt = requestBody.contents[0].parts[0].text;
     expect(generated.provider).toBe('gemini-api-key');
-    expect(generated.text).toContain('할머니');
+    expect(generated.text).toContain('할아버지');
+    expect(generated.text).toContain('오늘은 비가 올 수 있대요');
+    expect(generated.text).not.toContain('오늘 비 올 수 있대요');
     expect(generated.text).toContain('우산 꼭 챙기세요');
+    expect(prompt).toContain('actual grandchild speaking beside the listener');
+    expect(prompt).toContain('할아버지, 일어나실 시간이에요');
+    expect(prompt).toContain('avoid clipped wording like "비 올 수 있대요"');
+    expect(prompt).toContain('조심히 다녀오세요');
+  });
+
+  it('polishes grandchild to grandparent wake wording into respectful verb forms', async () => {
+    mockFetch.mockResolvedValueOnce(
+      geminiText('{"text":"할머니, 일어날 시간이에요! 오늘은 천천히 움직이면 컨디션이 좋대요."}'),
+    );
+
+    const generated = await generateDynamicAlarmTextWithVertex(ENV, {
+      mode: 'wake_fortune',
+      category: 'morning',
+      targetLanguage: 'ko',
+      dateLabel: '5월 20일 수요일',
+      relationshipLabel: '손주',
+      listenerTitle: '할머니',
+      fortuneProfile: 'gender=여성, birth date=1954-01-05, birth time=05:30',
+    });
+
+    const requestBody = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body));
+    const prompt = requestBody.contents[0].parts[0].text;
+    expect(generated.provider).toBe('gemini-api-key');
+    expect(generated.text).toContain('할머니, 일어나실 시간이에요');
+    expect(generated.text).not.toContain('할머니, 일어날 시간이에요');
+    expect(prompt).toContain('Speaker is a grandchild speaking to a grandparent');
+    expect(prompt).toContain('never write casual elder-address phrases like "할머니, 일어날 시간이에요"');
+  });
+
+  it('keeps sibling bedtime messages in natural banmal', async () => {
+    mockFetch.mockResolvedValueOnce(
+      geminiText('{"text":"누나, 벌써 잘 시간이에요. 휴대폰은 내려놓고 편안하게 쉬어요."}'),
+    );
+
+    const generated = await generateDynamicAlarmTextWithVertex(ENV, {
+      mode: 'sleep',
+      category: 'sleep',
+      targetLanguage: 'ko',
+      dateLabel: '5월 20일 수요일',
+      alarmTimeLabel: '23:00',
+      relationshipLabel: '형제·자매',
+      listenerTitle: '누나',
+    });
+
+    const requestBody = JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body));
+    const prompt = requestBody.contents[0].parts[0].text;
+    expect(generated.provider).toBe('gemini-api-key');
+    expect(generated.text).toBe('누나, 잘 시간이야. 휴대폰 내려놓고 얼른 자.');
+    expect(prompt).toContain('Create a sibling-style bedtime message in natural 반말');
+    expect(prompt).toContain('누나, 잘 시간이야. 휴대폰 내려놓고 얼른 자.');
   });
 
   it('prompts romantic partner cases with warm tone and flexible weather relay wording', async () => {
@@ -263,7 +321,7 @@ describe('generateDynamicAlarmTextWithVertex', () => {
     expect(generated.provider).toBe('gemini-api-key');
     expect(prompt).toContain('Romantic partner/spouse tone');
     expect(prompt).toContain('heart-fluttering');
-    expect(prompt).toContain('do not force a lead-in like "예보 보니까"');
+    expect(prompt).toContain('Avoid robotic connector phrases like "예보 보니까"');
     expect(prompt).toContain('연인·남자친구·여자친구·아내·남편·배우자');
   });
 


### PR DESCRIPTION
﻿Closes #373

## Summary
- Keep Android voice alarm repeats on the existing MediaPlayer after the first fade-in so repeated voice playback stays loud.
- Add duplicate ringing-start protection and repeat loudness handling for voice-only alarm playback.
- Improve Korean dynamic alarm prompt guidance and post-processing for grandchild-to-grandparent, sibling bedtime, weather, and fortune wording.
- Include focused backend tests for relationship register and prompt polish behavior.

## Validation
- `npx vitest run test/vertex-translate.test.ts`
- `npm run typecheck`
- `./gradlew.bat :app:testDebugUnitTest :app:assembleDebug`
