### PR TITLE
chore: 백엔드 커스텀 도메인 api.alarm-talk.com 설정

### DIFF
--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -2,6 +2,16 @@ name = "voice-alarm-api"
 main = "src/index.ts"
 compatibility_date = "2024-12-01"
 
+# 커스텀 도메인. alarm-talk.com zone 이 Cloudflare 계정에 등록(추가)된 뒤 `wrangler deploy`
+# 시 api.alarm-talk.com 이 이 Worker 에 연결된다. zone 미등록 상태면 배포가 실패하므로,
+# 도메인 연결 전까지는 아래 routes 를 주석 처리하고 기본 *.workers.dev 를 사용한다.
+routes = [
+  { pattern = "api.alarm-talk.com", custom_domain = true }
+]
+
+# 계정 변경 시: wrangler 는 로그인된 계정을 사용한다. 특정 계정으로 고정하려면
+# account_id = "<your-account-id>" 를 추가한다.
+
 [vars]
 ENVIRONMENT = "development"
 


### PR DESCRIPTION
## 변경 내용
- `packages/backend/wrangler.toml` 에 custom domain route 추가: `api.alarm-talk.com`
- `alarm-talk.com` zone 이 Cloudflare 계정에 등록된 뒤 `wrangler deploy` 시 자동 연결
- zone 미등록 상태에서는 배포가 실패하므로, 연결 전까지 route 주석 처리 + 기본 `*.workers.dev` 사용 안내
- 계정 고정용 `account_id` 안내 주석 추가

## 후속 (이 PR 범위 밖)
- 앱 base URL 기본값 교체(백엔드 도메인 실제 연결 후):
  - Android `app/build.gradle.kts` `voiceAlarmApiBaseUrl`
  - iOS `Info.plist` `VOICE_ALARM_API_BASE_URL`
- Cloudflare 계정 변경 시 재설정: R2 버킷, `wrangler secret`, cron, account_id

## 검증
- [ ] `alarm-talk.com` zone 등록 후 `wrangler deploy` 로 도메인 연결 확인