### PR TITLE
feat(android): 메시지 탭에 무료·개인 플랜 잠금 표시

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -428,6 +428,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                     selectedTab = selectedTab,
                     unreadAlarmCount = if (selectedTab == NativeTab.Alarms) 0 else unreadAlarmCount,
                     unreadMessageCount = receivedNotes.count { it.readAt.isNullOrBlank() },
+                    // 메시지는 커플/가족 전용 — 무료·개인 플랜은 잠금 표시.
+                    messagesLocked = !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup),
                     onSelectTab = ::navigateToTab,
                 )
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkBottomBar.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkBottomBar.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,11 +14,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -40,6 +44,7 @@ internal fun AlarmTalkBottomBar(
     selectedTab: NativeTab,
     unreadAlarmCount: Int,
     unreadMessageCount: Int,
+    messagesLocked: Boolean,
     onSelectTab: (NativeTab) -> Unit,
 ) {
     Surface(
@@ -86,6 +91,7 @@ internal fun AlarmTalkBottomBar(
                 icon = Icons.AutoMirrored.Outlined.Message,
                 label = "메시지",
                 badgeCount = unreadMessageCount,
+                locked = messagesLocked,
                 onSelectTab = onSelectTab,
                 modifier = Modifier.weight(1f),
             )
@@ -100,6 +106,7 @@ internal fun AlarmTalkTabItem(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     label: String,
     badgeCount: Int = 0,
+    locked: Boolean = false,
     onSelectTab: (NativeTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -138,28 +145,47 @@ internal fun AlarmTalkTabItem(
             )
             .padding(vertical = 6.dp),
     ) {
-        BadgedBox(
-            badge = {
-                if (badgeCount > 0) {
-                    Badge(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ) {
-                        Text(text = badgeLabel(badgeCount))
+        Box(contentAlignment = Alignment.Center) {
+            BadgedBox(
+                badge = {
+                    if (!locked && badgeCount > 0) {
+                        Badge(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError,
+                        ) {
+                            Text(text = badgeLabel(badgeCount))
+                        }
                     }
-                }
-            },
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = label,
-                tint = if (selected) {
-                    selectedContentColor
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
                 },
-                modifier = Modifier.size(22.dp),
-            )
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = label,
+                    tint = if (selected) {
+                        selectedContentColor
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            if (locked) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .offset(x = 9.dp, y = (-4).dp)
+                        .size(15.dp)
+                        .background(MaterialTheme.colorScheme.surface, CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Lock,
+                        contentDescription = "잠금",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
+            }
         }
         Text(
             text = label,


### PR DESCRIPTION
## 요약
메시지는 커플/가족 이용권 전용입니다. 커플/가족 접근 권한이 없는 **무료·개인 플랜**에서 하단 **메시지 탭** 아이콘에 자물쇠 배지를 표시해 사전에 알 수 있게 합니다.

## 변경
- `AlarmTalkBottomBar`: `locked` 파라미터 추가, 아이콘 우상단에 자물쇠 오버레이(잠금 시 배지 숨김)
- `AlarmTalkApp`: `messagesLocked = !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)` 전달

탭 시 동작은 기존과 동일(권한 없으면 "메시지는 커플/가족 이용권에서 사용할 수 있어요" 게이트 다이얼로그).

> 참고: FE 전용 변경이라 백엔드 배포는 없습니다.

## 테스트
- `:app:assembleDevDebug` BUILD SUCCESSFUL
- 실기기(무료 계정): 메시지 탭 자물쇠 배지 표시 확인

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)