### PR TITLE
fix(ios): CI 테스트 전체 green화 — 기존 실패 5건 해결(스킵 제거)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -130,25 +130,18 @@ jobs:
       - name: Run unit tests
         run: |
           set -o pipefail
-          # 아래 -skip-testing 목록은 이 PR 이전부터 실패하던(CI 처음 도입으로 드러난)
-          # 테스트들로, 본 변경과 무관하다. 별도로 추적/수정 예정이라 게이트에서 제외한다.
-          #  - AuthViewModelTests(refreshUser): CI 시뮬레이터에 코드서명/Keychain 엔타이틀먼트가
-          #    없어 KeychainStore.saveSession 이 errSecMissingEntitlement 로 실패(개발 시뮬레이터/
-          #    실기기에서는 통과).
-          #  - AlarmSoundResolverTests: 오디오 staging 이 실행 환경(파일/AVAsset)에 의존.
-          #  - LocalAlarmRecordCodableTests / TimeWheelPickerLogicTests: 기존부터 어긋난 단언.
+          # 시뮬레이터 ad-hoc 서명("-")으로 빌드해 앱에 Keychain / App Group 엔타이틀먼트가
+          # 부여되도록 한다. (CODE_SIGNING_ALLOWED=NO 면 엔타이틀먼트가 없어
+          # KeychainStore.saveSession / App Group 컨테이너 접근이 실패한다.)
           xcodebuild \
             -project VoiceAlarmNative.xcodeproj \
             -scheme VoiceAlarm \
             -configuration Debug \
             -destination "id=${{ steps.sim.outputs.udid }}" \
             -skipPackagePluginValidation \
-            -skip-testing:VoiceAlarmTests/AuthViewModelTests/test_refreshUser_setsPendingDeletion_whenStatusPending \
-            -skip-testing:VoiceAlarmTests/AuthViewModelTests/test_refreshUser_success_clearsLastNetworkError_andPreservesAppleUserId \
-            -skip-testing:VoiceAlarmTests/AlarmSoundResolverTests/test_resolve_voiceOnly_withCachedAudioWithinLimit_attemptsStagingOrFallsBack \
-            -skip-testing:VoiceAlarmTests/LocalAlarmRecordCodableTests/test_legacy17FieldJSONCompatibility \
-            -skip-testing:VoiceAlarmTests/TimeWheelPickerLogicTests/test_combine_outOfRangeDisplayIsClamped \
-            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=YES \
             test 2>&1 | tee xcodebuild-test.log
 
       - name: Upload test log

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -142,6 +142,7 @@ jobs:
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES \
+            GENERATE_INFOPLIST_FILE=YES \
             test 2>&1 | tee xcodebuild-test.log
 
       - name: Upload test log

--- a/apps/ios-native/VoiceAlarm/AlarmSoundStaging.swift
+++ b/apps/ios-native/VoiceAlarm/AlarmSoundStaging.swift
@@ -165,6 +165,12 @@ enum AlarmSoundStaging {
         guard let exporter = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
             throw AlarmSoundStagingError.writeFailed("AVAssetExportSession init failed.")
         }
+        // 손상/비오디오 입력에서는 .caf 가 지원되지 않아 outputFileType 설정 시
+        // ObjC 예외(NSInvalidArgumentException)가 던져진다. Swift `try?` 로 못 잡으므로
+        // 지원 여부를 먼저 확인해 미지원이면 graceful 하게 throw → 호출부가 in-app 폴백.
+        guard exporter.supportedFileTypes.contains(.caf) else {
+            throw AlarmSoundStagingError.writeFailed("Output type .caf unsupported for source.")
+        }
         exporter.outputFileType = .caf
         exporter.outputURL = dst
 

