### PR TITLE
feat: 랜딩 SEO 메타와 듀얼 스토어 CTA 강화

### DIFF
--- a/apps/landing/app/[locale]/layout.tsx
+++ b/apps/landing/app/[locale]/layout.tsx
@@ -3,10 +3,7 @@ import { notFound } from "next/navigation";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { routing, type Locale } from "@/i18n/routing";
-
-// TODO: 새 도메인 확정 후 SITE_URL 갱신 (AlarmTalk 리브랜딩 — Phase 미정)
-const SITE_URL = "https://waker.com";
-const SITE_NAME = "AlarmTalk";
+import { ORGANIZATION, SITE_NAME, SITE_URL } from "@/lib/site";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -66,7 +63,23 @@ export default async function LocaleLayout({
 
   setRequestLocale(locale);
 
+  const organizationLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: ORGANIZATION.name,
+    legalName: ORGANIZATION.legalName,
+    url: ORGANIZATION.url,
+    logo: ORGANIZATION.logo,
+    ...(ORGANIZATION.sameAs.length > 0 ? { sameAs: ORGANIZATION.sameAs } : {}),
+  };
+
   return (
-    <NextIntlClientProvider>{children}</NextIntlClientProvider>
+    <NextIntlClientProvider>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}
+      />
+      {children}
+    </NextIntlClientProvider>
   );
 }

--- a/apps/landing/app/[locale]/page.tsx
+++ b/apps/landing/app/[locale]/page.tsx
@@ -1,4 +1,4 @@
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import { SiteHeader } from "@/components/site-header";
 import { Hero } from "@/components/sections/hero";
 import { Trust } from "@/components/sections/trust";
@@ -12,6 +12,9 @@ import { Scenarios } from "@/components/sections/scenarios";
 import { Faq } from "@/components/sections/faq";
 import { Waitlist } from "@/components/sections/waitlist";
 import { SiteFooter } from "@/components/sections/site-footer";
+import { SITE_NAME, SITE_URL, STORE_LINKS } from "@/lib/site";
+
+type FaqItem = { q: string; a: string };
 
 export default async function HomePage({
   params,
@@ -21,8 +24,51 @@ export default async function HomePage({
   const { locale } = await params;
   setRequestLocale(locale);
 
+  const tMeta = await getTranslations({ locale, namespace: "meta" });
+  const tFaq = await getTranslations({ locale, namespace: "faq" });
+  const faqItems = tFaq.raw("items") as FaqItem[];
+
+  const softwareApplicationLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: SITE_NAME,
+    description: tMeta("description"),
+    applicationCategory: "LifestyleApplication",
+    operatingSystem: "Android, iOS",
+    url: `${SITE_URL}/${locale}`,
+    inLanguage: locale,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    ...(STORE_LINKS.googlePlay !== "#" || STORE_LINKS.appStore !== "#"
+      ? {
+          downloadUrl: [STORE_LINKS.googlePlay, STORE_LINKS.appStore].filter(
+            (u) => u !== "#",
+          ),
+        }
+      : {}),
+  };
+
+  const faqPageLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: { "@type": "Answer", text: item.a },
+    })),
+  };
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(softwareApplicationLd),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageLd) }}
+      />
       <SiteHeader />
       <main className="relative">
         <Hero />

--- a/apps/landing/app/robots.ts
+++ b/apps/landing/app/robots.ts
@@ -1,7 +1,5 @@
 ﻿import type { MetadataRoute } from "next";
-
-// TODO: 새 도메인 확정 후 갱신 (AlarmTalk 리브랜딩 — Phase 미정)
-const SITE_URL = "https://waker.com";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
 

--- a/apps/landing/app/sitemap.ts
+++ b/apps/landing/app/sitemap.ts
@@ -1,8 +1,7 @@
 ﻿import type { MetadataRoute } from "next";
 import { routing } from "@/i18n/routing";
+import { SITE_URL } from "@/lib/site";
 
-// TODO: 새 도메인 확정 후 갱신 (AlarmTalk 리브랜딩 — Phase 미정)
-const SITE_URL = "https://waker.com";
 const PAGES = ["", "privacy", "terms"] as const;
 
 export const dynamic = "force-static";

