### PR TITLE
앱 버전 게이트 + 설정 약관/처리방침 링크

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 data class FamilyAlarmQuietWindow(
     val days: List<Int> = listOf(1, 2, 3, 4, 5),
@@ -142,6 +143,13 @@ data class ConsentStatusResponse(
     @SerializedName("policy_version") val policyVersion: String = "1",
 )
 
+data class AppVersionResponse(
+    val platform: String = "android",
+    @SerializedName("min_supported_version") val minSupportedVersion: Int = 1,
+    @SerializedName("latest_version") val latestVersion: Int = 1,
+    @SerializedName("store_url") val storeUrl: String = "",
+)
+
 interface AuthApi {
     @POST("auth/email-code")
     suspend fun requestEmailVerification(@Body request: EmailVerificationRequest): EmailVerificationResponse
@@ -180,4 +188,7 @@ interface AuthApi {
         @Header("Authorization") authorization: String,
         @Body request: RecordConsentsRequest,
     ): RecordConsentsResponse
+
+    @GET("app/version")
+    suspend fun appVersion(@Query("platform") platform: String = "android"): AppVersionResponse
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceAlarmApiClient.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceAlarmApiClient.kt
@@ -24,6 +24,7 @@ object VoiceAlarmApiClient {
     fun create(
         baseUrl: String = BuildConfig.VOICE_ALARM_API_BASE_URL,
         unauthorizedHandler: UnauthorizedHandler? = null,
+        appVersionCode: Int = 0,
     ): VoiceAlarmApi {
         val logging = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
@@ -32,10 +33,20 @@ object VoiceAlarmApiClient {
                 HttpLoggingInterceptor.Level.NONE
             }
         }
+        // 모든 요청에 앱 버전/플랫폼을 실어 보내 백엔드가 버전별로 응답을 분기하거나
+        // 로그·통계에 활용할 수 있게 한다. (구버전 앱 식별 → 강제/권장 업데이트 판단의 토대)
+        val versionHeader = okhttp3.Interceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("X-App-Platform", "android")
+                .header("X-App-Version", appVersionCode.toString())
+                .build()
+            chain.proceed(request)
+        }
         val builder = OkHttpClient.Builder()
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .addInterceptor(versionHeader)
             .addInterceptor(logging)
         if (unauthorizedHandler != null) {
             builder.authenticator(UnauthorizedAuthenticator(unauthorizedHandler))

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/UpdateRequiredScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/UpdateRequiredScreen.kt
@@ -1,0 +1,72 @@
+package com.alarmtalk.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SystemUpdate
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * 설치 버전이 백엔드 최소지원버전 미만일 때 표시되는 차단 화면.
+ * 로그인 여부와 무관하게 앱 진입을 막고 스토어 업데이트만 유도한다.
+ */
+@Composable
+internal fun UpdateRequiredScreen(
+    contentPadding: PaddingValues,
+    onUpdate: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.SystemUpdate,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = "업데이트가 필요해요",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "원활하고 안전한 이용을 위해\n최신 버전으로 업데이트해 주세요.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(32.dp))
+        Button(
+            onClick = onUpdate,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
+        ) {
+            Text("업데이트하기")
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/VoiceAlarmApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/VoiceAlarmApp.kt
@@ -202,6 +202,10 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
         bulkOpenedSettingsTargets = emptySet()
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.checkAppVersion()
+    }
+
     LaunchedEffect(message) {
         val currentMessage = message ?: return@LaunchedEffect
         snackbarHostState.showSnackbar(currentMessage)
@@ -462,7 +466,7 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
 
     Scaffold(
         bottomBar = {
-            if (authSession != null && !viewModel.showOnboarding && currentTab != null) {
+            if (authSession != null && !viewModel.showOnboarding && !viewModel.updateRequired && currentTab != null) {
                 VoiceAlarmBottomBar(
                     selectedTab = selectedTab,
                     unreadAlarmCount = if (selectedTab == NativeTab.Alarms) 0 else unreadAlarmCount,
@@ -472,6 +476,18 @@ internal fun VoiceAlarmApp(viewModel: MainViewModel = viewModel()) {
             }
         },
     ) { padding ->
+      if (viewModel.updateRequired) {
+          UpdateRequiredScreen(
+              contentPadding = padding,
+              onUpdate = {
+                  val url = viewModel.updateStoreUrl.ifBlank {
+                      "https://play.google.com/store/apps/details?id=com.alarmtalk.app"
+                  }
+                  context.openWebUrl(url)
+              },
+          )
+          return@Scaffold
+      }
       if (authSession == null) {
           when (val route = authRoute) {
               AuthRoute.Landing -> LandingScreen(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -62,6 +62,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         ?.takeIf { it.isNotBlank() }
         ?.let(accessSnapshotStore::read)
         ?: AccessSnapshot()
+    // 현재 설치된 앱의 versionCode. 모든 요청 헤더(X-App-Version)와 강제 업데이트 판단에 사용.
+    internal val appVersionCode: Int = runCatching {
+        val info = application.packageManager.getPackageInfo(application.packageName, 0)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            info.longVersionCode.toInt()
+        } else {
+            @Suppress("DEPRECATION") info.versionCode
+        }
+    }.getOrDefault(0)
+
     internal val api = VoiceAlarmApiClient.create(
         unauthorizedHandler = object : VoiceAlarmApiClient.UnauthorizedHandler {
             override fun onUnauthorized() {
@@ -70,6 +80,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 handleUnauthorized()
             }
         },
+        appVersionCode = appVersionCode,
     )
 
     /**
@@ -174,6 +185,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     // 필수 개인정보/약관 동의가 아직 안 된 경우 true → 로그인 후 동의 화면을 띄운다.
     var needsConsent by mutableStateOf(false)
+        internal set
+
+    // 설치 버전이 백엔드 최소지원버전 미만이면 true → 로그인 전부터 업데이트 차단 화면을 띄운다.
+    var updateRequired by mutableStateOf(false)
+        internal set
+    var updateStoreUrl by mutableStateOf("")
         internal set
 
     var permissionGateRequest by mutableStateOf<PermissionTarget?>(null)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -366,6 +366,23 @@ internal fun MainViewModel.deleteAccount(revokeGoogleAccess: suspend () -> Unit 
     }
 }
 
+// 앱 시작 시 백엔드 최소지원버전을 조회한다. 설치 버전이 그 미만이면 updateRequired=true 로
+// 두어 VoiceAlarmApp 이 업데이트 차단 화면을 띄운다. (로그인 여부와 무관하게 동작)
+// 네트워크 실패 시에는 앱 사용을 막지 않는다.
+internal fun MainViewModel.checkAppVersion() {
+    viewModelScope.launch {
+        runCatching {
+            api.appVersion("android")
+        }.onSuccess { policy ->
+            updateStoreUrl = policy.storeUrl
+            updateRequired = appVersionCode in 1 until policy.minSupportedVersion
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to check app version", error)
+            updateRequired = false
+        }
+    }
+}
+
 // 로그인 후 필수 동의 여부를 서버에 확인한다. 미동의면 needsConsent=true 로 두어
 // VoiceAlarmApp 이 동의 화면을 띄운다. 네트워크 실패 시에는 앱 진입을 막지 않는다.
 internal fun MainViewModel.checkConsentStatus() {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/settings/SettingsScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/settings/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package com.alarmtalk.app
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
@@ -130,6 +133,22 @@ internal fun SettingsScreen(
                         promptPreferences.fortuneBirthTime,
                     ),
                     onClick = { showFortuneInfoDialog = true },
+                )
+            }
+        }
+
+        item {
+            SettingsCard(title = "약관 및 정책") {
+                SettingsRow(
+                    label = "서비스 이용약관",
+                    value = null,
+                    onClick = { context.openExternalUrl("https://alarm-talk.com/ko/terms") },
+                )
+                HorizontalDivider()
+                SettingsRow(
+                    label = "개인정보 처리방침",
+                    value = null,
+                    onClick = { context.openExternalUrl("https://alarm-talk.com/ko/privacy") },
                 )
             }
         }
@@ -769,6 +788,14 @@ private fun quietDaysLabel(days: List<Int>): String {
 }
 
 private fun dayLabels(): List<String> = listOf("일", "월", "화", "수", "목", "금", "토")
+
+private fun Context.openExternalUrl(url: String) {
+    runCatching {
+        startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+}
 
 private fun isHourText(value: String): Boolean =
     value.toIntOrNull()?.let { it in 0..23 } == true

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -129,6 +129,19 @@ app.get('/api/tts/presets', noStore, async (c) => {
   return c.json({ presets: await loadTtsPresets(c.env) });
 });
 
+// 앱 버전 정책 (인증 불필요) — 구버전 앱이 로그인 전에도 강제/권장 업데이트를 판단한다.
+app.get('/api/app/version', noStore, async (c) => {
+  const { appVersionPolicy } = await import('./lib/app-version');
+  const platform = c.req.query('platform') || c.req.header('X-App-Platform') || 'android';
+  const policy = appVersionPolicy(platform);
+  return c.json({
+    platform: (platform || 'android').toLowerCase(),
+    min_supported_version: policy.minSupported,
+    latest_version: policy.latest,
+    store_url: policy.storeUrl,
+  });
+});
+
 // 이메일+비밀번호 가입/로그인 (인증 미들웨어 미적용)
 app.route('/api/auth', authRoutes);
 

--- a/packages/backend/src/lib/app-version.ts
+++ b/packages/backend/src/lib/app-version.ts
@@ -1,0 +1,33 @@
+// 앱 버전 정책 — 구버전 앱과 신버전 BE/DB 가 공존하는 동안 클라이언트가 스스로
+// 강제/권장 업데이트를 판단할 수 있도록 최소·최신 지원 버전을 내려준다.
+//
+// 운영 방식:
+//  - minSupported: 이 버전 미만은 강제 업데이트(앱이 차단 화면 표시). 평소 1 로 두어
+//    아무도 막지 않다가, 필수 기능(예: 동의)을 강제해야 할 때만 올린다.
+//  - latest: 권장 업데이트 기준(앱이 비차단 배너 표시).
+//  versionCode(Android) / build number(iOS) 정수 기준.
+
+export interface AppVersionPolicy {
+  minSupported: number;
+  latest: number;
+  storeUrl: string;
+}
+
+const ANDROID: AppVersionPolicy = {
+  minSupported: 1,
+  latest: 6,
+  storeUrl: 'https://play.google.com/store/apps/details?id=com.alarmtalk.app',
+};
+
+const IOS: AppVersionPolicy = {
+  minSupported: 1,
+  latest: 1,
+  storeUrl: 'https://apps.apple.com/app/alarmtalk',
+};
+
+const POLICIES: Record<string, AppVersionPolicy> = { android: ANDROID, ios: IOS };
+
+export function appVersionPolicy(platform: string | undefined | null): AppVersionPolicy {
+  const key = (platform ?? '').trim().toLowerCase();
+  return POLICIES[key] ?? ANDROID;
+}

--- a/packages/backend/test/app-version.test.ts
+++ b/packages/backend/test/app-version.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { appVersionPolicy } from '../src/lib/app-version';
+
+describe('appVersionPolicy', () => {
+  it('android 정책 반환', () => {
+    const p = appVersionPolicy('android');
+    expect(p.minSupported).toBeGreaterThanOrEqual(1);
+    expect(p.latest).toBeGreaterThanOrEqual(p.minSupported);
+    expect(p.storeUrl).toContain('play.google.com');
+  });
+
+  it('ios 정책 반환', () => {
+    const p = appVersionPolicy('ios');
+    expect(p.storeUrl).toContain('apps.apple.com');
+  });
+
+  it('대소문자 무시', () => {
+    expect(appVersionPolicy('Android')).toEqual(appVersionPolicy('android'));
+  });
+
+  it('알 수 없는/빈 플랫폼은 android 로 폴백', () => {
+    expect(appVersionPolicy('windows')).toEqual(appVersionPolicy('android'));
+    expect(appVersionPolicy('')).toEqual(appVersionPolicy('android'));
+    expect(appVersionPolicy(undefined)).toEqual(appVersionPolicy('android'));
+    expect(appVersionPolicy(null)).toEqual(appVersionPolicy('android'));
+  });
+
+  it('minSupported 는 평소 1 이라 기존 사용자를 막지 않는다', () => {
+    expect(appVersionPolicy('android').minSupported).toBe(1);
+  });
+});


### PR DESCRIPTION
## 배경
AAB 올려도 사용자 버전이 제각각이라 구버전 앱 ↔ 신버전 BE/DB 공존. 버전 신호 + 강제 업데이트 수단이 필요. 또한 동의와 별개로 약관/처리방침을 앱 내에서 언제든 볼 수 있어야 함.

## 변경
### 버전 호환 / 강제 업데이트
- 클라이언트: OkHttp 인터셉터로 모든 요청에 `X-App-Version`(versionCode)·`X-App-Platform` 헤더 추가.
- 백엔드: 공개 `GET /api/app/version` — 플랫폼별 `min_supported_version`/`latest_version`/`store_url` 반환(`lib/app-version.ts`).
- 앱 시작 시 조회 → 설치 버전 < min 이면 로그인 전부터 `UpdateRequiredScreen` 으로 차단, 스토어로 유도.
- 기본 `minSupported=1` 이라 현재 차단되는 사용자 없음. 동의 같은 필수 기능을 강제할 때 값만 올리면 됨(dev 자동배포).

### 설정 약관/정책 링크
- 설정에 "약관 및 정책" 카드 추가 → 서비스 이용약관 / 개인정보 처리방침 웹 링크(`alarm-talk.com/ko/{terms,privacy}`). 로그인 여부 무관 노출.

## 검증
- 백엔드: `app-version` 정책 단위 테스트 추가, 전체 1333 테스트 통과, `tsc` 클린.
- Android: `assembleDevDebug` 빌드 성공, dev 단말 설치 확인.

## 하위호환 메모
- 응답은 가산적(Gson 무시) — 구버전 앱 안전.
- 헤더는 추가만 — 서버는 없어도 동작.
- 버전 엔드포인트 실패 시 차단 안 함(graceful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)