### PR TITLE
fix(ios): 콜드 부팅 시 미로딩 스누즈 상태를 한도 도달로 오인하지 않도록

### DIFF
--- a/apps/ios-native/VoiceAlarm/AlarmAppContext.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmAppContext.swift
@@ -114,9 +114,20 @@ final class AlarmAppContext {
 
     // MARK: - Snooze
 
-    func canSnooze(alarmKitIDString: String) -> Bool {
-        guard let record = store?.recordByAlarmKitID(alarmKitIDString) else { return false }
-        return record.canSnooze
+    /// 스누즈 가부를 3-state 로 구분한다.
+    /// - `.allow`: 기록이 로드돼 있고 다시 울림 가능.
+    /// - `.deny` : 기록이 로드돼 있고 한도 도달 / 다시 울림 비활성.
+    /// - `.unknown`: store 미주입이거나 디스크 로드 전, 또는 기록을 찾지 못함 —
+    ///   판단 근거가 없으므로 호출 측은 안전한 기본값(다시 울림)으로 처리해야 한다.
+    ///
+    /// 콜드 부팅으로 `LocalAlarmStore` 의 async 디스크 로드가 끝나기 전 스누즈가
+    /// 들어오면 `recordByAlarmKitID` 가 nil 이라, 단순 Bool 로는 "한도 도달" 과
+    /// 구분되지 않아 알람을 꺼버리는 회귀가 있었다. `hasLoadedFromDisk` 와 기록
+    /// 존재 여부를 `.deny` 판단에서 분리해 그 회귀를 막는다.
+    func snoozeDecision(alarmKitIDString: String) -> AlarmSnoozeDecision {
+        guard let store, store.hasLoadedFromDisk else { return .unknown }
+        guard let record = store.recordByAlarmKitID(alarmKitIDString) else { return .unknown }
+        return record.canSnooze ? .allow : .deny
     }
 
     /// LiveActivity 의 Snooze 버튼이 눌렸을 때 호출.
@@ -162,6 +173,15 @@ final class AlarmAppContext {
             ]
         )
     }
+}
+
+/// 스누즈 인텐트가 알람을 종료(한도 도달)할지, 다시 울릴지 판단한 결과.
+/// `.unknown` 은 store 미로딩/기록없음 등 판단 불가 상태로, 호출 측에서는
+/// 안전하게 다시 울림으로 처리한다.
+enum AlarmSnoozeDecision {
+    case allow
+    case deny
+    case unknown
 }
 
 // MARK: - LocalAlarmStore convenience

--- a/apps/ios-native/VoiceAlarm/AlarmIntents.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmIntents.swift
@@ -99,13 +99,15 @@ struct SnoozeAlarmIntent: LiveActivityIntent {
         // 다시 울림이 꺼져 있거나 snoozeRepeatLimit 에 도달했다면 countdown 으로
         // 재무장하지 않고 알람을 종료시켜야 한다.
         //
-        // ctx 가 nil 인 경우(락스크린에서 콜드 부팅 직후 Scene .task 미실행)에는
-        // 한도를 판단할 수 없으므로 종료가 아니라 다시 울림을 기본값으로 둔다.
-        // 종료는 ctx 가 존재하고 명시적으로 canSnooze == false 일 때만 수행한다.
-        // (잘못 종료하면 사용자가 의도한 다시 울림이 사라지는 회귀가 되므로.)
+        // 판단은 3-state 로 한다. 락스크린 콜드 부팅 직후(Scene .task 미실행으로
+        // ctx 가 nil 이거나, ctx 는 있어도 LocalAlarmStore 의 디스크 로드 전이라
+        // 기록을 못 찾는 경우)에는 한도를 알 수 없으므로 .unknown 이 되고, 종료가
+        // 아니라 다시 울림을 기본값으로 둔다. 종료는 기록이 로드돼 한도 도달/비활성이
+        // 명확한 .deny 일 때만 수행한다. (잘못 종료하면 사용자가 의도한 다시 울림이
+        // 사라지는 회귀가 되므로.)
         let ctx = AlarmAppContext.shared
-        let limitReached = ctx?.canSnooze(alarmKitIDString: uuid.uuidString) == false
-        if limitReached {
+        let decision = ctx?.snoozeDecision(alarmKitIDString: uuid.uuidString) ?? .unknown
+        if decision == .deny {
             // 한도 도달 / 다시 울림 비활성 — Android 처럼 알람을 끝낸다.
             do {
                 try AlarmManager.shared.stop(id: uuid)


### PR DESCRIPTION
## 배경
PR #424의 Codex 리뷰(P2)에서 지적된 iOS 스누즈 회귀를 수정합니다.

## 문제
락스크린에서 앱이 콜드 부팅될 때 `AlarmAppContext` 는 설치됐지만 `LocalAlarmStore` 의 async 디스크 로드가 끝나기 전이면 `recordByAlarmKitID` 가 nil 을 반환합니다. 기존 `canSnooze(alarmKitIDString:)` 는 이 경우도 `false` 를 돌려줘서, 스누즈 인텐트가 **한도 도달로 오인하고 알람을 종료** → 사용자가 의도한 다시 울림이 사라졌습니다.

## 수정
- `canSnooze(alarmKitIDString:) -> Bool` 을 **`snoozeDecision(alarmKitIDString:) -> AlarmSnoozeDecision`** (`.allow` / `.deny` / `.unknown`) 으로 교체.
- `hasLoadedFromDisk` 와 기록 존재 여부를 `.deny` 판단에서 분리.
- 미로딩 / 기록없음 / ctx-nil → `.unknown` → **안전하게 다시 울림(countdown)**.
- 알람 종료는 기록이 로드돼 한도 도달/비활성이 명확한 **`.deny` 일 때만**.

## 영향 범위
- `canSnooze(alarmKitIDString:)` 의 호출처는 `AlarmIntents.swift` 단 한 곳뿐이라 안전하게 교체됨.
- 기존 ctx-nil 처리(다시 울림 기본값)는 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)