### PR TITLE
chore(android): dev 플레이버 런처 라벨을 "dev" 로 설정

### DIFF
--- a/apps/android-native/app/src/dev/res/values/strings.xml
+++ b/apps/android-native/app/src/dev/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- dev 플레이버 전용 런처 라벨. prod(릴리스)는 main 의 "AlarmTalk" 를 그대로 사용하고,
+         dev 빌드만 "dev" 로 표시해 플레이스토어 설치본과 구분한다. -->
+    <string name="app_name">dev</string>
+</resources>


### PR DESCRIPTION
## 변경
dev 플레이버(`com.alarmtalk.app.dev`) 전용 `strings.xml` 로 `app_name` 을 `"dev"` 로 오버라이드.

## 이유
- 플레이스토어 prod 설치본(`com.alarmtalk.app`, 라벨 "AlarmTalk")과 런처에서 헷갈리지 않도록 dev 설치본을 "dev" 로 표시.
- prod/릴리스 라벨은 기존 "AlarmTalk" 유지 (dev 플레이버에만 적용).

## 검증
`assembleDevDebug` APK 의 `aapt dump badging` → `application-label:'dev'`, 패키지 `com.alarmtalk.app.dev` 확인. 연결 기기 설치 시 prod 와 별개 아이콘으로 공존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)