### PR TITLE
Promote closed test invite code flow

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -76,6 +77,7 @@ internal fun SubscriptionPanel(
 ) {
     var checkoutTarget by remember { mutableStateOf<CheckoutSelection?>(null) }
     var changeTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
+    var testCodeTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
     var showCancelDialog by remember { mutableStateOf(false) }
     var showLeaveDialog by remember { mutableStateOf(false) }
     var shareTarget by remember { mutableStateOf<List<VoucherItem>>(emptyList()) }
@@ -181,9 +183,9 @@ internal fun SubscriptionPanel(
                     hasActiveSubscription = hasActive,
                     busy = billingBusy || shareBusy,
                     vouchers = vouchersForPlan,
-                    onPurchase = { checkoutTarget = CheckoutSelection(option = option, gift = false) },
-                    onGift = { checkoutTarget = CheckoutSelection(option = option, gift = true) },
-                    onChange = { changeTarget = option },
+                    onPurchase = { testCodeTarget = option },
+                    onGift = { testCodeTarget = option },
+                    onChange = { testCodeTarget = option },
                     onShareVouchers = { refreshAndOpenVoucherShare(option.key) },
                 )
             }
@@ -206,6 +208,18 @@ internal fun SubscriptionPanel(
                 )
             }
         }
+    }
+
+    testCodeTarget?.let { option ->
+        TestInviteCodeDialog(
+            target = option,
+            busy = billingBusy,
+            onDismiss = { testCodeTarget = null },
+            onRegisterCode = { code ->
+                testCodeTarget = null
+                onRegisterCode(code)
+            },
+        )
     }
 
     if (showCancelDialog) {
@@ -296,6 +310,52 @@ internal fun SubscriptionPanel(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TestInviteCodeDialog(
+    target: SubscriptionPlanOption,
+    busy: Boolean,
+    onDismiss: () -> Unit,
+    onRegisterCode: (String) -> Unit,
+) {
+    var code by remember(target.key) { mutableStateOf("") }
+    val prefix = if (target.key == "personal") "GIFT" else "INV"
+    val maxCodeLength = if (prefix == "GIFT") 19 else 18
+
+    BillingActionDialog(
+        title = "${target.name} 테스트 코드 등록",
+        description = "테스트 버전이므로 초대 코드를 등록해주세요.",
+        onDismiss = onDismiss,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(
+                value = code,
+                onValueChange = { value ->
+                    code = value
+                        .uppercase()
+                        .filter { it.isLetterOrDigit() || it == '-' }
+                        .take(maxCodeLength)
+                },
+                placeholder = { Text("$prefix-XXXX-XXXX-XXXX") },
+                singleLine = true,
+                enabled = !busy,
+                shape = WakerInputShape,
+                colors = wakerOutlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            BillingDialogButton(
+                label = "코드 등록",
+                primary = true,
+                onClick = {
+                    val trimmed = code.trim()
+                    if (trimmed.isNotBlank()) {
+                        onRegisterCode(trimmed)
+                    }
+                },
+            )
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -193,6 +193,23 @@ private fun billingFailureMessage(errorCode: String?, fallback: String): String 
         "PLAN_INACTIVE" -> "지금은 선택할 수 없는 이용권이에요"
         "FREE_NOT_BILLABLE" -> "무료 이용권은 여기에서 적용할 수 없어요"
         "GIFT_PERSONAL_ONLY" -> "선물하기는 개인 이용권에서만 사용할 수 있어요"
+        "CHECKOUT_DISABLED" -> "테스트 버전에서는 초대 코드를 등록해 주세요"
+        "USER_NOT_FOUND" -> "로그인 정보를 다시 확인해 주세요"
+        else -> fallback
+    }
+
+private fun codeRegistrationFailureMessage(errorCode: String?, fallback: String): String =
+    when (errorCode) {
+        "CODE_REQUIRED" -> "코드를 입력해 주세요"
+        "INVALID_FORMAT" -> "코드 형식을 확인해 주세요"
+        "CODE_NOT_FOUND" -> "등록할 수 없는 코드예요"
+        "CODE_EXPIRED" -> "만료된 코드예요"
+        "CODE_ALREADY_USED" -> "이미 사용된 코드예요"
+        "CODE_ALREADY_REDEEMED_BY_YOU" -> "이미 등록한 코드예요"
+        "SELF_ISSUED" -> "본인이 발급한 코드는 등록할 수 없어요"
+        "GROUP_FULL" -> "이미 정원이 찬 코드예요"
+        "INVALID_GIFT_PLAN", "INVALID_INVITE_PLAN" -> "코드와 이용권 종류가 맞지 않아요"
+        "PLAN_NOT_FOUND" -> "코드의 이용권 정보를 찾지 못했어요"
         "USER_NOT_FOUND" -> "로그인 정보를 다시 확인해 주세요"
         else -> fallback
     }
@@ -239,7 +256,10 @@ internal fun MainViewModel.registerCode(code: String) {
             }
         }.onFailure { error ->
             Log.e(TAG, "Failed to register code", error)
-            message = userFacingError(error, "코드 등록에 실패했어요")
+            message = codeRegistrationFailureMessage(
+                apiErrorCode(error),
+                userFacingError(error, "코드 등록에 실패했어요"),
+            )
         }
         billingBusy = false
     }

--- a/docs/tech/README.md
+++ b/docs/tech/README.md
@@ -458,6 +458,21 @@ Auto-detects format:
 
 Errors: `INVALID_FORMAT` `EXPIRED` `ALREADY_USED` `NOT_FOUND` `SELF_INVITE` `GROUP_FULL`.
 
+#### `POST /billing/test-codes`
+
+Internal closed-test helper. Authenticated issuer emails from
+`TEST_CODE_ISSUER_EMAILS` (defaults to `gyuwon05@gmail.com`) can issue free
+test access codes while real Google Play Billing is not connected.
+
+```json
+Req: { "plan_key": "personal" | "couple" | "family", "count": 1, "days": 30 }
+Res: { "success": true, "first_redeemer_becomes_owner": true, "codes": [...] }
+```
+
+For `personal`, codes use `GIFT-XXXX-XXXX-XXXX`. For `couple` and `family`,
+codes use `INV-XXXX-XXXX-XXXX`; the first user who registers the code becomes
+the owner of the new shared plan group. These bootstrap codes are single-use.
+
 ### Public endpoints
 
 - `GET /` — health check (returns DB connectivity).

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -76,6 +76,54 @@ type FamilyShareCodeResult =
       };
     };
 
