### PR TITLE
refactor(ios): 의미 단위 중복 통합 + AlarmEditorSheet 분할

### DIFF
--- a/apps/ios-native/VoiceAlarm/AuthViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/AuthViewModel.swift
@@ -574,24 +574,4 @@ final class AuthViewModel: ObservableObject {
 //
 // `VoiceAlarmAPI.swift` 의 fileprivate `nilIfBlank` 와 동일 시맨틱을 내부 노출로
 // 재선언한다. 모듈 내 다른 파일이 import 없이 쓸 수 있도록 internal 가시성.
-private extension Optional where Wrapped == String {
-    var nilIfBlank: String? {
-        switch self {
-        case .some(let value):
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        case .none:
-            return nil
-        }
-    }
-}
 
-private extension String {
-    var containsKorean: Bool {
-        contains { character in
-            character.unicodeScalars.contains { scalar in
-                (0xAC00...0xD7A3).contains(Int(scalar.value))
-            }
-        }
-    }
-}

--- a/apps/ios-native/VoiceAlarm/AuthViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/AuthViewModel.swift
@@ -143,7 +143,7 @@ final class AuthViewModel: ObservableObject {
     }
 
     func handleAppleAuthorizationFailure(_ error: Error) {
-        statusMessage = Self.userFacingErrorMessage(error, fallback: "Apple 로그인에 실패했어요. 다시 시도해 주세요.")
+        statusMessage = userFacingErrorMessage(error, fallback: "Apple 로그인에 실패했어요. 다시 시도해 주세요.")
     }
 
     func loginWithApple(
@@ -179,7 +179,7 @@ final class AuthViewModel: ObservableObject {
             // 필수 약관 미동의면 동의 화면으로 게이팅.
             await checkConsentStatus()
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "Apple 로그인에 실패했어요. 다시 시도해 주세요.")
+            statusMessage = userFacingErrorMessage(error, fallback: "Apple 로그인에 실패했어요. 다시 시도해 주세요.")
         }
     }
 
@@ -195,7 +195,7 @@ final class AuthViewModel: ObservableObject {
             _ = try await VoiceAlarmAPI.shared.requestEmailVerification(email: email)
             statusMessage = "인증 코드를 보냈어요. 메일을 확인해 주세요."
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "인증 코드를 보내지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "인증 코드를 보내지 못했어요")
         }
     }
 
@@ -216,7 +216,7 @@ final class AuthViewModel: ObservableObject {
             statusMessage = "이메일 인증이 완료됐어요."
             return true
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "인증 코드가 맞지 않아요")
+            statusMessage = userFacingErrorMessage(error, fallback: "인증 코드가 맞지 않아요")
             return false
         }
     }
@@ -238,7 +238,7 @@ final class AuthViewModel: ObservableObject {
             // 필수 약관 미동의면 동의 화면으로 게이팅.
             await checkConsentStatus()
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "로그인에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "로그인에 실패했어요")
         }
     }
 
@@ -267,7 +267,7 @@ final class AuthViewModel: ObservableObject {
             // 신규 가입자는 필수 약관 동의가 필요 — 동의 화면으로 게이팅.
             await checkConsentStatus()
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "회원가입에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "회원가입에 실패했어요")
         }
     }
 
@@ -301,7 +301,7 @@ final class AuthViewModel: ObservableObject {
                     lastNetworkError = "이 계정으로는 접근할 수 없는 기능이 있어요."
                 } else {
                     // 5xx, 4xx 기타 오류는 세션을 유지하되 영어 서버 메시지를 그대로 노출하지 않는다.
-                    lastNetworkError = Self.userFacingErrorMessage(
+                    lastNetworkError = userFacingErrorMessage(
                         apiError,
                         fallback: "서버에 일시적으로 연결할 수 없어요."
                     )
@@ -393,7 +393,7 @@ final class AuthViewModel: ObservableObject {
             await refreshUser()
             statusMessage = "프로필을 저장했어요."
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "프로필을 저장하지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "프로필을 저장하지 못했어요")
         }
     }
 
@@ -442,7 +442,7 @@ final class AuthViewModel: ObservableObject {
             }
             signOut(message: "회원 탈퇴가 완료됐어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "회원 탈퇴에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "회원 탈퇴에 실패했어요")
         }
     }
 
@@ -466,7 +466,7 @@ final class AuthViewModel: ObservableObject {
             }
             signOut(message: "회원 탈퇴가 접수됐어요. 30일 안에 다시 로그인하면 취소할 수 있어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "회원 탈퇴 신청에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "회원 탈퇴 신청에 실패했어요")
         }
     }
 
@@ -486,7 +486,7 @@ final class AuthViewModel: ObservableObject {
             pendingDeletion = false
             statusMessage = "회원 탈퇴를 취소했어요. 계정이 복구됐어요."
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "탈퇴 취소에 실패했어요. 다시 시도해 주세요")
+            statusMessage = userFacingErrorMessage(error, fallback: "탈퇴 취소에 실패했어요. 다시 시도해 주세요")
         }
     }
 
@@ -528,7 +528,7 @@ final class AuthViewModel: ObservableObject {
             needsConsent = false
             statusMessage = "동의가 완료됐어요"
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "동의 기록에 실패했어요. 다시 시도해 주세요")
+            statusMessage = userFacingErrorMessage(error, fallback: "동의 기록에 실패했어요. 다시 시도해 주세요")
         }
     }
 
@@ -547,18 +547,6 @@ final class AuthViewModel: ObservableObject {
         return value.isEmpty ? nil : value
     }
 
-    static func userFacingErrorMessage(_ error: Error, fallback: String) -> String {
-        guard let apiError = error as? APIError else {
-            let message = error.localizedDescription
-            return message.containsKorean ? message : fallback
-        }
-        switch apiError {
-        case .invalidResponse:
-            return fallback
-        case .server(_, let message, _):
-            return message.containsKorean ? message : fallback
-        }
-    }
 
     // MARK: - Testing support
     //

--- a/apps/ios-native/VoiceAlarm/DynamicVoiceRefreshService.swift
+++ b/apps/ios-native/VoiceAlarm/DynamicVoiceRefreshService.swift
@@ -63,11 +63,11 @@ final class DynamicVoiceRefreshService {
                         randomContext: alarm.voiceRandomContext ?? RandomPromptContext.defaultContext.rawValue,
                         alarmHour: alarm.hour,
                         alarmMinute: alarm.minute,
-                        weatherCountry: Self.nonEmpty(alarm.voiceWeatherCountry),
-                        weatherCity: Self.nonEmpty(alarm.voiceWeatherCity),
-                        fortuneGender: Self.nonEmpty(alarm.voiceFortuneGender),
-                        fortuneBirthDate: Self.nonEmpty(alarm.voiceFortuneBirthDate),
-                        fortuneBirthTime: Self.nonEmpty(alarm.voiceFortuneBirthTime)
+                        weatherCountry: (alarm.voiceWeatherCountry).nilIfBlank,
+                        weatherCity: (alarm.voiceWeatherCity).nilIfBlank,
+                        fortuneGender: (alarm.voiceFortuneGender).nilIfBlank,
+                        fortuneBirthDate: (alarm.voiceFortuneBirthDate).nilIfBlank,
+                        fortuneBirthTime: (alarm.voiceFortuneBirthTime).nilIfBlank
                     ),
                     token: token
                 )
@@ -145,8 +145,4 @@ final class DynamicVoiceRefreshService {
         }
     }
 
-    private static func nonEmpty(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
 }

--- a/apps/ios-native/VoiceAlarm/RemoteAlarmSyncViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/RemoteAlarmSyncViewModel.swift
@@ -73,7 +73,7 @@ final class RemoteAlarmSyncViewModel: ObservableObject {
             voiceProfiles = try await profilesTask
             statusMessage = "서버 동기화 완료"
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "알람 정보를 불러오지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "알람 정보를 불러오지 못했어요")
         }
     }
 
@@ -107,7 +107,7 @@ final class RemoteAlarmSyncViewModel: ObservableObject {
             await refresh(session: session, force: true)
         } catch {
             store.markSyncFailed(id: record.id)
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "알람 변경사항을 저장하지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "알람 변경사항을 저장하지 못했어요")
         }
     }
 
@@ -123,7 +123,7 @@ final class RemoteAlarmSyncViewModel: ObservableObject {
             try await pull.runOnce()
             statusMessage = "전체 동기화 완료"
         } catch {
-            statusMessage = Self.userFacingErrorMessage(
+            statusMessage = userFacingErrorMessage(
                 error,
                 fallback: "알람 정보를 불러오거나 변경사항을 저장하지 못했어요"
             )
@@ -137,21 +137,9 @@ final class RemoteAlarmSyncViewModel: ObservableObject {
             try await api.deleteAlarm(id: remoteID, token: token)
             await refresh(session: session)
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "알람 삭제에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "알람 삭제에 실패했어요")
         }
     }
 
-    static func userFacingErrorMessage(_ error: Error, fallback: String) -> String {
-        guard let apiError = error as? APIError else {
-            let message = error.localizedDescription
-            return message.containsKorean ? message : fallback
-        }
-        switch apiError {
-        case .invalidResponse:
-            return fallback
-        case .server(_, let message, _):
-            return message.containsKorean ? message : fallback
-        }
-    }
 }
 

