### PR TITLE
feat(landing): App Store 배지 제거 + 히어로 CTA를 실제 액션으로 정비

### DIFF
--- a/apps/landing/components/sections/hero.tsx
+++ b/apps/landing/components/sections/hero.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, ChevronDown } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { PhonePreview } from "../phone-preview";
 import { StoreBadges } from "../store-badges";
@@ -25,15 +25,15 @@ export function Hero() {
             {t("description")}
           </p>
 
-          <div className="mt-10">
-            <StoreBadges />
-            <a
-              href="#waitlist"
-              className="group mt-5 inline-flex items-center gap-1.5 text-[13.5px] font-medium text-text-muted transition hover:text-text"
-            >
-              {t("waitlistHint")}
-              <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" />
-            </a>
+          <div className="mt-10 flex flex-col gap-4">
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+              <a href="#waitlist" className="group btn btn-primary">
+                {t("ctaPrimary")}
+                <ArrowRight className="ml-2 h-4 w-4 transition group-hover:translate-x-0.5" />
+              </a>
+              <StoreBadges />
+            </div>
+            <p className="text-[13px] text-text-faint">{t("ctaNote")}</p>
           </div>
         </div>
 
@@ -41,15 +41,6 @@ export function Hero() {
           <PhonePreview />
         </div>
       </div>
-
-      <a
-        href="#voices"
-        aria-label={t("scrollHint")}
-        className="group absolute bottom-3 left-1/2 hidden -translate-x-1/2 flex-col items-center gap-2 text-[10.5px] font-semibold uppercase tracking-[0.18em] text-text-faint transition hover:text-text-muted md:flex"
-      >
-        {t("scrollHint")}
-        <ChevronDown className="h-4 w-4 animate-bounce text-text-faint group-hover:text-text-muted" />
-      </a>
     </section>
   );
 }

--- a/apps/landing/components/store-badges.tsx
+++ b/apps/landing/components/store-badges.tsx
@@ -1,19 +1,6 @@
 import { useTranslations } from "next-intl";
 import { STORE_LINKS } from "@/lib/site";
 
