### PR TITLE
chore: 릴리스 versionCode 7 + 버전정책 latest 7

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -87,7 +87,7 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 6
+        versionCode = 7
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/backend/src/lib/app-version.ts
+++ b/packages/backend/src/lib/app-version.ts
@@ -15,7 +15,7 @@ export interface AppVersionPolicy {
 
 const ANDROID: AppVersionPolicy = {
   minSupported: 1,
-  latest: 6,
+  latest: 7,
   storeUrl: 'https://play.google.com/store/apps/details?id=com.alarmtalk.app',
 };
 


### PR DESCRIPTION
Play 업로드용 prod AAB(versionCode 7) 빌드에 맞춰 버전 bump. `app-version.ts` latest 7, `minSupported` 1 유지(강제 업데이트 0명).

🤖 Generated with [Claude Code](https://claude.com/claude-code)