--- a/apps/ios-native/VoiceAlarmTests/LocalAlarmRecordCodableTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/LocalAlarmRecordCodableTests.swift
@@ -139,8 +139,10 @@ final class LocalAlarmRecordCodableTests: XCTestCase {
         XCTAssertEqual(decoded.origin, AlarmOrigin.localOwned.rawValue)
         // fireAtMillis 가 JSON 에 없으므로 fallback 으로 채워졌어야.
         XCTAssertGreaterThan(decoded.fireAtMillis, 0)
-        // updatedAt Date(700000000) → millis 700_000_000_000.
-        XCTAssertEqual(decoded.updatedAtMillis, 700_000_000_000)
+        // legacy "updatedAt" 는 Swift Date 기본 인코딩(.deferredToDate = 2001 기준 초)으로
+        // 저장됐다. JSONDecoder 기본 전략도 동일하게 timeIntervalSinceReferenceDate 로 읽으므로
+        // 700000000 초(2001 기준) → unix 1678307200 초 → 1678307200000 ms.
+        XCTAssertEqual(decoded.updatedAtMillis, 1_678_307_200_000)
     }
 
     func test_alarmKitID_decodesUUIDObjectFromLegacyJSON() throws {

--- a/apps/ios-native/VoiceAlarmTests/TimeWheelPickerLogicTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/TimeWheelPickerLogicTests.swift
@@ -60,8 +60,10 @@ final class TimeWheelPickerLogicTests: XCTestCase {
 
     func test_combine_outOfRangeDisplayIsClamped() {
         // 휠 wrap 이 실수로 0 이나 13 을 흘려보내도 안전한 값으로 클램프되어야 한다.
+        // combine 은 displayHour 를 1...12 로 clamp 한다: 0→1, 13→12.
+        // 13(PM) → clamp 12 → base 0 → +12 = 12(정오). (combine 구현과 일치.)
         XCTAssertEqual(TimeWheelMath.combine(displayHour: 0, isPM: false), 1)
-        XCTAssertEqual(TimeWheelMath.combine(displayHour: 13, isPM: true), 0)
+        XCTAssertEqual(TimeWheelMath.combine(displayHour: 13, isPM: true), 12)
     }
 
     // MARK: - Round trip


### PR DESCRIPTION
## 개요
직전 PR(#437)에서 iOS 테스트 CI를 처음 도입하며 드러난 **기존 실패 5건**을 모두 해결하고 `-skip-testing` 제외 목록을 전부 제거했습니다. 이제 전체 단위 테스트가 게이트됩니다.

## 원인별 해결
**테스트 기대값이 틀렸던 2건 (코드가 정상)**
- `TimeWheelMath.combine(13, PM)`: 13→clamp 12→정오 `12`가 정답. 기대 `0`→`12`.
- `LocalAlarmRecord` legacy `updatedAt`: Swift `Date` 기본(`.deferredToDate`, 2001 기준 초) 디코딩이라 `1678307200000` ms가 정답. 기대 `700000000000`→`1678307200000`.

**CI 환경 문제였던 2건 (앱 정상)**
- `AuthViewModelTests`(refreshUser): CI 시뮬레이터 미서명으로 Keychain 엔타이틀먼트가 없어 실패하던 것 → 테스트 job을 **ad-hoc 서명**(`CODE_SIGN_IDENTITY=-`)으로 빌드해 Keychain/App Group 엔타이틀먼트 부여. 테스트 타깃 서명용 `GENERATE_INFOPLIST_FILE=YES` 추가.

**실제 프로덕션 하드닝 1건**
- `AlarmSoundStaging`: 손상/비오디오 캐시에서 `exporter.outputFileType = .caf` 설정이 `NSInvalidArgumentException`(ObjC 예외)을 던져 `try?`로 못 잡고 크래시 → `supportedFileTypes`로 `.caf` 지원 여부를 먼저 확인해 미지원이면 graceful throw → 호출부가 in-app 캐시 재생으로 폴백. (실사용 시 손상 오디오 크래시 방지)

## 검증
- ✅ iOS Build (macOS)
- ✅ iOS Unit Tests — **스킵 0건, 전체 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)