### PR TITLE
fix(android): dev 디버그 서명 고정 + 보이스 프로필 최소 길이 검증

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ apps/android-native/*.iml
 *.jks
 *.keystore
 apps/android-native/keystore.properties
+apps/android-native/dev-debug-keystore.properties
 
 # Native iOS local/generated files
 apps/ios-native/DerivedData/

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -79,6 +79,16 @@ val releaseKeystoreProps = rootProject.file("keystore.properties")
         Properties().apply { propsFile.inputStream().use { load(it) } }
     }
 
+// dev 플레이버 디버그 서명을 팀 공용 키스토어로 고정한다. 이렇게 해야 어느 PC/CI 에서 빌드해도
+// SHA-1 이 동일하게 유지되어 Google 로그인(OAuth Android 클라이언트의 SHA-1 매칭)이 항상 통과한다.
+// 파일이 없으면(예: 외부 기여자) 기본 debug.keystore 로 폴백한다.
+val devDebugKeystoreProps = rootProject.file("dev-debug-keystore.properties")
+    .takeIf { it.exists() }
+    ?.let { propsFile ->
+        Properties().apply { propsFile.inputStream().use { load(it) } }
+    }
+    ?.takeIf { rootProject.file(it.getProperty("storeFile") ?: "").exists() }
+
 android {
     namespace = "com.alarmtalk.app"
     compileSdk = 35
@@ -118,6 +128,25 @@ android {
     val alarmTalkProdSentryDsn = providers.gradleProperty("alarmTalkProdSentryDsn")
         .orElse("")
         .get()
+
+    signingConfigs {
+        if (releaseKeystoreProps != null) {
+            create("release") {
+                storeFile = rootProject.file(releaseKeystoreProps.getProperty("storeFile"))
+                storePassword = releaseKeystoreProps.getProperty("storePassword")
+                keyAlias = releaseKeystoreProps.getProperty("keyAlias")
+                keyPassword = releaseKeystoreProps.getProperty("keyPassword")
+            }
+        }
+        if (devDebugKeystoreProps != null) {
+            create("devDebug") {
+                storeFile = rootProject.file(devDebugKeystoreProps.getProperty("storeFile"))
+                storePassword = devDebugKeystoreProps.getProperty("storePassword")
+                keyAlias = devDebugKeystoreProps.getProperty("keyAlias")
+                keyPassword = devDebugKeystoreProps.getProperty("keyPassword")
+            }
+        }
+    }
 
     flavorDimensions += "environment"
     productFlavors {
@@ -162,18 +191,15 @@ android {
         }
     }
 
-    signingConfigs {
-        if (releaseKeystoreProps != null) {
-            create("release") {
-                storeFile = rootProject.file(releaseKeystoreProps.getProperty("storeFile"))
-                storePassword = releaseKeystoreProps.getProperty("storePassword")
-                keyAlias = releaseKeystoreProps.getProperty("keyAlias")
-                keyPassword = releaseKeystoreProps.getProperty("keyPassword")
+    buildTypes {
+        debug {
+            // 디버그 빌드를 공용 키스토어로 고정 서명 → 어느 PC/CI 에서 빌드해도 SHA-1 동일.
+            // (Google 로그인은 패키지명 + SHA-1 매칭이라 dev OAuth 클라이언트에 등록된
+            // 8E:05:92… 와 항상 일치해야 통과.) 파일이 없으면 기본 debug.keystore 폴백.
+            if (devDebugKeystoreProps != null) {
+                signingConfig = signingConfigs.getByName("devDebug")
             }
         }
-    }
-
-    buildTypes {
         release {
             if (releaseKeystoreProps != null) {
                 signingConfig = signingConfigs.getByName("release")

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -1032,10 +1032,15 @@ internal fun VoiceProfileManagementPanel(
         val listenerRequiredError = createSubmitAttempted && resolvedListener.isBlank()
         val hasSeparatedSpeakers = detectedSpeakers.isNotEmpty()
         val fileInputLocked = separatingBusy || hasSeparatedSpeakers
-        val canSubmitRecord = inputMode == VoiceCaptureMode.Record
+        // 1분 미만이면 "다음" 으로 넘어가지 못하게 막는다. 녹음은 selectedAudio 길이,
+        // 파일은 실제 업로드되는 crop 구간 길이로 판정(백엔드 MIN_UPLOAD_DURATION_MS 와 동일 기준).
+        // 짧으면 stopRecording/prepareSelectedFile 가 안내 메시지를 이미 띄운다.
+        val canSubmitRecord = inputMode == VoiceCaptureMode.Record &&
+            (selectedAudio?.durationMillis ?: 0L) >= VoiceProfileAudioLimits.MIN_DURATION_MILLIS
         val canSubmitSingleFile = inputMode == VoiceCaptureMode.File &&
             fileSpeakerMode == FileSpeakerMode.Single &&
-            selectedFileUri != null
+            selectedFileUri != null &&
+            (cropEndMillis - cropStartMillis) >= VoiceProfileAudioLimits.MIN_DURATION_MILLIS
         Dialog(
             onDismissRequest = {
                 if (!voiceProfileBusy && !separatingBusy) closeCreateDialog()


### PR DESCRIPTION
@
develop 작업 중 working tree 에 쌓여 있던 android 변경 두 건을 정리합니다.

## 1. dev 디버그 빌드 서명 고정 (`build.gradle.kts`)
- 어느 PC/CI 에서 빌드해도 dev 디버그 APK 의 **SHA-1 을 동일하게 고정**(공용 `alarmtalk-dev-debug.jks`) → Google 로그인(패키지명+SHA-1 매칭)이 항상 통과
- `dev-debug-keystore.properties` 가 있고 `storeFile` 이 실제 존재할 때만 적용, 없으면 기본 `debug.keystore` 로 폴백
- `dev-debug-keystore.properties` 는 **로컬 전용**이라 `.gitignore` 에 추가 (release `keystore.properties` 와 동일 정책, 파일 자체는 커밋하지 않음)

## 2. 보이스 프로필 최소 길이 검증 (`VoiceProfileManagementPanel.kt`)
- 1분 미만 입력이면 "다음" 진행 차단 → 업로드 후 서버 거부되던 흐름을 입력 단계에서 선차단
- 녹음은 `selectedAudio` 길이, 파일은 실제 업로드되는 crop 구간 길이로 판정(백엔드 `MIN_UPLOAD_DURATION_MS` 와 동일 기준)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@