--- a/apps/ios-native/VoiceAlarm/RemoteAlarmSyncViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/RemoteAlarmSyncViewModel.swift
@@ -155,12 +155,3 @@ final class RemoteAlarmSyncViewModel: ObservableObject {
     }
 }
 
-private extension String {
-    var containsKorean: Bool {
-        contains { character in
-            character.unicodeScalars.contains { scalar in
-                (0xAC00...0xD7A3).contains(Int(scalar.value))
-            }
-        }
-    }
-}

--- a/apps/ios-native/VoiceAlarm/Services/IAP/SubscriptionManager.swift
+++ b/apps/ios-native/VoiceAlarm/Services/IAP/SubscriptionManager.swift
@@ -277,12 +277,3 @@ enum PurchaseResult: Equatable {
     }
 }
 
-private extension String {
-    var containsKorean: Bool {
-        contains { character in
-            character.unicodeScalars.contains { scalar in
-                (0xAC00...0xD7A3).contains(Int(scalar.value))
-            }
-        }
-    }
-}

--- a/apps/ios-native/VoiceAlarm/SocialFeatureViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/SocialFeatureViewModel.swift
@@ -834,12 +834,3 @@ final class SocialFeatureViewModel: ObservableObject {
     }
 }
 
-private extension String {
-    var containsKorean: Bool {
-        contains { character in
-            character.unicodeScalars.contains { scalar in
-                (0xAC00...0xD7A3).contains(Int(scalar.value))
-            }
-        }
-    }
-}

--- a/apps/ios-native/VoiceAlarm/SocialFeatureViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/SocialFeatureViewModel.swift
@@ -298,7 +298,7 @@ final class SocialFeatureViewModel: ObservableObject {
             await refreshAllAfterMutation(session: session, successMessage: "코드를 등록했어요.")
             return Self.codeRegistrationDestination(responseType: response.type, code: code)
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "코드 등록에 실패했어요.")
+            statusMessage = userFacingErrorMessage(error, fallback: "코드 등록에 실패했어요.")
             return nil
         }
     }
@@ -327,7 +327,7 @@ final class SocialFeatureViewModel: ObservableObject {
             noteText = ""
             await refreshAllAfterMutation(session: session, successMessage: "메시지를 보냈어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "메시지 전송에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "메시지 전송에 실패했어요")
         }
     }
 
@@ -379,7 +379,7 @@ final class SocialFeatureViewModel: ObservableObject {
             if isMissingNoteAudio(error) {
                 unavailableAudioNoteIDs.insert(note.id)
             }
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "음성 메시지를 재생하지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "음성 메시지를 재생하지 못했어요")
         }
     }
 
@@ -581,18 +581,6 @@ final class SocialFeatureViewModel: ObservableObject {
         }
     }
 
-    static func userFacingErrorMessage(_ error: Error, fallback: String) -> String {
-        guard let apiError = error as? APIError else {
-            let message = error.localizedDescription
-            return message.containsKorean ? message : fallback
-        }
-        switch apiError {
-        case .invalidResponse:
-            return fallback
-        case .server(_, let message, _):
-            return message.containsKorean ? message : fallback
-        }
-    }
 
     static func scopedRefreshErrorMessage(label: String, error: Error, fallback: String) -> String {
         "\(label): \(userFacingErrorMessage(error, fallback: fallback))"
@@ -649,7 +637,7 @@ final class SocialFeatureViewModel: ObservableObject {
                 successMessage: "이용권에서 나갔어요. 무료 이용권으로 전환됐어요."
             )
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "이용권에서 나가지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "이용권에서 나가지 못했어요")
         }
     }
 
@@ -667,7 +655,7 @@ final class SocialFeatureViewModel: ObservableObject {
             _ = try await api.removeFamilyMember(groupId: groupId, userId: userId, token: token)
             await refreshAllAfterMutation(session: session, successMessage: "멤버를 내보냈어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "멤버를 내보내지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "멤버를 내보내지 못했어요")
         }
     }
 
@@ -685,7 +673,7 @@ final class SocialFeatureViewModel: ObservableObject {
             _ = try await api.transferFamilyOwnership(groupId: groupId, newOwnerId: newOwnerId, token: token)
             await refreshAllAfterMutation(session: session, successMessage: "소유권을 이양했어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "소유권을 이양하지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "소유권을 이양하지 못했어요")
         }
     }
 
@@ -752,7 +740,7 @@ final class SocialFeatureViewModel: ObservableObject {
             )
             await refreshAllAfterMutation(session: session, successMessage: "음성 메시지를 보냈어요.")
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "음성 메시지 전송에 실패했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "음성 메시지 전송에 실패했어요")
         }
     }
 
@@ -829,7 +817,7 @@ final class SocialFeatureViewModel: ObservableObject {
             )
             statusMessage = "캐릭터 경험치를 반영했어요."
         } catch {
-            statusMessage = Self.userFacingErrorMessage(error, fallback: "성장 기록을 반영하지 못했어요")
+            statusMessage = userFacingErrorMessage(error, fallback: "성장 기록을 반영하지 못했어요")
         }
     }
 }

