### PR TITLE
refactor(ios): 중복 헬퍼 통합 (timeLabel, quietDaysLabel)

### DIFF
--- a/apps/ios-native/VoiceAlarm/Views/Common/HelperFormatters.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Common/HelperFormatters.swift
@@ -17,6 +17,13 @@ enum HelperFormatters {
         weekdays.first { $0.value == value }?.label ?? ""
     }
 
+    /// 밀리초를 "분:초"(m:ss) 로 표기. 오디오 크롭/길이 표시에 공용으로 쓴다.
+    /// Android `audioTimeLabel` 대응. (여러 뷰에 흩어져 있던 동일 구현을 통합.)
+    static func audioTimeLabel(_ millis: Int) -> String {
+        let seconds = max(0, millis / 1000)
+        return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
     /// Android `stageEmoji` 와 같은 캐릭터 단계 이모지. nil/unknown 은 씨앗.
     static func characterStageEmoji(_ stage: String?) -> String {
         switch stage {
@@ -83,7 +90,8 @@ enum HelperFormatters {
     }
 
     /// 요일 묶음 라벨. 0=일 … 6=토. Android `quietDaysLabel` 와 동일한 스마트 그룹핑.
-    private static func quietDaysLabel(_ days: [Int]) -> String {
+    /// (에디터의 FamilyAlarmScheduleRules 와 공용으로 쓰도록 internal.)
+    static func quietDaysLabel(_ days: [Int]) -> String {
         let sorted = Array(Set(days)).sorted()
         switch sorted {
         case []: return "없음"

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorComponents.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorComponents.swift
@@ -82,10 +82,10 @@ struct LocalAlarmAudioEditor: View {
     private var durationLabel: String {
         switch mode {
         case .record:
-            return timeLabel(elapsedMs)
+            return HelperFormatters.audioTimeLabel(elapsedMs)
         case .file:
             guard let fileDurationMs else { return "0:00" }
-            return timeLabel(max(0, min(cropEndMs, fileDurationMs) - cropStartMs))
+            return HelperFormatters.audioTimeLabel(max(0, min(cropEndMs, fileDurationMs) - cropStartMs))
         }
     }
 
@@ -139,7 +139,7 @@ struct LocalAlarmAudioEditor: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(isRecording ? "녹음 중..." : (hasRecording ? "녹음을 저장했어요." : "녹음 또는 파일 업로드"))
                         .font(theme.typography.labelLarge)
-                    Text("\(durationLabel) / \(timeLabel(Int(AlarmAudioLimits.maxDurationMillis)))")
+                    Text("\(durationLabel) / \(HelperFormatters.audioTimeLabel(Int(AlarmAudioLimits.maxDurationMillis)))")
                         .font(theme.typography.bodySmall)
                         .foregroundStyle(theme.palette.onSurfaceVariant)
                         .monospacedDigit()
@@ -171,7 +171,7 @@ struct LocalAlarmAudioEditor: View {
                     Text(fileName ?? "파일 업로드")
                         .font(theme.typography.labelLarge)
                         .lineLimit(1)
-                    Text(fileDurationMs.map { "전체 \(timeLabel($0)) · 사용할 구간 \(durationLabel)" } ?? "최대 \(AlarmAudioLimits.maxDurationMillis / 1000)초")
+                    Text(fileDurationMs.map { "전체 \(HelperFormatters.audioTimeLabel($0)) · 사용할 구간 \(durationLabel)" } ?? "최대 \(AlarmAudioLimits.maxDurationMillis / 1000)초")
                         .font(theme.typography.bodySmall)
                         .foregroundStyle(theme.palette.onSurfaceVariant)
                 }
@@ -184,7 +184,7 @@ struct LocalAlarmAudioEditor: View {
 
             if let fileDurationMs, fileDurationMs > Int(AlarmAudioLimits.maxDurationMillis) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("자를 구간 \(timeLabel(cropStartMs)) - \(timeLabel(min(cropEndMs, fileDurationMs)))")
+                    Text("자를 구간 \(HelperFormatters.audioTimeLabel(cropStartMs)) - \(HelperFormatters.audioTimeLabel(min(cropEndMs, fileDurationMs)))")
                         .font(.caption.weight(.semibold))
                     Slider(
                         value: Binding(
@@ -212,7 +212,7 @@ struct LocalAlarmAudioEditor: View {
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
-    private func timeLabel(_ millis: Int) -> String {
+    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
         let seconds = max(0, millis / 1000)
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
     }
@@ -334,7 +334,7 @@ enum FamilyAlarmScheduleRules {
 
     static func quietScheduleLabel(_ member: FamilyGroupMember) -> String {
         quietWindows(member).map { window in
-            "\(quietDaysLabel(window.days)) \(window.start)-\(window.end)"
+            "\(HelperFormatters.quietDaysLabel(window.days)) \(window.start)-\(window.end)"
         }.joined(separator: " · ")
     }
 
@@ -442,22 +442,6 @@ enum FamilyAlarmScheduleRules {
         return trimmed.isEmpty ? fallback : trimmed
     }
 
-    private static func quietDaysLabel(_ days: [Int]) -> String {
-        let sorted = Array(Set(days)).sorted()
-        switch sorted {
-        case []:
-            return "없음"
-        case [1, 2, 3, 4, 5]:
-            return "평일"
-        case [0, 6]:
-            return "주말"
-        case [0, 1, 2, 3, 4, 5, 6]:
-            return "매일"
-        default:
-            let labels = ["일", "월", "화", "수", "목", "금", "토"]
-            return sorted.map { labels[max(0, min(6, $0))] }.joined(separator: ",")
-        }
-    }
 }
 
 struct EditorLanguageOption: Identifiable {

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorComponents.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorComponents.swift
@@ -212,10 +212,6 @@ struct LocalAlarmAudioEditor: View {
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
-    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
-        let seconds = max(0, millis / 1000)
-        return String(format: "%d:%02d", seconds / 60, seconds % 60)
-    }
 }
 
 struct FamilyAlarmTargetPicker: View {

--- a/apps/ios-native/VoiceAlarm/Views/Voices/SpeakerSeparationFlow.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/SpeakerSeparationFlow.swift
@@ -812,10 +812,6 @@ struct SpeakerSeparationFlow: View {
         localError = nil
     }
 
-    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
-        let seconds = max(0, millis / 1000)
-        return String(format: "%d:%02d", seconds / 60, seconds % 60)
-    }
 }
 
 #if DEBUG

--- a/apps/ios-native/VoiceAlarm/Views/Voices/SpeakerSeparationFlow.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/SpeakerSeparationFlow.swift
@@ -229,7 +229,7 @@ struct SpeakerSeparationFlow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(preparedSourceName)
                         .font(.subheadline.weight(.semibold))
-                    Text("전체 \(timeLabel(durationMs)) · 사용할 구간 \(timeLabel(effectiveDurationMs))")
+                    Text("전체 \(HelperFormatters.audioTimeLabel(durationMs)) · 사용할 구간 \(HelperFormatters.audioTimeLabel(effectiveDurationMs))")
                         .font(.caption)
                         .foregroundStyle(VoiceAlarmTheme.textSecondary)
                 }
@@ -247,7 +247,7 @@ struct SpeakerSeparationFlow: View {
 
             if durationMs > VoiceProfileLimits.maxDurationMs {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("자를 구간 \(timeLabel(cropStartMs)) - \(timeLabel(cropEndMs))")
+                    Text("자를 구간 \(HelperFormatters.audioTimeLabel(cropStartMs)) - \(HelperFormatters.audioTimeLabel(cropEndMs))")
                         .font(.caption.weight(.semibold))
                     Slider(
                         value: Binding(
@@ -266,7 +266,7 @@ struct SpeakerSeparationFlow: View {
 
             VoiceSegmentPreviewPlayer(
                 title: "선택 구간 미리듣기",
-                subtitle: "\(timeLabel(cropStartMs)) - \(timeLabel(effectiveEndMs))",
+                subtitle: "\(HelperFormatters.audioTimeLabel(cropStartMs)) - \(HelperFormatters.audioTimeLabel(effectiveEndMs))",
                 audioURL: url,
                 startMs: cropStartMs,
                 endMs: effectiveEndMs,
@@ -812,7 +812,7 @@ struct SpeakerSeparationFlow: View {
         localError = nil
     }
 
-    private func timeLabel(_ millis: Int) -> String {
+    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
         let seconds = max(0, millis / 1000)
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
     }

--- a/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
@@ -698,10 +698,6 @@ struct VoiceCloneUploadFlow: View {
         localError = nil
     }
 
-    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
-        let seconds = max(0, millis / 1000)
-        return String(format: "%d:%02d", seconds / 60, seconds % 60)
-    }
 
     private func startLevelAnimation() {
         levelTimer?.invalidate()

--- a/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Voices/VoiceCloneUploadFlow.swift
@@ -304,7 +304,7 @@ struct VoiceCloneUploadFlow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(selectedFileName ?? "선택한 파일")
                         .font(.subheadline.weight(.semibold))
-                    Text("전체 \(timeLabel(durationMs)) · 사용할 구간 \(timeLabel(effectiveDurationMs))")
+                    Text("전체 \(HelperFormatters.audioTimeLabel(durationMs)) · 사용할 구간 \(HelperFormatters.audioTimeLabel(effectiveDurationMs))")
                         .font(.caption)
                         .foregroundStyle(VoiceAlarmTheme.textSecondary)
                 }
@@ -320,7 +320,7 @@ struct VoiceCloneUploadFlow: View {
 
             if durationMs > VoiceProfileLimits.maxDurationMs {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("자를 구간 \(timeLabel(cropStartMs)) - \(timeLabel(effectiveEndMs))")
+                    Text("자를 구간 \(HelperFormatters.audioTimeLabel(cropStartMs)) - \(HelperFormatters.audioTimeLabel(effectiveEndMs))")
                         .font(.caption.weight(.semibold))
                     Slider(
                         value: Binding(
@@ -339,7 +339,7 @@ struct VoiceCloneUploadFlow: View {
 
             VoiceSegmentPreviewPlayer(
                 title: "선택 구간 미리듣기",
-                subtitle: "\(timeLabel(cropStartMs)) - \(timeLabel(effectiveEndMs))",
+                subtitle: "\(HelperFormatters.audioTimeLabel(cropStartMs)) - \(HelperFormatters.audioTimeLabel(effectiveEndMs))",
                 audioURL: url,
                 startMs: cropStartMs,
                 endMs: effectiveEndMs,
@@ -698,7 +698,7 @@ struct VoiceCloneUploadFlow: View {
         localError = nil
     }
 
-    private func timeLabel(_ millis: Int) -> String {
+    private func HelperFormatters.audioTimeLabel(_ millis: Int) -> String {
         let seconds = max(0, millis / 1000)
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
     }


### PR DESCRIPTION
공통으로 쓰이는데 복붙돼 있던 헬퍼를 단일 출처로 통합. 동작/디자인 변경 없음.

- `audioTimeLabel`(ms→m:ss): 3개 뷰(AlarmEditorComponents/SpeakerSeparationFlow/VoiceCloneUploadFlow)에 동일 구현 → `HelperFormatters.audioTimeLabel` 로 통합, 호출부 재지정
- `quietDaysLabel`(요일 묶음): HelperFormatters ↔ AlarmEditorComponents 중복 → HelperFormatters 의 것을 internal 로 공개해 에디터가 재사용

> 작은 nil-체크 헬퍼(`nonEmpty`/`clean`, 3줄)는 타입별 지역 헬퍼라 통합 시 결합도만 올라가 그대로 둠.

✅ iOS Build + Unit Tests 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)