### PR TITLE
fix(ios): enforce snooze repeat limit to match Android

### DIFF
--- a/apps/ios-native/VoiceAlarm/AlarmIntents.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmIntents.swift
@@ -59,10 +59,13 @@ struct StopAlarmIntent: LiveActivityIntent {
 
 // MARK: - SnoozeAlarmIntent
 //
-// secondaryButtonBehavior = .countdown 일 때 OS 가 자동으로 호출.
-// `AlarmManager/countdown(id:)` — https://developer.apple.com/documentation/AlarmKit/AlarmManager/countdown(id:)
-// AlarmKitViewModel.makeConfiguration 에서 `countdownDuration.postAlert =
-// snoozeMinutes * 60` 로 등록했기 때문에 OS 가 그 만큼 countdown 후 다시 alert.
+// secondaryButtonBehavior = .custom 이라 OS 는 자동 재무장하지 않고 이 intent 만
+// 호출한다. 한도(canSnooze) 를 확인해 분기한다:
+//  - 다시 울림 가능: `AlarmManager/countdown(id:)` 로 직접 재무장.
+//    https://developer.apple.com/documentation/AlarmKit/AlarmManager/countdown(id:)
+//    makeConfiguration 의 `countdownDuration.postAlert = snoozeMinutes * 60` 만큼
+//    countdown 후 다시 alert.
+//  - 한도 도달 / 비활성: Android AlarmRepository.snooze() 처럼 stop(id:) 로 종료.
 //
 // snoozeMinutes 파라미터는 OS UI 에서 노출되지 않으나, App Intent shortcut
 // 으로 직접 호출될 가능성과 우리 측 markSnoozed(newFireAtMillis:) 계산을 위해
@@ -92,14 +95,31 @@ struct SnoozeAlarmIntent: LiveActivityIntent {
         guard let uuid = UUID(uuidString: alarmID) else {
             return .result()
         }
-        do {
-            try AlarmManager.shared.countdown(id: uuid)
-        } catch {
-            // ignored
-        }
-        if let ctx = AlarmAppContext.shared,
-           ctx.canSnooze(alarmKitIDString: uuid.uuidString) {
-            await ctx.handleAlarmSnoozed(
+        // Android AlarmRepository.snooze() 와 동일하게 한도를 먼저 확인한다.
+        // 다시 울림이 꺼져 있거나 snoozeRepeatLimit 에 도달했다면 countdown 으로
+        // 재무장하지 않고 알람을 종료시켜야 한다.
+        //
+        // ctx 가 nil 인 경우(락스크린에서 콜드 부팅 직후 Scene .task 미실행)에는
+        // 한도를 판단할 수 없으므로 종료가 아니라 다시 울림을 기본값으로 둔다.
+        // 종료는 ctx 가 존재하고 명시적으로 canSnooze == false 일 때만 수행한다.
+        // (잘못 종료하면 사용자가 의도한 다시 울림이 사라지는 회귀가 되므로.)
+        let ctx = AlarmAppContext.shared
+        let limitReached = ctx?.canSnooze(alarmKitIDString: uuid.uuidString) == false
+        if limitReached {
+            // 한도 도달 / 다시 울림 비활성 — Android 처럼 알람을 끝낸다.
+            do {
+                try AlarmManager.shared.stop(id: uuid)
+            } catch {
+                // ignored
+            }
+            await ctx?.handleAlarmStopped(alarmKitIDString: uuid.uuidString)
+        } else {
+            do {
+                try AlarmManager.shared.countdown(id: uuid)
+            } catch {
+                // ignored
+            }
+            await ctx?.handleAlarmSnoozed(
                 alarmKitIDString: uuid.uuidString,
                 snoozeMinutesOverride: snoozeMinutes > 0 ? snoozeMinutes : nil
             )

--- a/apps/ios-native/VoiceAlarm/AlarmKitViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmKitViewModel.swift
@@ -356,11 +356,16 @@ final class AlarmKitViewModel: ObservableObject {
         typealias AlarmConfiguration = AlarmManager.AlarmConfiguration<VoiceAlarmMetadata>
         let stopButton = AlarmButton(text: "알람 끄기", textColor: .white, systemImageName: "stop.fill")
         let snoozeButton = AlarmButton(text: "다시 울리기", textColor: .white, systemImageName: "moon.zzz.fill")
+        // .custom 으로 두어 다시 울림 분기 전체를 SnoozeAlarmIntent 가 결정하게 한다.
+        // .countdown 이면 OS 가 secondaryIntent 와 별개로 postAlert countdown 을
+        // 자동 재무장하므로, snoozeRepeatLimit 도달 시에도 알람이 계속 되살아난다
+        // (Android AlarmRepository.snooze() 의 한도 종료 동작과 어긋남). .custom 은
+        // OS 자동 동작을 끄고 우리 intent 가 countdown(id:) / stop(id:) 을 직접 호출.
         let alert = AlarmPresentation.Alert(
             title: LocalizedStringResource(stringLiteral: record.label),
             stopButton: stopButton,
             secondaryButton: snoozeButton,
-            secondaryButtonBehavior: .countdown
+            secondaryButtonBehavior: .custom
         )
         let countdown = AlarmPresentation.Countdown(
             title: LocalizedStringResource(stringLiteral: "\(record.label) 다시 울릴 준비 중")


### PR DESCRIPTION
> **Draft 사유:** AlarmKit 동작 변경(`.countdown` → `.custom`)이 포함되어 **실기기 검증 전**입니다. Windows 환경이라 빌드/실행 불가. 머지 전 on-device 확인 필요.

## 배경
Android를 기준으로 iOS 스누즈 동작에 로직 갭이 있었어요. Android `AlarmRepository.snooze()`는 `snoozeCount >= snoozeRepeatLimit`이면 재예약을 거부해 알람을 종료시키는데, iOS는 한도를 무시하고 무한히 다시 울릴 수 있었습니다.

## 원인
- `SnoozeAlarmIntent.perform()`이 `AlarmManager.countdown(id:)`를 **무조건** 호출.
- alert가 `secondaryButtonBehavior: .countdown`이라 OS가 intent와 별개로 스누즈를 자동 재무장.

## 변경
- alert를 `.custom`으로 변경 → secondary intent가 스누즈 분기의 유일한 권한이 됨.
- `perform()`에서 `canSnooze`로 분기: 가능하면 `countdown(id:)`로 재무장, 한도 도달/스누즈 비활성이면 `stop(id:)` + `handleAlarmStopped`로 종료 (Android와 일치).
- `AlarmAppContext`가 nil인 경우(락스크린 콜드부팅)는 한도 판단 불가 → 안전하게 스누즈를 기본값으로 (의도한 스누즈를 잘못 종료하지 않도록).

## ⚠️ 머지 전 실기기 검증 필요
- 일반 스누즈가 `snoozeMinutes` 후 정상 재무장되는지
- `snoozeRepeatLimit` 도달 시 다시 스누즈되지 않고 종료되는지
- 스누즈 비활성 알람이 secondary 버튼에서 종료되는지