--- a/apps/ios-native/VoiceAlarm/StringExtensions.swift
+++ b/apps/ios-native/VoiceAlarm/StringExtensions.swift
@@ -4,6 +4,12 @@ import Foundation
 // (containsKorean ×5, nilIfBlank ×2 중복 제거)
 
 extension String {
+    /// 공백 trim 후 빈 문자열이면 nil. (nonEmpty/clean 등으로 흩어져 있던 동일 로직 통합.)
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// 한글(가-힣) 음절이 하나라도 포함되는지.
     var containsKorean: Bool {
         contains { character in

--- a/apps/ios-native/VoiceAlarm/StringExtensions.swift
+++ b/apps/ios-native/VoiceAlarm/StringExtensions.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// 여러 ViewModel/뷰에 복붙돼 있던 String 헬퍼를 단일 출처로 통합한다.
+// (containsKorean ×5, nilIfBlank ×2 중복 제거)
+
+extension String {
+    /// 한글(가-힣) 음절이 하나라도 포함되는지.
+    var containsKorean: Bool {
+        contains { character in
+            character.unicodeScalars.contains { scalar in
+                (0xAC00...0xD7A3).contains(Int(scalar.value))
+            }
+        }
+    }
+}
+
+extension Optional where Wrapped == String {
+    /// 공백 trim 후 빈 문자열이면 nil.
+    var nilIfBlank: String? {
+        switch self {
+        case .some(let value):
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case .none:
+            return nil
+        }
+    }
+}

--- a/apps/ios-native/VoiceAlarm/UserFacingError.swift
+++ b/apps/ios-native/VoiceAlarm/UserFacingError.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// API/네트워크 에러를 사용자에게 보여줄 한국어 메시지로 변환한다.
+/// 서버 메시지에 한국어가 있으면 그대로, 없으면 `fallback` 을 쓴다.
+///
+/// AuthViewModel / RemoteAlarmSyncViewModel / SocialFeatureViewModel 에 동일하게
+/// 복붙돼 있던 구현을 단일 출처로 통합한 것.
+func userFacingErrorMessage(_ error: Error, fallback: String) -> String {
+    guard let apiError = error as? APIError else {
+        let message = error.localizedDescription
+        return message.containsKorean ? message : fallback
+    }
+    switch apiError {
+    case .invalidResponse:
+        return fallback
+    case .server(_, let message, _):
+        return message.containsKorean ? message : fallback
+    }
+}

--- a/apps/ios-native/VoiceAlarm/Views/Alarms/AlarmsListView.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Alarms/AlarmsListView.swift
@@ -158,7 +158,7 @@ struct AlarmsListView: View {
                 actionMessage = alarmKit.statusMessage ?? "알람 복사에 실패했어요."
             }
         } catch {
-            actionMessage = RemoteAlarmSyncViewModel.userFacingErrorMessage(
+            actionMessage = userFacingErrorMessage(
                 error,
                 fallback: "알람 복사에 실패했어요."
             )

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditDraft.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditDraft.swift
@@ -187,10 +187,10 @@ struct AlarmEditDraft: Equatable {
         guard let record,
               record.playModeEnum != .alarmOnly,
               record.voiceSourceEnum != .localAudio,
-              nonEmpty(record.localAudioUri) != nil,
-              nonEmpty(record.audioCacheKey) != nil,
-              let selectedProfileID = nonEmpty(selectedProfileID),
-              selectedProfileID == nonEmpty(record.voiceProfileId) else {
+              (record.localAudioUri).nilIfBlank != nil,
+              (record.audioCacheKey).nilIfBlank != nil,
+              let selectedProfileID = (selectedProfileID).nilIfBlank,
+              selectedProfileID == (record.voiceProfileId).nilIfBlank else {
             return false
         }
 
@@ -199,8 +199,8 @@ struct AlarmEditDraft: Equatable {
         let activeLanguage = (randomPrompt || translateText)
             ? language.trimmingCharacters(in: .whitespacesAndNewlines)
             : "ko"
-        guard activeCategory == (nonEmpty(record.voiceCategory) ?? "custom"),
-              activeLanguage == (nonEmpty(record.voiceLanguage) ?? "ko") else {
+        guard activeCategory == ((record.voiceCategory).nilIfBlank ?? "custom"),
+              activeLanguage == ((record.voiceLanguage).nilIfBlank ?? "ko") else {
             return false
         }
 
@@ -212,7 +212,7 @@ struct AlarmEditDraft: Equatable {
         let expectedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !expectedText.isEmpty else { return false }
         return !record.voiceRandomPrompt &&
-            expectedText == nonEmpty(record.voiceText)
+            expectedText == (record.voiceText).nilIfBlank
     }
 
     // MARK: - Convert to record
@@ -256,11 +256,11 @@ struct AlarmEditDraft: Equatable {
             voiceLanguage: alarmOnly ? nil : existing?.voiceLanguage,
             voiceRandomPrompt: !alarmOnly && voiceRandomPrompt,
             voiceRandomContext: !alarmOnly && voiceRandomPrompt ? promptContext.rawValue : nil,
-            voiceWeatherCountry: storesWeather ? nonEmpty(voiceWeatherCountry) : nil,
-            voiceWeatherCity: storesWeather ? nonEmpty(voiceWeatherCity) : nil,
-            voiceFortuneGender: storesFortune ? nonEmpty(voiceFortuneGender) : nil,
-            voiceFortuneBirthDate: storesFortune ? nonEmpty(voiceFortuneBirthDate) : nil,
-            voiceFortuneBirthTime: storesFortune ? nonEmpty(voiceFortuneBirthTime) : nil,
+            voiceWeatherCountry: storesWeather ? (voiceWeatherCountry).nilIfBlank : nil,
+            voiceWeatherCity: storesWeather ? (voiceWeatherCity).nilIfBlank : nil,
+            voiceFortuneGender: storesFortune ? (voiceFortuneGender).nilIfBlank : nil,
+            voiceFortuneBirthDate: storesFortune ? (voiceFortuneBirthDate).nilIfBlank : nil,
+            voiceFortuneBirthTime: storesFortune ? (voiceFortuneBirthTime).nilIfBlank : nil,
             dynamicVoicePreparedForFireAtMillis: !alarmOnly && voiceRandomPrompt
                 ? existing?.dynamicVoicePreparedForFireAtMillis
                 : nil,
@@ -289,7 +289,3 @@ struct AlarmEditDraft: Equatable {
     }
 }
 
-private func nonEmpty(_ value: String?) -> String? {
-    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    return trimmed.isEmpty ? nil : trimmed
-}

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet+AlarmModeSection.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet+AlarmModeSection.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+// AlarmEditorSheet 의 '알람 방식' 섹션 분리(파일 길이 축소). 동작/디자인 불변.
+extension AlarmEditorSheet {
+    var alarmModeSection: some View {
+            Section("알람 방식") {
+                VoicePlayModePicker(
+                    mode: $draft.playMode,
+                    voiceLocked: voicePlanLocked,
+                    onLockedVoiceClick: showVoicePlanLockedAlert
+                )
+                    .onChange(of: draft.playMode) { _, newMode in
+                        voiceStudio.preparedAlarm = nil
+                        if newMode == .alarmOnly {
+                            draft.voiceRepeat = true
+                            draft.voiceVolumePercent = 100
+                        } else {
+                            selectDefaultVoiceProfileIfNeeded()
+                        }
+                    }
+                    .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+
+                if draft.playMode != .alarmOnly {
+                    Picker("음성 소스", selection: $voiceSourceMode) {
+                        Text("목소리").tag(VoiceSource.ttsProfile)
+                        Text("녹음/파일").tag(VoiceSource.localAudio)
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: voiceSourceMode) { _, newValue in
+                        voiceStudio.preparedAlarm = nil
+                        localPreviewPlayer.stop()
+                        if newValue == .ttsProfile {
+                            localRecorder.stop()
+                        }
+                    }
+
+                    if voiceSourceMode == .ttsProfile {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("목소리")
+                                .font(theme.typography.titleSmall)
+                            AlarmVoiceProfilePicker(
+                                ownProfiles: voiceStudio.profiles,
+                                familyVoices: voiceStudio.familyVoices,
+                                selectedProfileID: voiceStudio.selectedProfileID,
+                                onSelectOwn: { profile in
+                                    voiceStudio.selectedProfileID = profile.id
+                                    voiceStudio.preparedAlarm = nil
+                                },
+                                onSelectShared: { profile in
+                                    if profile.requiresViewerInfo {
+                                        sharedVoiceSetupTarget = profile
+                                    } else {
+                                        voiceStudio.selectedProfileID = profile.id
+                                        voiceStudio.preparedAlarm = nil
+                                    }
+                                }
+                            )
+                            Text(preparedVoiceLabel)
+                                .font(theme.typography.bodySmall)
+                                .foregroundStyle(theme.palette.onSurfaceVariant)
+                            Button {
+                                onJumpToVoices()
+                            } label: {
+                                Label("음성 탭에서 만들기", systemImage: "waveform")
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Toggle("랜덤 문구 사용", isOn: Binding(
+                            get: { voiceStudio.randomPrompt },
+                            set: { enabled in
+                                voiceStudio.randomPrompt = enabled
+                                voiceStudio.preparedAlarm = nil
+                                if !enabled && !voiceStudio.translateText {
+                                    voiceStudio.ttsLanguage = "ko"
+                                }
+                            }
+                        ))
+                            .tint(theme.palette.primary)
+                        if voiceStudio.randomPrompt {
+                            Picker("랜덤 컨텍스트", selection: $voiceStudio.randomContext) {
+                                ForEach(RandomPromptContext.alarmEditorCases, id: \.rawValue) { context in
+                                    Text(context.label).tag(context.rawValue)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .onChange(of: voiceStudio.randomContext) { _, _ in
+                                voiceStudio.preparedAlarm = nil
+                            }
+                            Picker("언어", selection: $voiceStudio.ttsLanguage) {
+                                ForEach(ttsLanguages, id: \.code) { option in
+                                    Text(option.label).tag(option.code)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .onChange(of: voiceStudio.ttsLanguage) { _, _ in
+                                voiceStudio.preparedAlarm = nil
+                            }
+                            Text("선택한 상황에 맞춰 깨움말을 자동으로 만들어요.")
+                                .font(theme.typography.bodySmall)
+                                .foregroundStyle(theme.palette.onSurfaceVariant)
+                            if activePromptContext.usesWeather {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("날씨 지역")
+                                        .font(theme.typography.titleSmall)
+                                    WeatherLocationInputFields(
+                                        country: $voiceStudio.weatherCountry,
+                                        city: $voiceStudio.weatherCity,
+                                        helperText: "날씨가 들어간 깨움말에 사용할 지역이에요."
+                                    )
+                                    if !voiceStudio.hasWeatherInfo || targetWeatherReady {
+                                        Text(targetWeatherReady ? "상대가 저장한 날씨 지역을 사용해요." : "날씨가 들어간 문구를 쓰려면 지역을 입력해 주세요.")
+                                            .font(theme.typography.bodySmall)
+                                            .foregroundStyle(theme.palette.onSurfaceVariant)
+                                    }
+                                }
+                                .padding(.top, 4)
+                            }
+                            if activePromptContext.usesFortune {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text("운세 정보")
+                                        .font(theme.typography.titleSmall)
+                                    FortunePromptInputFields(
+                                        gender: $voiceStudio.fortuneGender,
+                                        birthDate: $voiceStudio.fortuneBirthDate,
+                                        birthTime: $voiceStudio.fortuneBirthTime,
+                                        helperText: "운세가 들어간 깨움말을 만들 때만 사용해요."
+                                    )
+                                    if !voiceStudio.hasFortuneInfo || targetFortuneReady {
+                                        Text(targetFortuneReady ? "상대가 저장한 운세 정보를 사용해요." : "운세가 들어간 문구를 쓰려면 성별, 생년월일, 태어난 시간이 필요해요.")
+                                            .font(theme.typography.bodySmall)
+                                            .foregroundStyle(theme.palette.onSurfaceVariant)
+                                    }
+                                }
+                                .padding(.top, 4)
+                            }
+                        } else {
+                            ManualVoiceMessageEditor(
+                                text: $voiceStudio.ttsText,
+                                translationEnabled: $voiceStudio.translateText,
+                                language: $voiceStudio.ttsLanguage,
+                                onInvalidatePreparedAudio: { voiceStudio.preparedAlarm = nil }
+                            )
+                        }
+                    } else {
+                        LocalAlarmAudioEditor(
+                            mode: $localAudioMode,
+                            isRecording: localRecorder.isRecording,
+                            elapsedMs: Int(localRecorder.elapsedSeconds * 1000),
+                            hasRecording: localRecorder.latestRecordingURL != nil,
+                            existingAudioLabel: existingLocalAudioLabel,
+                            fileName: selectedLocalAudioName,
+                            fileDurationMs: selectedLocalAudioDurationMs,
+                            cropStartMs: $localAudioCropStartMs,
+                            cropEndMs: $localAudioCropEndMs,
+                            isPreviewing: localPreviewPlayer.isPlaying,
+                            message: localAudioMessage,
+                            onModeChange: handleLocalAudioModeChange,
+                            onRecord: toggleLocalRecording,
+                            onPickFile: { localAudioFileImporterPresented = true },
+                            onPreview: previewLocalAlarmAudio,
+                            onClear: clearLocalAlarmAudio
+                        )
+                    }
+
+                    if draft.playMode == .voiceOnly {
+                        VoiceRepeatEditor(isRepeating: $draft.voiceRepeat)
+                    }
+                    VoiceVolumeEditor(volumePercent: $draft.voiceVolumePercent)
+                }
+            }
+    }
+}

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
@@ -554,11 +554,11 @@ struct AlarmEditorSheet: View {
         let context = RandomPromptContext.normalized(voiceStudio.randomContext)
         record.voiceRandomPrompt = enabled
         record.voiceRandomContext = enabled ? context.rawValue : nil
-        record.voiceWeatherCountry = enabled && context.usesWeather ? nonEmpty(voiceStudio.weatherCountry) : nil
-        record.voiceWeatherCity = enabled && context.usesWeather ? nonEmpty(voiceStudio.weatherCity) : nil
-        record.voiceFortuneGender = enabled && context.usesFortune ? nonEmpty(voiceStudio.fortuneGender) : nil
-        record.voiceFortuneBirthDate = enabled && context.usesFortune ? nonEmpty(voiceStudio.fortuneBirthDate) : nil
-        record.voiceFortuneBirthTime = enabled && context.usesFortune ? nonEmpty(voiceStudio.fortuneBirthTime) : nil
+        record.voiceWeatherCountry = enabled && context.usesWeather ? (voiceStudio.weatherCountry).nilIfBlank : nil
+        record.voiceWeatherCity = enabled && context.usesWeather ? (voiceStudio.weatherCity).nilIfBlank : nil
+        record.voiceFortuneGender = enabled && context.usesFortune ? (voiceStudio.fortuneGender).nilIfBlank : nil
+        record.voiceFortuneBirthDate = enabled && context.usesFortune ? (voiceStudio.fortuneBirthDate).nilIfBlank : nil
+        record.voiceFortuneBirthTime = enabled && context.usesFortune ? (voiceStudio.fortuneBirthTime).nilIfBlank : nil
     }
 
     private func showVoicePlanLockedAlert() {
@@ -866,7 +866,7 @@ struct AlarmEditorSheet: View {
                     recipientUserId: recipient.userId,
                     wakeAt: String(format: "%02d:%02d", draft.hour, draft.minute),
                     voiceUploadId: upload.id,
-                    label: nonEmpty(draft.label) ?? "가족이 보낸 음성",
+                    label: (draft.label).nilIfBlank ?? "가족이 보낸 음성",
                     dubTargetLanguage: nil,
                     repeatDays: RemoteAlarmMapper.repeatDays(fromMask: draft.repeatDaysMask)
                 )
@@ -1091,10 +1091,6 @@ struct AlarmEditorSheet: View {
         return Int((seconds * 1000).rounded())
     }
 
-    private func nonEmpty(_ value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
 
     private func localAudioUploadDisplayName(for url: URL) -> String {
         switch localAudioMode {

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
@@ -14,19 +14,19 @@ import UniformTypeIdentifiers
 /// 등) 는 `AlarmEditDraft.toRecord(...)` 가 기존 record 의 값을 보존하며 다시
 /// 합쳐 돌려준다.
 struct AlarmEditorSheet: View {
-    @EnvironmentObject private var auth: AuthViewModel
-    @EnvironmentObject private var store: LocalAlarmStore
-    @EnvironmentObject private var alarmKit: AlarmKitViewModel
-    @EnvironmentObject private var remoteSync: RemoteAlarmSyncViewModel
-    @EnvironmentObject private var voiceStudio: VoiceStudioViewModel
-    @EnvironmentObject private var socialFeatures: SocialFeatureViewModel
-    @EnvironmentObject private var subscriptions: SubscriptionManager
+    @EnvironmentObject var auth: AuthViewModel
+    @EnvironmentObject var store: LocalAlarmStore
+    @EnvironmentObject var alarmKit: AlarmKitViewModel
+    @EnvironmentObject var remoteSync: RemoteAlarmSyncViewModel
+    @EnvironmentObject var voiceStudio: VoiceStudioViewModel
+    @EnvironmentObject var socialFeatures: SocialFeatureViewModel
+    @EnvironmentObject var subscriptions: SubscriptionManager
 
-    @StateObject private var holidayStore = HolidayStore()
-    @StateObject private var localRecorder = VoiceRecorder()
-    @StateObject private var localPreviewPlayer = AudioPreviewPlayer()
+    @StateObject var holidayStore = HolidayStore()
+    @StateObject var localRecorder = VoiceRecorder()
+    @StateObject var localPreviewPlayer = AudioPreviewPlayer()
 
-    @Environment(\.voiceAlarmTheme) private var theme
+    @Environment(\.voiceAlarmTheme) var theme
 
     /// 부모(MainTabsView)가 넘기는 target — 새 알람 vs 기존 알람 수정 구분.
     let target: AlarmEditorTarget
@@ -39,26 +39,26 @@ struct AlarmEditorSheet: View {
 
     // MARK: - Form state
 
-    @State private var draft: AlarmEditDraft = .newDefault()
-    @State private var didLoadInitial = false
-    @State private var validationAlert: ValidationAlertContent?
-    @State private var isWorking = false
-    @State private var sharedVoiceSetupTarget: FamilyVoiceProfile?
-    @State private var selectedFamilyRecipientID: String?
-    @State private var voiceSourceMode: VoiceSource = .ttsProfile
-    @State private var localAudioMode: AlarmLocalAudioInputMode = .record
-    @State private var localAudioMessage: String?
-    @State private var localAudioFileImporterPresented = false
-    @State private var selectedLocalAudioURL: URL?
-    @State private var selectedLocalAudioName: String?
-    @State private var selectedLocalAudioDurationMs: Int?
-    @State private var localAudioCropStartMs = 0
-    @State private var localAudioCropEndMs = Int(AlarmAudioLimits.maxDurationMillis)
-    @State private var clearExistingLocalAudio = false
+    @State var draft: AlarmEditDraft = .newDefault()
+    @State var didLoadInitial = false
+    @State var validationAlert: ValidationAlertContent?
+    @State var isWorking = false
+    @State var sharedVoiceSetupTarget: FamilyVoiceProfile?
+    @State var selectedFamilyRecipientID: String?
+    @State var voiceSourceMode: VoiceSource = .ttsProfile
+    @State var localAudioMode: AlarmLocalAudioInputMode = .record
+    @State var localAudioMessage: String?
+    @State var localAudioFileImporterPresented = false
+    @State var selectedLocalAudioURL: URL?
+    @State var selectedLocalAudioName: String?
+    @State var selectedLocalAudioDurationMs: Int?
+    @State var localAudioCropStartMs = 0
+    @State var localAudioCropEndMs = Int(AlarmAudioLimits.maxDurationMillis)
+    @State var clearExistingLocalAudio = false
 
-    private static let familyAlarmMinLeadMillis: Int64 = 30 * 60 * 1000
+    static let familyAlarmMinLeadMillis: Int64 = 30 * 60 * 1000
 
-    private struct ValidationAlertContent: Identifiable {
+    struct ValidationAlertContent: Identifiable {
         let id = UUID()
         let title: String
         let message: String
@@ -102,172 +102,7 @@ struct AlarmEditorSheet: View {
                 }
             }
 
-            Section("알람 방식") {
-                VoicePlayModePicker(
-                    mode: $draft.playMode,
-                    voiceLocked: voicePlanLocked,
-                    onLockedVoiceClick: showVoicePlanLockedAlert
-                )
-                    .onChange(of: draft.playMode) { _, newMode in
-                        voiceStudio.preparedAlarm = nil
-                        if newMode == .alarmOnly {
-                            draft.voiceRepeat = true
-                            draft.voiceVolumePercent = 100
-                        } else {
-                            selectDefaultVoiceProfileIfNeeded()
-                        }
-                    }
-                    .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
-
-                if draft.playMode != .alarmOnly {
-                    Picker("음성 소스", selection: $voiceSourceMode) {
-                        Text("목소리").tag(VoiceSource.ttsProfile)
-                        Text("녹음/파일").tag(VoiceSource.localAudio)
-                    }
-                    .pickerStyle(.segmented)
-                    .onChange(of: voiceSourceMode) { _, newValue in
-                        voiceStudio.preparedAlarm = nil
-                        localPreviewPlayer.stop()
-                        if newValue == .ttsProfile {
-                            localRecorder.stop()
-                        }
-                    }
-
-                    if voiceSourceMode == .ttsProfile {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("목소리")
-                                .font(theme.typography.titleSmall)
-                            AlarmVoiceProfilePicker(
-                                ownProfiles: voiceStudio.profiles,
-                                familyVoices: voiceStudio.familyVoices,
-                                selectedProfileID: voiceStudio.selectedProfileID,
-                                onSelectOwn: { profile in
-                                    voiceStudio.selectedProfileID = profile.id
-                                    voiceStudio.preparedAlarm = nil
-                                },
-                                onSelectShared: { profile in
-                                    if profile.requiresViewerInfo {
-                                        sharedVoiceSetupTarget = profile
-                                    } else {
-                                        voiceStudio.selectedProfileID = profile.id
-                                        voiceStudio.preparedAlarm = nil
-                                    }
-                                }
-                            )
-                            Text(preparedVoiceLabel)
-                                .font(theme.typography.bodySmall)
-                                .foregroundStyle(theme.palette.onSurfaceVariant)
-                            Button {
-                                onJumpToVoices()
-                            } label: {
-                                Label("음성 탭에서 만들기", systemImage: "waveform")
-                            }
-                            .buttonStyle(.bordered)
-                        }
-
-                        Toggle("랜덤 문구 사용", isOn: Binding(
-                            get: { voiceStudio.randomPrompt },
-                            set: { enabled in
-                                voiceStudio.randomPrompt = enabled
-                                voiceStudio.preparedAlarm = nil
-                                if !enabled && !voiceStudio.translateText {
-                                    voiceStudio.ttsLanguage = "ko"
-                                }
-                            }
-                        ))
-                            .tint(theme.palette.primary)
-                        if voiceStudio.randomPrompt {
-                            Picker("랜덤 컨텍스트", selection: $voiceStudio.randomContext) {
-                                ForEach(RandomPromptContext.alarmEditorCases, id: \.rawValue) { context in
-                                    Text(context.label).tag(context.rawValue)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .onChange(of: voiceStudio.randomContext) { _, _ in
-                                voiceStudio.preparedAlarm = nil
-                            }
-                            Picker("언어", selection: $voiceStudio.ttsLanguage) {
-                                ForEach(ttsLanguages, id: \.code) { option in
-                                    Text(option.label).tag(option.code)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .onChange(of: voiceStudio.ttsLanguage) { _, _ in
-                                voiceStudio.preparedAlarm = nil
-                            }
-                            Text("선택한 상황에 맞춰 깨움말을 자동으로 만들어요.")
-                                .font(theme.typography.bodySmall)
-                                .foregroundStyle(theme.palette.onSurfaceVariant)
-                            if activePromptContext.usesWeather {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    Text("날씨 지역")
-                                        .font(theme.typography.titleSmall)
-                                    WeatherLocationInputFields(
-                                        country: $voiceStudio.weatherCountry,
-                                        city: $voiceStudio.weatherCity,
-                                        helperText: "날씨가 들어간 깨움말에 사용할 지역이에요."
-                                    )
-                                    if !voiceStudio.hasWeatherInfo || targetWeatherReady {
-                                        Text(targetWeatherReady ? "상대가 저장한 날씨 지역을 사용해요." : "날씨가 들어간 문구를 쓰려면 지역을 입력해 주세요.")
-                                            .font(theme.typography.bodySmall)
-                                            .foregroundStyle(theme.palette.onSurfaceVariant)
-                                    }
-                                }
-                                .padding(.top, 4)
-                            }
-                            if activePromptContext.usesFortune {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    Text("운세 정보")
-                                        .font(theme.typography.titleSmall)
-                                    FortunePromptInputFields(
-                                        gender: $voiceStudio.fortuneGender,
-                                        birthDate: $voiceStudio.fortuneBirthDate,
-                                        birthTime: $voiceStudio.fortuneBirthTime,
-                                        helperText: "운세가 들어간 깨움말을 만들 때만 사용해요."
-                                    )
-                                    if !voiceStudio.hasFortuneInfo || targetFortuneReady {
-                                        Text(targetFortuneReady ? "상대가 저장한 운세 정보를 사용해요." : "운세가 들어간 문구를 쓰려면 성별, 생년월일, 태어난 시간이 필요해요.")
-                                            .font(theme.typography.bodySmall)
-                                            .foregroundStyle(theme.palette.onSurfaceVariant)
-                                    }
-                                }
-                                .padding(.top, 4)
-                            }
-                        } else {
-                            ManualVoiceMessageEditor(
-                                text: $voiceStudio.ttsText,
-                                translationEnabled: $voiceStudio.translateText,
-                                language: $voiceStudio.ttsLanguage,
-                                onInvalidatePreparedAudio: { voiceStudio.preparedAlarm = nil }
-                            )
-                        }
-                    } else {
-                        LocalAlarmAudioEditor(
-                            mode: $localAudioMode,
-                            isRecording: localRecorder.isRecording,
-                            elapsedMs: Int(localRecorder.elapsedSeconds * 1000),
-                            hasRecording: localRecorder.latestRecordingURL != nil,
-                            existingAudioLabel: existingLocalAudioLabel,
-                            fileName: selectedLocalAudioName,
-                            fileDurationMs: selectedLocalAudioDurationMs,
-                            cropStartMs: $localAudioCropStartMs,
-                            cropEndMs: $localAudioCropEndMs,
-                            isPreviewing: localPreviewPlayer.isPlaying,
-                            message: localAudioMessage,
-                            onModeChange: handleLocalAudioModeChange,
-                            onRecord: toggleLocalRecording,
-                            onPickFile: { localAudioFileImporterPresented = true },
-                            onPreview: previewLocalAlarmAudio,
-                            onClear: clearLocalAlarmAudio
-                        )
-                    }
-
-                    if draft.playMode == .voiceOnly {
-                        VoiceRepeatEditor(isRepeating: $draft.voiceRepeat)
-                    }
-                    VoiceVolumeEditor(volumePercent: $draft.voiceVolumePercent)
-                }
-            }
+            alarmModeSection
 
             Section("스누즈") {
                 Toggle("스누즈 허용", isOn: $draft.snoozeEnabled)
@@ -422,36 +257,36 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private var saveButtonTitle: String {
+    var saveButtonTitle: String {
         target.editingAlarmID == nil ? "저장" : "수정 저장"
     }
 
-    private var navigationTitle: String {
+    var navigationTitle: String {
         if target.familyAlarmMode { return "상대 알람 맞추기" }
         return target.editingAlarmID == nil ? "알람 만들기" : "알람 수정"
     }
 
-    private var activePromptContext: RandomPromptContext {
+    var activePromptContext: RandomPromptContext {
         RandomPromptContext.normalized(voiceStudio.randomContext)
     }
 
-    private var targetWeatherReady: Bool {
+    var targetWeatherReady: Bool {
         target.familyAlarmMode && selectedFamilyRecipient?.dynamicPromptSettingsState?.weatherReady == true
     }
 
-    private var targetFortuneReady: Bool {
+    var targetFortuneReady: Bool {
         target.familyAlarmMode && selectedFamilyRecipient?.dynamicPromptSettingsState?.fortuneReady == true
     }
 
-    private var voicePlanLocked: Bool {
+    var voicePlanLocked: Bool {
         !currentPlan.meetsOrExceeds(.personal)
     }
 
-    private var familyAlarmLocked: Bool {
+    var familyAlarmLocked: Bool {
         socialFeatures.familyGroup?.group == nil && !currentPlan.meetsOrExceeds(.couple)
     }
 
-    private var currentPlan: PlanTier {
+    var currentPlan: PlanTier {
         PlanTier.bestKnown(
             serverSubscription: socialFeatures.subscription,
             storeTier: subscriptions.currentTier,
@@ -459,24 +294,24 @@ struct AlarmEditorSheet: View {
         )
     }
 
-    private var defaultPlayModeForPlan: AlarmPlayMode {
+    var defaultPlayModeForPlan: AlarmPlayMode {
         voicePlanLocked ? .alarmOnly : .soundThenVoice
     }
 
-    private var preparedVoiceLabel: String {
+    var preparedVoiceLabel: String {
         guard let prepared = voiceStudio.preparedAlarm else {
             return "아직 생성한 음성이 없어요. 음성 탭에서 음성을 생성해 주세요."
         }
         return "\(prepared.text) · \(prepared.language) · 로컬 캐시 완료"
     }
 
-    private var editingAlarm: LocalAlarmRecord? {
+    var editingAlarm: LocalAlarmRecord? {
         target.editingAlarmID.flatMap { id in
             store.alarms.first { $0.id == id }
         }
     }
 
-    private var existingLocalAudioLabel: String? {
+    var existingLocalAudioLabel: String? {
         guard selectedLocalAudioURL == nil,
               localRecorder.latestRecordingURL == nil,
               !clearExistingLocalAudio,
@@ -488,7 +323,7 @@ struct AlarmEditorSheet: View {
         return "저장된 녹음/파일 음성을 사용 중이에요."
     }
 
-    private var familyRecipients: [FamilyGroupMember] {
+    var familyRecipients: [FamilyGroupMember] {
         let currentUserID = auth.session?.user.id
         let currentEmail = auth.session?.user.email
         return (socialFeatures.familyGroup?.members ?? []).filter { member in
@@ -498,7 +333,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private var selectedFamilyRecipient: FamilyGroupMember? {
+    var selectedFamilyRecipient: FamilyGroupMember? {
         if let selectedFamilyRecipientID,
            let selected = familyRecipients.first(where: { $0.userId == selectedFamilyRecipientID }) {
             return selected
@@ -508,7 +343,7 @@ struct AlarmEditorSheet: View {
 
     // MARK: - Initial load
 
-    private func loadInitialState() {
+    func loadInitialState() {
         if let editingID = target.editingAlarmID,
            let alarm = store.alarms.first(where: { $0.id == editingID }) {
             draft = AlarmEditDraft(from: alarm)
@@ -527,7 +362,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func loadVoicePromptState(from alarm: LocalAlarmRecord?) {
+    func loadVoicePromptState(from alarm: LocalAlarmRecord?) {
         let saved = savedPromptPreferences()
         voiceStudio.selectedProfileID = alarm?.voiceProfileId
         voiceStudio.preparedAlarm = nil
@@ -544,12 +379,12 @@ struct AlarmEditorSheet: View {
         voiceStudio.fortuneBirthTime = alarm?.voiceFortuneBirthTime ?? saved.fortuneBirthTime
     }
 
-    private func savedPromptPreferences() -> DynamicPromptPreferences {
+    func savedPromptPreferences() -> DynamicPromptPreferences {
         let server = DynamicPromptPreferences.from(settings: auth.session?.user.dynamicPromptSettings)
         return server == DynamicPromptPreferences() ? .loadFromDefaults() : server
     }
 
-    private func applyVoicePromptState(to record: inout LocalAlarmRecord) {
+    func applyVoicePromptState(to record: inout LocalAlarmRecord) {
         let enabled = record.playModeEnum != .alarmOnly && voiceStudio.randomPrompt
         let context = RandomPromptContext.normalized(voiceStudio.randomContext)
         record.voiceRandomPrompt = enabled
@@ -561,14 +396,14 @@ struct AlarmEditorSheet: View {
         record.voiceFortuneBirthTime = enabled && context.usesFortune ? (voiceStudio.fortuneBirthTime).nilIfBlank : nil
     }
 
-    private func showVoicePlanLockedAlert() {
+    func showVoicePlanLockedAlert() {
         validationAlert = ValidationAlertContent(
             title: "이용권이 필요해요",
             message: "무료 이용권에서는 알람만 사용할 수 있어요."
         )
     }
 
-    private func selectDefaultFamilyRecipientIfNeeded() {
+    func selectDefaultFamilyRecipientIfNeeded() {
         guard target.familyAlarmMode else { return }
         if let selectedFamilyRecipientID,
            familyRecipients.contains(where: { $0.userId == selectedFamilyRecipientID }) {
@@ -579,7 +414,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func selectDefaultVoiceProfileIfNeeded() {
+    func selectDefaultVoiceProfileIfNeeded() {
         guard draft.playMode != .alarmOnly else { return }
         let selected = voiceStudio.selectedProfileID
         let readyOwn = voiceStudio.profiles.filter { $0.isReadyForAlarmSelection }
@@ -598,7 +433,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func selectFamilyRecipient(_ userID: String) {
+    func selectFamilyRecipient(_ userID: String) {
         selectedFamilyRecipientID = userID
         voiceStudio.preparedAlarm = nil
         guard let recipient = familyRecipients.first(where: { $0.userId == userID }) else { return }
@@ -612,7 +447,7 @@ struct AlarmEditorSheet: View {
 
     // MARK: - Save flow
 
-    private func saveFlow() async {
+    func saveFlow() async {
         guard !isWorking else { return }
         isWorking = true
         defer { isWorking = false }
@@ -789,7 +624,7 @@ struct AlarmEditorSheet: View {
         onSchedulingDidFinish()
     }
 
-    private func generateVoiceAndSave() async {
+    func generateVoiceAndSave() async {
         let prepared = await voiceStudio.generateTTS(
             session: auth.session,
             alarmHour: draft.hour,
@@ -802,7 +637,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func validateFamilyAlarmTarget() -> FamilyGroupMember? {
+    func validateFamilyAlarmTarget() -> FamilyGroupMember? {
         guard let recipient = selectedFamilyRecipient else {
             validationAlert = ValidationAlertContent(
                 title: "받을 사람이 없어요",
@@ -846,7 +681,7 @@ struct AlarmEditorSheet: View {
         return recipient
     }
 
-    private func createFamilyTargetAlarm(
+    func createFamilyTargetAlarm(
         recipient: FamilyGroupMember,
         localVoiceSource: FamilyLocalVoiceUploadSource?
     ) async {
@@ -904,7 +739,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func handleLocalAudioModeChange(_ mode: AlarmLocalAudioInputMode) {
+    func handleLocalAudioModeChange(_ mode: AlarmLocalAudioInputMode) {
         localPreviewPlayer.stop()
         if mode == .file {
             localRecorder.clearLatest()
@@ -920,7 +755,7 @@ struct AlarmEditorSheet: View {
         localAudioMessage = nil
     }
 
-    private func toggleLocalRecording() {
+    func toggleLocalRecording() {
         localPreviewPlayer.stop()
         if localRecorder.isRecording {
             localRecorder.stop()
@@ -945,7 +780,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func importLocalAlarmAudio(_ source: URL) async {
+    func importLocalAlarmAudio(_ source: URL) async {
         do {
             let importedURL = try copyImportedAudio(source)
             let durationMs = try await readAudioDurationMs(importedURL)
@@ -963,7 +798,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func previewLocalAlarmAudio() {
+    func previewLocalAlarmAudio() {
         if localPreviewPlayer.isPlaying {
             localPreviewPlayer.stop()
             return
@@ -984,7 +819,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func clearLocalAlarmAudio() {
+    func clearLocalAlarmAudio() {
         localPreviewPlayer.stop()
         localRecorder.clearLatest()
         selectedLocalAudioURL = nil
@@ -996,7 +831,7 @@ struct AlarmEditorSheet: View {
         localAudioMessage = "음성 오디오를 지웠어요."
     }
 
-    private func cachedLocalAudioForSave(existing: LocalAlarmRecord?) async throws -> CachedLocalAlarmAudio {
+    func cachedLocalAudioForSave(existing: LocalAlarmRecord?) async throws -> CachedLocalAlarmAudio {
         let hasNewSource = selectedLocalAudioURL != nil || localRecorder.latestRecordingURL != nil
         if hasNewSource {
             let prepared = try await preparedLocalAlarmAudioSource()
@@ -1024,7 +859,7 @@ struct AlarmEditorSheet: View {
         return CachedLocalAlarmAudio(fileName: existing.localAudioUri ?? "", cacheKey: cacheKey)
     }
 
-    private func existingLocalAudioURL() -> URL? {
+    func existingLocalAudioURL() -> URL? {
         guard !clearExistingLocalAudio,
               let alarm = editingAlarm,
               alarm.voiceSourceEnum == .localAudio,
@@ -1034,7 +869,7 @@ struct AlarmEditorSheet: View {
         return AudioCacheStore.shared.cachedURL(for: cacheKey)
     }
 
-    private func preparedLocalAlarmAudioSource() async throws -> (url: URL, durationMs: Int) {
+    func preparedLocalAlarmAudioSource() async throws -> (url: URL, durationMs: Int) {
         switch localAudioMode {
         case .record:
             guard let url = localRecorder.latestRecordingURL else {
@@ -1065,7 +900,7 @@ struct AlarmEditorSheet: View {
         }
     }
 
-    private func copyImportedAudio(_ source: URL) throws -> URL {
+    func copyImportedAudio(_ source: URL) throws -> URL {
         let scoped = source.startAccessingSecurityScopedResource()
         defer {
             if scoped {
@@ -1081,7 +916,7 @@ struct AlarmEditorSheet: View {
         return destination
     }
 
-    private func readAudioDurationMs(_ url: URL) async throws -> Int {
+    func readAudioDurationMs(_ url: URL) async throws -> Int {
         let asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
         let duration = try await asset.load(.duration)
         let seconds = CMTimeGetSeconds(duration)
@@ -1092,7 +927,7 @@ struct AlarmEditorSheet: View {
     }
 
 
-    private func localAudioUploadDisplayName(for url: URL) -> String {
+    func localAudioUploadDisplayName(for url: URL) -> String {
         switch localAudioMode {
         case .record:
             return "alarm-recording.m4a"
@@ -1107,7 +942,7 @@ struct AlarmEditorSheet: View {
 
     // MARK: - Error formatting
 
-    private func errorMessage(_ error: AlarmEditDraft.ValidationError) -> String {
+    func errorMessage(_ error: AlarmEditDraft.ValidationError) -> String {
         switch error {
         case .invalidHour:
             return "시간(0–23) 값이 올바르지 않아요."

--- a/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
+++ b/apps/ios-native/VoiceAlarm/Views/Editor/AlarmEditorSheet.swift
@@ -896,7 +896,7 @@ struct AlarmEditorSheet: View {
         } catch {
             validationAlert = ValidationAlertContent(
                 title: "상대 알람 설정에 실패했어요",
-                message: RemoteAlarmSyncViewModel.userFacingErrorMessage(
+                message: userFacingErrorMessage(
                     error,
                     fallback: "상대 알람 설정에 실패했어요."
                 )

--- a/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceAlarmAPI.swift
@@ -850,17 +850,6 @@ enum APIError: LocalizedError {
     }
 }
 
-private extension Optional where Wrapped == String {
-    var nilIfBlank: String? {
-        switch self {
-        case .some(let value):
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        case .none:
-            return nil
-        }
-    }
-}
 
 private extension Data {
     mutating func appendMultipartLine(_ value: String) {

--- a/apps/ios-native/VoiceAlarm/VoiceAlarmAPIModels.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceAlarmAPIModels.swift
@@ -31,13 +31,13 @@ struct DynamicPromptSettings: Codable, Equatable {
         fortune: DynamicPromptFortuneSettings = DynamicPromptFortuneSettings(gender: nil, birthDate: nil, birthTime: nil)
     ) {
         self.weather = DynamicPromptWeatherSettings(
-            country: Self.clean(weather.country),
-            city: Self.clean(weather.city)
+            country: (weather.country).nilIfBlank,
+            city: (weather.city).nilIfBlank
         )
         self.fortune = DynamicPromptFortuneSettings(
-            gender: Self.clean(fortune.gender),
-            birthDate: Self.clean(fortune.birthDate),
-            birthTime: Self.clean(fortune.birthTime)
+            gender: (fortune.gender).nilIfBlank,
+            birthDate: (fortune.birthDate).nilIfBlank,
+            birthTime: (fortune.birthTime).nilIfBlank
         )
     }
 
@@ -61,10 +61,6 @@ struct DynamicPromptSettings: Codable, Equatable {
         )
     }
 
-    private static func clean(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
 }
 
 struct DynamicPromptSettingsState: Codable, Equatable {
@@ -107,25 +103,25 @@ struct DynamicPromptPreferences: Codable, Equatable {
     func toSettings() -> DynamicPromptSettings {
         DynamicPromptSettings(
             weather: DynamicPromptWeatherSettings(
-                country: clean(weatherCountry),
-                city: clean(weatherCity)
+                country: (weatherCountry).nilIfBlank,
+                city: (weatherCity).nilIfBlank
             ),
             fortune: DynamicPromptFortuneSettings(
-                gender: clean(fortuneGender),
-                birthDate: clean(fortuneBirthDate),
-                birthTime: clean(fortuneBirthTime)
+                gender: (fortuneGender).nilIfBlank,
+                birthDate: (fortuneBirthDate).nilIfBlank,
+                birthTime: (fortuneBirthTime).nilIfBlank
             )
         )
     }
 
     var weatherReady: Bool {
-        clean(weatherCountry) != nil && clean(weatherCity) != nil
+        (weatherCountry).nilIfBlank != nil && (weatherCity).nilIfBlank != nil
     }
 
     var fortuneReady: Bool {
-        clean(fortuneGender) != nil &&
-            clean(fortuneBirthDate) != nil &&
-            clean(fortuneBirthTime) != nil
+        (fortuneGender).nilIfBlank != nil &&
+            (fortuneBirthDate).nilIfBlank != nil &&
+            (fortuneBirthTime).nilIfBlank != nil
     }
 
     private func normalized() -> DynamicPromptPreferences {
@@ -138,10 +134,6 @@ struct DynamicPromptPreferences: Codable, Equatable {
         )
     }
 
-    private func clean(_ value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
 }
 
 struct AuthUser: Codable, Equatable, Identifiable {
@@ -198,7 +190,7 @@ struct AuthUser: Codable, Equatable, Identifiable {
         self.familyAlarmQuietStart = firstWindow.start
         self.familyAlarmQuietEnd = firstWindow.end
         self.familyAlarmQuietWindows = quietWindows
-        self.appleUserId = Self.clean(appleUserId)
+        self.appleUserId = (appleUserId).nilIfBlank
         self.dynamicPromptSettings = dynamicPromptSettings ?? .empty
         let trimmedDeletion = deletionStatus.trimmingCharacters(in: .whitespacesAndNewlines)
         self.deletionStatus = trimmedDeletion.isEmpty ? "active" : trimmedDeletion
@@ -271,10 +263,6 @@ struct AuthUser: Codable, Equatable, Identifiable {
         return Array(normalized.prefix(8))
     }
 
-    private static func clean(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
 }
 
 struct RemoteAlarmListResponse: Decodable {

--- a/apps/ios-native/VoiceAlarm/VoiceStudioViewModel+ErrorMapping.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceStudioViewModel+ErrorMapping.swift
@@ -109,12 +109,3 @@ extension VoiceStudioViewModel {
     ]
 }
 
-private extension String {
-    var containsKorean: Bool {
-        contains { character in
-            character.unicodeScalars.contains { scalar in
-                (0xAC00...0xD7A3).contains(Int(scalar.value))
-            }
-        }
-    }
-}

--- a/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
+++ b/apps/ios-native/VoiceAlarm/VoiceStudioViewModel.swift
@@ -103,10 +103,10 @@ final class VoiceStudioViewModel: ObservableObject {
     }
 
     private var selectedListenerTitle: String? {
-        if let listener = selectedProfile?.listenerTitle, let trimmed = nonEmpty(listener) {
+        if let listener = selectedProfile?.listenerTitle, let trimmed = (listener).nilIfBlank {
             return trimmed
         }
-        if let listener = selectedFamilyVoice?.listenerTitle, let trimmed = nonEmpty(listener) {
+        if let listener = selectedFamilyVoice?.listenerTitle, let trimmed = (listener).nilIfBlank {
             return trimmed
         }
         return nil
@@ -119,13 +119,13 @@ final class VoiceStudioViewModel: ObservableObject {
     }
 
     var hasWeatherInfo: Bool {
-        nonEmpty(weatherCountry) != nil && nonEmpty(weatherCity) != nil
+        (weatherCountry).nilIfBlank != nil && (weatherCity).nilIfBlank != nil
     }
 
     var hasFortuneInfo: Bool {
-        nonEmpty(fortuneGender) != nil &&
-            nonEmpty(fortuneBirthDate) != nil &&
-            nonEmpty(fortuneBirthTime) != nil
+        (fortuneGender).nilIfBlank != nil &&
+            (fortuneBirthDate).nilIfBlank != nil &&
+            (fortuneBirthTime).nilIfBlank != nil
     }
 
     /// 슬롯이 가득 찼는지 — VoiceProfileManagementPanel 의 슬롯 카드/추가 버튼 비활성에 사용.
@@ -509,7 +509,7 @@ final class VoiceStudioViewModel: ObservableObject {
             statusMessage = "로그인이 필요해요."
             return nil
         }
-        let resolvedName = nonEmpty(name) ?? "분리한 목소리"
+        let resolvedName = (name).nilIfBlank ?? "분리한 목소리"
         guard durationMs >= VoiceProfileLimits.minDurationMs else {
             statusMessage = "1분 이상 들리는 구간이 필요해요."
             return nil
@@ -659,11 +659,11 @@ final class VoiceStudioViewModel: ObservableObject {
                     randomContext: randomPrompt ? promptContext.rawValue : nil,
                     alarmHour: randomPrompt ? alarmHour : nil,
                     alarmMinute: randomPrompt ? alarmMinute : nil,
-                    weatherCountry: targetUserId == nil && randomPrompt && promptContext.usesWeather ? nonEmpty(weatherCountry) : nil,
-                    weatherCity: targetUserId == nil && randomPrompt && promptContext.usesWeather ? nonEmpty(weatherCity) : nil,
-                    fortuneGender: targetUserId == nil && randomPrompt && promptContext.usesFortune ? nonEmpty(fortuneGender) : nil,
-                    fortuneBirthDate: targetUserId == nil && randomPrompt && promptContext.usesFortune ? nonEmpty(fortuneBirthDate) : nil,
-                    fortuneBirthTime: targetUserId == nil && randomPrompt && promptContext.usesFortune ? nonEmpty(fortuneBirthTime) : nil,
+                    weatherCountry: targetUserId == nil && randomPrompt && promptContext.usesWeather ? (weatherCountry).nilIfBlank : nil,
+                    weatherCity: targetUserId == nil && randomPrompt && promptContext.usesWeather ? (weatherCity).nilIfBlank : nil,
+                    fortuneGender: targetUserId == nil && randomPrompt && promptContext.usesFortune ? (fortuneGender).nilIfBlank : nil,
+                    fortuneBirthDate: targetUserId == nil && randomPrompt && promptContext.usesFortune ? (fortuneBirthDate).nilIfBlank : nil,
+                    fortuneBirthTime: targetUserId == nil && randomPrompt && promptContext.usesFortune ? (fortuneBirthTime).nilIfBlank : nil,
                     listenerTitle: selectedListenerTitle,
                     targetUserId: targetUserId
                 ),
@@ -810,10 +810,6 @@ final class VoiceStudioViewModel: ObservableObject {
         }
     }
 
-    private func nonEmpty(_ value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
 
     private func isNotFoundError(_ error: Error) -> Bool {
         if case APIError.server(let status, _, _) = error {
@@ -834,7 +830,7 @@ final class VoiceStudioViewModel: ObservableObject {
         relationshipLabel: String?,
         listenerTitle: String?
     ) -> RequiredVoiceProfileFields? {
-        let normalizedName = nonEmpty(name) ?? fallbackName.flatMap { nonEmpty($0) }
+        let normalizedName = (name).nilIfBlank ?? fallbackName.flatMap { ($0).nilIfBlank }
         guard let normalizedName else {
             statusMessage = "목소리 이름을 입력해 주세요."
             return nil
@@ -856,11 +852,11 @@ final class VoiceStudioViewModel: ObservableObject {
         relationshipLabel: String?,
         listenerTitle: String?
     ) -> (relationshipLabel: String, listenerTitle: String)? {
-        guard let relationshipLabel = nonEmpty(relationshipLabel ?? "") else {
+        guard let relationshipLabel = (relationshipLabel ?? "").nilIfBlank else {
             statusMessage = "나와의 관계를 입력해 주세요."
             return nil
         }
-        guard let listenerTitle = nonEmpty(listenerTitle ?? "") else {
+        guard let listenerTitle = (listenerTitle ?? "").nilIfBlank else {
             statusMessage = "이 목소리가 나를 부를 호칭을 입력해 주세요."
             return nil
         }

--- a/apps/ios-native/VoiceAlarmTests/AuthViewModelTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/AuthViewModelTests.swift
@@ -164,7 +164,7 @@ final class AuthViewModelTests: XCTestCase {
         let error = APIError.server(status: 500, message: "Internal Server Error", errorCode: nil)
 
         XCTAssertEqual(
-            AuthViewModel.userFacingErrorMessage(error, fallback: "로그인에 실패했어요"),
+            userFacingErrorMessage(error, fallback: "로그인에 실패했어요"),
             "로그인에 실패했어요"
         )
     }
@@ -173,7 +173,7 @@ final class AuthViewModelTests: XCTestCase {
         let error = APIError.server(status: 400, message: "이미 가입된 이메일이에요", errorCode: nil)
 
         XCTAssertEqual(
-            AuthViewModel.userFacingErrorMessage(error, fallback: "회원가입에 실패했어요"),
+            userFacingErrorMessage(error, fallback: "회원가입에 실패했어요"),
             "이미 가입된 이메일이에요"
         )
     }

--- a/apps/ios-native/VoiceAlarmTests/RemoteAlarmSyncViewModelTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/RemoteAlarmSyncViewModelTests.swift
@@ -7,7 +7,7 @@ final class RemoteAlarmSyncViewModelTests: XCTestCase {
         let error = APIError.server(status: 500, message: "Internal Server Error", errorCode: nil)
 
         XCTAssertEqual(
-            RemoteAlarmSyncViewModel.userFacingErrorMessage(error, fallback: "알람 정보를 불러오지 못했어요"),
+            userFacingErrorMessage(error, fallback: "알람 정보를 불러오지 못했어요"),
             "알람 정보를 불러오지 못했어요"
         )
     }
@@ -16,7 +16,7 @@ final class RemoteAlarmSyncViewModelTests: XCTestCase {
         let error = APIError.server(status: 400, message: "이미 삭제된 알람이에요", errorCode: nil)
 
         XCTAssertEqual(
-            RemoteAlarmSyncViewModel.userFacingErrorMessage(error, fallback: "알람 삭제에 실패했어요"),
+            userFacingErrorMessage(error, fallback: "알람 삭제에 실패했어요"),
             "이미 삭제된 알람이에요"
         )
     }

--- a/apps/ios-native/VoiceAlarmTests/SocialFeatureViewModelBillingTests.swift
+++ b/apps/ios-native/VoiceAlarmTests/SocialFeatureViewModelBillingTests.swift
@@ -98,7 +98,7 @@ final class SocialFeatureViewModelBillingTests: XCTestCase {
     func test_userFacingErrorMessage_usesFallbackForEnglishServerMessageLikeAndroid() {
         let error = APIError.server(status: 400, message: "User not found", errorCode: nil)
         XCTAssertEqual(
-            SocialFeatureViewModel.userFacingErrorMessage(error, fallback: "이용권에서 나가지 못했어요"),
+            userFacingErrorMessage(error, fallback: "이용권에서 나가지 못했어요"),
             "이용권에서 나가지 못했어요"
         )
     }
@@ -106,7 +106,7 @@ final class SocialFeatureViewModelBillingTests: XCTestCase {
     func test_userFacingErrorMessage_keepsKoreanServerMessageLikeAndroid() {
         let error = APIError.server(status: 400, message: "이미 처리된 요청이에요", errorCode: nil)
         XCTAssertEqual(
-            SocialFeatureViewModel.userFacingErrorMessage(error, fallback: "fallback"),
+            userFacingErrorMessage(error, fallback: "fallback"),
             "이미 처리된 요청이에요"
         )
     }


### PR DESCRIPTION
공통 로직 중복을 단일 출처로 통합하고, dense 뷰 하나를 축소. **동작/디자인 변경 없음** — iOS build+test CI 통과.

## 중복 통합 (DRY)
- `String.containsKorean` ×5 → `StringExtensions.swift` 1곳
- `Optional<String>.nilIfBlank` ×2 → 1곳
- `nonEmpty`/`clean`(빈값→nil) ×7, 호출 53곳 → `String(?).nilIfBlank`
- `userFacingErrorMessage` ×3, 호출 26곳 → `UserFacingError.swift` 공용 free 함수

> Android는 이미 DRY(`trimmedOrNull` 등 단일화)라 손댈 곳 없었음.

## 파일 축소
- `AlarmEditorSheet.swift` 1130 → **961줄**: 멤버 private→internal 후 '알람 방식' 섹션을 `AlarmEditorSheet+AlarmModeSection.swift` 의 computed view 로 분리

## 보류(합의)
- `VoiceProfileManagementPanel.kt`(1244), `AlarmEditorScreen.kt`(1206): 지역 `remember` 상태가 촘촘히 결합된 단일 컴포저블. 텍스트 치환으로 안전하게 못 쪼개고, 줄 수만으로 갈아엎는 건 회귀 위험이 커서 **의도적으로 유지**. 필요 시 IDE의 state-holder 리팩토링으로 진행 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)