+interface TestCodeVoucher {
+  id: string;
+  code: string;
+  plan_id: string;
+  plan_key: string;
+  plan_name: string;
+  plan_type: string;
+  status: 'issued';
+  issued_at: string;
+  expires_at: string;
+  max_uses: number;
+  use_count: number;
+}
+
+function isBillingStubEnabled(env: Partial<AppEnv['Bindings']> | undefined): boolean {
+  if (env?.BILLING_STUB_ENABLED === 'true' || env?.BILLING_STUB_ENABLED === '1') return true;
+  if (env?.BILLING_STUB_ENABLED === 'false' || env?.BILLING_STUB_ENABLED === '0') return false;
+  return env?.ENVIRONMENT !== 'production';
+}
+
+function checkoutDisabledResponse() {
+  return {
+    error: 'Checkout is disabled for this test build. Register an invite code.',
+    error_code: 'CHECKOUT_DISABLED',
+  };
+}
+
+function allowedTestCodeIssuerEmails(env: Partial<AppEnv['Bindings']> | undefined): Set<string> {
+  const raw = env?.TEST_CODE_ISSUER_EMAILS?.trim() || 'gyuwon05@gmail.com';
+  return new Set(
+    raw
+      .split(',')
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function isTestCodeIssuer(env: Partial<AppEnv['Bindings']> | undefined, email: string): boolean {
+  return allowedTestCodeIssuerEmails(env).has(email.trim().toLowerCase());
+}
+
+function readInteger(value: unknown, fallback: number): number | null {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) return Number(value.trim());
+  return null;
+}
+
 function normalizeBillablePlan(row: Record<string, unknown>): BillablePlan {
   return {
     id: String(row.id),
@@ -183,6 +231,10 @@ async function createPaidSubscriptionArtifacts(
 }
 
 billingMutation.post('/checkout', async (c) => {
+  if (!isBillingStubEnabled(c.env)) {
+    return c.json(checkoutDisabledResponse(), 409);
+  }
+
   const db = getDB(c.env);
 
   const body = await c.req
@@ -266,6 +318,102 @@ billingMutation.post('/checkout', async (c) => {
     plan: planResponse(billablePlan),
     plan_group: checkoutResult.plan_group,
     voucher: checkoutResult.voucher,
+  });
+});
+
+billingMutation.post('/test-codes', async (c) => {
+  const userEmail = c.get('userEmail') || '';
+  if (!isTestCodeIssuer(c.env, userEmail)) {
+    return c.json({ error: 'Test code issuer access is required', error_code: 'FORBIDDEN' }, 403);
+  }
+
+  const issuerUserPk = await resolveUserPk(c);
+  if (!issuerUserPk) {
+    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
+  }
+
+  const body = await c.req
+    .json<{ plan_key?: unknown; count?: unknown; days?: unknown }>()
+    .catch((): { plan_key?: unknown; count?: unknown; days?: unknown } => ({
+      plan_key: undefined,
+      count: undefined,
+      days: undefined,
+    }));
+
+  const planKey = typeof body.plan_key === 'string' ? body.plan_key.trim() : '';
+  const count = readInteger(body.count, 1);
+  const days = readInteger(body.days, 30);
+
+  if (!planKey) {
+    return c.json({ error: 'plan_key is required', error_code: 'PLAN_KEY_REQUIRED' }, 400);
+  }
+  if (count === null || count < 1 || count > 50) {
+    return c.json({ error: 'count must be between 1 and 50', error_code: 'INVALID_COUNT' }, 400);
+  }
+  if (days === null || days < 1 || days > 365) {
+    return c.json({ error: 'days must be between 1 and 365', error_code: 'INVALID_DAYS' }, 400);
+  }
+
+  const db = getDB(c.env);
+  const planRes = await db.execute({
+    sql: `SELECT id, key, name, plan_type, period_days, max_members, price_krw, is_active
+          FROM plans WHERE key = ?`,
+    args: [planKey],
+  });
+  if (planRes.rows.length === 0) {
+    return c.json({ error: 'Plan not found', error_code: 'PLAN_NOT_FOUND' }, 400);
+  }
+
+  const plan = planRes.rows[0]!;
+  if (Number(plan.is_active) !== 1) {
+    return c.json({ error: 'Plan is inactive', error_code: 'PLAN_INACTIVE' }, 400);
+  }
+
+  const planType = String(plan.plan_type);
+  if (!PAID_PLAN_TYPES.has(planType)) {
+    return c.json({ error: 'Free plan is not supported for test codes', error_code: 'FREE_NOT_BILLABLE' }, 400);
+  }
+
+  const billablePlan = normalizeBillablePlan(plan);
+  const kind = billablePlan.plan_type === 'personal' ? 'gift' : 'invite';
+  const issuedAt = new Date();
+  const issuedAtIso = issuedAt.toISOString();
+  const expiresAtIso = new Date(issuedAt.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  const codes = await withWriteTransaction(db, async (tx) => {
+    const issuedCodes: TestCodeVoucher[] = [];
+    for (let i = 0; i < count; i++) {
+      const issued = await issueVoucherCode(tx, {
+        kind,
+        planId: billablePlan.id,
+        issuerUserId: issuerUserPk,
+        issuerSubscriptionId: null,
+        issuedAt: issuedAtIso,
+        expiresAt: expiresAtIso,
+        maxUses: 1,
+      });
+      issuedCodes.push({
+        id: issued.id,
+        code: issued.code,
+        plan_id: billablePlan.id,
+        plan_key: billablePlan.key,
+        plan_name: billablePlan.name,
+        plan_type: billablePlan.plan_type,
+        status: 'issued',
+        issued_at: issuedAtIso,
+        expires_at: issued.expires_at,
+        max_uses: issued.max_uses,
+        use_count: issued.use_count,
+      });
+    }
+    return issuedCodes;
+  });
+
+  return c.json({
+    success: true,
+    plan: planResponse(billablePlan),
+    first_redeemer_becomes_owner: billablePlan.plan_type === 'family',
+    codes,
   });
 });
 
@@ -464,6 +612,10 @@ billingMutation.post('/cancel', async (c) => {
 });
 
 billingMutation.post('/change-plan', async (c) => {
+  if (!isBillingStubEnabled(c.env)) {
+    return c.json(checkoutDisabledResponse(), 409);
+  }
+
   const userPk = await resolveUserPk(c);
   if (!userPk) {
     return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -24,6 +24,8 @@ export interface Env {
   PASSWORD_PEPPER: string;
   ENVIRONMENT: string;
   INIT_DB_SECRET?: string;
+  BILLING_STUB_ENABLED?: string;
+  TEST_CODE_ISSUER_EMAILS?: string;
   SENTRY_DSN?: string;
   VOICE_BUCKET?: R2Bucket;
 }

--- a/packages/backend/test/billing-test-codes.test.ts
+++ b/packages/backend/test/billing-test-codes.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import billingMutation from '../src/routes/billing-mutation';
+
+const PLAN_PERSONAL = {
+  id: '70000000-0000-4000-8000-000000000002',
+  key: 'personal',
+  name: 'Personal',
+  plan_type: 'personal',
+  period_days: 30,
+  max_members: 1,
+  price_krw: 4900,
+  is_active: 1,
+};
+
+const PLAN_COUPLE = {
+  id: '70000000-0000-4000-8000-000000000004',
+  key: 'couple',
+  name: 'Couple',
+  plan_type: 'family',
+  period_days: 30,
+  max_members: 2,
+  price_krw: 7900,
+  is_active: 1,
+};
+
+const PLAN_FAMILY = {
+  id: '70000000-0000-4000-8000-000000000003',
+  key: 'family',
+  name: 'Family',
+  plan_type: 'family',
+  period_days: 30,
+  max_members: 6,
+  price_krw: 9900,
+  is_active: 1,
+};
+
+function buildApp(email = 'gyuwon05@gmail.com') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware('google-admin', email));
+  app.route('/billing', billingMutation);
+  return app;
+}
+
+beforeEach(() => {
+  mockDB.reset();
+});
+
+describe('POST /billing/test-codes', () => {
+  it('allows gyuwon05@gmail.com to issue a personal test code', async () => {
+    mockDB.pushResult([{ id: 'admin-pk' }]);
+    mockDB.pushResult([PLAN_PERSONAL]);
+    mockDB.pushResult([], 1);
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/test-codes', { plan_key: 'personal' }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.first_redeemer_becomes_owner).toBe(false);
+    expect(body.codes).toHaveLength(1);
+    expect(body.codes[0].code).toMatch(/^GIFT-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT OR IGNORE INTO voucher_codes'));
+    expect(insert?.args[3]).toBe(PLAN_PERSONAL.id);
+    expect(insert?.args[4]).toBe('admin-pk');
+    expect(insert?.args[5]).toBeNull();
+    expect(insert?.args[8]).toBe(1);
+  });
+
+  it('issues couple codes as first-redeemer-owned invite codes', async () => {
+    mockDB.pushResult([{ id: 'admin-pk' }]);
+    mockDB.pushResult([PLAN_COUPLE]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/test-codes', { plan_key: 'couple', count: 2, days: 14 }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.first_redeemer_becomes_owner).toBe(true);
+    expect(body.codes).toHaveLength(2);
+    expect(body.codes[0].code).toMatch(/^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(body.codes[0].plan_key).toBe('couple');
+    expect(body.codes[0].max_uses).toBe(1);
+  });
+
+  it('issues family codes without binding them to the issuer group', async () => {
+    mockDB.pushResult([{ id: 'admin-pk' }]);
+    mockDB.pushResult([PLAN_FAMILY]);
+    mockDB.pushResult([], 1);
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/test-codes', { plan_key: 'family' }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.first_redeemer_becomes_owner).toBe(true);
+    expect(body.codes[0].code).toMatch(/^INV-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT OR IGNORE INTO voucher_codes'));
+    expect(insert?.args[5]).toBeNull();
+  });
+
+  it('rejects non-issuer emails', async () => {
+    const res = await buildApp('other@example.com').request(
+      jsonReq('POST', '/billing/test-codes', { plan_key: 'family' }),
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('FORBIDDEN');
+    expect(mockDB.calls).toHaveLength(0);
+  });
+
+  it('validates count and days limits', async () => {
+    mockDB.pushResult([{ id: 'admin-pk' }]);
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/test-codes', { plan_key: 'family', count: 0, days: 366 }),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_COUNT');
+  });
+});
+
+describe('billing checkout test-build guard', () => {
+  it('blocks mock checkout in production unless the server explicitly enables billing stubs', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/checkout', { plan_key: 'personal' }),
+      undefined,
+      { ENVIRONMENT: 'production' } as AppEnv['Bindings'],
+    );
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error_code).toBe('CHECKOUT_DISABLED');
+    expect(mockDB.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Promote the closed-test invite-code billing flow from develop to main
- Includes Android test-code registration UI and backend test-code issuer API
- Keeps Play-test access code based until real Google Play Billing is wired

## Validation
- Develop PR #403 passed CI, CodeQL, and iOS Build
- Local checks before merge: `npm run test --workspace=backend`, `npm run typecheck --workspace=backend`, `./gradlew.bat :app:compileDevDebugKotlin :app:compileProdDebugKotlin`