--- a/apps/landing/components/sections/hero.tsx
+++ b/apps/landing/components/sections/hero.tsx
@@ -1,6 +1,7 @@
-import { ArrowRight, Smartphone } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { PhonePreview } from "../phone-preview";
+import { StoreBadges } from "../store-badges";
 
 export function Hero() {
   const t = useTranslations("hero");
@@ -24,26 +25,15 @@ export function Hero() {
             {t("description")}
           </p>
 
-          <div className="mt-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-            <a href="#waitlist" className="btn btn-primary group">
-              {t("primary")}
-              <ArrowRight className="ml-2 h-4 w-4 transition group-hover:translate-x-0.5" />
+          <div className="mt-10">
+            <StoreBadges />
+            <a
+              href="#waitlist"
+              className="group mt-5 inline-flex items-center gap-1.5 text-[13.5px] font-medium text-text-muted transition hover:text-text"
+            >
+              {t("waitlistHint")}
+              <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" />
             </a>
-
-            {/* QR placeholder card */}
-            <div className="flex items-center gap-3 rounded-full border border-line bg-surface p-1.5 pr-5">
-              <div className="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-raised text-text-muted">
-                <Smartphone className="h-4 w-4" />
-              </div>
-              <div className="flex flex-col leading-tight">
-                <span className="whitespace-nowrap text-[12px] font-semibold text-text">
-                  {t("qrLabel")}
-                </span>
-                <span className="whitespace-nowrap text-[10.5px] text-text-faint">
-                  {t("qrCaption")}
-                </span>
-              </div>
-            </div>
           </div>
         </div>
 

--- a/apps/landing/components/store-badges.tsx
+++ b/apps/landing/components/store-badges.tsx
@@ -1,0 +1,80 @@
+import { useTranslations } from "next-intl";
+import { STORE_LINKS } from "@/lib/site";
+
+function AppStoreGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-6 w-6"
+    >
+      <path d="M16.365 1.43c.043 1.18-.34 2.34-1.099 3.18-.74.83-1.95 1.47-3.13 1.38-.05-1.15.41-2.34 1.16-3.16.77-.83 2.06-1.45 3.07-1.4Zm3.59 16.21c-.62 1.34-.92 1.94-1.72 3.13-1.13 1.67-2.72 3.74-4.69 3.76-1.75.02-2.2-1.13-4.57-1.12-2.37.01-2.86 1.14-4.61 1.12-1.97-.02-3.48-1.9-4.61-3.57-3.18-4.7-3.51-10.21-1.55-13.14 1.39-2.07 3.59-3.29 5.66-3.29 2.11 0 3.43 1.16 5.17 1.16 1.69 0 2.72-1.16 5.16-1.16 1.84 0 3.79.99 5.18 2.71-4.55 2.49-3.81 8.99 1.58 10.4Z" />
+    </svg>
+  );
+}
+
+function GooglePlayGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="h-6 w-6"
+    >
+      <path
+        fill="#5BC9F4"
+        d="M3.6 1.78c-.36.21-.6.62-.6 1.16v18.12c0 .53.24.94.6 1.16l9.6-10.22-9.6-10.22Z"
+      />
+      <path
+        fill="#FFCD40"
+        d="M16.86 8.34 13.2 12l3.66 3.66 4.54-2.6c1.06-.61 1.06-2.13 0-2.74l-4.54-2.58Z"
+      />
+      <path
+        fill="#FF625B"
+        d="M16.86 8.34 4.62 1.36c-.38-.22-.78-.21-1.02-.04l9.6 10.22 3.66-3.2Z"
+      />
+      <path
+        fill="#52C16C"
+        d="M16.86 15.66 13.2 12l-9.6 10.22c.24.17.64.18 1.02-.04l12.24-6.52Z"
+      />
+    </svg>
+  );
+}
+
+export function StoreBadges() {
+  const t = useTranslations("store");
+  return (
+    <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+      <a
+        href={STORE_LINKS.appStore}
+        aria-label={t("appStoreAria")}
+        className="group inline-flex items-center gap-3 rounded-2xl border border-line bg-surface px-5 py-3 transition hover:border-line/0 hover:bg-raised"
+      >
+        <AppStoreGlyph />
+        <span className="flex flex-col leading-tight">
+          <span className="text-[10px] uppercase tracking-wider text-text-faint">
+            {t("appStoreEyebrow")}
+          </span>
+          <span className="text-[15px] font-semibold text-text">
+            {t("appStoreLabel")}
+          </span>
+        </span>
+      </a>
+      <a
+        href={STORE_LINKS.googlePlay}
+        aria-label={t("googlePlayAria")}
+        className="group inline-flex items-center gap-3 rounded-2xl border border-line bg-surface px-5 py-3 transition hover:border-line/0 hover:bg-raised"
+      >
+        <GooglePlayGlyph />
+        <span className="flex flex-col leading-tight">
+          <span className="text-[10px] uppercase tracking-wider text-text-faint">
+            {t("googlePlayEyebrow")}
+          </span>
+          <span className="text-[15px] font-semibold text-text">
+            {t("googlePlayLabel")}
+          </span>
+        </span>
+      </a>
+    </div>
+  );
+}

