### PR TITLE
fix(android): 런치/로그인 크래시 수정 (AuthUser.copy NPE 등)

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -87,8 +87,8 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
-        versionName = "0.1.0"
+        versionCode = 8
+        versionName = "0.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -87,8 +87,8 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 8
-        versionName = "0.1.1"
+        versionCode = 9
+        versionName = "0.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/VoiceAlarmApplication.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/VoiceAlarmApplication.kt
@@ -11,12 +11,20 @@ import io.sentry.android.core.SentryAndroid
 class VoiceAlarmApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        initializeSentry()
-        NotificationChannels.ensure(this)
-        RemoteAlarmSyncScheduler.ensurePeriodic(this)
-        if (AuthSessionStore(this).read() != null) {
-            RemoteAlarmSyncScheduler.runOnce(this)
-        }
+        // 각 초기화 단계의 실패가 앱 진입을 막지 않도록 개별 보호한다.
+        // (release 빌드에서 Sentry/WorkManager 등 초기화가 던지면 첫 화면 전에
+        //  프로세스가 즉시 종료되던 문제를 방지. 실패는 로그로만 남기고 계속 진행.)
+        runCatching { initializeSentry() }
+            .onFailure { Log.e(TAG, "Sentry init failed", it) }
+        runCatching { NotificationChannels.ensure(this) }
+            .onFailure { Log.e(TAG, "NotificationChannels init failed", it) }
+        runCatching { RemoteAlarmSyncScheduler.ensurePeriodic(this) }
+            .onFailure { Log.e(TAG, "RemoteAlarmSyncScheduler.ensurePeriodic failed", it) }
+        runCatching {
+            if (AuthSessionStore(this).read() != null) {
+                RemoteAlarmSyncScheduler.runOnce(this)
+            }
+        }.onFailure { Log.e(TAG, "RemoteAlarmSyncScheduler.runOnce failed", it) }
         Log.i(TAG, "Voice Alarm native application started")
     }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
@@ -189,7 +189,13 @@ class AuthSessionStore(context: Context) {
         )
         val firstQuietWindow = quietWindows.firstOrNull()
             ?: FamilyAlarmQuietWindow(days = legacyDays, start = legacyStart, end = legacyEnd)
+        // Gson 은 Kotlin 기본값을 무시하고 JSON 에 없는 필드를 null 로 남긴다. 백엔드
+        // 응답(특히 Google 로그인)이나 구버전이 저장한 세션에 일부 필드가 빠지면
+        // non-null 프로퍼티가 null 이 되고, copy() 생성자의 null 체크에서 NPE 가 난다.
+        // 누락 가능한 non-null 필드를 모두 null-안전하게 채워 넘긴다.
         return user.copy(
+            id = runCatching { user.id }.getOrNull().orEmpty(),
+            email = runCatching { user.email }.getOrNull().orEmpty(),
             name = runCatching { user.name }.getOrNull().orEmpty(),
             plan = runCatching { user.plan }.getOrNull()?.takeIf { it.isNotBlank() } ?: "free",
             familyAlarmQuietDays = firstQuietWindow.days,
@@ -199,6 +205,8 @@ class AuthSessionStore(context: Context) {
             dynamicPromptSettings = normalizeDynamicPromptSettings(
                 runCatching { user.dynamicPromptSettings }.getOrNull(),
             ),
+            deletionStatus = runCatching { user.deletionStatus }.getOrNull()
+                ?.takeIf { it.isNotBlank() } ?: "active",
         )
     }
 


### PR DESCRIPTION
## 증상
- Play(prod release) 빌드가 업데이트 설치 후 켜자마자 종료, 또는 Google 로그인 시 종료.

## 근본 원인 (Play vitals 스택으로 확정)
`AuthUser.copy()` 에서 `NullPointerException`:
`AuthSessionStore.normalizeUser → user.copy(...)`. 백엔드 Google 로그인 응답(및 구버전이
저장한 세션)에 `deletion_status` 가 없어 Gson 이 non-null 필드를 null 로 남기고,
copy() 생성자의 null 체크에서 NPE 발생.
- 업데이트 설치 시: 구버전 저장 세션 복원(refreshAppSession) 경로에서 런치 직후 종료
- 로그인 시: 새 Google 응답 저장 경로에서 종료

## 수정
- `normalizeUser` 의 copy 에 누락 가능한 non-null 필드(`deletionStatus`, 방어적으로
  `id`/`email`)를 null-안전하게 채워 넘김 → 모든 provider/버전 스큐에서 안전.
- (방어) `VoiceAlarmApplication.onCreate` 초기화(Sentry/알림채널/스케줄러)를 runCatching 으로 보호.
- versionCode 9 / versionName 0.1.2 (Play 재업로드용).

## 검증
- `:app:bundleProdRelease` (R8+서명) BUILD SUCCESSFUL → AAB(vc9) 생성.
- 원인 스택이 명확해 타깃 수정. 업로드 후 Play vitals 재확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)