### PR TITLE
기존/신규 가입자 필수 약관 동의 게이트

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
@@ -120,6 +120,28 @@ data class DeleteAccountResponse(
     val success: Boolean,
 )
 
+data class ConsentItemRequest(
+    val type: String,
+    val agreed: Boolean,
+    val version: String? = null,
+)
+
+data class RecordConsentsRequest(
+    val consents: List<ConsentItemRequest>,
+)
+
+data class RecordConsentsResponse(
+    val success: Boolean = false,
+    val recorded: Int = 0,
+)
+
+data class ConsentStatusResponse(
+    @SerializedName("needs_consent") val needsConsent: Boolean = false,
+    val required: List<String> = emptyList(),
+    val missing: List<String> = emptyList(),
+    @SerializedName("policy_version") val policyVersion: String = "1",
+)
+
 interface AuthApi {
     @POST("auth/email-code")
     suspend fun requestEmailVerification(@Body request: EmailVerificationRequest): EmailVerificationResponse
@@ -149,4 +171,13 @@ interface AuthApi {
 
     @DELETE("user/me")
     suspend fun deleteAccount(@Header("Authorization") authorization: String): DeleteAccountResponse
+
+    @GET("user/consents/status")
+    suspend fun consentStatus(@Header("Authorization") authorization: String): ConsentStatusResponse
+
+    @POST("user/consents")
+    suspend fun recordConsents(
+        @Header("Authorization") authorization: String,
+        @Body request: RecordConsentsRequest,
+    ): RecordConsentsResponse
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/VoiceAlarmApp.kt
@@ -2,6 +2,7 @@ package com.alarmtalk.app
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import androidx.activity.compose.BackHandler
@@ -247,6 +248,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
     LaunchedEffect(authSession?.token) {
         if (authSession != null) {
             viewModel.checkOnboardingFor(authSession.user.id)
+            viewModel.checkConsentStatus()
             viewModel.preloadVoiceProfiles()
             viewModel.preloadSocial()
             viewModel.preloadCharacterAndBilling()
@@ -499,6 +501,16 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
           }
           return@Scaffold
       }
+      if (viewModel.needsConsent) {
+          ConsentScreen(
+              contentPadding = padding,
+              busy = authBusy,
+              onAgree = { marketingAgreed -> viewModel.submitConsents(marketingAgreed) },
+              onOpenTerms = { context.openWebUrl("https://alarm-talk.com/ko/terms") },
+              onOpenPrivacy = { context.openWebUrl("https://alarm-talk.com/ko/privacy") },
+          )
+          return@Scaffold
+      }
       if (viewModel.showOnboarding) {
           OnboardingScreen(
               contentPadding = padding,
@@ -743,6 +755,14 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
               PrettySnackbar(message = data.visuals.message)
           }
       }
+    }
+}
+
+private fun Context.openWebUrl(url: String) {
+    runCatching {
+        startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/ConsentScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/ConsentScreen.kt
@@ -1,0 +1,159 @@
+package com.alarmtalk.app
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * 로그인 후 필수 약관/개인정보 동의를 받는 게이트 화면.
+ * 신규 가입자뿐 아니라 기존 가입자도 미동의 시 이 화면을 통과해야 앱을 쓸 수 있다.
+ *
+ * 필수: 만14세 이상 / 이용약관 / 개인정보 처리방침
+ * 선택: 광고성 정보 수신(마케팅)
+ */
+@Composable
+internal fun ConsentScreen(
+    contentPadding: PaddingValues,
+    busy: Boolean,
+    onAgree: (marketingAgreed: Boolean) -> Unit,
+    onOpenTerms: () -> Unit,
+    onOpenPrivacy: () -> Unit,
+) {
+    var age14 by remember { mutableStateOf(false) }
+    var terms by remember { mutableStateOf(false) }
+    var privacy by remember { mutableStateOf(false) }
+    var marketing by remember { mutableStateOf(false) }
+
+    val allRequiredChecked = age14 && terms && privacy
+    val allChecked = allRequiredChecked && marketing
+
+    fun setAll(value: Boolean) {
+        age14 = value
+        terms = value
+        privacy = value
+        marketing = value
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .padding(horizontal = 24.dp),
+    ) {
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = "서비스 이용을 위해\n약관에 동의해 주세요",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "원활한 서비스 제공을 위해 아래 약관에 대한 동의가 필요해요.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(Modifier.height(24.dp))
+            ConsentRow(
+                checked = allChecked,
+                onCheckedChange = ::setAll,
+                label = "약관 전체 동의",
+                emphasized = true,
+            )
+            Spacer(Modifier.height(4.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(4.dp))
+            ConsentRow(
+                checked = age14,
+                onCheckedChange = { age14 = it },
+                label = "[필수] 만 14세 이상입니다",
+            )
+            ConsentRow(
+                checked = terms,
+                onCheckedChange = { terms = it },
+                label = "[필수] 이용약관 동의",
+                onOpenDetail = onOpenTerms,
+            )
+            ConsentRow(
+                checked = privacy,
+                onCheckedChange = { privacy = it },
+                label = "[필수] 개인정보 처리방침 동의",
+                onOpenDetail = onOpenPrivacy,
+            )
+            ConsentRow(
+                checked = marketing,
+                onCheckedChange = { marketing = it },
+                label = "[선택] 광고성 정보 수신 동의",
+            )
+        }
+
+        Button(
+            onClick = { onAgree(marketing) },
+            enabled = allRequiredChecked && !busy,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+                .height(50.dp),
+        ) {
+            Text(if (busy) "처리 중…" else "동의하고 시작하기")
+        }
+    }
+}
+
+@Composable
+private fun ConsentRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    emphasized: Boolean = false,
+    onOpenDetail: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        Spacer(Modifier.height(0.dp))
+        Text(
+            text = label,
+            modifier = Modifier.weight(1f),
+            style = if (emphasized) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyLarge,
+            fontWeight = if (emphasized) FontWeight.Bold else FontWeight.Normal,
+        )
+        if (onOpenDetail != null) {
+            TextButton(onClick = onOpenDetail) { Text("보기") }
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -172,6 +172,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var showOnboarding by mutableStateOf(false)
         internal set
 
+    // 필수 개인정보/약관 동의가 아직 안 된 경우 true → 로그인 후 동의 화면을 띄운다.
+    var needsConsent by mutableStateOf(false)
+        internal set
+
     var permissionGateRequest by mutableStateOf<PermissionTarget?>(null)
         internal set
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -213,6 +213,7 @@ internal fun MainViewModel.logout(signOutGoogle: suspend () -> Unit = {}) {
         authSessionStore.clear()
         clearUserScopedRemoteState()
         authSession = null
+        needsConsent = false
         message = "로그아웃했어요"
         authBusy = false
     }
@@ -362,6 +363,57 @@ internal fun MainViewModel.deleteAccount(revokeGoogleAccess: suspend () -> Unit 
         } finally {
             authBusy = false
         }
+    }
+}
+
+// 로그인 후 필수 동의 여부를 서버에 확인한다. 미동의면 needsConsent=true 로 두어
+// VoiceAlarmApp 이 동의 화면을 띄운다. 네트워크 실패 시에는 앱 진입을 막지 않는다.
+internal fun MainViewModel.checkConsentStatus() {
+    val session = authSession ?: return
+    val authorization = com.alarmtalk.app.network.VoiceAlarmApiClient.bearer(session.token)
+    viewModelScope.launch {
+        runCatching {
+            api.consentStatus(authorization)
+        }.onSuccess { status ->
+            needsConsent = status.needsConsent
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to check consent status", error)
+            needsConsent = false
+        }
+    }
+}
+
+// 동의 화면 제출. 필수(terms/privacy/age14)는 항상 동의로, marketing(광고성 정보 수신)은
+// 사용자 선택값으로 기록한다. 성공 시 동의 화면을 닫는다.
+internal fun MainViewModel.submitConsents(marketingAgreed: Boolean) {
+    val session = authSession
+    if (session == null) {
+        message = "로그인 후 사용할 수 있어요"
+        return
+    }
+    val authorization = com.alarmtalk.app.network.VoiceAlarmApiClient.bearer(session.token)
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.recordConsents(
+                authorization,
+                com.alarmtalk.app.network.RecordConsentsRequest(
+                    consents = listOf(
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "terms", agreed = true),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "privacy", agreed = true),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "age14", agreed = true),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "marketing", agreed = marketingAgreed),
+                    ),
+                ),
+            )
+        }.onSuccess {
+            needsConsent = false
+            message = "동의가 완료됐어요"
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to record consents", error)
+            message = userFacingError(error, "동의 기록에 실패했어요. 다시 시도해 주세요")
+        }
+        authBusy = false
     }
 }
 

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -334,6 +334,10 @@ user.delete('/me', async (c) => {
 // consent_type: 'terms'(이용약관·필수), 'privacy'(개인정보·필수), 'marketing'(마케팅·선택),
 // 'age14'(만14세이상·필수). 동일 (user_id, consent_type) 최신 행이 현재 동의 상태.
 const ALLOWED_CONSENT_TYPES = new Set(['terms', 'privacy', 'marketing', 'age14']);
+// 가입/이용에 반드시 필요한 필수 동의. marketing(광고성 정보 수신) 은 선택이라 제외.
+const REQUIRED_CONSENT_TYPES = ['terms', 'privacy', 'age14'] as const;
+// 처리방침/약관 버전. 정책을 개정하면 이 값을 올려 기존 가입자 재동의를 유도한다.
+const CURRENT_POLICY_VERSION = '1';
 const DELETION_GRACE_DAYS = 30;
 
 user.post('/consents', async (c) => {
@@ -412,6 +416,39 @@ user.get('/consents', async (c) => {
   } catch (err) {
     logRouteError(c, err);
     return c.json({ error: 'Failed to load consents', error_code: 'CONSENT_LOAD_FAILED' }, 500);
+  }
+});
+
+// 동의 상태 조회. 기존 가입자/신규 가입자 모두 로그인 후 이 결과로 재동의 화면을 띄운다.
+// needs_consent = 필수 동의 중 하나라도 (미기록 | 미동의 | 현재 정책버전과 불일치) 이면 true.
+user.get('/consents/status', async (c) => {
+  const userPk = c.get('userIdPK');
+  const db = getDB(c.env);
+  try {
+    const res = await db.execute({
+      sql: `SELECT consent_type, policy_version, agreed
+            FROM user_consents WHERE user_id = ? ORDER BY created_at DESC, rowid DESC`,
+      args: [userPk],
+    });
+    const latest = new Map<string, { agreed: boolean; version: string }>();
+    for (const row of res.rows) {
+      const type = String(row.consent_type);
+      if (latest.has(type)) continue; // 유형별 최신 1건만
+      latest.set(type, { agreed: Number(row.agreed) === 1, version: String(row.policy_version) });
+    }
+    const missing = REQUIRED_CONSENT_TYPES.filter((type) => {
+      const cur = latest.get(type);
+      return !cur || !cur.agreed || cur.version !== CURRENT_POLICY_VERSION;
+    });
+    return c.json({
+      needs_consent: missing.length > 0,
+      required: REQUIRED_CONSENT_TYPES,
+      missing,
+      policy_version: CURRENT_POLICY_VERSION,
+    });
+  } catch (err) {
+    logRouteError(c, err);
+    return c.json({ error: 'Failed to load consent status', error_code: 'CONSENT_STATUS_FAILED' }, 500);
   }
 });
 

--- a/packages/backend/test/compliance-verify.test.ts
+++ b/packages/backend/test/compliance-verify.test.ts
@@ -34,9 +34,9 @@ function authAs(userId = SUB, userPk = PK) {
   };
 }
 
-function buildApp() {
+function buildApp(userId = SUB, userPk = PK) {
   const app = new Hono<AppEnv>();
-  app.use('*', authAs());
+  app.use('*', authAs(userId, userPk));
   app.route('/user', userRoutes);
   return app;
 }
@@ -116,6 +116,68 @@ describe('동의 기록 — 마케팅(광고성 정보 수신) 포함', () => {
     const res = await app.request(req('POST', '/user/consents', { consents: [{ type: 'sell_my_data', agreed: true }] }));
     expect(res.status).toBe(400);
     expect((await res.json()).error_code).toBe('INVALID_CONSENT_TYPE');
+  });
+});
+
+describe('동의 상태 — 기존/신규 가입자 재동의 판단', () => {
+  const NEW_SUB = 'no-consent-sub';
+  const NEW_PK = 'no-consent-pk';
+
+  it('동의 기록이 없는 사용자는 needs_consent=true, 필수 3종 모두 missing', async () => {
+    await db.execute({
+      sql: `INSERT INTO users (id, google_id, email, name) VALUES (?, ?, ?, ?)`,
+      args: [NEW_PK, NEW_SUB, 'noconsent@test.com', 'No Consent'],
+    });
+    const app = buildApp(NEW_SUB, NEW_PK);
+    const res = await app.request(req('GET', '/user/consents/status'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    console.log('[GET /consents/status — 미동의]', JSON.stringify(body));
+    expect(body.needs_consent).toBe(true);
+    expect(body.missing.sort()).toEqual(['age14', 'privacy', 'terms']);
+  });
+
+  it('필수 3종 동의 기록 후 needs_consent=false (marketing 미동의여도 무관)', async () => {
+    const app = buildApp(NEW_SUB, NEW_PK);
+    await app.request(
+      req('POST', '/user/consents', {
+        consents: [
+          { type: 'terms', agreed: true },
+          { type: 'privacy', agreed: true },
+          { type: 'age14', agreed: true },
+          { type: 'marketing', agreed: false },
+        ],
+      }),
+    );
+    const res = await app.request(req('GET', '/user/consents/status'));
+    const body = await res.json();
+    console.log('[GET /consents/status — 동의완료]', JSON.stringify(body));
+    expect(body.needs_consent).toBe(false);
+    expect(body.missing).toEqual([]);
+  });
+
+  it('필수 중 하나(privacy)만 미동의면 needs_consent=true, missing=[privacy]', async () => {
+    const SUB2 = 'partial-sub';
+    const PK2 = 'partial-pk';
+    await db.execute({
+      sql: `INSERT INTO users (id, google_id, email, name) VALUES (?, ?, ?, ?)`,
+      args: [PK2, SUB2, 'partial@test.com', 'Partial'],
+    });
+    const app = buildApp(SUB2, PK2);
+    await app.request(
+      req('POST', '/user/consents', {
+        consents: [
+          { type: 'terms', agreed: true },
+          { type: 'privacy', agreed: false },
+          { type: 'age14', agreed: true },
+        ],
+      }),
+    );
+    const res = await app.request(req('GET', '/user/consents/status'));
+    const body = await res.json();
+    console.log('[GET /consents/status — 부분동의]', JSON.stringify(body));
+    expect(body.needs_consent).toBe(true);
+    expect(body.missing).toEqual(['privacy']);
   });
 });
 


### PR DESCRIPTION
## 배경
로그인해도 동의 화면이 안 떠서, 기존 가입자가 개인정보 처리방침/약관에 동의할 방법이 없었음. 신규 가입자도 동의 UI 미연동 상태.

## 변경
### 백엔드
- `GET /api/user/consents/status` 추가: 필수 동의(`terms`/`privacy`/`age14`)가 미기록·미동의·정책버전 불일치면 `needs_consent=true` 와 `missing[]` 반환.
- 정책 개정 시 `CURRENT_POLICY_VERSION` 만 올리면 기존 가입자 전원 재동의 유도.

### Android
- 로그인 직후 `consents/status` 조회 → 미동의면 `ConsentScreen` 게이트 표시(온보딩보다 우선).
- 필수(만14세·이용약관·개인정보 처리방침) + 선택(광고성 정보 수신) 체크박스, 약관/처리방침 웹 링크(`alarm-talk.com/ko/{terms,privacy}`), 동의 시 `POST /api/user/consents` 기록.
- 기존 가입자/신규 가입자 모두 적용. 로그아웃 시 상태 초기화.

## 검증
- 백엔드: 실DB(인메모리 마이그레이션) 기반 상태 엔드포인트 테스트 추가 — 미동의 `needs_consent=true`, 필수 기록 후 `false`, 부분동의 시 `missing=[privacy]`. 전체 백엔드 1328 테스트 통과, `tsc` 클린.
- Android: `assembleDevDebug` 빌드 성공, dev 단말 설치 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)