### PR TITLE
feat(backend): 무료 플랜용 스톡 알람 클립 생성·노출

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -123,6 +123,40 @@ app.post('/api/init-db', async (c) => {
   }
 });
 
+// 무료 플랜용 스톡 알람 클립 생성 (dev 전용 / prod 는 x-init-db-secret 필요).
+// Workers 서브리퀘스트 캡을 피하려고 한 번에 max 개(기본 2)만 생성하고 remaining 을
+// 돌려준다. 호출자가 remaining 이 0 이 될 때까지 반복 호출한다 (멱등).
+app.post('/api/admin/seed-stock-clips', async (c) => {
+  if (!canRunInitDb(c)) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  try {
+    const max = Math.min(Math.max(parseInt(c.req.query('max') || '2', 10) || 2, 1), 12);
+    const { findMissingStockTargets, generateStockClip } = await import('./lib/stock-clips');
+    const db = getDB(c.env);
+    const missing = await findMissingStockTargets(db);
+    const batch = missing.slice(0, max);
+    const generated = [];
+    for (const target of batch) {
+      generated.push(await generateStockClip(db, c.env, target));
+    }
+    return c.json({
+      success: true,
+      generated,
+      generated_count: generated.length,
+      remaining: missing.length - generated.length,
+    });
+  } catch (err) {
+    return c.json(
+      {
+        error: 'Stock clip seed failed',
+        detail: err instanceof Error ? err.message : 'Unknown error',
+      },
+      500,
+    );
+  }
+});
+
 // 공개 라우트 (인증 불필요)
 app.get('/api/tts/presets', noStore, async (c) => {
   const { loadTtsPresets } = await import('./lib/tts-presets');

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -961,6 +961,19 @@ export const migrations: Migration[] = [
                 '제시카', 'cgSgspJ2msm6clMCkdW9', 'ready', 1, 0, 0)`,
     ],
   },
+  {
+    // 무료 플랜용 "스톡 알람 클립" — 시스템 보이스로 서버에서 미리 합성해 둔 고정 음성.
+    //  - messages.is_preset=1 + voice_profile_id(시스템 보이스) + category + language 조합으로 식별.
+    //  - 무료 플랜은 랜덤 생성 없이 이 클립을 그대로 받아 알람에 붙여 쓴다 (생성 비용 0).
+    //  - 실제 클립은 POST /api/admin/seed-stock-clips (dev 전용) 로 생성한다.
+    id: 44,
+    name: 'messages-language-for-stock-clips',
+    statements: [
+      `ALTER TABLE messages ADD COLUMN language TEXT`,
+      `CREATE INDEX IF NOT EXISTS idx_messages_stock
+        ON messages(is_preset, voice_profile_id, category, language)`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/stock-clips.ts
+++ b/packages/backend/src/lib/stock-clips.ts
@@ -1,0 +1,238 @@
+import type { Client } from '@libsql/client/web';
+import type { Env } from '../types';
+import { R2VoiceStorage } from './r2-storage';
+import { computeTtsCacheKey, generatedTtsObjectKey } from './audio-cache';
+import { createSynthesisAttempts, normalizeSynthesisLanguage } from './voice-provider';
+import { prepareAlarmTextWithVertex } from './vertex-translate';
+
+/** 시스템 스톡 보이스의 소유자(로그인 불가, 발급 전용). migrations.ts #43 과 동일. */
+export const SYSTEM_VOICE_LIBRARY_USER_ID = '70000000-0000-4000-9000-000000000001';
+
+/** 스톡 클립을 만들 언어. 한국어 베이스 → 영어/일본어는 Vertex 로 번역. */
+export const STOCK_CLIP_LANGUAGES = ['ko', 'en', 'ja'] as const;
+
+/**
+ * 스톡 클립 프리셋. baseText 는 태그 없는 한국어 한 줄이며, 합성 직전에
+ * Vertex 로 (번역 +) ElevenLabs v3 딜리버리 태그 1개를 자동 부여한다.
+ *
+ * 지금은 "기상" 1종만 테스트로 둔다. 카테고리를 늘리려면 여기에 추가하면
+ * findMissingStockTargets 가 자동으로 (보이스 × 언어) 매트릭스를 채운다.
+ */
+export const STOCK_CLIP_PRESETS = [
+  {
+    category: 'morning',
+    baseText: '좋은 아침이에요. 일어나실 시간이에요. 오늘도 좋은 하루 되세요.',
+  },
+] as const;
+
+export interface SystemVoiceRow {
+  id: string;
+  name: string;
+  elevenlabsVoiceId: string;
+}
+
+export interface StockClipTarget {
+  voiceProfileId: string;
+  voiceName: string;
+  elevenlabsVoiceId: string;
+  category: string;
+  baseText: string;
+  language: string;
+}
+
+export interface GeneratedStockClip {
+  message_id: string;
+  voice_profile_id: string;
+  voice_name: string;
+  category: string;
+  language: string;
+  text: string;
+}
+
+/** 합성 준비된(ready) 시스템 보이스 목록. */
+export async function listSystemVoices(db: Client): Promise<SystemVoiceRow[]> {
+  const res = await db.execute({
+    sql: `SELECT id, name, elevenlabs_voice_id
+          FROM voice_profiles
+          WHERE COALESCE(is_system, 0) = 1
+            AND deleted_at IS NULL
+            AND status = 'ready'
+            AND elevenlabs_voice_id IS NOT NULL
+          ORDER BY id ASC`,
+    args: [],
+  });
+  return res.rows
+    .map((row) => ({
+      id: String(row.id),
+      name: String(row.name),
+      elevenlabsVoiceId: String(row.elevenlabs_voice_id ?? ''),
+    }))
+    .filter((row) => row.elevenlabsVoiceId.length > 0);
+}
+
+/** 아직 생성되지 않은 (보이스 × 카테고리 × 언어) 조합. */
+export async function findMissingStockTargets(db: Client): Promise<StockClipTarget[]> {
+  const voices = await listSystemVoices(db);
+
+  const existing = await db.execute({
+    sql: `SELECT voice_profile_id, category, language
+          FROM messages
+          WHERE COALESCE(is_preset, 0) = 1 AND audio_url IS NOT NULL`,
+    args: [],
+  });
+  const seen = new Set(
+    existing.rows.map(
+      (row) => `${row.voice_profile_id}|${row.category}|${row.language}`,
+    ),
+  );
+
+  const targets: StockClipTarget[] = [];
+  for (const voice of voices) {
+    for (const preset of STOCK_CLIP_PRESETS) {
+      for (const language of STOCK_CLIP_LANGUAGES) {
+        const lang = normalizeSynthesisLanguage(language);
+        if (seen.has(`${voice.id}|${preset.category}|${lang}`)) continue;
+        targets.push({
+          voiceProfileId: voice.id,
+          voiceName: voice.name,
+          elevenlabsVoiceId: voice.elevenlabsVoiceId,
+          category: preset.category,
+          baseText: preset.baseText,
+          language: lang,
+        });
+      }
+    }
+  }
+  return targets;
+}
+
+/** 표시용 텍스트에서 [tag] 마커 제거 (앱에는 태그 없이 보여준다). */
+function stripDeliveryTags(text: string): string {
+  return text
+    .replace(/\[[a-z][a-z -]{1,32}\]/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * 스톡 클립 1개 생성: Vertex 로 문구/번역/태그 → ElevenLabs 합성 → R2 저장 →
+ * messages(is_preset=1) + generated_audio_assets insert. 멱등 보장은 호출자
+ * (findMissingStockTargets) 가 담당한다.
+ */
+export async function generateStockClip(
+  db: Client,
+  env: Env,
+  target: StockClipTarget,
+): Promise<GeneratedStockClip> {
+  const language = normalizeSynthesisLanguage(target.language);
+
+  const prepared = await prepareAlarmTextWithVertex(env, target.baseText, {
+    targetLanguage: language,
+    sourceLanguage: 'ko',
+    translate: language !== 'ko',
+    autoTag: true,
+  });
+  const synthesisText = prepared.text;
+  const displayText = stripDeliveryTags(synthesisText) || stripDeliveryTags(target.baseText);
+  const deliveryTagsJson = JSON.stringify(prepared.tags);
+
+  const attempts = createSynthesisAttempts({
+    env,
+    profile: { elevenlabs_voice_id: target.elevenlabsVoiceId },
+    text: synthesisText,
+    language,
+    category: target.category,
+  });
+  if (attempts.length === 0) {
+    throw new Error('No synthesis provider available (ELEVENLABS_API_KEY missing?)');
+  }
+  const attempt = attempts[0]!;
+
+  const cacheKey = await computeTtsCacheKey({
+    provider: attempt.provider,
+    providerVoiceId: attempt.providerVoiceId,
+    voiceProfileId: target.voiceProfileId,
+    modelId: attempt.modelId,
+    language,
+    languageCode: language,
+    text: synthesisText,
+    outputFormat: attempt.outputFormat,
+    voiceSettings: attempt.voiceSettings,
+  });
+
+  const generated = await attempt.synthesize();
+  const bytes = generated.bytes;
+
+  if (!env.VOICE_BUCKET) {
+    throw new Error('VOICE_BUCKET (R2) is not configured.');
+  }
+  const storage = new R2VoiceStorage(env.VOICE_BUCKET);
+  const audioObjectKey = generatedTtsObjectKey(
+    SYSTEM_VOICE_LIBRARY_USER_ID,
+    cacheKey,
+    generated.outputFormat,
+  );
+  await storage.storeAtKey(audioObjectKey, {
+    bytes,
+    userId: SYSTEM_VOICE_LIBRARY_USER_ID,
+    mimeType: generated.mimeType,
+    originalName: `stock_${cacheKey}.${generated.outputFormat}`,
+  });
+  const audioUrl = `r2://${audioObjectKey}`;
+
+  const messageId = crypto.randomUUID();
+  await db.execute({
+    sql: `INSERT INTO messages
+          (id, user_id, voice_profile_id, text, synthesis_text, delivery_tags_json,
+           category, language, is_preset, audio_url)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+    args: [
+      messageId,
+      SYSTEM_VOICE_LIBRARY_USER_ID,
+      target.voiceProfileId,
+      displayText,
+      synthesisText,
+      deliveryTagsJson,
+      target.category,
+      language,
+      audioUrl,
+    ],
+  });
+
+  await db.execute({
+    sql: `INSERT OR IGNORE INTO generated_audio_assets
+          (id, user_id, voice_profile_id, message_id, provider, provider_voice_id,
+           model_id, language, request_hash, text, original_text, delivery_tags_json,
+           category, audio_url, audio_object_key, audio_format, mime_type, size_bytes)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      crypto.randomUUID(),
+      SYSTEM_VOICE_LIBRARY_USER_ID,
+      target.voiceProfileId,
+      messageId,
+      generated.provider,
+      generated.providerVoiceId,
+      generated.modelId,
+      language,
+      cacheKey,
+      synthesisText,
+      displayText,
+      deliveryTagsJson,
+      target.category,
+      audioUrl,
+      audioObjectKey,
+      generated.outputFormat,
+      generated.mimeType,
+      bytes.byteLength,
+    ],
+  });
+
+  return {
+    message_id: messageId,
+    voice_profile_id: target.voiceProfileId,
+    voice_name: target.voiceName,
+    category: target.category,
+    language,
+    text: displayText,
+  };
+}

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -1112,6 +1112,14 @@ tts.get('/messages/:id/audio', async (c) => {
                 WHERE a.message_id = messages.id
                   AND a.target_user_id IN (?, ?)
               )
+              OR (
+                COALESCE(messages.is_preset, 0) = 1
+                AND EXISTS (
+                  SELECT 1 FROM voice_profiles vp
+                  WHERE vp.id = messages.voice_profile_id
+                    AND COALESCE(vp.is_system, 0) = 1
+                )
+              )
             )`,
     args: [id, ...ownerIds, ...ownerIds],
   });
@@ -1229,6 +1237,37 @@ tts.delete('/messages/:id', async (c) => {
 
 tts.get('/presets', async (c) => {
   return c.json({ presets: await loadTtsPresets(c.env) });
+});
+
+// 무료 플랜용 스톡(미리 만든) 알람 클립 목록. 시스템 보이스로 서버에서 합성해 둔
+// 고정 클립을 보이스 × 언어 × 카테고리로 노출한다. 오디오는 message_id 로
+// GET /tts/messages/:id/audio 에서 받는다 (스톡은 모든 사용자가 조회 가능).
+tts.get('/stock-clips', async (c) => {
+  const db = getDB(c.env);
+  const result = await db.execute({
+    sql: `SELECT m.id AS message_id, m.voice_profile_id, m.text, m.category, m.language,
+                 m.delivery_tags_json, m.audio_url, vp.name AS voice_name
+          FROM messages m
+          JOIN voice_profiles vp ON vp.id = m.voice_profile_id
+          WHERE COALESCE(m.is_preset, 0) = 1
+            AND COALESCE(vp.is_system, 0) = 1
+            AND vp.deleted_at IS NULL
+            AND m.audio_url IS NOT NULL
+          ORDER BY vp.id ASC, m.category ASC, m.language ASC`,
+    args: [],
+  });
+  return c.json({
+    clips: result.rows.map((row) => ({
+      message_id: row.message_id,
+      voice_profile_id: row.voice_profile_id,
+      voice_name: row.voice_name,
+      category: row.category,
+      language: row.language,
+      text: row.text,
+      audio_url: row.audio_url,
+      tags: parseDeliveryTags(row.delivery_tags_json),
+    })),
+  });
 });
 
 async function findCachedGeneratedAudio(


### PR DESCRIPTION
## 요약
무료 플랜이 **랜덤 생성 없이** 서버에서 미리 만들어 둔 고정 알람 음성(스톡 클립)을 그대로 받아 쓸 수 있도록 백엔드를 추가했습니다. (생성 비용 0, 미리듣기 가능)

## 변경
- **마이그레이션 #44**: `messages.language` 컬럼 + 스톡 식별 인덱스
- **`lib/stock-clips.ts`**: 시스템 보이스로 Vertex(문구·번역·태그) → ElevenLabs 합성 → R2 저장 → `messages(is_preset=1)` + `generated_audio_assets` 생성. 기존 테이블 재사용
- **`POST /api/admin/seed-stock-clips`** (dev 전용): 서브리퀘스트 캡 회피용 배치 생성(`?max=`), 멱등
- **`GET /api/tts/stock-clips`**: 보이스 × 언어(ko/en/ja) × 카테고리(morning) 목록
- **`GET /tts/messages/:id/audio`**: 스톡(시스템) 클립은 모든 사용자가 조회 가능하도록 권한 확장 (미리듣기·다운로드용)

현재 스코프: `morning` 1종 × 4 보이스 × 3 언어 = 12개 (테스트).

## 테스트
- `npm test` 1360 passed
- `tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)