### PR TITLE
fix(backend): 시스템 보이스 시드 이메일 unique 충돌 수정

### DIFF
--- a/packages/backend/scripts/issue-dev-gift-code.ts
+++ b/packages/backend/scripts/issue-dev-gift-code.ts
@@ -106,9 +106,10 @@ async function main(): Promise<void> {
     args: [SYSTEM_ISSUER_GOOGLE_ID],
   });
   if (issuerRes.rows.length === 0) {
+    // users.email unique 인덱스 — 다른 시스템 계정과 이메일이 겹치지 않게 한다.
     await db.execute({
       sql: `INSERT INTO users (id, google_id, email, name, plan)
-            VALUES (?, ?, 'system@alarm-talk.com', 'System Voucher Issuer', 'free')`,
+            VALUES (?, ?, 'voucher-issuer@alarm-talk.com', 'System Voucher Issuer', 'free')`,
       args: [crypto.randomUUID(), SYSTEM_ISSUER_GOOGLE_ID],
     });
     issuerRes = await db.execute({

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -937,9 +937,12 @@ export const migrations: Migration[] = [
     name: 'system-stock-voices',
     statements: [
       `ALTER TABLE voice_profiles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0`,
+      // 주의: users.email 에 unique 인덱스가 있어 이메일은 다른 시스템 계정과
+      // 절대 겹치면 안 된다 (겹치면 INSERT OR IGNORE 가 조용히 무시되고
+      // 이어지는 voice_profiles 시드가 FK 로 실패).
       `INSERT OR IGNORE INTO users (id, google_id, email, name, plan)
         VALUES ('70000000-0000-4000-9000-000000000001', 'system:voice-library',
-                'system@alarm-talk.com', 'AlarmTalk 기본 목소리', 'free')`,
+                'voice-library@alarm-talk.com', 'AlarmTalk 기본 목소리', 'free')`,
       `INSERT OR IGNORE INTO voice_profiles
         (id, user_id, name, elevenlabs_voice_id, status, is_system, is_shared, is_draft)
         VALUES ('70000000-0000-4000-9000-000000000101', '70000000-0000-4000-9000-000000000001',


### PR DESCRIPTION
## 요약

PR #452 의 migration 43(system-stock-voices)이 dev 적용 시 실패한 원인 수정.

- users.email 에 unique 인덱스(idx_users_email_unique)가 있는데, 시스템 보이스
  소유 유저와 dev 바우처 발급자가 같은 system@alarm-talk.com 을 쓰고 있었음
- INSERT OR IGNORE 가 이메일 충돌로 조용히 무시 → 이어지는 voice_profiles
  시드가 FOREIGN KEY 로 실패
- 시스템 계정별 고유 이메일(voice-library@ / voucher-issuer@)로 분리

dev DB 는 시스템 유저를 수동 삽입 후 migration 43 재실행으로 복구 완료
(스톡 보이스 4종 시드 확인). 이 수정은 프로덕션 등 새 환경에서의 재발 방지용.

## 테스트
- backend: vitest 1,360 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)