### PR TITLE
feat(backend): remove free-plan alarm count limit

### DIFF
--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -178,19 +178,6 @@ alarmMutation.post('/', async (c) => {
     );
   }
 
-  if (user.rows.length > 0 && user.rows[0]!.plan === 'free') {
-    const alarmCount = await db.execute({
-      sql: 'SELECT COUNT(*) as count FROM alarms WHERE user_id = ? OR target_user_id = ?',
-      args: [alarmOwner, alarmOwner],
-    });
-    if (Number(alarmCount.rows[0]!.count) >= 2) {
-      return c.json(
-        { error: '무료 플랜은 최대 2개의 알람만 설정 가능합니다.', error_code: 'FREE_PLAN_LIMIT' },
-        403,
-      );
-    }
-  }
-
   // Raw-audio alarms have no real TTS message but the schema still requires
   // message_id (NOT NULL). Insert a "raw" placeholder message that points at
   // the same audio URL so the alarm row is satisfied. We attach it to the

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -84,22 +84,9 @@ describe('POST /alarms', () => {
     expect(res.status).toBe(201);
   });
 
-  it('무료 플랜 2개 제한 — 3번째 알람 거부', async () => {
+  it('무료 플랜도 알람 개수 제한 없이 생성 허용', async () => {
     // user plan → free
     mockDB.pushResult([{ plan: 'free' }]);
-    // alarm count → 2
-    mockDB.pushResult([{ count: 2 }]);
-
-    const res = await buildApp().request(jsonReq('POST', '/alarms', validBody));
-    expect(res.status).toBe(403);
-    expect((await res.json()).error_code).toBe('FREE_PLAN_LIMIT');
-  });
-
-  it('무료 플랜 2개 미만이면 생성 허용', async () => {
-    // user plan → free
-    mockDB.pushResult([{ plan: 'free' }]);
-    // alarm count → 1
-    mockDB.pushResult([{ count: 1 }]);
     // message check → found
     mockDB.pushResult([{ id: ID.message }]);
     // INSERT
@@ -374,15 +361,6 @@ describe('POST /alarms', () => {
     );
     expect(res.status).toBe(400);
     expect((await res.json()).error_code).toBe('INVALID_REPEAT_DAYS');
-  });
-
-  it('무료 플랜 count 문자열 "2" → Number() 변환 후 거부', async () => {
-    mockDB.pushResult([{ plan: 'free' }]);
-    mockDB.pushResult([{ count: '2' }]);
-
-    const res = await buildApp().request(jsonReq('POST', '/alarms', validBody));
-    expect(res.status).toBe(403);
-    expect((await res.json()).error_code).toBe('FREE_PLAN_LIMIT');
   });
 
   it('time "00:00" 경계값 허용', async () => {

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -199,15 +199,13 @@ describe('POST /alarm — 알람 생성', () => {
     expect(res.status).toBe(403);
   });
 
-  it('���료 플랜 알람 2개 초과면 403', async () => {
+  it('���료 플랜 무료 플랜도 알람 개수 제한 없이 201', async () => {
     mockDB.pushResult([{ plan: 'free' }]); // user plan
-    mockDB.pushResult([{ count: 2 }]); // alarm count
+    mockDB.pushResult([{ id: ID.message }]); // message exists
+    mockDB.pushResult([], 1); // insert alarm
     const app = buildApp();
     const res = await app.request(jsonReq('POST', '/alarm', { message_id: ID.message, time: '07:00' }));
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error).toContain('무료 플랜');
-    expect(body.error_code).toBe('FREE_PLAN_LIMIT');
+    expect(res.status).toBe(201);
   });
 
   it('메시지가 존재하지 않으면 404', async () => {


### PR DESCRIPTION
## Summary
- 무료 플랜의 알람 2개 제한(`FREE_PLAN_LIMIT`)을 제거해 모든 플랜에서 알람 개수 제한 없이 생성 가능하도록 변경
- `alarm-mutation.ts` 의 `POST /` 핸들러에서 free 플랜일 때 `SELECT COUNT(*)` 후 403 반환하던 블록 삭제
- 스키마 변경 없음 → 마이그레이션 불필요

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `vitest run test/alarm-mutation.test.ts test/alarm.test.ts` — 105 passed
- 영향받은 테스트(무료 플랜 제한 관련)를 제한 없는 생성 성공으로 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)