### PR TITLE
feat(android): 무료 기본 목소리 사용성 개선 + 사용 가이드/울림 화면 디자인

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/SystemVoices.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/SystemVoices.kt
@@ -9,3 +9,9 @@ const val SYSTEM_VOICE_ID_PREFIX = "70000000-0000-4000-9000-"
 
 /** 시스템 제공(스톡) 보이스 id 인지 — 무료 플랜에서도 사용할 수 있다. */
 fun isSystemVoiceId(id: String?): Boolean = id?.startsWith(SYSTEM_VOICE_ID_PREFIX) == true
+
+/**
+ * 스톡 클립 카테고리. greeting 은 목소리 창에서 "이 목소리 들어보기" 샘플 전용이라
+ * 알람 에디터의 기본 제공 음성 목록에서는 제외한다.
+ */
+const val STOCK_GREETING_CATEGORY = "greeting"

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/TtsApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/TtsApi.kt
@@ -67,6 +67,20 @@ data class TtsMessageAudioResponse(
     @SerializedName("voice_profile_id") val voiceProfileId: String? = null,
 )
 
+data class StockClipListResponse(
+    val clips: List<StockClip> = emptyList(),
+)
+
+data class StockClip(
+    @SerializedName("message_id") val messageId: String,
+    @SerializedName("voice_profile_id") val voiceProfileId: String,
+    @SerializedName("voice_name") val voiceName: String? = null,
+    val category: String? = null,
+    val language: String? = null,
+    val text: String = "",
+    @SerializedName("audio_url") val audioUrl: String? = null,
+)
+
 interface TtsApi {
     @POST("tts/generate")
     suspend fun generateTts(
@@ -76,6 +90,9 @@ interface TtsApi {
 
     @GET("tts/messages")
     suspend fun listTtsMessages(@Header("Authorization") authorization: String): TtsMessageListResponse
+
+    @GET("tts/stock-clips")
+    suspend fun getStockClips(@Header("Authorization") authorization: String): StockClipListResponse
 
     @GET("tts/messages/{id}/audio")
     suspend fun getTtsMessageAudio(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ringing/RingingActivity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ringing/RingingActivity.kt
@@ -9,8 +9,16 @@ import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,8 +27,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
@@ -29,11 +39,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.Snooze
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
@@ -43,13 +50,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.animation.core.Animatable
+import androidx.compose.ui.graphics.graphicsLayer
 import com.alarmtalk.app.alarm.AlarmContract.EXTRA_ALARM_ID
 import com.alarmtalk.app.alarm.RingingService
 import com.alarmtalk.app.data.AlarmAppContainer
@@ -57,7 +75,12 @@ import com.alarmtalk.app.data.AlarmEntity
 import com.alarmtalk.app.data.AlarmPlayModes
 import com.alarmtalk.app.data.SnoozeRepeatLimits
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+import kotlin.math.roundToInt
 
 class RingingActivity : ComponentActivity() {
     private var alarmId by mutableStateOf<String?>(null)
@@ -156,6 +179,11 @@ class RingingActivity : ComponentActivity() {
     }
 }
 
+// 가이드 .ring 디자인의 다크 블루→블랙 그라데이션 배경.
+private val RingingBackground = Brush.verticalGradient(
+    listOf(Color(0xFF11355A), Color(0xFF0A1726), Color(0xFF06080E)),
+)
+
 @Composable
 private fun RingingRoute(
     uiState: RingingUiState,
@@ -185,139 +213,298 @@ private fun RingingRoute(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(horizontal = 24.dp, vertical = 28.dp),
+                .background(RingingBackground)
+                .systemBarsPadding()
+                .padding(horizontal = 28.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            RingingStatusPill()
-            Column(
-                modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
+            Spacer(Modifier.height(54.dp))
+            Text(
+                text = uiState.dateText,
+                color = Color(0xFFA6BDDA),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(6.dp))
+            RingingClock(ampm = uiState.ampm, time = uiState.timeText)
+
+            Spacer(Modifier.height(30.dp))
+            RingingVoiceCard(uiState)
+
+            Spacer(Modifier.weight(1f))
+
+            if (uiState.snoozeEnabled) {
+                RingingSnoozeButton(
+                    minutes = uiState.snoozeMinutes,
+                    onSnooze = onSnooze,
+                )
+                Spacer(Modifier.height(14.dp))
+            }
+            RingingSlideToDismiss(onDismiss = onDismiss)
+            Spacer(Modifier.height(28.dp))
+        }
+    }
+}
+
+@Composable
+private fun RingingClock(ampm: String, time: String) {
+    Row(
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (ampm.isNotBlank()) {
+            Text(
+                text = ampm,
+                modifier = Modifier.padding(bottom = 18.dp),
+                color = Color(0xFFA6BDDA),
+                fontSize = 26.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Text(
+            text = time,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontSize = 104.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = (-3).sp,
+        )
+    }
+}
+
+@Composable
+private fun RingingVoiceCard(uiState: RingingUiState) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .widthIn(max = 440.dp),
+        shape = RoundedCornerShape(28.dp),
+        color = Color(0xFF122034).copy(alpha = 0.66f),
+        border = BorderStroke(1.dp, Color(0x24FFFFFF)),
+    ) {
+        Column(modifier = Modifier.padding(22.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Surface(
-                    modifier = Modifier.size(112.dp),
+                    modifier = Modifier.size(46.dp),
                     shape = CircleShape,
                     color = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ) {
                     Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = Icons.Outlined.Alarm,
-                            contentDescription = null,
-                            modifier = Modifier.size(58.dp),
-                        )
+                        val initial = uiState.avatarLabel
+                        if (initial != null) {
+                            Text(
+                                text = initial,
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Outlined.Alarm,
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
                 }
-                Spacer(Modifier.height(24.dp))
-                Text(
-                    text = uiState.title,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = uiState.subtitle,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                uiState.voiceText?.let { voiceText ->
-                    Spacer(Modifier.height(22.dp))
-                    RingingVoiceText(voiceText)
+                Spacer(Modifier.width(13.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = uiState.title,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = uiState.subtitle,
+                        color = Color(0xFFA6BDDA),
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
-                Spacer(Modifier.height(24.dp))
-                RingingVoiceWaveform()
             }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(14.dp),
-            ) {
-                if (uiState.snoozeEnabled) {
-                    OutlinedButton(
-                        onClick = onSnooze,
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(58.dp),
-                        shape = RoundedCornerShape(18.dp),
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.onSurface,
-                        ),
-                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-                    ) {
-                        Icon(Icons.Outlined.Snooze, contentDescription = null)
-                        Spacer(Modifier.width(8.dp))
-                        Text("다시 울리기")
-                    }
-                }
-                Button(
-                    onClick = onDismiss,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(58.dp),
-                    shape = RoundedCornerShape(18.dp),
-                ) {
-                    Text("알람 끄기")
-                }
+            Spacer(Modifier.height(16.dp))
+            RingingVoiceWaveform()
+            uiState.voiceText?.let { voiceText ->
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "“$voiceText”",
+                    color = Color(0xFFDBE7F6),
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }
 }
 
 @Composable
-private fun RingingStatusPill() {
+private fun RingingSnoozeButton(minutes: Int, onSnooze: () -> Unit) {
     Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.72f),
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        onClick = onSnooze,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(62.dp),
+        shape = RoundedCornerShape(22.dp),
+        color = Color.White.copy(alpha = 0.07f),
+        border = BorderStroke(1.dp, Color(0x24FFFFFF)),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(7.dp),
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                imageVector = Icons.Outlined.GraphicEq,
+                imageVector = Icons.Outlined.Snooze,
                 contentDescription = null,
-                modifier = Modifier.size(17.dp),
+                tint = Color(0xFFCFDDEE),
+                modifier = Modifier.size(20.dp),
             )
+            Spacer(Modifier.width(9.dp))
             Text(
-                text = "알람 울림",
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold,
+                text = "${minutes}분 뒤 다시 알림",
+                color = Color(0xFFCFDDEE),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+private val SlideTrackBrush = Brush.verticalGradient(
+    listOf(Color(0x2E9ECBFF), Color(0x0F9ECBFF)),
+)
+private val SlideKnobBrush = Brush.verticalGradient(
+    listOf(Color(0xFFBFE0FF), Color(0xFF9ECBFF)),
+)
+
+@Composable
+private fun RingingSlideToDismiss(onDismiss: () -> Unit) {
+    val scope = rememberCoroutineScope()
+    val density = androidx.compose.ui.platform.LocalDensity.current
+    val knobSizePx = with(density) { 64.dp.toPx() }
+    val edgePadPx = with(density) { 6.dp.toPx() }
+
+    var trackWidthPx by remember { mutableStateOf(0) }
+    val offsetX = remember { Animatable(0f) }
+    val maxOffset = (trackWidthPx - knobSizePx - edgePadPx * 2).coerceAtLeast(0f)
+
+    // 라벨은 노브가 이동할수록 서서히 사라진다.
+    val labelAlpha = if (maxOffset <= 0f) 1f else (1f - offsetX.value / maxOffset).coerceIn(0f, 1f)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(76.dp)
+            .onSizeChanged { trackWidthPx = it.width }
+            .clip(RoundedCornerShape(26.dp))
+            .background(SlideTrackBrush)
+            .background(Color.Transparent),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        // 1dp 라이트블루 보더.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val stroke = 1.dp.toPx()
+            drawRoundRect(
+                color = Color(0x4D9ECBFF),
+                topLeft = Offset(stroke / 2f, stroke / 2f),
+                size = androidx.compose.ui.geometry.Size(
+                    size.width - stroke,
+                    size.height - stroke,
+                ),
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(26.dp.toPx()),
+                style = Stroke(width = stroke),
+            )
+        }
+
+        Text(
+            text = "밀어서 끄기",
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 60.dp, end = 24.dp)
+                .graphicsLayer { alpha = labelAlpha },
+            color = Color(0xFFDCECFF),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+
+        SlideHintArrows(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 22.dp)
+                .graphicsLayer { alpha = labelAlpha },
+        )
+
+        Box(
+            modifier = Modifier
+                .padding(start = 6.dp)
+                .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+                .size(64.dp)
+                .clip(RoundedCornerShape(21.dp))
+                .background(SlideKnobBrush)
+                .pointerInput(maxOffset) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            if (maxOffset > 0f && offsetX.value >= maxOffset * 0.7f) {
+                                scope.launch {
+                                    offsetX.animateTo(maxOffset)
+                                    onDismiss()
+                                }
+                            } else {
+                                scope.launch { offsetX.animateTo(0f) }
+                            }
+                        },
+                    ) { change, dragAmount ->
+                        change.consume()
+                        scope.launch {
+                            val next = (offsetX.value + dragAmount).coerceIn(0f, maxOffset)
+                            offsetX.snapTo(next)
+                        }
+                    }
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Alarm,
+                contentDescription = "밀어서 끄기",
+                tint = Color(0xFF06243E),
+                modifier = Modifier.size(24.dp),
             )
         }
     }
 }
 
 @Composable
-private fun RingingVoiceText(text: String) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .widthIn(max = 420.dp),
-        shape = RoundedCornerShape(22.dp),
-        color = MaterialTheme.colorScheme.surface,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+private fun SlideHintArrows(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "slideHint")
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium,
-            textAlign = TextAlign.Center,
-            maxLines = 4,
-            overflow = TextOverflow.Ellipsis,
-        )
+        repeat(3) { index ->
+            val alpha by transition.animateFloat(
+                initialValue = 0.25f,
+                targetValue = 0.9f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(durationMillis = 750, delayMillis = index * 180, easing = LinearEasing),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+                label = "arrow$index",
+            )
+            Canvas(modifier = Modifier.size(11.dp)) {
+                val w = 2.4.dp.toPx()
+                val color = Color(0xFFDCECFF).copy(alpha = alpha)
+                // 오른쪽을 가리키는 셰브론.
+                drawLine(color, Offset(size.width * 0.3f, size.height * 0.2f), Offset(size.width * 0.75f, size.height * 0.5f), strokeWidth = w)
+                drawLine(color, Offset(size.width * 0.75f, size.height * 0.5f), Offset(size.width * 0.3f, size.height * 0.8f), strokeWidth = w)
+            }
+        }
     }
 }
 
@@ -325,8 +512,8 @@ private fun RingingVoiceText(text: String) {
 private fun RingingVoiceWaveform() {
     Row(
         modifier = Modifier
-            .fillMaxWidth(0.76f)
-            .height(54.dp),
+            .fillMaxWidth()
+            .height(40.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -339,7 +526,7 @@ private fun RingingVoiceWaveform() {
             Box(
                 modifier = Modifier
                     .width(2.dp)
-                    .height((8 + level * 42).dp)
+                    .height((8 + level * 30).dp)
                     .background(
                         color = when (index) {
                             in 5..14 -> MaterialTheme.colorScheme.primary
@@ -355,14 +542,19 @@ private fun RingingVoiceWaveform() {
 
 private data class RingingUiState(
     val title: String = "알람이 울리고 있어요",
-    val subtitle: String = "지금 알람을 확인해 주세요",
+    val subtitle: String = "지금 울리고 있어요",
     val voiceText: String? = null,
     val snoozeEnabled: Boolean = true,
+    val snoozeMinutes: Int = 5,
+    val dateText: String = todayDateLabel(),
+    val ampm: String = currentAmPmLabel(),
+    val timeText: String = currentTimeLabel(),
+    /** 보이스 카드 아바타에 표시할 라벨 첫 글자 — null 이면 알람 아이콘. */
+    val avatarLabel: String? = null,
 )
 
 private fun AlarmEntity.toRingingUiState(): RingingUiState {
     val customTitle = label.trim().takeIf { it.isNotBlank() && it != "알람" }
-    val timeText = alarmTimeLabel(hour, minute)
     val voiceMessage = voiceText
         ?.trim()
         ?.takeIf { it.isNotBlank() && playMode != AlarmPlayModes.ALARM_ONLY }
@@ -373,18 +565,43 @@ private fun AlarmEntity.toRingingUiState(): RingingUiState {
             )
 
     return RingingUiState(
-        title = customTitle ?: timeText,
-        subtitle = if (customTitle != null) timeText else ringingModeLabel(playMode, voiceMessage != null),
+        title = customTitle ?: "알람이 울리고 있어요",
+        subtitle = if (customTitle != null) {
+            ringingModeLabel(playMode, voiceMessage != null)
+        } else {
+            "지금 울리고 있어요"
+        },
         voiceText = voiceMessage,
         snoozeEnabled = snoozeAvailable,
+        snoozeMinutes = snoozeMinutes,
+        dateText = todayDateLabel(),
+        ampm = if (hour < 12) "오전" else "오후",
+        timeText = alarmClockLabel(hour, minute),
+        avatarLabel = customTitle?.take(1),
     )
 }
 
-private fun alarmTimeLabel(hour: Int, minute: Int): String {
-    val marker = if (hour < 12) "오전" else "오후"
+private fun todayDateLabel(): String {
+    val today = LocalDate.now()
+    val weekday = today.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
+    return "${today.monthValue}월 ${today.dayOfMonth}일 $weekday"
+}
+
+private fun currentAmPmLabel(): String {
+    val hour = java.time.LocalTime.now().hour
+    return if (hour < 12) "오전" else "오후"
+}
+
+private fun currentTimeLabel(): String {
+    val now = java.time.LocalTime.now()
+    return alarmClockLabel(now.hour, now.minute)
+}
+
+/** "6:30" 형태(12시간제, 분 0패딩) — 큰 시계 표시용. */
+private fun alarmClockLabel(hour: Int, minute: Int): String {
     val hour12 = hour % 12
     val displayHour = if (hour12 == 0) 12 else hour12
-    return "$marker $displayHour:${"%02d".format(minute)}"
+    return "$displayHour:${"%02d".format(minute)}"
 }
 
 private fun ringingModeLabel(playMode: String, hasVoiceText: Boolean): String = when {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
@@ -1,20 +1,31 @@
 package com.alarmtalk.app
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Message
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.alarmtalk.app.ui.guide.CoachMarkOverlay
+import com.alarmtalk.app.ui.guide.CoachMarkRegistry
+import com.alarmtalk.app.ui.guide.CoachMarkStep
+import com.alarmtalk.app.ui.guide.UsageGuideStore
+import com.alarmtalk.app.ui.guide.coachMarkTarget
 import com.alarmtalk.app.data.AlarmEntity
 import com.alarmtalk.app.data.CachedAlarmAudio
 import com.alarmtalk.app.data.CharacterEventEntity
@@ -31,6 +42,34 @@ import com.alarmtalk.app.network.TtsGenerateResponse
 import com.alarmtalk.app.network.VoiceProfile
 import com.alarmtalk.app.network.VoiceSpeakerSegment
 import com.alarmtalk.app.network.VoucherItem
+
+// 홈 첫 방문 안내 — 다음 알람 히어로 / 빠른 시작 타일에 스포트라이트.
+private const val GUIDE_TARGET_HOME_HERO = "home_next_alarm"
+private const val GUIDE_TARGET_HOME_QUICK = "home_quick_start"
+
+private val homeCoachSteps = listOf(
+    CoachMarkStep(
+        targetKey = GUIDE_TARGET_HOME_HERO,
+        title = "다음 알람을 한눈에",
+        body = "다음에 울릴 알람을 여기서 바로 확인하고, 눌러서 시각이나 목소리를 바꿀 수 있어요.",
+    ),
+    CoachMarkStep(
+        targetKey = GUIDE_TARGET_HOME_QUICK,
+        title = "여기서 바로 시작해요",
+        body = "‘목소리 만들기’로 깨워줄 목소리를 등록하고, ‘새 알람’으로 알람을 추가할 수 있어요.",
+    ),
+)
+
+// 목소리 등록 첫 방문 안내 — 내 목소리 만들기 버튼에 스포트라이트.
+private const val GUIDE_TARGET_VOICE_CREATE = "voice_register_create"
+
+private val voiceRegisterCoachSteps = listOf(
+    CoachMarkStep(
+        targetKey = GUIDE_TARGET_VOICE_CREATE,
+        title = "내 목소리를 만들어요",
+        body = "여기서 1분 남짓 녹음하거나 음성 파일을 올리면, 그 목소리로 알람을 깨워줘요. 만든 목소리는 가족·연인과 공유할 수도 있어요.",
+    ),
+)
 
 @Composable
 internal fun AlarmListScreen(
@@ -66,6 +105,8 @@ internal fun AlarmListScreen(
     onPromoteDraftVoice: suspend (String) -> Unit,
     onDeleteDraftVoice: suspend (String) -> Unit,
     onGenerateTts: suspend (TtsGenerateRequest) -> TtsGenerateResponse,
+    stockClips: List<com.alarmtalk.app.network.StockClip>,
+    onDownloadStockAudio: suspend (String) -> com.alarmtalk.app.network.TtsMessageAudioResponse,
     onRenameVoiceProfile: (String, String, String, String) -> Unit,
     onShareVoiceProfile: (String, Boolean) -> Unit,
     onUpdateSharedVoiceInfo: (String, String, String) -> Unit,
@@ -114,7 +155,28 @@ internal fun AlarmListScreen(
     val voiceLocked = voicePlanLocked || !permissions.recordAudio
     val alarmLocked = !permissions.alarmReady
 
+    val appContext = LocalContext.current.applicationContext
+    val usageGuideStore = remember(appContext) { UsageGuideStore(appContext) }
+    val coachMarkRegistry = remember { CoachMarkRegistry() }
+    val listState = rememberLazyListState()
+
+    // 홈/목소리 탭 첫 방문 시 한 번만 자동 노출. 로그인 후 콘텐츠가 보일 때만 띄운다.
+    var homeGuideVisible by remember {
+        mutableStateOf(
+            selectedTab == NativeTab.Home && authSession != null &&
+                !usageGuideStore.hasSeen(UsageGuideStore.GUIDE_HOME),
+        )
+    }
+    var voiceGuideVisible by remember {
+        mutableStateOf(
+            selectedTab == NativeTab.Voices && authSession != null &&
+                !usageGuideStore.hasSeen(UsageGuideStore.GUIDE_VOICE_REGISTER),
+        )
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxSize()
             .padding(contentPadding),
@@ -125,18 +187,21 @@ internal fun AlarmListScreen(
             NativeTab.Home -> {
                 item { HomeHeader() }
                 item {
-                    NextAlarmHeroCard(
-                        nextAlarm = nextAlarm,
-                        onClick = {
-                            if (nextAlarm == null) {
-                                onCreateAlarm()
-                            } else {
-                                onEditAlarm(nextAlarm)
-                            }
-                        },
-                    )
+                    Box(modifier = Modifier.coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_HOME_HERO)) {
+                        NextAlarmHeroCard(
+                            nextAlarm = nextAlarm,
+                            onClick = {
+                                if (nextAlarm == null) {
+                                    onCreateAlarm()
+                                } else {
+                                    onEditAlarm(nextAlarm)
+                                }
+                            },
+                        )
+                    }
                 }
                 item {
+                    Box(modifier = Modifier.coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_HOME_QUICK)) {
                     QuickStartGrid(
                         onRecordVoice = {
                             when {
@@ -151,6 +216,7 @@ internal fun AlarmListScreen(
                         voiceLocked = voiceLocked,
                         alarmLocked = alarmLocked,
                     )
+                    }
                 }
                 item {
                     CharacterMiniCard(
@@ -165,6 +231,7 @@ internal fun AlarmListScreen(
                     ScreenHeader(title = "목소리")
                 }
                 item {
+                    Box(modifier = Modifier.coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_VOICE_CREATE)) {
                     VoiceProfileManagementPanel(
                         voiceProfiles = voiceProfiles,
                         familyVoices = familyVoices,
@@ -179,12 +246,15 @@ internal fun AlarmListScreen(
                         onPromoteDraftVoice = onPromoteDraftVoice,
                         onDeleteDraftVoice = onDeleteDraftVoice,
                         onGenerateTts = onGenerateTts,
+                        stockClips = stockClips,
+                        onDownloadStockAudio = onDownloadStockAudio,
                         onRenameVoiceProfile = onRenameVoiceProfile,
                         onShareVoiceProfile = onShareVoiceProfile,
                         onUpdateSharedVoiceInfo = onUpdateSharedVoiceInfo,
                         onDeleteVoiceProfile = onDeleteVoiceProfile,
                         onOpenBilling = { onSelectTab(NativeTab.Billing) },
                     )
+                    }
                 }
             }
 
@@ -299,6 +369,30 @@ internal fun AlarmListScreen(
                     )
                 }
             }
+        }
+    }
+
+        if (homeGuideVisible && selectedTab == NativeTab.Home) {
+            CoachMarkOverlay(
+                steps = homeCoachSteps,
+                registry = coachMarkRegistry,
+                listState = listState,
+                onFinish = {
+                    usageGuideStore.markSeen(UsageGuideStore.GUIDE_HOME)
+                    homeGuideVisible = false
+                },
+            )
+        }
+        if (voiceGuideVisible && selectedTab == NativeTab.Voices) {
+            CoachMarkOverlay(
+                steps = voiceRegisterCoachSteps,
+                registry = coachMarkRegistry,
+                listState = listState,
+                onFinish = {
+                    usageGuideStore.markSeen(UsageGuideStore.GUIDE_VOICE_REGISTER)
+                    voiceGuideVisible = false
+                },
+            )
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -226,6 +226,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
             viewModel.checkAccountStatus()
             viewModel.checkConsentStatus()
             viewModel.preloadVoiceProfiles()
+            viewModel.loadStockClips()
             viewModel.preloadSocial()
             viewModel.preloadCharacterAndBilling()
             viewModel.preloadNotes()
@@ -261,6 +262,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
             }
             NativeTab.Voices -> {
                 viewModel.preloadVoiceProfiles()
+                viewModel.loadStockClips()
                 viewModel.preloadSocial()
             }
             NativeTab.Alarms -> viewModel.syncNow()
@@ -542,6 +544,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                           },
                           onDeleteDraftVoice = viewModel::deleteDraftVoice,
                           onGenerateTts = viewModel::generateTtsAudio,
+                          stockClips = viewModel.stockClips,
+                          onDownloadStockAudio = { messageId -> viewModel.downloadTtsMessageAudio(messageId) },
                           onRenameVoiceProfile = viewModel::renameVoiceProfile,
                           onShareVoiceProfile = viewModel::setVoiceProfileShared,
                           onUpdateSharedVoiceInfo = { id, relationship, listener ->
@@ -620,10 +624,12 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                       voiceProfiles = voiceProfiles,
                       familyVoices = familyVoices,
                       voiceProfileBusy = voiceProfileBusy,
+                      stockClips = viewModel.stockClips,
                       onCancel = ::goBackInApp,
                       onOpenBilling = { navController.navigateTopLevelTab(NativeTab.Billing) },
                       onCreateVoiceProfile = { navController.navigateTopLevelTab(NativeTab.Voices) },
                       onGenerateTts = viewModel::generateTtsAudio,
+                      onDownloadStockAudio = { messageId -> viewModel.downloadTtsMessageAudio(messageId) },
                       onUpdateDynamicPromptSettings = viewModel::updateDynamicPromptSettings,
                       onUpdateSharedVoiceInfo = { id, relationship, listener, onSuccess ->
                           viewModel.updateSharedVoiceViewerInfo(id, relationship, listener, onSuccess)
@@ -658,10 +664,12 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                           voiceProfiles = voiceProfiles,
                           familyVoices = familyVoices,
                           voiceProfileBusy = voiceProfileBusy,
+                          stockClips = viewModel.stockClips,
                           onCancel = ::goBackInApp,
                           onOpenBilling = { navController.navigateTopLevelTab(NativeTab.Billing) },
                           onCreateVoiceProfile = { navController.navigateTopLevelTab(NativeTab.Voices) },
                           onGenerateTts = viewModel::generateTtsAudio,
+                          onDownloadStockAudio = { messageId -> viewModel.downloadTtsMessageAudio(messageId) },
                           onUpdateDynamicPromptSettings = viewModel::updateDynamicPromptSettings,
                           onUpdateSharedVoiceInfo = { id, relationship, listener, onSuccess ->
                               viewModel.updateSharedVoiceViewerInfo(id, relationship, listener, onSuccess)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -58,8 +58,10 @@ import com.alarmtalk.app.network.DynamicPromptSettings
 import com.alarmtalk.app.network.FamilyGroupCurrentResponse
 import com.alarmtalk.app.network.FamilyGroupMember
 import com.alarmtalk.app.network.FamilyVoiceProfile
+import com.alarmtalk.app.network.StockClip
 import com.alarmtalk.app.network.TtsGenerateRequest
 import com.alarmtalk.app.network.TtsGenerateResponse
+import com.alarmtalk.app.network.TtsMessageAudioResponse
 import com.alarmtalk.app.network.VoiceProfile
 import com.alarmtalk.app.network.trimmedOrNull
 import com.alarmtalk.app.ui.guide.CoachMarkOverlay
@@ -77,6 +79,7 @@ private enum class AudioPreviewTarget {
     SelectedCrop,
     CachedAudio,
     SharedVoiceInfo,
+    StockClip,
 }
 
 // 처음 알람을 만드는 사용자를 위한 위치 앵커형 코치마크 가이드.
@@ -123,10 +126,12 @@ internal fun AlarmEditorScreen(
     voiceProfiles: List<VoiceProfile>,
     familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
+    stockClips: List<StockClip>,
     onCancel: () -> Unit,
     onOpenBilling: () -> Unit,
     onCreateVoiceProfile: () -> Unit,
     onGenerateTts: suspend (TtsGenerateRequest) -> TtsGenerateResponse,
+    onDownloadStockAudio: suspend (String) -> TtsMessageAudioResponse,
     onUpdateDynamicPromptSettings: (DynamicPromptSettings) -> Unit,
     onUpdateSharedVoiceInfo: (String, String, String, () -> Unit) -> Unit,
     onSave: (AlarmDraft) -> Unit,
@@ -173,6 +178,7 @@ internal fun AlarmEditorScreen(
     var previewTarget by remember { mutableStateOf<AudioPreviewTarget?>(null) }
     var previewPreparing by remember { mutableStateOf(false) }
     var previewStopJob by remember { mutableStateOf<Job?>(null) }
+    var previewingStockMessageId by remember { mutableStateOf<String?>(null) }
     var voicePlanGateOpen by remember { mutableStateOf(false) }
     var sharedVoiceInfoTarget by remember { mutableStateOf<FamilyVoiceProfile?>(null) }
     val familyRecipients = remember(familyGroup, authSession?.user?.id, authSession?.user?.email) {
@@ -275,6 +281,7 @@ internal fun AlarmEditorScreen(
         mediaPlayer = null
         previewTarget = null
         previewPreparing = false
+        previewingStockMessageId = null
     }
 
     fun startPreparedPreview(
@@ -443,6 +450,75 @@ internal fun AlarmEditorScreen(
                 Log.e(TAG, "Failed to preview shared voice in alarm editor", error)
                 stopPreview()
                 audioMessage = userFacingError(error, "미리듣기를 재생하지 못했어요.")
+            }
+        }
+    }
+
+    fun previewStockClip(clip: StockClip) {
+        if (previewPreparing) return
+        // 이미 같은 클립을 재생 중이면 정지.
+        if (previewingStockMessageId == clip.messageId && mediaPlayer != null) {
+            stopPreview()
+            return
+        }
+        scope.launch {
+            stopPreview()
+            previewTarget = AudioPreviewTarget.StockClip
+            previewPreparing = true
+            previewingStockMessageId = clip.messageId
+            runCatching {
+                val response = onDownloadStockAudio(clip.messageId)
+                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
+                withContext(Dispatchers.IO) {
+                    audioStore.cacheGeneratedAudio(
+                        bytes = audioBytes,
+                        format = response.audioFormat,
+                        rawAudioUri = response.audioUrl,
+                        displayName = "stock_preview_${clip.messageId}",
+                        cacheKey = "stock_preview_${clip.messageId}",
+                        messageId = clip.messageId,
+                    )
+                }
+            }.onSuccess { cached ->
+                startPreparedPreview(
+                    uri = Uri.parse(cached.localAudioUri),
+                    target = AudioPreviewTarget.StockClip,
+                )
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to preview stock clip in alarm editor", error)
+                stopPreview()
+                audioMessage = userFacingError(error, "미리듣기를 재생하지 못했어요.")
+            }
+        }
+    }
+
+    fun selectStockClip(clip: StockClip) {
+        if (isSaving || previewPreparing) return
+        scope.launch {
+            runCatching {
+                val response = onDownloadStockAudio(clip.messageId)
+                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
+                withContext(Dispatchers.IO) {
+                    audioStore.cacheGeneratedAudio(
+                        bytes = audioBytes,
+                        format = response.audioFormat,
+                        rawAudioUri = response.audioUrl,
+                        displayName = "stock_${clip.messageId}",
+                        cacheKey = "stock_${clip.messageId}",
+                        messageId = clip.messageId,
+                    )
+                }
+            }.onSuccess { cached ->
+                editor.setStockClipAudio(
+                    audio = cached,
+                    profileId = clip.voiceProfileId,
+                    messageId = clip.messageId,
+                    text = clip.text,
+                )
+                audioMessage = "기본 제공 음성을 선택했어요."
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to select stock clip in alarm editor", error)
+                audioMessage = userFacingError(error, "기본 제공 음성을 선택하지 못했어요.")
             }
         }
     }
@@ -1070,6 +1146,11 @@ internal fun AlarmEditorScreen(
                                 voiceProfiles = voiceProfiles,
                                 familyVoices = familyVoices,
                                 voiceProfileBusy = voiceProfileBusy,
+                                stockClips = stockClips,
+                                selectedStockMessageId = editor.ttsMessageId,
+                                previewingStockMessageId = previewingStockMessageId,
+                                onPreviewStockClip = { clip -> previewStockClip(clip) },
+                                onSelectStockClip = { clip -> selectStockClip(clip) },
                                 freeVoiceTier = freeVoiceTier,
                                 onLockedFeature = ::showVoicePlanGate,
                                 audioMessage = audioMessage,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
@@ -237,6 +237,24 @@ internal class AlarmEditorState(
         generatedTtsKey = buildTtsKey(profileId, text, activeVoiceCategory(), activeVoiceLanguage())
     }
 
+    fun setStockClipAudio(
+        audio: CachedAlarmAudio,
+        profileId: String,
+        messageId: String,
+        text: String,
+    ) {
+        voiceSource = VoiceSources.TTS_PROFILE
+        voiceProfileId = profileId
+        voiceRandomPrompt = false
+        voiceTranslationEnabled = false
+        voiceText = text
+        localAudioUri = audio.localAudioUri
+        audioCacheKey = audio.cacheKey
+        rawAudioUri = audio.rawAudioUri
+        ttsMessageId = messageId.takeIf { it.isNotBlank() }
+        generatedTtsKey = buildTtsKey(profileId, text, activeVoiceCategory(), activeVoiceLanguage())
+    }
+
     fun activeVoiceLanguage(): String =
         if (voiceRandomPrompt || voiceTranslationEnabled) voiceLanguage else "ko"
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
@@ -14,12 +14,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
+import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -39,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.data.AlarmAudioLimits
 import com.alarmtalk.app.data.AlarmPlayModes
@@ -53,6 +60,11 @@ internal fun VoiceAudioCard(
     voiceProfiles: List<VoiceProfile>,
     familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
+    stockClips: List<com.alarmtalk.app.network.StockClip>,
+    selectedStockMessageId: String?,
+    previewingStockMessageId: String?,
+    onPreviewStockClip: (com.alarmtalk.app.network.StockClip) -> Unit,
+    onSelectStockClip: (com.alarmtalk.app.network.StockClip) -> Unit,
     // 무료 플랜 제한 모드 — 녹음/파일·직접 입력·동적 문구는 [onLockedFeature] 로 게이트.
     freeVoiceTier: Boolean,
     onLockedFeature: () -> Unit,
@@ -164,18 +176,33 @@ internal fun VoiceAudioCard(
                 } else if (profileOptions.isEmpty()) {
                     NoUsableVoiceProfileCallout(onCreateVoiceProfileClick)
                 } else {
-                    VoiceProfileOptionList(
+                    VoiceProfileSelector(
                         options = profileOptions,
-                        selected = editor.voiceProfileId ?: "",
+                        selectedId = editor.voiceProfileId ?: "",
                         onSelect = { option ->
                             val sharedProfile = option.sharedProfile
                             if (sharedProfile?.requiresViewerInfo() == true) {
                                 onSharedVoiceInfoRequired(sharedProfile)
-                                return@VoiceProfileOptionList
+                                return@VoiceProfileSelector
                             }
                             editor.voiceProfileId = option.id
                             editor.clearTtsMeta()
                         },
+                    )
+                }
+                // 유료 플랜은 랜덤 문구/직접 입력으로 충분하므로 기본 제공(스톡) 음성은
+                // 무료 플랜에서만 노출한다.
+                if (freeVoiceTier) {
+                    StockClipDropdown(
+                        clips = stockClips.filter {
+                            it.voiceProfileId == editor.voiceProfileId &&
+                                it.category != com.alarmtalk.app.data.STOCK_GREETING_CATEGORY
+                        },
+                        isSystemVoice = com.alarmtalk.app.data.isSystemVoiceId(editor.voiceProfileId),
+                        selectedStockMessageId = selectedStockMessageId,
+                        previewingStockMessageId = previewingStockMessageId,
+                        onPreviewStockClip = onPreviewStockClip,
+                        onSelectStockClip = onSelectStockClip,
                     )
                 }
                 if (selectedProfileUnavailable) {
@@ -383,19 +410,74 @@ private fun NoUsableVoiceProfileCallout(
     }
 }
 
+// 목소리가 여러 개(내 목소리 + 공유받은 + 기본 제공)면 목록이 길어지므로,
+// 평소엔 선택된 목소리 1줄만 보여주고 누르면 펼쳐서 전체에서 고르는 접이식 선택기.
 @Composable
-private fun VoiceProfileOptionList(
+private fun VoiceProfileSelector(
     options: List<VoiceProfileOption>,
-    selected: String,
+    selectedId: String,
     onSelect: (VoiceProfileOption) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        options.forEach { option ->
-            VoiceProfileOptionRow(
-                option = option,
-                selected = selected == option.id,
-                onClick = { onSelect(option) },
-            )
+    var expanded by remember { mutableStateOf(false) }
+    val selectedOption = options.firstOrNull { it.id == selectedId } ?: options.firstOrNull()
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+    ) {
+        Column {
+            Surface(
+                onClick = { expanded = !expanded },
+                color = Color.Transparent,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(3.dp),
+                    ) {
+                        Text(
+                            text = selectedOption?.name ?: "목소리 선택",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        if (selectedOption != null) {
+                            MutedText(selectedOption.detail)
+                        }
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Icon(
+                        imageVector = if (expanded) {
+                            Icons.Outlined.KeyboardArrowUp
+                        } else {
+                            Icons.Outlined.KeyboardArrowDown
+                        },
+                        contentDescription = if (expanded) "접기" else "펼치기",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (expanded) {
+                Column(
+                    modifier = Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    options.forEach { option ->
+                        VoiceProfileOptionRow(
+                            option = option,
+                            selected = option.id == selectedId,
+                            onClick = {
+                                onSelect(option)
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -449,6 +531,170 @@ private fun VoiceProfileOptionRow(
             VoiceSelectionDot(selected = selected)
         }
     }
+}
+
+@Composable
+private fun StockClipDropdown(
+    clips: List<com.alarmtalk.app.network.StockClip>,
+    isSystemVoice: Boolean,
+    selectedStockMessageId: String?,
+    previewingStockMessageId: String?,
+    onPreviewStockClip: (com.alarmtalk.app.network.StockClip) -> Unit,
+    onSelectStockClip: (com.alarmtalk.app.network.StockClip) -> Unit,
+) {
+    if (!isSystemVoice || clips.isEmpty()) return
+    var expanded by remember { mutableStateOf(false) }
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
+    ) {
+        Column {
+            Surface(
+                onClick = { expanded = !expanded },
+                color = Color.Transparent,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(3.dp),
+                    ) {
+                        Text("기본 제공 알람 음성", fontWeight = FontWeight.SemiBold)
+                        MutedText("미리 듣고 바로 사용할 수 있어요")
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Icon(
+                        imageVector = if (expanded) {
+                            Icons.Outlined.KeyboardArrowUp
+                        } else {
+                            Icons.Outlined.KeyboardArrowDown
+                        },
+                        contentDescription = if (expanded) "접기" else "펼치기",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (expanded) {
+                // 언어를 먼저 고르고 해당 언어 클립 하나만 보여준다.
+                val langs = remember(clips) {
+                    clips.mapNotNull { it.language }
+                        .distinct()
+                        .sortedBy {
+                            val i = StockClipLanguageOrder.indexOf(it)
+                            if (i < 0) Int.MAX_VALUE else i
+                        }
+                }
+                val selectedClipLang = clips.firstOrNull { it.messageId == selectedStockMessageId }?.language
+                var selectedLang by remember(clips) {
+                    mutableStateOf(
+                        selectedClipLang ?: langs.firstOrNull { it == "ko" } ?: langs.firstOrNull().orEmpty(),
+                    )
+                }
+                val activeClip = clips.firstOrNull { it.language == selectedLang } ?: clips.firstOrNull()
+                Column(
+                    modifier = Modifier.padding(start = 14.dp, end = 14.dp, bottom = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        langs.forEach { lang ->
+                            FilterChip(
+                                selected = lang == selectedLang,
+                                onClick = { selectedLang = lang },
+                                label = { Text(stockClipLanguageLabel(lang)) },
+                            )
+                        }
+                    }
+                    if (activeClip != null) {
+                        StockClipRow(
+                            clip = activeClip,
+                            selected = activeClip.messageId == selectedStockMessageId,
+                            previewing = activeClip.messageId == previewingStockMessageId,
+                            onPreview = { onPreviewStockClip(activeClip) },
+                            onSelect = { onSelectStockClip(activeClip) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StockClipRow(
+    clip: com.alarmtalk.app.network.StockClip,
+    selected: Boolean,
+    previewing: Boolean,
+    onPreview: () -> Unit,
+    onSelect: () -> Unit,
+) {
+    Surface(
+        onClick = onSelect,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = if (selected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
+        },
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 14.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Text(
+                    text = clip.text,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.onSecondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            IconButton(onClick = onPreview) {
+                Icon(
+                    imageVector = if (previewing) {
+                        Icons.Outlined.Stop
+                    } else {
+                        Icons.Outlined.PlayArrow
+                    },
+                    contentDescription = if (previewing) "정지" else "미리듣기",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            if (selected) {
+                Icon(
+                    imageVector = Icons.Outlined.Check,
+                    contentDescription = "선택됨",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+            }
+        }
+    }
+}
+
+private val StockClipLanguageOrder = listOf("ko", "en", "ja")
+
+private fun stockClipLanguageLabel(language: String?): String = when (language) {
+    "ko" -> "한국어"
+    "en" -> "English"
+    "ja" -> "日本語"
+    else -> language.orEmpty()
 }
 
 @Composable

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
@@ -10,11 +10,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -192,17 +194,20 @@ private fun CoachMarkCard(
             .fillMaxSize()
             .onSizeChanged { overlayHeightPx = it.height },
     ) {
-        val offsetY = if (hole == null) {
+        // 카드가 상태바/내비게이션바 밑으로 깔려 화면을 벗어나지 않도록 안전 영역 안에 둔다.
+        val topInsetPx = WindowInsets.systemBars.getTop(density).toFloat()
+        val bottomInsetPx = WindowInsets.systemBars.getBottom(density).toFloat()
+        val minY = topInsetPx
+        val maxY = (overlayHeightPx - cardHeightPx - bottomInsetPx).coerceAtLeast(minY)
+        val rawY = if (hole == null) {
             // 대상 미등록 — 화면 중앙에 폴백.
-            ((overlayHeightPx - cardHeightPx) / 2f).coerceAtLeast(0f)
+            (overlayHeightPx - cardHeightPx) / 2f
         } else {
             val below = hole.bottom + gapPx
-            if (below + cardHeightPx <= overlayHeightPx || hole.top - gapPx - cardHeightPx < 0f) {
-                below.coerceAtMost((overlayHeightPx - cardHeightPx).coerceAtLeast(0).toFloat())
-            } else {
-                hole.top - gapPx - cardHeightPx
-            }
+            val above = hole.top - gapPx - cardHeightPx
+            if (below + cardHeightPx <= overlayHeightPx - bottomInsetPx || above < minY) below else above
         }
+        val offsetY = rawY.coerceIn(minY, maxY)
 
         Surface(
             modifier = Modifier
@@ -220,36 +225,14 @@ private fun CoachMarkCard(
                 modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
+                // 단계가 여럿일 때만 진행 표시(가이드 N / M). 한 단계뿐이면 점·카운터 모두 생략.
+                if (stepCount > 1) {
                     Text(
                         text = "가이드 ${stepIndex + 1} / $stepCount",
                         style = MaterialTheme.typography.labelMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.primary,
                     )
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(5.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        repeat(stepCount) { dot ->
-                            Box(
-                                modifier = Modifier
-                                    .size(if (dot == stepIndex) 7.dp else 5.dp)
-                                    .background(
-                                        if (dot == stepIndex) {
-                                            MaterialTheme.colorScheme.primary
-                                        } else {
-                                            MaterialTheme.colorScheme.outlineVariant
-                                        },
-                                        CircleShape,
-                                    ),
-                            )
-                        }
-                    }
                 }
                 Text(
                     text = step.title,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/UsageGuideStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/UsageGuideStore.kt
@@ -21,5 +21,7 @@ class UsageGuideStore(context: Context) {
         private const val PREFS_NAME = "usage_guide_seen"
         const val GUIDE_ALARM_EDITOR = "alarm_editor_v1"
         const val GUIDE_VOICE_CREATE = "voice_create_v1"
+        const val GUIDE_HOME = "home_v1"
+        const val GUIDE_VOICE_REGISTER = "voice_register_v1"
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -153,6 +153,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var ttsMessages by mutableStateOf<List<TtsMessage>>(emptyList())
         internal set
 
+    var stockClips by mutableStateOf<List<com.alarmtalk.app.network.StockClip>>(emptyList())
+        internal set
+
     var ttsMessageBusy by mutableStateOf(false)
         internal set
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
@@ -515,3 +515,17 @@ internal suspend fun MainViewModel.downloadTtsMessageAudio(messageId: String): T
         api.getTtsMessageAudio(AlarmTalkApiClient.bearer(session.token), messageId)
     }
 }
+
+internal fun MainViewModel.loadStockClips() {
+    val session = authSession ?: return
+    if (stockClips.isNotEmpty()) return
+    viewModelScope.launch {
+        runCatching {
+            api.getStockClips(AlarmTalkApiClient.bearer(session.token)).clips
+        }.onSuccess { clips ->
+            stockClips = clips
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to load stock clips", error)
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -29,6 +29,8 @@ import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Badge
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -48,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -58,6 +61,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
 import com.alarmtalk.app.data.AlarmAudioStore
+import com.alarmtalk.app.data.STOCK_GREETING_CATEGORY
 import com.alarmtalk.app.data.AlarmVoiceRecorder
 import com.alarmtalk.app.data.CachedAlarmAudio
 import com.alarmtalk.app.data.VoiceProfileAudioLimits
@@ -164,6 +168,8 @@ internal fun VoiceProfileManagementPanel(
     onPromoteDraftVoice: suspend (String) -> Unit,
     onDeleteDraftVoice: suspend (String) -> Unit,
     onGenerateTts: suspend (TtsGenerateRequest) -> TtsGenerateResponse,
+    stockClips: List<com.alarmtalk.app.network.StockClip>,
+    onDownloadStockAudio: suspend (String) -> com.alarmtalk.app.network.TtsMessageAudioResponse,
     onRenameVoiceProfile: (String, String, String, String) -> Unit,
     onShareVoiceProfile: (String, Boolean) -> Unit,
     onUpdateSharedVoiceInfo: (String, String, String) -> Unit,
@@ -221,6 +227,10 @@ internal fun VoiceProfileManagementPanel(
     var mediaPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
     var filePreviewPreparing by remember { mutableStateOf(false) }
     var filePreviewPlaying by remember { mutableStateOf(false) }
+    // 기본 제공 목소리는 정보성이라 평소엔 접어두고 헤더만 보여준다.
+    var systemVoicesExpanded by remember { mutableStateOf(false) }
+    // 지금 인사말 샘플을 재생 중인 기본 목소리 id (재생 아이콘 토글용).
+    var playingGreetingVoiceId by remember { mutableStateOf<String?>(null) }
     // 시스템 스톡 보이스는 "내 목소리" 수 제한·관리 액션에서 제외한다.
     val systemVoices = voiceProfiles.filter { it.isSystem == true }
     val ownVoices = voiceProfiles.filter { it.isSystem != true }
@@ -234,6 +244,54 @@ internal fun VoiceProfileManagementPanel(
         mediaPlayer = null
         filePreviewPreparing = false
         filePreviewPlaying = false
+        playingGreetingVoiceId = null
+    }
+
+    // 기본 목소리 행을 누르면 그 목소리의 인사말 샘플(greeting 스톡 클립)을 들려준다.
+    fun playGreeting(profile: VoiceProfile) {
+        if (playingGreetingVoiceId == profile.id) {
+            stopMediaPreview()
+            return
+        }
+        val clip = stockClips.firstOrNull {
+            it.voiceProfileId == profile.id && it.category == STOCK_GREETING_CATEGORY
+        } ?: stockClips.firstOrNull { it.voiceProfileId == profile.id }
+        if (clip == null) {
+            localMessage = "이 목소리의 미리듣기를 준비 중이에요."
+            return
+        }
+        scope.launch {
+            stopMediaPreview()
+            playingGreetingVoiceId = profile.id
+            runCatching {
+                val response = onDownloadStockAudio(clip.messageId)
+                val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
+                val cached = withContext(Dispatchers.IO) {
+                    audioStore.cacheGeneratedAudio(
+                        bytes = bytes,
+                        format = response.audioFormat,
+                        rawAudioUri = response.audioUrl,
+                        displayName = "greeting_${clip.messageId}",
+                        cacheKey = "greeting_${clip.messageId}",
+                        messageId = clip.messageId,
+                    )
+                }
+                val player = MediaPlayer.create(context, Uri.parse(cached.localAudioUri))
+                    ?: return@runCatching
+                mediaPlayer = player.apply {
+                    setOnCompletionListener {
+                        it.release()
+                        if (mediaPlayer === it) mediaPlayer = null
+                        if (playingGreetingVoiceId == profile.id) playingGreetingVoiceId = null
+                    }
+                    start()
+                }
+            }.onFailure { error ->
+                Log.e(TAG, "Failed to play greeting preview", error)
+                if (playingGreetingVoiceId == profile.id) playingGreetingVoiceId = null
+                localMessage = userFacingError(error, "미리듣기를 재생하지 못했어요.")
+            }
+        }
     }
 
     fun applySelectedAudio(audio: CachedAlarmAudio) {
@@ -824,13 +882,40 @@ internal fun VoiceProfileManagementPanel(
         }
 
         if (systemVoices.isNotEmpty()) {
-            Text(
-                text = "기본 목소리",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold,
-            )
-            systemVoices.forEach { profile ->
-                SystemVoiceProfileRow(profile = profile)
+            Surface(
+                onClick = { systemVoicesExpanded = !systemVoicesExpanded },
+                color = Color.Transparent,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "기본 목소리 ${systemVoices.size}종",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Icon(
+                        imageVector = if (systemVoicesExpanded) {
+                            Icons.Outlined.KeyboardArrowUp
+                        } else {
+                            Icons.Outlined.KeyboardArrowDown
+                        },
+                        contentDescription = if (systemVoicesExpanded) "접기" else "펼치기",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (systemVoicesExpanded) {
+                systemVoices.forEach { profile ->
+                    SystemVoiceProfileRow(
+                        profile = profile,
+                        playing = playingGreetingVoiceId == profile.id,
+                        onPlay = { playGreeting(profile) },
+                    )
+                }
             }
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
@@ -571,8 +571,13 @@ internal fun VoiceSharedBadge() {
 
 /** 시스템 제공(스톡) 보이스 행 — 수정/삭제/공유 액션 없이 정보만 보여준다. */
 @Composable
-internal fun SystemVoiceProfileRow(profile: VoiceProfile) {
+internal fun SystemVoiceProfileRow(
+    profile: VoiceProfile,
+    playing: Boolean,
+    onPlay: () -> Unit,
+) {
     OutlinedCard(
+        onClick = onPlay,
         shape = WakerCardShape,
         border = wakerCardBorder(),
         colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -596,13 +601,16 @@ internal fun SystemVoiceProfileRow(profile: VoiceProfile) {
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
             }
-            Column(
+            Text(
+                text = profile.name,
+                fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(3.dp),
-            ) {
-                Text(profile.name, fontWeight = FontWeight.SemiBold)
-                MutedText("기본 제공 목소리 · 모든 이용권에서 사용 가능")
-            }
+            )
+            Icon(
+                imageVector = if (playing) Icons.Outlined.Pause else Icons.Outlined.PlayArrow,
+                contentDescription = if (playing) "정지" else "들어보기",
+                tint = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }


### PR DESCRIPTION
## 요약
무료 플랜이 **서버에서 미리 만든 고정 음성(스톡 클립)** 을 미리듣고 알람에 바로 쓸 수 있게 하고, 목소리 선택·사용 가이드·울림 화면 UI를 다듬었습니다. 백엔드는 별도 PR(#459, #460, #461)로 이미 머지·배포됨.

## 변경 내용
### 무료 스톡 음성 (미리듣기 + 부착)
- `GET /tts/stock-clips` 연동(`TtsApi`, `MainViewModel.stockClips`, `loadStockClips`)
- 알람 에디터 "기본 제공 알람 음성" 드롭다운 — **언어(한국어/English/日本語) 선택 + 클립 1개**, 미리듣기/선택
- 무료 티어는 클립을 다운로드해 부착(`setStockClipAudio`) → 저장 시 생성 게이트를 거치지 않음
- 유료 티어는 랜덤 문구가 있으므로 드롭다운 숨김

### 목소리 선택/창
- "알람에서 들을 목소리" **접이식 선택기**(선택된 것만, 펼쳐서 변경)
- 목소리 창 **기본 목소리**: 행 탭 시 인사말 샘플 재생, 설명 줄 제거, "기본 목소리 N종" 접이식

### 사용 가이드(코치마크)
- 홈 2단계 + 음성 등록 1단계, `UsageGuideStore`로 1회만 노출
- 단일 단계는 진행표시(1/1·점) 생략, 시스템 바 인셋만큼 카드 위치 보정(화면 밖 방지)

### 울림 화면 재디자인
- 그라데이션 배경 · 큰 시간/날짜 · 음성 카드 · "N분 뒤 다시 알림" 필 · "밀어서 끄기" 슬라이드(드래그 노브). 기존 dismiss/snooze 동작 유지

## 테스트
- `:app:assembleDevDebug` BUILD SUCCESSFUL
- 실기기(갤럭시) 설치 후 스톡 드롭다운·언어 전환·무료 선택·코치마크·기본목소리 인사말 재생 확인. 울림 화면은 실제 알람으로 확인 예정.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)