### PR TITLE
fix: 사용자 데이터 전송 보안 및 계정 삭제 URL 추가

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -80,7 +80,7 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 4
+        versionCode = 5
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/apps/android-native/app/src/main/AndroidManifest.xml
+++ b/apps/android-native/app/src/main/AndroidManifest.xml
@@ -21,9 +21,11 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.VoiceAlarm">
+        android:theme="@style/Theme.VoiceAlarm"
+        android:usesCleartextTraffic="false">
 
         <meta-data
             android:name="io.sentry.auto-init"

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/RemoteAlarmMapper.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/RemoteAlarmMapper.kt
@@ -35,6 +35,5 @@ object RemoteAlarmMapper {
 
     fun isRemoteAudioUrl(value: String): Boolean =
         value.startsWith("https://", ignoreCase = true) ||
-            value.startsWith("http://", ignoreCase = true) ||
             value.startsWith("r2://", ignoreCase = true)
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceAlarmApiClient.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceAlarmApiClient.kt
@@ -3,6 +3,7 @@ package com.alarmtalk.app.network
 import com.alarmtalk.app.BuildConfig
 import java.util.concurrent.TimeUnit
 import okhttp3.Authenticator
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -51,8 +52,12 @@ object VoiceAlarmApiClient {
 
     fun bearer(token: String): String = "Bearer $token"
 
-    private fun normalizeBaseUrl(baseUrl: String): String =
-        if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+    private fun normalizeBaseUrl(baseUrl: String): String {
+        val normalized = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+        val parsed = normalized.toHttpUrl()
+        require(parsed.isHttps) { "VOICE_ALARM_API_BASE_URL must use https." }
+        return normalized
+    }
 
     /**
      * 401 응답을 받으면 한 번만 콜백을 호출하고 재시도 없이 응답을 그대로 흘려보낸다.

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/social/SocialPanels.kt
@@ -393,7 +393,9 @@ internal fun VoiceMessagePanel(
             loadingNoteId = note.id
             runCatching {
                 val directUrl = note.audioUrl?.takeIf {
-                    it.startsWith("http") || it.startsWith("file:") || it.startsWith("content:")
+                    it.startsWith("https://", ignoreCase = true) ||
+                        it.startsWith("file:", ignoreCase = true) ||
+                        it.startsWith("content:", ignoreCase = true)
                 }
                 if (directUrl != null) {
                     MediaPlayer.create(context, Uri.parse(directUrl))

--- a/apps/android-native/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android-native/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/network/RemoteAlarmMapperTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/network/RemoteAlarmMapperTest.kt
@@ -48,6 +48,19 @@ class RemoteAlarmMapperTest {
     }
 
     @Test
+    fun cleartextRemoteAudioUrlIsNotReferenced() {
+        val alarm = alarm(
+            playMode = AlarmPlayModes.ALARM_VOICE,
+            rawAudioUri = "http://cdn.example.com/alarm.m4a",
+        )
+
+        val request = RemoteAlarmMapper.toWriteRequest(alarm)
+
+        assertEquals("sound-only", request.mode)
+        assertNull(request.rawAudioUrl)
+    }
+
+    @Test
     fun generatedTtsUsesMessageIdInsteadOfRawR2Url() {
         val alarm = alarm(
             playMode = AlarmPlayModes.ALARM_VOICE,

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/network/VoiceAlarmApiClientTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/network/VoiceAlarmApiClientTest.kt
@@ -1,0 +1,13 @@
+package com.alarmtalk.app.network
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class VoiceAlarmApiClientTest {
+    @Test
+    fun createRejectsCleartextBaseUrl() {
+        assertThrows(IllegalArgumentException::class.java) {
+            VoiceAlarmApiClient.create(baseUrl = "http://api.example.com/api/")
+        }
+    }
+}

--- a/apps/ios-native/VoiceAlarm/RemoteAlarmMapper.swift
+++ b/apps/ios-native/VoiceAlarm/RemoteAlarmMapper.swift
@@ -232,6 +232,6 @@ enum RemoteAlarmMapper {
     /// Android `RemoteAlarmMapper.isRemoteAudioUrl` 동일.
     static func isRemoteAudioUrl(_ value: String) -> Bool {
         let lower = value.lowercased()
-        return lower.hasPrefix("https://") || lower.hasPrefix("http://") || lower.hasPrefix("r2://")
+        return lower.hasPrefix("https://") || lower.hasPrefix("r2://")
     }
 }

--- a/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
@@ -500,7 +500,7 @@ extension TtsGenerateResponse {
             return nil
         }
         let lower = key.lowercased()
-        if lower.hasPrefix("r2://") || lower.hasPrefix("https://") || lower.hasPrefix("http://") {
+        if lower.hasPrefix("r2://") || lower.hasPrefix("https://") {
             return key
         }
         return "r2://\(key)"
@@ -1661,7 +1661,8 @@ final class VoiceAlarmAPI: @unchecked Sendable {
 
     private static func defaultBaseURL() -> URL {
         if let value = Bundle.main.object(forInfoDictionaryKey: "VOICE_ALARM_API_BASE_URL") as? String,
-           let url = URL(string: value) {
+           let url = URL(string: value),
+           url.scheme == "https" {
             return url
         }
         return URL(string: "https://api.alarm-talk.com/api")!

--- a/apps/landing/app/[locale]/account-deletion/page.tsx
+++ b/apps/landing/app/[locale]/account-deletion/page.tsx
@@ -1,0 +1,294 @@
+import type { Metadata } from "next";
+import { Mail, Smartphone, ShieldCheck } from "lucide-react";
+import { hasLocale } from "next-intl";
+import { setRequestLocale } from "next-intl/server";
+import { routing, type Locale } from "@/i18n/routing";
+import { SiteFooter } from "@/components/sections/site-footer";
+import { SiteHeader } from "@/components/site-header";
+import { SITE_NAME, SITE_URL } from "@/lib/site";
+
+const PRIVACY_EMAIL = "privacy@alarm-talk.com";
+
+const CONTENT = {
+  ko: {
+    title: "계정 및 데이터 삭제",
+    description:
+      "AlarmTalk 계정과 관련 데이터를 삭제하거나 삭제를 요청하는 방법을 안내합니다.",
+    eyebrow: "Account deletion",
+    headline: "AlarmTalk 계정과 데이터를 삭제할 수 있습니다.",
+    intro:
+      "앱에서 직접 회원 탈퇴를 진행하거나, 앱에 접근할 수 없는 경우 개인정보 담당자에게 삭제 요청을 보낼 수 있습니다.",
+    appTitle: "앱에서 삭제",
+    appBody:
+      "AlarmTalk 앱을 열고 설정 > 계정 > 회원 탈퇴를 선택하세요. 탈퇴가 완료되면 서버에 저장된 계정 데이터가 삭제 또는 비식별화됩니다.",
+    requestTitle: "웹에서 요청",
+    requestBody:
+      "앱에 로그인할 수 없거나 기기를 사용할 수 없다면 아래 이메일로 삭제 요청을 보내주세요. 본인 확인 후 처리 결과를 안내합니다.",
+    mailCta: "삭제 요청 메일 보내기",
+    emailSubject: "AlarmTalk 계정 및 데이터 삭제 요청",
+    emailBody:
+      "AlarmTalk 계정 및 관련 데이터 삭제를 요청합니다.\n\n가입 이메일 또는 로그인 제공자:\n요청 사유(선택):\n",
+    scopeTitle: "삭제되는 데이터",
+    scopeItems: [
+      "계정 식별 정보와 로그인 연결 정보",
+      "서버에 동기화된 알람 설정",
+      "음성 프로필, 업로드 음성, 생성 음성 및 관련 메타데이터",
+      "가족/파트너 연결, 메시지, 캐릭터와 이용 기록",
+    ],
+    retainedTitle: "일부 보관될 수 있는 데이터",
+    retainedBody:
+      "법령상 보관 의무, 결제 정산, 분쟁 대응, 보안 로그처럼 꼭 필요한 기록은 정해진 기간 동안 제한적으로 보관될 수 있습니다. 기기에 저장된 로컬 알람 파일은 앱 데이터 삭제 또는 알람 삭제로 직접 정리해야 할 수 있습니다.",
+    timingTitle: "처리 기준",
+    timingBody:
+      "본인 확인에 필요한 정보를 받은 뒤 지체 없이 처리합니다. 추가 확인이 필요한 경우 이메일로 연락드립니다.",
+  },
+  en: {
+    title: "Account and Data Deletion",
+    description:
+      "How to delete or request deletion of your AlarmTalk account and related data.",
+    eyebrow: "Account deletion",
+    headline: "You can delete your AlarmTalk account and data.",
+    intro:
+      "You can delete your account in the app, or email our privacy contact if you cannot access the app.",
+    appTitle: "Delete in the app",
+    appBody:
+      "Open AlarmTalk and go to Settings > Account > Delete account. After deletion, account data stored on our servers is deleted or anonymized.",
+    requestTitle: "Request on the web",
+    requestBody:
+      "If you cannot sign in to the app or no longer have access to your device, send a deletion request by email. We will verify ownership and reply with the result.",
+    mailCta: "Send deletion request",
+    emailSubject: "AlarmTalk account and data deletion request",
+    emailBody:
+      "I request deletion of my AlarmTalk account and related data.\n\nSign-in email or provider:\nReason (optional):\n",
+    scopeTitle: "Data deleted",
+    scopeItems: [
+      "Account identifiers and sign-in connection data",
+      "Alarm settings synchronized to the server",
+      "Voice profiles, uploaded voices, generated voices, and related metadata",
+      "Family or partner connections, messages, character data, and usage records",
+    ],
+    retainedTitle: "Data that may be retained",
+    retainedBody:
+      "Records required for legal retention, payment settlement, dispute handling, or security logs may be kept for a limited period. Local alarm files stored on your device may need to be removed by deleting app data or deleting alarms.",
+    timingTitle: "Processing",
+    timingBody:
+      "After we receive the information needed to verify ownership, we process the request without undue delay. We will email you if additional verification is needed.",
+  },
+  ja: {
+    title: "アカウントとデータの削除",
+    description:
+      "AlarmTalk のアカウントと関連データを削除、または削除依頼する方法を案内します。",
+    eyebrow: "Account deletion",
+    headline: "AlarmTalk のアカウントとデータを削除できます。",
+    intro:
+      "アプリ内でアカウント削除を行うか、アプリにアクセスできない場合はプライバシー窓口へ削除依頼を送信できます。",
+    appTitle: "アプリで削除",
+    appBody:
+      "AlarmTalk アプリを開き、設定 > アカウント > アカウント削除を選択してください。削除後、サーバー上のアカウントデータは削除または匿名化されます。",
+    requestTitle: "Web から依頼",
+    requestBody:
+      "アプリにログインできない場合や端末を利用できない場合は、下記メールアドレスに削除依頼を送ってください。本人確認後、処理結果をご案内します。",
+    mailCta: "削除依頼メールを送信",
+    emailSubject: "AlarmTalk account and data deletion request",
+    emailBody:
+      "AlarmTalk アカウントと関連データの削除を依頼します。\n\n登録メールまたはログイン提供元:\n理由（任意）:\n",
+    scopeTitle: "削除されるデータ",
+    scopeItems: [
+      "アカウント識別情報とログイン連携情報",
+      "サーバーに同期されたアラーム設定",
+      "音声プロフィール、アップロード音声、生成音声と関連メタデータ",
+      "家族・パートナー連携、メッセージ、キャラクター情報、利用記録",
+    ],
+    retainedTitle: "一部保持される可能性があるデータ",
+    retainedBody:
+      "法令上の保存義務、決済精算、紛争対応、セキュリティログなど必要な記録は、定められた期間に限り保持される場合があります。端末内のローカルアラームファイルは、アプリデータまたはアラームを削除して整理する必要があります。",
+    timingTitle: "処理基準",
+    timingBody:
+      "本人確認に必要な情報を受け取った後、遅滞なく処理します。追加確認が必要な場合はメールでご連絡します。",
+  },
+} satisfies Record<Locale, {
+  title: string;
+  description: string;
+  eyebrow: string;
+  headline: string;
+  intro: string;
+  appTitle: string;
+  appBody: string;
+  requestTitle: string;
+  requestBody: string;
+  mailCta: string;
+  emailSubject: string;
+  emailBody: string;
+  scopeTitle: string;
+  scopeItems: string[];
+  retainedTitle: string;
+  retainedBody: string;
+  timingTitle: string;
+  timingBody: string;
+}>;
+
+export const dynamic = "force-static";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  if (!hasLocale(routing.locales, locale)) return {};
+
+  const copy = CONTENT[locale as Locale];
+
+  return {
+    title: copy.title,
+    description: copy.description,
+    alternates: {
+      canonical: `/${locale}/account-deletion`,
+      languages: {
+        ...Object.fromEntries(
+          routing.locales.map((l) => [l, `/${l}/account-deletion`]),
+        ),
+        "x-default": `/${routing.defaultLocale}/account-deletion`,
+      },
+    },
+    openGraph: {
+      type: "website",
+      locale: ({ ko: "ko_KR", en: "en_US", ja: "ja_JP" } as const)[
+        locale as Locale
+      ],
+      url: `${SITE_URL}/${locale}/account-deletion`,
+      siteName: SITE_NAME,
+      title: copy.title,
+      description: copy.description,
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function AccountDeletionPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const copy = CONTENT[locale as Locale] ?? CONTENT.ko;
+  const mailSearch = new URLSearchParams({
+    subject: copy.emailSubject,
+    body: copy.emailBody,
+  });
+  const mailHref = `mailto:${PRIVACY_EMAIL}?${mailSearch.toString()}`;
+
+  return (
+    <>
+      <SiteHeader />
+      <main>
+        <section className="mx-auto max-w-6xl px-5 pb-14 pt-16 md:px-8 lg:pb-20 lg:pt-24">
+          <div className="max-w-3xl">
+            <span className="eyebrow">{copy.eyebrow}</span>
+            <h1 className="mt-6 text-[40px] font-bold leading-[1.08] text-text sm:text-[56px] lg:text-[64px]">
+              {copy.headline}
+            </h1>
+            <p className="mt-7 max-w-[680px] text-[17px] leading-[1.7] text-text-muted">
+              {copy.intro}
+            </p>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="hairline" />
+          <div className="mx-auto grid max-w-6xl gap-4 px-5 py-14 md:grid-cols-2 md:px-8 lg:py-20">
+            <InfoPanel
+              icon={<Smartphone className="h-5 w-5" />}
+              title={copy.appTitle}
+              body={copy.appBody}
+            />
+            <InfoPanel
+              icon={<Mail className="h-5 w-5" />}
+              title={copy.requestTitle}
+              body={copy.requestBody}
+            >
+              <a href={mailHref} className="btn btn-primary mt-6">
+                {copy.mailCta}
+              </a>
+              <p className="mt-4 text-[13px] text-text-faint">
+                {PRIVACY_EMAIL}
+              </p>
+            </InfoPanel>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="hairline" />
+          <div className="mx-auto max-w-6xl px-5 py-14 md:px-8 lg:py-20">
+            <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr]">
+              <div>
+                <span className="inline-flex rounded-full border border-line bg-raised px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-text-faint">
+                  Data scope
+                </span>
+                <h2 className="mt-5 text-[28px] font-bold leading-[1.2] text-text sm:text-[36px]">
+                  {copy.scopeTitle}
+                </h2>
+              </div>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {copy.scopeItems.map((item) => (
+                  <li key={item} className="card p-5 text-[14.5px] leading-[1.65] text-text-muted">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="relative">
+          <div className="hairline" />
+          <div className="mx-auto grid max-w-6xl gap-4 px-5 py-14 md:grid-cols-2 md:px-8 lg:py-20">
+            <InfoPanel
+              icon={<ShieldCheck className="h-5 w-5" />}
+              title={copy.retainedTitle}
+              body={copy.retainedBody}
+            />
+            <InfoPanel
+              icon={<Mail className="h-5 w-5" />}
+              title={copy.timingTitle}
+              body={copy.timingBody}
+            />
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}
+
+function InfoPanel({
+  icon,
+  title,
+  body,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="card p-7 lg:p-8">
+      <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-line bg-raised text-accent">
+        {icon}
+      </div>
+      <h2 className="mt-5 text-[22px] font-semibold leading-[1.3] text-text">
+        {title}
+      </h2>
+      <p className="mt-3 text-[14.5px] leading-[1.75] text-text-muted">
+        {body}
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/apps/landing/app/sitemap.ts
+++ b/apps/landing/app/sitemap.ts
@@ -2,7 +2,7 @@
 import { routing } from "@/i18n/routing";
 import { SITE_URL } from "@/lib/site";
 
-const PAGES = ["", "company", "contact", "privacy", "terms"] as const;
+const PAGES = ["", "company", "contact", "privacy", "terms", "account-deletion"] as const;
 
 export const dynamic = "force-static";
 

--- a/apps/landing/components/sections/site-footer.tsx
+++ b/apps/landing/components/sections/site-footer.tsx
@@ -117,6 +117,14 @@ export function SiteFooter() {
                     {t("linkTerms")}
                   </Link>
                 </li>
+                <li>
+                  <Link
+                    href="/account-deletion"
+                    className="whitespace-nowrap text-text-muted hover:text-text"
+                  >
+                    {t("linkAccountDeletion")}
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -184,6 +184,7 @@
     "linkContact": "Contact",
     "linkPrivacy": "Privacy",
     "linkTerms": "Terms",
+    "linkAccountDeletion": "Account deletion",
     "rights": "All rights reserved.",
     "made": "Made in Korea"
   },

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -184,6 +184,7 @@
     "linkContact": "お問い合わせ",
     "linkPrivacy": "プライバシーポリシー",
     "linkTerms": "利用規約",
+    "linkAccountDeletion": "アカウント削除",
     "rights": "All rights reserved.",
     "made": "韓国でつくっています"
   },

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -184,6 +184,7 @@
     "linkContact": "문의",
     "linkPrivacy": "개인정보 처리방침",
     "linkTerms": "이용약관",
+    "linkAccountDeletion": "계정 삭제",
     "rights": "All rights reserved.",
     "made": "한국에서 만들었습니다"
   },

--- a/docs/legal/store-disclosures.ko.md
+++ b/docs/legal/store-disclosures.ko.md
@@ -7,7 +7,8 @@
 - Privacy Policy URL: `https://alarm-talk.com/ko/privacy/`
 - Terms URL: `https://alarm-talk.com/ko/terms/`
 - Support URL: `https://alarm-talk.com/ko/contact/`
-- Account deletion URL 또는 앱 내 경로: 앱 설정 > 계정 > 계정 삭제
+- Account deletion URL: `https://alarm-talk.com/ko/account-deletion/`
+- App account deletion path: 앱 설정 > 계정 > 회원 탈퇴
 
 ## 2. Google Play Data safety 예상 항목
 

--- a/packages/backend/src/lib/audio-loader.ts
+++ b/packages/backend/src/lib/audio-loader.ts
@@ -25,7 +25,7 @@ export async function loadAudioBytes(
     if (!stored) return null;
     bytes = stored.bytes;
     format = audioFormatFromMime(stored.meta.mimeType) ?? format;
-  } else if (audioUrl.startsWith('http://') || audioUrl.startsWith('https://')) {
+  } else if (audioUrl.startsWith('https://')) {
     const audioRes = await fetch(audioUrl);
     if (!audioRes.ok) return null;
     bytes = new Uint8Array(await audioRes.arrayBuffer());

--- a/packages/backend/src/routes/alarm-helpers.ts
+++ b/packages/backend/src/routes/alarm-helpers.ts
@@ -6,6 +6,7 @@ export const VIBRATION_PATTERNS = ['default', 'strong', 'none'] as const;
 export type VibrationPattern = (typeof VIBRATION_PATTERNS)[number];
 export const WAKE_MODES = ['sound_then_voice', 'voice_only'] as const;
 export type WakeMode = (typeof WAKE_MODES)[number];
+const MAX_REMOTE_AUDIO_URL_LENGTH = 2048;
 
 export type AlarmRow = Record<string, unknown> & {
   repeat_days?: unknown;
@@ -94,6 +95,7 @@ export function validateAlarmFields(body: {
   message_id?: string | null;
   is_active?: boolean;
   target_user_id?: string;
+  raw_audio_url?: string | null;
 }): FieldError | null {
   if (body.message_id != null && !UUID_RE.test(body.message_id)) {
     return { error: 'Invalid message_id format', error_code: 'INVALID_MESSAGE_ID' };
@@ -101,6 +103,12 @@ export function validateAlarmFields(body: {
 
   if (body.target_user_id !== undefined && typeof body.target_user_id !== 'string') {
     return { error: 'Invalid target_user_id', error_code: 'INVALID_TARGET_USER' };
+  }
+
+  if (body.raw_audio_url !== undefined && body.raw_audio_url !== null) {
+    if (typeof body.raw_audio_url !== 'string' || !isEncryptedRemoteAudioUrl(body.raw_audio_url.trim())) {
+      return { error: 'raw_audio_url must be r2:// or https://', error_code: 'INVALID_RAW_AUDIO_URL' };
+    }
   }
 
   if (body.mode !== undefined && !ALARM_MODES.includes(body.mode as AlarmMode)) {
@@ -152,4 +160,9 @@ export function validateAlarmFields(body: {
   }
 
   return null;
+}
+
+export function isEncryptedRemoteAudioUrl(value: string): boolean {
+  return value.length <= MAX_REMOTE_AUDIO_URL_LENGTH &&
+    (value.startsWith('r2://') || value.startsWith('https://'));
 }

--- a/packages/backend/src/routes/notes.ts
+++ b/packages/backend/src/routes/notes.ts
@@ -38,7 +38,7 @@ notes.post('/', async (c) => {
   if (receiverId === senderPk) return c.json({ error: '자기 자신에게는 보낼 수 없습니다', error_code: 'SELF_NOTE' }, 400);
 
   if (audioUrl && !isValidAudioUrl(audioUrl)) {
-    return c.json({ error: 'audio_url must be r2://, http://, or https://', error_code: 'INVALID_AUDIO_URL' }, 400);
+    return c.json({ error: 'audio_url must be r2:// or https://', error_code: 'INVALID_AUDIO_URL' }, 400);
   }
 
   const receiverRes = await db.execute({
@@ -268,7 +268,6 @@ function isValidAudioUrl(audioUrl: string): boolean {
   return audioUrl.length <= MAX_NOTE_AUDIO_URL_LENGTH &&
     (
       audioUrl.startsWith('r2://') ||
-      audioUrl.startsWith('http://') ||
       audioUrl.startsWith('https://')
     );
 }

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -52,6 +52,14 @@ describe('POST /alarms', () => {
     expect((await res.json()).error_code).toBe('INVALID_ALARM_MODE');
   });
 
+  it('cleartext raw_audio_url이면 400', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', raw_audio_url: 'http://cdn.example.com/alarm.m4a' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_RAW_AUDIO_URL');
+  });
+
   it('target_user_id 가 친구 아닌 경우 403 NOT_FRIENDS', async () => {
     // friendship query → no rows
     mockDB.pushResult([]);

--- a/packages/backend/test/notes.test.ts
+++ b/packages/backend/test/notes.test.ts
@@ -201,6 +201,18 @@ describe('POST /notes — 쪽지 전송', () => {
     expect(res.status).toBe(400);
     expect((await res.json()).error_code).toBe('INVALID_AUDIO_URL');
   });
+
+  it('rejects cleartext audio_url schemes', async () => {
+    mockDB.pushResult([{ id: 'pk1' }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('POST', '/notes', {
+      receiver_id: 'pk2',
+      text: 'voice note',
+      audio_url: 'http://example.com/audio.mp3',
+    }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_AUDIO_URL');
+  });
 });
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- Android/iOS/backend에서 cleartext 원격 오디오와 HTTP API base URL을 차단했습니다.
- Google Play 제출용 계정 및 데이터 삭제 안내 페이지를 추가했습니다.
- 새 AAB 업로드를 위해 Android versionCode를 5로 올렸습니다.

## Test plan
- [x] .\gradlew.bat :app:testDevDebugUnitTest
- [x] npm run test --workspace=backend -- alarm-mutation.test.ts notes.test.ts
- [x] npm run typecheck --workspace=@voicealarm/landing
- [x] npm run build --workspace=@voicealarm/landing