### PR TITLE
fix(landing): Vercel 리디렉션 추가 — /privacy 등 비로케일 경로 404 해결 (main hotfix)

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -18,6 +18,14 @@ npm run build        # 정적 사이트를 out/ 디렉토리로 export
 
 `next.config.ts`의 `output: "export"`로 정적 사이트가 생성됩니다. Cloudflare Pages, Vercel, S3 등 어디든 배포 가능합니다.
 
+## 배포 (Vercel)
+
+프로덕션은 Vercel에 배포되어 있습니다.
+
+- **리디렉션은 `vercel.json`이 담당합니다.** `output: "export"`에서는 `next.config.ts`의 `redirects()`가 동작하지 않고, `public/_redirects`(Netlify/Cloudflare Pages 형식)는 Vercel이 무시합니다. `_redirects`는 다른 정적 호스트로 옮길 때를 대비한 백업입니다.
+- 로케일 프리픽스 없는 경로(`/privacy`, `/terms`, `/account-deletion`, `/company`, `/contact`)는 `/ko/...`로 308 리디렉션됩니다. 스토어 심사(Google Play 개인정보처리방침 URL 등)에 `https://alarm-talk.com/privacy` 같은 짧은 URL을 제출해도 동작해야 하기 때문입니다.
+- **도메인 설정**: 코드의 canonical/sitemap/robots는 모두 `https://alarm-talk.com`(non-www, `lib/site.ts`의 `SITE_URL`)을 기준으로 합니다. Vercel 대시보드의 Domains 설정에서 반드시 `alarm-talk.com`을 primary로 두고 `www.alarm-talk.com`을 308로 apex에 리디렉션해야 합니다. 반대로 설정하면 canonical URL이 리디렉션을 가리키게 되어 Search Console에서 색인 문제가 발생합니다.
+
 ## 디자인 토큰
 
 `apps/android-native`의 `LandingScreen.kt`와 동기화된 다크 톤입니다 (`app/globals.css`의 `@theme` 블록). 앱과 랜딩의 첫 진입 톤을 일치시키기 위해 색·타이포·곡률을 같은 값으로 유지합니다.

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/:page(privacy|terms|account-deletion|company|contact)",
+      "destination": "/ko/:page/",
+      "permanent": true
+    },
+    {
+      "source": "/:page(privacy|terms|account-deletion|company|contact)/",
+      "destination": "/ko/:page/",
+      "permanent": true
+    },
+    { "source": "/", "destination": "/ko/", "permanent": false }
+  ]
+}


### PR DESCRIPTION
develop에 머지된 #455 의 랜딩 수정만 main 에 cherry-pick 한 핫픽스입니다.

develop 전체를 main 에 머지하면 `packages/backend` 변경이 포함되어 백엔드 prod 배포·prod DB 마이그레이션이 트리거되므로, `apps/landing` 변경만 분리했습니다 (백엔드 워크플로 트리거 없음).

## 변경 사항

- `apps/landing/vercel.json`: `/privacy`, `/terms`, `/account-deletion`, `/company`, `/contact` → `/ko/...` 308 리디렉션, `/` → `/ko/` 307 리디렉션
- README 배포 섹션 추가 (Vercel 리디렉션 구조·도메인 primary=apex 요건)

## 배경

Google Play 심사에서 개인정보처리방침 URL `https://alarm-talk.com/privacy` 무응답으로 반려. 페이지가 `/ko/privacy/` 에만 존재했고 `public/_redirects` 는 Vercel 에서 무시됨. 상세는 #455 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)