### PR TITLE
feat: 문의 페이지(/contact) 추가

### DIFF
--- a/apps/landing/app/[locale]/contact/page.tsx
+++ b/apps/landing/app/[locale]/contact/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from "next";
+import { ArrowUpRight } from "lucide-react";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { hasLocale, useTranslations } from "next-intl";
+import { routing, type Locale } from "@/i18n/routing";
+import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/sections/site-footer";
+import { SITE_NAME, SITE_URL } from "@/lib/site";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) return {};
+
+  const t = await getTranslations({ locale, namespace: "contact.meta" });
+  const title = t("title");
+  const description = t("description");
+
+  const ogLocale = ({ ko: "ko_KR", en: "en_US", ja: "ja_JP" } as const)[
+    locale as Locale
+  ];
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/${locale}/contact`,
+      languages: Object.fromEntries(
+        routing.locales.map((l) => [l, `/${l}/contact`]),
+      ),
+    },
+    openGraph: {
+      type: "website",
+      locale: ogLocale,
+      url: `${SITE_URL}/${locale}/contact`,
+      siteName: SITE_NAME,
+      title,
+      description,
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function ContactPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <>
+      <SiteHeader />
+      <main className="relative">
+        <ContactHero />
+        <Channels />
+        <ResponseNote />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}
+
+function ContactHero() {
+  const t = useTranslations("contact.hero");
+  return (
+    <section className="relative">
+      <div className="mx-auto max-w-6xl px-5 pb-16 pt-16 md:px-8 lg:pb-20 lg:pt-24">
+        <div className="max-w-3xl">
+          <span className="eyebrow">{t("eyebrow")}</span>
+          <h1 className="mt-6 text-[44px] font-bold leading-[1.05] tracking-[-0.03em] text-text sm:text-[58px] lg:text-[64px]">
+            {t("headline1")}
+            <br />
+            <span className="text-accent">{t("headline2")}</span>
+          </h1>
+          <p className="mt-7 max-w-[620px] text-[17px] leading-[1.65] text-text-muted">
+            {t("description")}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type ChannelItem = {
+  tag: string;
+  title: string;
+  body: string;
+  email: string;
+  cta: string;
+};
+
+function Channels() {
+  const t = useTranslations("contact.channels");
+  const items = t.raw("items") as ChannelItem[];
+  return (
+    <section className="relative">
+      <div className="hairline" />
+      <div className="mx-auto max-w-6xl px-5 py-16 md:px-8 lg:py-24">
+        <div className="max-w-3xl">
+          <h2 className="text-[28px] font-bold leading-[1.2] tracking-[-0.02em] text-text sm:text-[36px]">
+            {t("headline")}
+          </h2>
+          <p className="mt-4 text-[15.5px] leading-[1.65] text-text-muted">
+            {t("description")}
+          </p>
+        </div>
+
+        <ul className="mt-12 grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <li key={item.email} className="card group flex flex-col p-7">
+              <span className="inline-flex w-fit items-center rounded-full border border-line bg-raised px-2.5 py-1 text-[10.5px] font-semibold uppercase tracking-wider text-text-faint">
+                {item.tag}
+              </span>
+              <h3 className="mt-5 text-[20px] font-semibold leading-[1.3] tracking-[-0.01em] text-text">
+                {item.title}
+              </h3>
+              <p className="mt-3 text-[14.5px] leading-[1.65] text-text-muted">
+                {item.body}
+              </p>
+              <a
+                href={`mailto:${item.email}`}
+                className="mt-6 inline-flex items-center justify-between gap-3 rounded-2xl border border-line bg-surface px-4 py-3 transition hover:border-line/0 hover:bg-raised"
+              >
+                <span className="flex flex-col leading-tight">
+                  <span className="text-[10.5px] uppercase tracking-wider text-text-faint">
+                    {item.cta}
+                  </span>
+                  <span className="text-[14px] font-semibold text-text">
+                    {item.email}
+                  </span>
+                </span>
+                <ArrowUpRight className="h-4 w-4 text-text-muted transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-text" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function ResponseNote() {
+  const t = useTranslations("contact.note");
+  return (
+    <section className="relative">
+      <div className="hairline" />
+      <div className="mx-auto max-w-6xl px-5 py-16 md:px-8 lg:py-20">
+        <div className="card mx-auto max-w-3xl p-8 lg:p-10">
+          <h2 className="text-[20px] font-semibold leading-[1.3] tracking-[-0.01em] text-text sm:text-[22px]">
+            {t("headline")}
+          </h2>
+          <p className="mt-4 text-[14.5px] leading-[1.7] text-text-muted">
+            {t("body")}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/landing/app/sitemap.ts
+++ b/apps/landing/app/sitemap.ts
@@ -2,7 +2,7 @@
 import { routing } from "@/i18n/routing";
 import { SITE_URL } from "@/lib/site";
 
-const PAGES = ["", "company", "privacy", "terms"] as const;
+const PAGES = ["", "company", "contact", "privacy", "terms"] as const;
 
 export const dynamic = "force-static";
 

--- a/apps/landing/components/sections/site-footer.tsx
+++ b/apps/landing/components/sections/site-footer.tsx
@@ -87,13 +87,12 @@ export function SiteFooter() {
                   </a>
                 </li>
                 <li>
-                  {/* TODO: /contact 페이지 도입 후 Link 로 교체 */}
-                  <a
-                    href="mailto:hello@alarmtalk.app"
+                  <Link
+                    href="/contact"
                     className="whitespace-nowrap text-text-muted hover:text-text"
                   >
                     {t("linkContact")}
-                  </a>
+                  </Link>
                 </li>
               </ul>
             </div>

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -171,6 +171,56 @@
     "googlePlayLabel": "Google Play",
     "googlePlayAria": "Get AlarmTalk on Google Play"
   },
+  "contact": {
+    "meta": {
+      "title": "Contact",
+      "description": "Four ways to talk to AlarmTalk — support, business, careers, and press."
+    },
+    "hero": {
+      "eyebrow": "Contact",
+      "headline1": "How can",
+      "headline2": "we help?",
+      "description": "Pick the channel that fits and email us. We usually reply within Korean business hours."
+    },
+    "channels": {
+      "headline": "Four contact channels",
+      "description": "Split by purpose so your email reaches the right person.",
+      "items": [
+        {
+          "tag": "Support",
+          "title": "App & account help",
+          "body": "Bugs, alarms not ringing, account or billing questions belong here.",
+          "email": "support@alarmtalk.app",
+          "cta": "Send email"
+        },
+        {
+          "tag": "Business",
+          "title": "Partnerships · B2B",
+          "body": "Team or company rollouts, licensing, integration proposals — write to business.",
+          "email": "business@alarmtalk.app",
+          "cta": "Send email"
+        },
+        {
+          "tag": "Careers · General",
+          "title": "Join us · general inquiries",
+          "body": "Interested in joining the team, or have something that doesn't fit the other channels?",
+          "email": "hello@alarmtalk.app",
+          "cta": "Send email"
+        },
+        {
+          "tag": "Press",
+          "title": "Press & media",
+          "body": "Coverage, interviews, press kits — the media line gets the fastest reply.",
+          "email": "press@alarmtalk.app",
+          "cta": "Send email"
+        }
+      ]
+    },
+    "note": {
+      "headline": "Response policy",
+      "body": "We usually reply within 1–3 business days. Longer answers can take a little more. If you don't hear back, please check your spam folder too."
+    }
+  },
   "company": {
     "meta": {
       "title": "Company",

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -171,6 +171,56 @@
     "googlePlayLabel": "Google Play",
     "googlePlayAria": "Google Playでアラームトークを入手"
   },
+  "contact": {
+    "meta": {
+      "title": "お問い合わせ",
+      "description": "サポート・ビジネス・採用・プレスまで、アラームトークとの4つの窓口。"
+    },
+    "hero": {
+      "eyebrow": "Contact",
+      "headline1": "どんな件で",
+      "headline2": "お困りですか?"   ,
+      "description": "用件に合う窓口を選んでメールでご連絡ください。通常、平日(KST)の営業時間内に返信します。"
+    },
+    "channels": {
+      "headline": "4つの窓口",
+      "description": "目的別に分けています。最初から正しい担当者にメールが届くように。",
+      "items": [
+        {
+          "tag": "サポート",
+          "title": "アプリ・アカウントの問い合わせ",
+          "body": "不具合、アラームが鳴らない、アカウント・課金に関する質問はこちらへ。",
+          "email": "support@alarmtalk.app",
+          "cta": "メールで送る"
+        },
+        {
+          "tag": "ビジネス",
+          "title": "提携・B2B のご相談",
+          "body": "チーム・企業導入、ライセンス、連携提案などはビジネス窓口へ。",
+          "email": "business@alarmtalk.app",
+          "cta": "メールで送る"
+        },
+        {
+          "tag": "採用・一般",
+          "title": "採用・その他のお問い合わせ",
+          "body": "一緒に働きたい方、上記のどれにも当てはまらないご相談はこちら。",
+          "email": "hello@alarmtalk.app",
+          "cta": "メールで送る"
+        },
+        {
+          "tag": "プレス",
+          "title": "取材・メディア",
+          "body": "取材、インタビュー、プレスキットなどはメディア窓口にお送りください。",
+          "email": "press@alarmtalk.app",
+          "cta": "メールで送る"
+        }
+      ]
+    },
+    "note": {
+      "headline": "返信について",
+      "body": "通常、営業日ベースで1〜3日以内に返信します。長文の回答が必要な場合は少し時間がかかることがあります。届かない場合は迷惑メールフォルダもご確認ください。"
+    }
+  },
   "company": {
     "meta": {
       "title": "会社紹介",

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -171,6 +171,56 @@
     "googlePlayLabel": "Google Play",
     "googlePlayAria": "Google Play에서 알람톡 받기"
   },
+  "contact": {
+    "meta": {
+      "title": "문의",
+      "description": "사용 문의·제휴·언론·채용까지 알람톡과 이야기하는 네 가지 경로."
+    },
+    "hero": {
+      "eyebrow": "Contact",
+      "headline1": "어떻게",
+      "headline2": "도와드릴까요?",
+      "description": "용건에 맞는 채널을 골라 메일로 보내주세요. 보통 평일 영업시간(KST) 안에 답장합니다."
+    },
+    "channels": {
+      "headline": "네 가지 문의 채널",
+      "description": "용도에 따라 분리해 두었습니다. 한 메일이 정확한 담당자에게 닿도록.",
+      "items": [
+        {
+          "tag": "고객 지원",
+          "title": "앱·계정 사용 문의",
+          "body": "버그, 알람이 안 울리는 문제, 계정·결제 관련 문의는 여기로 보내주세요.",
+          "email": "support@alarmtalk.app",
+          "cta": "메일 보내기"
+        },
+        {
+          "tag": "비즈니스",
+          "title": "제휴·B2B 문의",
+          "body": "팀·기업 단위 도입, 라이선스, 통합 제안은 비즈니스 라인으로 부탁드립니다.",
+          "email": "business@alarmtalk.app",
+          "cta": "메일 보내기"
+        },
+        {
+          "tag": "채용·일반",
+          "title": "팀 합류·일반 문의",
+          "body": "함께 일하고 싶거나, 위 채널에 해당하지 않는 일반 문의가 있다면 이쪽으로.",
+          "email": "hello@alarmtalk.app",
+          "cta": "메일 보내기"
+        },
+        {
+          "tag": "미디어",
+          "title": "언론·홍보 문의",
+          "body": "취재, 인터뷰, 보도자료 관련은 미디어 라인으로 보내주시면 빠르게 답변드립니다.",
+          "email": "press@alarmtalk.app",
+          "cta": "메일 보내기"
+        }
+      ]
+    },
+    "note": {
+      "headline": "응답 안내",
+      "body": "보통 영업일 기준 1–3일 안에 답장합니다. 긴 답이 필요한 문의는 조금 더 걸릴 수 있어요. 회신이 며칠 늦어진다면 스팸함도 한 번 확인해 주세요."
+    }
+  },
   "company": {
     "meta": {
       "title": "회사 소개",


### PR DESCRIPTION
## 변경 내용
- `/{locale}/contact` 라우트 신규
- 섹션 구성
  - Hero — "어떻게 도와드릴까요?"
  - 4채널 카드: 고객 지원·비즈니스·채용/일반·미디어
  - 응답 안내 카드(평일 1–3일)
- Footer 문의 링크를 mailto에서 `/contact` 라우트로 교체
- `sitemap.ts`에 `contact` 경로 추가
- `generateMetadata`로 locale별 canonical/OG 메타 분리
- 다국어(ko/en/ja) 메시지 동기화

## 검증
- [x] `npm run typecheck` 통과
- [ ] 4개 mailto 카드 클릭 시 메일 클라이언트 열림 확인
- [ ] 회사 소개 페이지의 보조 CTA `/contact` 링크가 잘 이동하는지 확인

## 의존
- 베이스: #381 (`feat: 회사 소개 페이지(/company) 추가`)
- #379 → #381 → 이 PR 순서로 머지

Closes #382