### PR TITLE
chore(backend): .dev.vars.example 실제 필요한 키만 정리

### DIFF
--- a/packages/backend/.dev.vars.example
+++ b/packages/backend/.dev.vars.example
@@ -1,38 +1,45 @@
 # Local template for Cloudflare Worker secrets.
-# Copy to `.dev.vars.dev` and `.dev.vars.prod`.
-# Do not commit real values.
+# Copy to `.dev.vars.dev` and fill in real values. Do not commit real values.
+#
+# Keys map to scripts/sync-worker-secrets.ts (WORKER_SECRET_KEYS).
+# REQUIRED keys must be set or the Worker will fail to start.
 
 ENVIRONMENT=development
 
-# Cloudflare API credentials used only by local scripts.
-CLOUDFLARE_ACCOUNT_ID=
-CLOUDFLARE_API_TOKEN=
-
-# AI providers.
-PERSO_API_KEY=
-ELEVENLABS_API_KEY=
-GEMINI_API_KEY=
-GOOGLE_VERTEX_API_KEY=
-GOOGLE_VERTEX_CREDENTIALS_JSON=
-GOOGLE_VERTEX_LOCATION=global
-GOOGLE_VERTEX_MODEL=gemini-2.5-flash
-
-# Turso DB. Use a separate database/token per environment.
+# === Required ===
 TURSO_DATABASE_URL=libsql://your-env-db.turso.io
 TURSO_AUTH_TOKEN=
-
-# Auth.
 GOOGLE_CLIENT_ID=
 JWT_SECRET=
 PASSWORD_PEPPER=
-# Required only when running POST /api/init-db against production.
-INIT_DB_SECRET=
 
-# Optional.
+# === AI providers ===
+PERSO_API_KEY=
+ELEVENLABS_API_KEY=
+
+# Translation (Vertex). Use service-account JSON, or one of the API-key
+# fallbacks below (GOOGLE_VERTEX_API_KEY > GEMINI_API_KEY > GOOGLE_API_KEY).
+GOOGLE_VERTEX_CREDENTIALS_JSON=
+GOOGLE_VERTEX_API_KEY=
+GOOGLE_VERTEX_LOCATION=global
+GOOGLE_VERTEX_MODEL=gemini-2.5-flash
+
+# === Optional: Apple Sign-In ===
 APPLE_CLIENT_ID=
 APPLE_SHARED_SECRET=
+
+# === Optional: transactional email (Resend) ===
 RESEND_API_KEY=
 AUTH_EMAIL_FROM=AlarmTalk <no-reply@alarm-talk.com>
 AUTH_EMAIL_REPLY_TO=
-FIREBASE_PROJECT_ID=
+
+# === Optional: observability / misc ===
 SENTRY_DSN=
+FIREBASE_PROJECT_ID=
+# Required only when running POST /api/init-db.
+INIT_DB_SECRET=
+
+# === Local scripts only (not pushed as Worker secrets) ===
+# Used by sync-worker-secrets.ts and reset-test-data.ts.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=


### PR DESCRIPTION
## Summary
- `.dev.vars.example` 을 dev 환경 단일 운영에 맞춰 정리
- 코드에서 실제 참조하는 키만 남기고 **필수(Required) / 선택(Optional) / 로컬 스크립트 전용** 으로 구분
- 번역 폴백 키 `GEMINI_API_KEY`, `GOOGLE_API_KEY` 는 `GOOGLE_VERTEX_API_KEY` 로 대표되므로 example 에서 제외 (코드 폴백 자체는 유지)
- 키 목록은 `scripts/sync-worker-secrets.ts` 의 `WORKER_SECRET_KEYS` 기준

## 참고
- 실제 시크릿 파일(`.dev.vars`, `.dev.vars.dev`, `.dev.vars.prod`)은 `.gitignore` 에 잡혀 있고 git 히스토리에 올라간 적 없음 (확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)