### PR TITLE
feat: html lang 동적 동기화와 hreflang x-default 추가

### DIFF
--- a/apps/landing/app/[locale]/company/page.tsx
+++ b/apps/landing/app/[locale]/company/page.tsx
@@ -34,9 +34,12 @@ export async function generateMetadata({
     description,
     alternates: {
       canonical: `/${locale}/company`,
-      languages: Object.fromEntries(
-        routing.locales.map((l) => [l, `/${l}/company`]),
-      ),
+      languages: {
+        ...Object.fromEntries(
+          routing.locales.map((l) => [l, `/${l}/company`]),
+        ),
+        "x-default": `/${routing.defaultLocale}/company`,
+      },
     },
     openGraph: {
       type: "website",

--- a/apps/landing/app/[locale]/contact/page.tsx
+++ b/apps/landing/app/[locale]/contact/page.tsx
@@ -32,9 +32,12 @@ export async function generateMetadata({
     description,
     alternates: {
       canonical: `/${locale}/contact`,
-      languages: Object.fromEntries(
-        routing.locales.map((l) => [l, `/${l}/contact`]),
-      ),
+      languages: {
+        ...Object.fromEntries(
+          routing.locales.map((l) => [l, `/${l}/contact`]),
+        ),
+        "x-default": `/${routing.defaultLocale}/contact`,
+      },
     },
     openGraph: {
       type: "website",

--- a/apps/landing/app/[locale]/layout.tsx
+++ b/apps/landing/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { routing, type Locale } from "@/i18n/routing";
 import { ORGANIZATION, SITE_NAME, SITE_URL } from "@/lib/site";
+import { HtmlLangSync } from "@/components/html-lang-sync";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -32,9 +33,10 @@ export async function generateMetadata({
     applicationName: SITE_NAME,
     alternates: {
       canonical: `/${locale}`,
-      languages: Object.fromEntries(
-        routing.locales.map((l) => [l, `/${l}`])
-      ),
+      languages: {
+        ...Object.fromEntries(routing.locales.map((l) => [l, `/${l}`])),
+        "x-default": `/${routing.defaultLocale}`,
+      },
     },
     openGraph: {
       type: "website",
@@ -75,6 +77,7 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider>
+      <HtmlLangSync locale={locale} />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationLd) }}

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
       <body className="bg-aurora min-h-screen">
         <div className="grain" aria-hidden="true" />
         <div className="bg-grid pointer-events-none absolute inset-x-0 top-0 -z-0 h-[640px]" />

--- a/apps/landing/app/sitemap.ts
+++ b/apps/landing/app/sitemap.ts
@@ -19,12 +19,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
         priority:
           page === "" ? (locale === routing.defaultLocale ? 1 : 0.8) : 0.5,
         alternates: {
-          languages: Object.fromEntries(
-            routing.locales.map((l) => [
-              l,
-              `${SITE_URL}/${page ? `${l}/${page}/` : `${l}/`}`,
-            ]),
-          ),
+          languages: {
+            ...Object.fromEntries(
+              routing.locales.map((l) => [
+                l,
+                `${SITE_URL}/${page ? `${l}/${page}/` : `${l}/`}`,
+              ]),
+            ),
+            "x-default": `${SITE_URL}/${page ? `${routing.defaultLocale}/${page}/` : `${routing.defaultLocale}/`}`,
+          },
         },
       };
     }),

--- a/apps/landing/components/html-lang-sync.tsx
+++ b/apps/landing/components/html-lang-sync.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function HtmlLangSync({ locale }: { locale: string }) {
+  useEffect(() => {
+    if (document.documentElement.lang !== locale) {
+      document.documentElement.lang = locale;
+    }
+  }, [locale]);
+  return null;
+}


### PR DESCRIPTION
## 변경 내용
- `HtmlLangSync` 클라이언트 컴포넌트 신규 — locale 마다 `document.documentElement.lang`을 동기화 (스크린 리더/브라우저 접근성 보강)
- root `<html lang="ko">` 하드코딩에 `suppressHydrationWarning` 부여(클라이언트 보정 안전)
- locale 레이아웃 / `/company` / `/contact` / `sitemap` 의 `alternates.languages` 에 `x-default` 추가

## 배경 / 한계
정적 빌드(`output: "export"`) + middleware 미지원 조합에서 root layout 의 `<html lang>` 자체를 locale별 다른 HTML로 빌드하려면 `app/layout.tsx` / `app/page.tsx` 폐기 후 `app/[locale]/layout.tsx` 를 root layout 으로 승격해야 한다.
이 변경은 `/ → /{defaultLocale}` 리다이렉트를 호스팅 측이 책임지게 만들기 때문에, 정적 호스팅 결정(Cloudflare Pages / Vercel / Netlify 등) 이후 별도 PR 로 다룬다.

## 검증
- [x] `npm run typecheck` 통과
- [ ] 각 locale 페이지 진입 시 `document.documentElement.lang` 이 ko/en/ja 로 바뀌는지 DevTools 로 확인
- [ ] sitemap.xml 출력에 `xhtml:link rel="alternate" hreflang="x-default"` 가 포함되는지 확인

## 의존
- 베이스: #387 (`feat: 모바일 햄버거 메뉴 추가`)
- 머지 순서: #379 → #381 → #383 → #385 → #387 → 이 PR

## 후속
- 호스팅 결정 후 root layout 이전 PR(완전한 정적 lang 분기)

Closes #388