### PR TITLE
ci(android): gradle 빌드 + 단위테스트 워크플로우 추가

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,51 @@
+name: Android Build
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - "feat/**"
+      - "fix/**"
+      - "ci/**"
+      - "refactor/**"
+  pull_request:
+    branches: [develop, main]
+  workflow_dispatch:
+
+concurrency:
+  group: android-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-build:
+    name: VoiceAlarm (Android devDebug)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/android-native
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assemble devDebug + run unit tests
+        run: ./gradlew :app:assembleDevDebug :app:testDevDebugUnitTest --stacktrace
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-unit-test-report
+          path: apps/android-native/app/build/reports/tests/testDevDebugUnitTest
+          retention-days: 7
+          if-no-files-found: warn

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/network/AuthSessionStoreTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/network/AuthSessionStoreTest.kt
@@ -27,10 +27,12 @@ class AuthSessionStoreTest {
             AuthUser::class.java,
         )
 
-        val normalized = user.copy(
-            dynamicPromptSettings = normalizeDynamicPromptSettings(user.dynamicPromptSettings),
+        // 백엔드가 dynamic_prompt_settings 를 null 로 보내도 기본값으로 정규화돼야 한다.
+        // (실제 user copy 는 AuthSessionStore.normalizeUser 가 deletionStatus 등 모든 누락
+        //  non-null 필드를 null-안전하게 채우므로, 여기서는 핵심인 정규화 결과만 검증한다.)
+        assertEquals(
+            DynamicPromptSettings(),
+            normalizeDynamicPromptSettings(user.dynamicPromptSettings),
         )
-
-        assertEquals(DynamicPromptSettings(), normalized.dynamicPromptSettings)
     }
 }


### PR DESCRIPTION
## 개요
Android(코틀린/Compose)는 그동안 빌드 CI가 없어 컴파일 검증 수단이 없었습니다. 이후 Android 리팩토링/정리를 안전하게 하기 위한 **검증 게이트**로 gradle 빌드 + 단위테스트 워크플로우를 추가합니다.

## 내용
- `.github/workflows/android-build.yml`: ubuntu + JDK17에서 `:app:assembleDevDebug` + `:app:testDevDebugUnitTest` 실행 (push develop/main/feat/fix/ci/refactor, PR develop/main)
- 첫 도입으로 드러난 **기존 실패 단위테스트 1건 수정**: `AuthSessionStoreTest` 가 production 의 `normalizeUser` 를 우회한 취약한 부분 copy 를 호출해, 나중에 추가된 non-null `deletionStatus` 가 Gson null 로 남아 NPE 가 났음. 실제 의도(백엔드 null → 기본값 정규화)만 직접 검증하도록 정정. **production 코드 변경 없음.**

## 검증
- ✅ Android Build (devDebug assemble + 40 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)