--- a/apps/landing/lib/site.ts
+++ b/apps/landing/lib/site.ts
@@ -1,0 +1,24 @@
+const DEFAULT_SITE_URL = "https://alarmtalk.app";
+
+function normalize(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+export const SITE_URL = normalize(
+  process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL,
+);
+
+export const SITE_NAME = "AlarmTalk";
+
+export const STORE_LINKS = {
+  appStore: process.env.NEXT_PUBLIC_APP_STORE_URL ?? "#",
+  googlePlay: process.env.NEXT_PUBLIC_GOOGLE_PLAY_URL ?? "#",
+} as const;
+
+export const ORGANIZATION = {
+  name: "AlarmTalk",
+  legalName: "AlarmTalk",
+  url: SITE_URL,
+  logo: `${SITE_URL}/icon.svg`,
+  sameAs: [] as string[],
+} as const;

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -15,10 +15,7 @@
     "headline1": "The one alarm that",
     "headline2": "changes your morning.",
     "description": "Forget the beeping. Wake up to the real voice of someone you love — at the exact time. A real native alarm, not a push notification.",
-    "primary": "Get early access",
-    "secondary": "How it works",
-    "qrLabel": "Scan to download",
-    "qrCaption": "Use this QR at launch",
+    "waitlistHint": "Before launch — join the beta waitlist",
     "phone": {
       "greetTop": "Good morning,",
       "greetBottom": "whose voice woke you up?",
@@ -164,5 +161,13 @@
     "ko": "한국어",
     "en": "English",
     "ja": "日本語"
+  },
+  "store": {
+    "appStoreEyebrow": "Download on",
+    "appStoreLabel": "App Store",
+    "appStoreAria": "Get AlarmTalk on the App Store",
+    "googlePlayEyebrow": "GET IT ON",
+    "googlePlayLabel": "Google Play",
+    "googlePlayAria": "Get AlarmTalk on Google Play"
   }
 }

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -15,10 +15,7 @@
     "headline1": "あなたの朝を変える、",
     "headline2": "たった一つのアラーム。",
     "description": "ピー音はもう忘れて。大切な人の本物の声が、ぴったりの時間に鳴ります。プッシュ通知ではなく、本物のネイティブアラームで。",
-    "primary": "先行アクセス",
-    "secondary": "使い方を見る",
-    "qrLabel": "QRでダウンロード",
-    "qrCaption": "リリース時にこのQRから",
+    "waitlistHint": "正式リリース前 — ベータ待機リストに登録",
     "phone": {
       "greetTop": "おはよう、",
       "greetBottom": "誰の声で目覚めましたか?",
@@ -164,5 +161,13 @@
     "ko": "한국어",
     "en": "English",
     "ja": "日本語"
+  },
+  "store": {
+    "appStoreEyebrow": "Download on",
+    "appStoreLabel": "App Store",
+    "appStoreAria": "App Storeでアラームトークを入手",
+    "googlePlayEyebrow": "GET IT ON",
+    "googlePlayLabel": "Google Play",
+    "googlePlayAria": "Google Playでアラームトークを入手"
   }
 }

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -15,10 +15,7 @@
     "headline1": "당신의 아침을 바꾸는",
     "headline2": "단 하나의 알람.",
     "description": "삐— 소리는 잊으세요. 좋아하는 사람의 진짜 목소리가 정확한 시간에 울립니다. 푸시 알림이 아닌 진짜 알람으로요.",
-    "primary": "먼저 써보기",
-    "secondary": "어떻게 동작하나요",
-    "qrLabel": "QR로 내려받기",
-    "qrCaption": "출시되면 이 QR로",
+    "waitlistHint": "정식 출시 전, 베타 대기자로 먼저 등록하기",
     "phone": {
       "greetTop": "오늘 아침,",
       "greetBottom": "어떤 목소리로 깨어났나요?",
@@ -164,5 +161,13 @@
     "ko": "한국어",
     "en": "English",
     "ja": "日本語"
+  },
+  "store": {
+    "appStoreEyebrow": "Download on",
+    "appStoreLabel": "App Store",
+    "appStoreAria": "App Store에서 알람톡 받기",
+    "googlePlayEyebrow": "GET IT ON",
+    "googlePlayLabel": "Google Play",
+    "googlePlayAria": "Google Play에서 알람톡 받기"
   }
 }


### PR DESCRIPTION
## 변경 내용
- `SITE_URL`을 `NEXT_PUBLIC_SITE_URL` 환경변수로 분리하고 단일 출처 `apps/landing/lib/site.ts` 도입
- JSON-LD 구조화 데이터 3종 추가
  - `Organization` (locale 레이아웃)
  - `SoftwareApplication` (홈)
  - `FAQPage` (홈 FAQ 매핑)
- Hero CTA를 App Store·Google Play 듀얼 배지로 교체, 베타 대기자 동선은 보조 텍스트 링크로 유지
- 사용하지 않는 메시지 키(`primary`/`secondary`/`qrLabel`/`qrCaption`) 제거, `hero.waitlistHint`와 `store` 네임스페이스 추가
- `sitemap.ts` / `robots.ts`를 새 단일 출처로 정리(옛 `waker.com` 하드코딩 제거)

## 검증
- [x] `npm run typecheck` (apps/landing) 통과
- [ ] dev 서버에서 메타/JSON-LD/CTA 시각 확인
- [ ] App Store · Google Play 배지가 다크 톤에서 가독성 OK인지 확인

## 후속 PR
- `feat/landing-company-page` — /company 페이지 추가
- `feat/landing-contact-page` — /contact 페이지 추가
- `feat/landing-section-polish` — 시나리오·리뷰 슬롯·스크롤 인디케이터 보강

Closes #378