### PR TITLE
fix(landing): SITE_URL 환경변수에서 origin만 취하도록 보정

### DIFF
--- a/apps/landing/lib/site.ts
+++ b/apps/landing/lib/site.ts
@@ -1,12 +1,26 @@
 const DEFAULT_SITE_URL = "https://alarm-talk.com";
 
-function normalize(url: string): string {
-  return url.replace(/\/+$/, "");
+// 환경변수에 경로가 섞여 들어오면(`https://…/ko` 등) sitemap/canonical 전체가
+// `/ko/ko/` 같은 존재하지 않는 URL로 생성되므로 origin만 취한다.
+function resolveSiteUrl(raw: string | undefined): string {
+  if (!raw) return DEFAULT_SITE_URL;
+  try {
+    const url = new URL(raw);
+    if (url.pathname !== "/" || url.search || url.hash) {
+      console.warn(
+        `[site] NEXT_PUBLIC_SITE_URL 은 origin 만 허용합니다. "${raw}" → "${url.origin}" 으로 보정합니다.`,
+      );
+    }
+    return url.origin;
+  } catch {
+    console.warn(
+      `[site] NEXT_PUBLIC_SITE_URL "${raw}" 이 유효한 URL 이 아니라 기본값 ${DEFAULT_SITE_URL} 을 사용합니다.`,
+    );
+    return DEFAULT_SITE_URL;
+  }
 }
 
-export const SITE_URL = normalize(
-  process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL,
-);
+export const SITE_URL = resolveSiteUrl(process.env.NEXT_PUBLIC_SITE_URL);
 
 export const SITE_NAME = "AlarmTalk";
 


### PR DESCRIPTION
## 배경

프로덕션 사이트의 sitemap·canonical·hreflang 이 전부 존재하지 않는 `/ko/ko/` 형태 URL 로 생성되고 있었습니다 (robots.txt 도 `/ko/sitemap.xml` 을 가리킴). Search Console 의 `/ko/en/` 404 와 '적절한 표준 태그가 포함된 대체 페이지' 문제의 근본 원인입니다.

원인은 Vercel 의 `NEXT_PUBLIC_SITE_URL` 환경변수에 경로가 섞여 들어간 것(`https://www.alarm-talk.com/ko`)으로, 기존 `normalize()` 는 끝 슬래시만 제거해 경로를 거르지 못했습니다.

## 변경 사항

- `lib/site.ts`: 환경변수를 `new URL()` 로 파싱해 **origin 만** 사용. 경로/쿼리/해시가 섞이면 경고 후 origin 으로 보정, 파싱 불가면 기본값(`https://alarm-talk.com`) 폴백.

## 별도 필요한 작업 (Vercel 대시보드)

이 코드와 무관하게 `NEXT_PUBLIC_SITE_URL` 을 `https://alarm-talk.com` 으로 수정(또는 삭제)하고 redeploy 해야 www/apex 선택까지 바로잡힙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)