### PR TITLE
fix(backend): mark voice clone row failed when enrollment errors

### DIFF
--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -575,6 +575,9 @@ voiceProfile.post('/clone', async (c) => {
   const resolvedUserPk = c.get('userIdPK');
   const userPk = resolvedUserPk || userId;
   const db = getDB(c.env);
+  // INSERT 후 클론이 실패하면 catch 에서 이 row 를 'failed' 로 정리해야 한다.
+  // 그렇지 않으면 status 가 'processing' 에 영구히 갇혀 앱이 "생성중" 으로 표시된다.
+  let insertedProfileId: string | null = null;
 
   try {
     if (resolvedUserPk) {
@@ -693,6 +696,7 @@ voiceProfile.post('/clone', async (c) => {
         listenerTitle,
       ],
     });
+    insertedProfileId = profileId;
 
     const attempts = createEnrollmentAttempts({
       env: c.env,
@@ -751,6 +755,19 @@ voiceProfile.post('/clone', async (c) => {
   } catch (err) {
     logRouteError(c, err);
     const detail = err instanceof Error ? err.message : 'Unknown error';
+
+    // 'processing' 으로 INSERT 된 row 가 있으면 'failed' 로 종료시켜 stuck 방지.
+    if (insertedProfileId) {
+      try {
+        await db.execute({
+          sql: `UPDATE voice_profiles SET status = 'failed', updated_at = datetime('now')
+                WHERE id = ? AND status = 'processing'`,
+          args: [insertedProfileId],
+        });
+      } catch (markErr) {
+        logRouteError(c, markErr);
+      }
+    }
 
     if (isVoiceSlotExhaustedError(detail)) {
       return c.json(

--- a/packages/backend/test/voice-profile.test.ts
+++ b/packages/backend/test/voice-profile.test.ts
@@ -399,12 +399,20 @@ describe('POST /clone — 음성 클론 (voice-profile)', () => {
   it('ElevenLabs 실패 → 500 VOICE_CLONING_FAILED', async () => {
     mockDB.pushResult([{ count: 0 }]);
     mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
     mockCreateInstantClone.mockRejectedValue(new Error('API down'));
     const res = await req(buildApp(), cloneForm(new Uint8Array([1, 2]), 'test'));
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error_code).toBe('VOICE_CLONING_FAILED');
     expect(body.detail).toBe('API down');
+
+    // 클론 실패 시 stuck 'processing' 방지: 해당 row 를 'failed' 로 정리해야 한다.
+    const insertCall = mockDB.calls[1]!;
+    const insertedId = insertCall.args[0];
+    const failedCall = mockDB.calls.find((call) => call.sql.includes("status = 'failed'"));
+    expect(failedCall).toBeDefined();
+    expect(failedCall!.args).toContain(insertedId);
   });
 
   it('ElevenLabs 에 audioBuffer 전달 확인', async () => {


### PR DESCRIPTION
## 배경
Prod에서 목소리 생성(클론)이 실패한 뒤 voice profile row가 `status='processing'`("생성중")에 영구히 갇히는 인시던트가 있었어요. (실제 1건 발생 → 수동으로 `failed` 처리 완료)

## 원인
`/voice-profile/clone` 핸들러는 row를 `'processing'`으로 INSERT한 뒤 성공 시에만 `'ready'`로 UPDATE합니다. enrollment가 throw하면 `catch`는 에러 응답만 돌려주고 **row를 정리하지 않아** 영원히 `'processing'`에 남습니다. 5분 크론도 이걸 reconcile하지 않습니다.

## 변경
- INSERT된 profile id를 추적해 `catch`에서 `status='failed'`로 종료시킴 (의도된 상태 머신과 일치).
- 기존 클론-실패 테스트에 "row가 failed로 정리되는지" 단언 추가.

## 검증
- `tsc --noEmit` 통과
- `voice-profile.test.ts` 67개 통과

## 참고 (후속 가능)
워커가 INSERT 직후 타임아웃/크래시로 `catch`조차 못 도는 극단 케이스는 이 수정으로도 못 막습니다. 필요 시 크론에 "오래된 processing → failed" reconcile 추가를 후속으로 제안.