### PR TITLE
feat: 모바일 햄버거 메뉴 추가

### DIFF
--- a/apps/landing/components/mobile-menu.tsx
+++ b/apps/landing/components/mobile-menu.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Menu, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import { LocaleSwitcher } from "./locale-switcher";
+
+export function MobileMenu() {
+  const t = useTranslations("nav");
+  const tMenu = useTranslations("mobileMenu");
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  const links: { href: string; label: string }[] = [
+    { href: "/#voices", label: t("voices") },
+    { href: "/#how", label: t("how") },
+    { href: "/#faq", label: t("faq") },
+    { href: "/company", label: t("company") },
+    { href: "/contact", label: t("contact") },
+  ];
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={tMenu("open")}
+        aria-expanded={open}
+        aria-controls="mobile-menu-panel"
+        onClick={() => setOpen(true)}
+        className="inline-grid h-10 w-10 place-items-center rounded-full border border-line bg-surface text-text-muted transition hover:text-text md:hidden"
+      >
+        <Menu className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          id="mobile-menu-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-label={tMenu("panelLabel")}
+          className="fixed inset-0 z-50 flex flex-col bg-bg/95 backdrop-blur md:hidden"
+        >
+          <div className="flex items-center justify-between px-5 py-5">
+            <span className="text-[15px] font-bold tracking-tight text-text">
+              AlarmTalk
+            </span>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              aria-label={tMenu("close")}
+              onClick={() => setOpen(false)}
+              className="inline-grid h-10 w-10 place-items-center rounded-full border border-line bg-surface text-text-muted transition hover:text-text"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+
+          <nav className="flex flex-col gap-1 px-5 py-4">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className="rounded-2xl border border-transparent px-4 py-4 text-[18px] font-semibold text-text transition hover:border-line hover:bg-surface"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="mt-auto flex flex-col gap-4 border-t border-line px-5 py-6">
+            <LocaleSwitcher />
+            <Link
+              href="/#waitlist"
+              onClick={() => setOpen(false)}
+              className="btn btn-primary w-full"
+            >
+              {t("cta")}
+            </Link>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/landing/components/site-header.tsx
+++ b/apps/landing/components/site-header.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { BrandMark } from "./brand-mark";
+import { MobileMenu } from "./mobile-menu";
 
 export function SiteHeader() {
   const t = useTranslations("nav");
@@ -53,9 +54,12 @@ export function SiteHeader() {
           </Link>
         </nav>
 
-        <Link href="/#waitlist" className="btn btn-primary btn-sm">
-          {t("cta")}
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link href="/#waitlist" className="btn btn-primary btn-sm hidden sm:inline-flex">
+            {t("cta")}
+          </Link>
+          <MobileMenu />
+        </div>
       </div>
     </header>
   );

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -189,6 +189,11 @@
     "en": "English",
     "ja": "日本語"
   },
+  "mobileMenu": {
+    "open": "Open menu",
+    "close": "Close menu",
+    "panelLabel": "Site menu"
+  },
   "store": {
     "appStoreEyebrow": "Download on",
     "appStoreLabel": "App Store",

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -189,6 +189,11 @@
     "en": "English",
     "ja": "日本語"
   },
+  "mobileMenu": {
+    "open": "メニューを開く",
+    "close": "メニューを閉じる",
+    "panelLabel": "サイトメニュー"
+  },
   "store": {
     "appStoreEyebrow": "Download on",
     "appStoreLabel": "App Store",

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -189,6 +189,11 @@
     "en": "English",
     "ja": "日本語"
   },
+  "mobileMenu": {
+    "open": "메뉴 열기",
+    "close": "메뉴 닫기",
+    "panelLabel": "사이트 메뉴"
+  },
   "store": {
     "appStoreEyebrow": "Download on",
     "appStoreLabel": "App Store",


### PR DESCRIPTION
## 변경 내용
- `MobileMenu` 컴포넌트 신규(md 미만에서만 노출)
- 패널 구성: 특징/사용법/FAQ/회사 소개/문의 + 언어 스위처 + 베타 대기자 CTA
- ESC/외부 클릭/링크 이동 시 자동 닫힘
- 패널 열림 시 `body` 스크롤 락, 닫기 버튼에 초기 포커스
- 헤더 CTA 는 sm 이상에서만 노출(모바일은 햄버거가 담당)
- 다국어(ko/en/ja) `mobileMenu` 메시지 추가

## 검증
- [x] `npm run typecheck` 통과
- [ ] 모바일 폭에서 햄버거 → 패널 열림 → 링크 이동 시 자동 닫힘 확인
- [ ] ESC 키로 닫히는지, 스크롤 락 해제되는지 확인

## 의존
- 베이스: #385 (`feat: 랜딩 섹션 카피·시각 보완`)
- 머지 순서: #379 → #381 → #383 → #385 → 이 PR

Closes #386