### PR TITLE
fix(landing): Vercel 리디렉션 추가 — /privacy 등 비로케일 경로 404 해결

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -19,6 +19,14 @@ npm run build        # 정적 사이트를 out/ 디렉터리로 export
 
 `next.config.ts`의 `output: "export"`로 완전 정적 사이트가 생성됩니다(이미지 비최적화, `trailingSlash`). Cloudflare Pages, Vercel, S3 등 어디든 배포 가능합니다. 모노레포에서 Turbopack이 워크스페이스 루트를 추론하지 못하므로 `outputFileTracingRoot`/`turbopack.root`를 명시합니다.
 
+## 배포 (Vercel)
+
+프로덕션은 Vercel에 배포되어 있습니다.
+
+- **리디렉션은 `vercel.json`이 담당합니다.** `output: "export"`에서는 `next.config.ts`의 `redirects()`가 동작하지 않고, `public/_redirects`(Netlify/Cloudflare Pages 형식)는 Vercel이 무시합니다. `_redirects`는 다른 정적 호스트로 옮길 때를 대비한 백업입니다.
+- 로케일 프리픽스 없는 경로(`/privacy`, `/terms`, `/account-deletion`, `/company`, `/contact`)는 `/ko/...`로 308 리디렉션됩니다. 스토어 심사(Google Play 개인정보처리방침 URL 등)에 `https://alarm-talk.com/privacy` 같은 짧은 URL을 제출해도 동작해야 하기 때문입니다.
+- **도메인 설정**: 코드의 canonical/sitemap/robots는 모두 `https://alarm-talk.com`(non-www, `lib/site.ts`의 `SITE_URL`)을 기준으로 합니다. Vercel 대시보드의 Domains 설정에서 반드시 `alarm-talk.com`을 primary로 두고 `www.alarm-talk.com`을 308로 apex에 리디렉션해야 합니다. 반대로 설정하면 canonical URL이 리디렉션을 가리키게 되어 Search Console에서 색인 문제가 발생합니다.
+
 ## 다국어 (i18n)
 
 `next-intl` 기반. 모든 경로에 로케일 프리픽스가 붙습니다(`localePrefix: "always"`), 기본 `ko`.

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/:page(privacy|terms|account-deletion|company|contact)",
+      "destination": "/ko/:page/",
+      "permanent": true
+    },
+    {
+      "source": "/:page(privacy|terms|account-deletion|company|contact)/",
+      "destination": "/ko/:page/",
+      "permanent": true
+    },
+    { "source": "/", "destination": "/ko/", "permanent": false }
+  ]
+}


### PR DESCRIPTION
## 배경

Google Play 심사에서 개인정보처리방침 URL `https://alarm-talk.com/privacy` 가 응답하지 않아 반려되었습니다.

실제 동작을 확인한 결과:
- `https://alarm-talk.com/privacy` → 307 → `https://www.alarm-talk.com/privacy` → 308 → `/privacy/` → **404**
- 개인정보처리방침 페이지는 로케일 프리픽스가 붙은 `/ko/privacy/` 에만 존재
- 기존 `public/_redirects` 는 Netlify/Cloudflare Pages 형식이라 Vercel 에서 무시됨 (`output: "export"` 에서는 `next.config.ts` 의 `redirects()` 도 동작하지 않음)

## 변경 사항

- **`apps/landing/vercel.json` 추가**
  - `/privacy`, `/terms`, `/account-deletion`, `/company`, `/contact` (트레일링 슬래시 유무 모두) → `/ko/...` 308 리디렉션
  - `/` → `/ko/` 307 리디렉션 (기존 `_redirects` 의 의도를 Vercel 에서 실제로 동작하게 함)
- **README 에 배포 섹션 추가**: Vercel 리디렉션 구조와 도메인 설정 요건(primary = apex) 문서화

## 배포 후 별도 필요한 작업 (코드 외)

1. **Vercel 대시보드 → Domains**: 현재 apex(`alarm-talk.com`)가 www 로 리디렉션되도록 설정되어 있어, 코드의 canonical/sitemap(`https://alarm-talk.com`)과 충돌합니다. `alarm-talk.com` 을 primary 로, `www` 를 308 리디렉션으로 변경해야 Search Console 의 '적절한 표준 태그가 포함된 대체 페이지' 문제가 해소됩니다.
2. **Play Console**: 배포 후 `https://alarm-talk.com/privacy` 가 200(리디렉션 경유)으로 응답하는지 확인하고 재제출.

> 참고: Vercel 프로젝트의 Root Directory 가 `apps/landing` 으로 설정되어 있어야 이 `vercel.json` 이 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)