### PR TITLE
fix(landing): SITE_URL 환경변수에서 origin만 취하도록 보정 (main hotfix)

### DIFF
--- a/apps/landing/lib/site.ts
+++ b/apps/landing/lib/site.ts
@@ -1,12 +1,26 @@
 const DEFAULT_SITE_URL = "https://alarm-talk.com";
 
-function normalize(url: string): string {
-  return url.replace(/\/+$/, "");
+// 환경변수에 경로가 섞여 들어오면(`https://…/ko` 등) sitemap/canonical 전체가
+// `/ko/ko/` 같은 존재하지 않는 URL로 생성되므로 origin만 취한다.
+function resolveSiteUrl(raw: string | undefined): string {
+  if (!raw) return DEFAULT_SITE_URL;
+  try {
+    const url = new URL(raw);
+    if (url.pathname !== "/" || url.search || url.hash) {
+      console.warn(
+        `[site] NEXT_PUBLIC_SITE_URL 은 origin 만 허용합니다. "${raw}" → "${url.origin}" 으로 보정합니다.`,
+      );
+    }
+    return url.origin;
+  } catch {
+    console.warn(
+      `[site] NEXT_PUBLIC_SITE_URL "${raw}" 이 유효한 URL 이 아니라 기본값 ${DEFAULT_SITE_URL} 을 사용합니다.`,
+    );
+    return DEFAULT_SITE_URL;
+  }
 }
 
-export const SITE_URL = normalize(
-  process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL,
-);
+export const SITE_URL = resolveSiteUrl(process.env.NEXT_PUBLIC_SITE_URL);
 
 export const SITE_NAME = "AlarmTalk";
 


### PR DESCRIPTION
develop 에 머지된 #457 을 main 에 cherry-pick 한 핫픽스입니다. `apps/landing` 만 변경하므로 백엔드 prod 배포는 트리거되지 않습니다.

## 배경

프로덕션 sitemap·canonical·hreflang 이 전부 존재하지 않는 `/ko/ko/` 형태 URL 로 생성되던 문제 (Search Console `/ko/en/` 404 의 근본 원인). Vercel 의 `NEXT_PUBLIC_SITE_URL` 에 경로가 섞여 들어간 것이 원인으로, 환경변수에서 origin 만 취하도록 보정합니다. 상세는 #457 참고.

## 별도 필요한 작업 (Vercel 대시보드)

`NEXT_PUBLIC_SITE_URL` 을 `https://alarm-talk.com` 으로 수정(또는 삭제) 후 redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)