-function AppStoreGlyph() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-      className="h-6 w-6"
-    >
-      <path d="M16.365 1.43c.043 1.18-.34 2.34-1.099 3.18-.74.83-1.95 1.47-3.13 1.38-.05-1.15.41-2.34 1.16-3.16.77-.83 2.06-1.45 3.07-1.4Zm3.59 16.21c-.62 1.34-.92 1.94-1.72 3.13-1.13 1.67-2.72 3.74-4.69 3.76-1.75.02-2.2-1.13-4.57-1.12-2.37.01-2.86 1.14-4.61 1.12-1.97-.02-3.48-1.9-4.61-3.57-3.18-4.7-3.51-10.21-1.55-13.14 1.39-2.07 3.59-3.29 5.66-3.29 2.11 0 3.43 1.16 5.17 1.16 1.69 0 2.72-1.16 5.16-1.16 1.84 0 3.79.99 5.18 2.71-4.55 2.49-3.81 8.99 1.58 10.4Z" />
-    </svg>
-  );
-}
-
 function GooglePlayGlyph() {
   return (
     <svg
@@ -43,38 +30,42 @@ function GooglePlayGlyph() {
 
 export function StoreBadges() {
   const t = useTranslations("store");
+  const href = STORE_LINKS.googlePlay;
+  const live = href !== "#";
+
+  const inner = (
+    <>
+      <GooglePlayGlyph />
+      <span className="flex flex-col leading-tight">
+        <span className="text-[10px] uppercase tracking-wider text-text-faint">
+          {live ? t("googlePlayEyebrow") : t("comingSoonEyebrow")}
+        </span>
+        <span className="text-[15px] font-semibold text-text">
+          {t("googlePlayLabel")}
+        </span>
+      </span>
+    </>
+  );
+
+  // 정식 출시 전(URL 미설정)에는 죽은 링크 대신 정직한 '곧 출시' 상태로 노출한다.
+  if (!live) {
+    return (
+      <span
+        aria-label={t("comingSoonAria")}
+        className="inline-flex w-fit cursor-default items-center gap-3 rounded-2xl border border-dashed border-line bg-surface/50 px-5 py-3"
+      >
+        {inner}
+      </span>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-      <a
-        href={STORE_LINKS.appStore}
-        aria-label={t("appStoreAria")}
-        className="group inline-flex items-center gap-3 rounded-2xl border border-line bg-surface px-5 py-3 transition hover:border-line/0 hover:bg-raised"
-      >
-        <AppStoreGlyph />
-        <span className="flex flex-col leading-tight">
-          <span className="text-[10px] uppercase tracking-wider text-text-faint">
-            {t("appStoreEyebrow")}
-          </span>
-          <span className="text-[15px] font-semibold text-text">
-            {t("appStoreLabel")}
-          </span>
-        </span>
-      </a>
-      <a
-        href={STORE_LINKS.googlePlay}
-        aria-label={t("googlePlayAria")}
-        className="group inline-flex items-center gap-3 rounded-2xl border border-line bg-surface px-5 py-3 transition hover:border-line/0 hover:bg-raised"
-      >
-        <GooglePlayGlyph />
-        <span className="flex flex-col leading-tight">
-          <span className="text-[10px] uppercase tracking-wider text-text-faint">
-            {t("googlePlayEyebrow")}
-          </span>
-          <span className="text-[15px] font-semibold text-text">
-            {t("googlePlayLabel")}
-          </span>
-        </span>
-      </a>
-    </div>
+    <a
+      href={href}
+      aria-label={t("googlePlayAria")}
+      className="group inline-flex w-fit items-center gap-3 rounded-2xl border border-line bg-surface px-5 py-3 transition hover:border-line/0 hover:bg-raised"
+    >
+      {inner}
+    </a>
   );
 }

--- a/apps/landing/messages/en.json
+++ b/apps/landing/messages/en.json
@@ -17,6 +17,8 @@
     "headline1": "Wake up to",
     "headline2": "a voice you love.",
     "description": "Register a voice once, then freely create alarms that read any line you write — all in that voice.",
+    "ctaPrimary": "Join the beta waitlist",
+    "ctaNote": "Free to start · No marketing emails",
     "waitlistHint": "Before launch — join the beta waitlist",
     "scrollHint": "Scroll",
     "phone": {
@@ -200,12 +202,11 @@
     "panelLabel": "Site menu"
   },
   "store": {
-    "appStoreEyebrow": "Download on",
-    "appStoreLabel": "App Store",
-    "appStoreAria": "Get AlarmTalk on the App Store",
     "googlePlayEyebrow": "GET IT ON",
     "googlePlayLabel": "Google Play",
-    "googlePlayAria": "Get AlarmTalk on Google Play"
+    "googlePlayAria": "Get AlarmTalk on Google Play",
+    "comingSoonEyebrow": "COMING SOON",
+    "comingSoonAria": "Google Play release coming soon"
   },
   "contact": {
     "meta": {

--- a/apps/landing/messages/ja.json
+++ b/apps/landing/messages/ja.json
@@ -17,6 +17,8 @@
     "headline1": "好きな声で",
     "headline2": "目覚めるアラーム。",
     "description": "一度登録すれば、好きな文章をその声で読み上げるアラームを自由に作れます。",
+    "ctaPrimary": "ベータ待機リストに登録",
+    "ctaNote": "無料で開始・マーケティングメールなし",
     "waitlistHint": "正式リリース前 — ベータ待機リストに登録",
     "scrollHint": "Scroll",
     "phone": {
@@ -200,12 +202,11 @@
     "panelLabel": "サイトメニュー"
   },
   "store": {
-    "appStoreEyebrow": "Download on",
-    "appStoreLabel": "App Store",
-    "appStoreAria": "App Storeでアラームトークを入手",
     "googlePlayEyebrow": "GET IT ON",
     "googlePlayLabel": "Google Play",
-    "googlePlayAria": "Google Playでアラームトークを入手"
+    "googlePlayAria": "Google Playでアラームトークを入手",
+    "comingSoonEyebrow": "近日公開",
+    "comingSoonAria": "Google Play 正式リリース準備中"
   },
   "contact": {
     "meta": {

--- a/apps/landing/messages/ko.json
+++ b/apps/landing/messages/ko.json
@@ -17,6 +17,8 @@
     "headline1": "좋아하는 목소리로",
     "headline2": "깨어나는 알람.",
     "description": "한 번만 등록하면, 원하는 문장을 그 목소리로 읽어주는 알람을 자유롭게 만들 수 있어요.",
+    "ctaPrimary": "베타 대기자로 등록",
+    "ctaNote": "무료로 시작 · 마케팅 메일 없음",
     "waitlistHint": "정식 출시 전, 베타 대기자로 먼저 등록하기",
     "scrollHint": "Scroll",
     "phone": {
@@ -200,12 +202,11 @@
     "panelLabel": "사이트 메뉴"
   },
   "store": {
-    "appStoreEyebrow": "Download on",
-    "appStoreLabel": "App Store",
-    "appStoreAria": "App Store에서 알람톡 받기",
     "googlePlayEyebrow": "GET IT ON",
     "googlePlayLabel": "Google Play",
-    "googlePlayAria": "Google Play에서 알람톡 받기"
+    "googlePlayAria": "Google Play에서 알람톡 받기",
+    "comingSoonEyebrow": "곧 출시",
+    "comingSoonAria": "Google Play 정식 출시 준비 중"
   },
   "contact": {
     "meta": {


### PR DESCRIPTION
@
## 배경
정식 출시 전(베타 대기자 모집) 단계인데 히어로에 App Store / Google Play 배지가 **둘 다 `#`(죽은 링크)** 로 박혀 있어 동작 안 하는 가짜 버튼처럼, 전형적인 데모/템플릿 랜딩으로 보이던 문제를 정리합니다.

## 변경 사항
- **App Store 배지 제거** — Android 선출시 정책(FAQ "Android 먼저, iOS 추후")과 일치
- **Google Play "곧 출시" 상태** — 링크 미설정(`#`)이면 죽은 링크 대신 점선 비클릭 배지로 정직하게 노출. `NEXT_PUBLIC_GOOGLE_PLAY_URL` 주입 시 자동으로 라이브 클릭 배지로 전환
- **히어로 1차 CTA 교체** — 작은 텍스트 링크 → 실제 동작하는 "베타 대기자로 등록" 버튼(`#waitlist`)
- **AI 티 제거** — 바운스 `Scroll ↓` 힌트 삭제, 신뢰 한 줄("무료로 시작 · 마케팅 메일 없음") 추가
- **i18n** — ko/en/ja `hero.ctaPrimary`/`ctaNote` 추가, `store.appStore*` 제거 후 `comingSoon*` 추가

`STORE_LINKS.appStore` 환경 배선과 JSON-LD `downloadUrl`은 유지(`#`이면 자동 필터링되어 미노출 — iOS 출시 시 재사용).

## 검증
- `tsc --noEmit` 통과
- ko/en/ja JSON 파싱 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@