### PR TITLE
feat(android): 알람 편집기 저장 흐름 단순화·저장 불가 사유 표시

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorControls.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorControls.kt
@@ -390,6 +390,8 @@ internal val TtsCategories = listOf(
 )
 
 internal val RandomPromptContexts = listOf(
+    // 추가 정보 없이 바로 쓰는 고정 문구 풀 — 새 알람의 기본값. 무료 플랜은 이것만 사용 가능.
+    "preset" to "기본 문구",
     "wake_weather" to "기상 + 날씨",
     "wake_fortune" to "기상 + 운세",
     "meal" to "식사",

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -829,23 +830,32 @@ internal fun AlarmEditorScreen(
         return true
     }
 
-    fun canSaveTtsAlarm(): Boolean {
-        val profileId = editor.voiceProfileId?.takeIf { it.isNotBlank() } ?: return false
-        val text = editor.ttsTextForSave()
-        val profileAvailable = profileId in usableTtsProfileIds || editor.hasFreshTtsAudio(profileId, text)
-        if (!profileAvailable) return false
-        return if (editor.voiceRandomPrompt) {
-            randomPromptSettingsComplete()
-        } else {
-            editor.voiceText.trim().isNotBlank()
+    // 저장이 막힌 이유 — 비활성 버튼만으로는 무엇이 빠졌는지 알 수 없어
+    // 저장 버튼 위에 사유를 함께 보여준다. null 이면 저장 가능.
+    val editorSaveBlockedReason: String? = when {
+        editor.playMode == AlarmPlayModes.ALARM_ONLY -> null
+        editor.voiceSource == VoiceSources.LOCAL_AUDIO ->
+            if (selectedFileUri != null || !editor.localAudioUri.isNullOrBlank()) {
+                null
+            } else {
+                "들려줄 음성을 녹음하거나 파일로 선택해 주세요."
+            }
+        else -> {
+            val profileId = editor.voiceProfileId?.takeIf { it.isNotBlank() }
+            val text = editor.ttsTextForSave()
+            when {
+                profileId == null -> "알람에서 들을 목소리를 선택해 주세요."
+                profileId !in usableTtsProfileIds && !editor.hasFreshTtsAudio(profileId, text) ->
+                    "선택한 목소리를 쓸 수 없어요. 다른 목소리를 선택해 주세요."
+                editor.voiceRandomPrompt && !randomPromptSettingsComplete() ->
+                    "랜덤 문구 설정에서 날씨 지역·운세 정보를 채워 주세요."
+                !editor.voiceRandomPrompt && editor.voiceText.trim().isBlank() ->
+                    "들려줄 문구를 입력하거나 랜덤 문구를 켜 주세요."
+                else -> null
+            }
         }
     }
-
-    val editorCanSave = when {
-        editor.playMode == AlarmPlayModes.ALARM_ONLY -> true
-        editor.voiceSource == VoiceSources.LOCAL_AUDIO -> selectedFileUri != null || !editor.localAudioUri.isNullOrBlank()
-        else -> canSaveTtsAlarm()
-    }
+    val editorCanSave = editorSaveBlockedReason == null
 
     fun openRandomPromptSettings() {
         randomPromptWasEnabledWhenOpened = editor.voiceRandomPrompt
@@ -1161,6 +1171,16 @@ internal fun AlarmEditorScreen(
             ) {
                 Column {
                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+                    if (editorSaveBlockedReason != null) {
+                        Text(
+                            text = editorSaveBlockedReason,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                     Box(
                         modifier = Modifier
                             .padding(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
@@ -304,9 +304,10 @@ internal class AlarmEditorState(
                 voiceText = alarm?.voiceText,
                 voiceCategory = alarm?.voiceCategory ?: "morning",
                 voiceLanguage = alarm?.voiceLanguage ?: "ko",
+                // 새 알람은 랜덤(기본 문구) ON — 목소리만 고르면 추가 입력 없이 저장 가능.
                 voiceRandomPrompt = alarm?.voiceRandomPrompt ?: alarm?.let {
                     it.voiceSource == VoiceSources.TTS_PROFILE && it.voiceText.isNullOrBlank()
-                } ?: false,
+                } ?: true,
                 voiceRandomContext = alarm?.voiceRandomContext ?: DefaultRandomPromptContext,
                 voiceWeatherCountry = alarm?.voiceWeatherCountry,
                 voiceWeatherCity = alarm?.voiceWeatherCity,
@@ -360,5 +361,6 @@ internal fun randomContextUsesWeather(context: String?): Boolean =
     }
 
 private const val DefaultRandomTtsCategory = "morning"
-internal const val DefaultRandomPromptContext = "wake_weather"
+// 기본은 추가 입력이 필요 없는 고정 문구(preset) — 목소리만 고르면 바로 저장할 수 있다.
+internal const val DefaultRandomPromptContext = "preset"
 internal const val MinVoiceVolumePercent = 30


### PR DESCRIPTION
## 요약

알람 편집기에서 목소리를 골라도 저장 버튼이 이유 없이 비활성화돼 헷갈린다는
피드백 대응.

### 원인
- 새 알람의 기본이 직접 입력 모드라, 문구를 타이핑하기 전까지 저장이 막혔는데
  왜 막혔는지 어디에도 표시되지 않았음
- 랜덤 문구 옵션에 추가 입력이 필요 없는 preset(기본 문구) 항목 자체가 없어
  가장 쉬운 경로가 UI 에 존재하지 않았음

### 변경
- 랜덤 문구 종류에 기본 문구(preset) 를 첫 옵션으로 추가하고 기본값으로 지정
- 새 알람은 랜덤 문구 기본 ON → 목소리만 고르면 즉시 저장 가능
- 저장이 막힌 경우 사유를 저장 버튼 바로 위에 표시
  (문구 입력 필요 / 목소리 선택 필요 / 날씨·운세 정보 필요 등)
- 무료 플랜의 preset 강제값이 wake_weather 로 정규화돼 서버에서 403 으로
  거부되던 문제도 함께 해소

## 테스트
- android: assembleDevDebug + 단위 테스트 통과, 실기기(SM-A325N) 설치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)