### PR TITLE
feat(voice): 시스템 보이스 알람 스톡 클립 확장 + 아담 인사말 교체

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
@@ -621,7 +621,7 @@ private fun StockClipDropdown(
                 }
             }
             if (expanded) {
-                // 언어를 먼저 고르고 해당 언어 클립 하나만 보여준다.
+                // 언어를 먼저 고른 뒤, 해당 언어의 카테고리별 알람 클립을 모두 보여준다.
                 val langs = remember(clips) {
                     clips.mapNotNull { it.language }
                         .distinct()
@@ -636,7 +636,13 @@ private fun StockClipDropdown(
                         selectedClipLang ?: langs.firstOrNull { it == "ko" } ?: langs.firstOrNull().orEmpty(),
                     )
                 }
-                val activeClip = clips.firstOrNull { it.language == selectedLang } ?: clips.firstOrNull()
+                // 선택 언어의 클립을 앱 카테고리 순서(기상→점심→…)대로 노출한다.
+                // 언어 매칭이 하나도 없으면 최소한 첫 클립이라도 보여준다.
+                val activeClips = remember(clips, selectedLang) {
+                    clips.filter { it.language == selectedLang }
+                        .sortedBy { stockClipCategoryOrder(it.category) }
+                        .ifEmpty { clips.firstOrNull()?.let { listOf(it) } ?: emptyList() }
+                }
                 Column(
                     modifier = Modifier.padding(start = 14.dp, end = 14.dp, bottom = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -650,13 +656,13 @@ private fun StockClipDropdown(
                             )
                         }
                     }
-                    if (activeClip != null) {
+                    activeClips.forEach { clip ->
                         StockClipRow(
-                            clip = activeClip,
-                            selected = activeClip.messageId == selectedStockMessageId,
-                            previewing = activeClip.messageId == previewingStockMessageId,
-                            onPreview = { onPreviewStockClip(activeClip) },
-                            onSelect = { onSelectStockClip(activeClip) },
+                            clip = clip,
+                            selected = clip.messageId == selectedStockMessageId,
+                            previewing = clip.messageId == previewingStockMessageId,
+                            onPreview = { onPreviewStockClip(clip) },
+                            onSelect = { onSelectStockClip(clip) },
                         )
                     }
                 }
@@ -692,6 +698,17 @@ private fun StockClipRow(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(3.dp),
             ) {
+                stockClipCategoryLabel(clip.category)?.let { label ->
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (selected) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
                 Text(
                     text = clip.text,
                     style = MaterialTheme.typography.bodyMedium,
@@ -737,6 +754,16 @@ private fun stockClipLanguageLabel(language: String?): String = when (language) 
     "ja" -> "日本語"
     else -> language.orEmpty()
 }
+
+// 스톡 클립을 앱 카테고리 순서(TtsCategories)대로 정렬·표기한다. 알 수 없는
+// 카테고리(예: greeting)는 목록 끝으로 보내고 라벨은 숨긴다.
+private fun stockClipCategoryOrder(category: String?): Int {
+    val i = TtsCategories.indexOfFirst { (key, _) -> key == category }
+    return if (i < 0) Int.MAX_VALUE else i
+}
+
+private fun stockClipCategoryLabel(category: String?): String? =
+    TtsCategories.firstOrNull { (key, _) -> key == category }?.second
 
 @Composable
 private fun ManualVoiceMessageField(

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1090,6 +1090,41 @@ export const migrations: Migration[] = [
       `CREATE VIEW IF NOT EXISTS "voucher_redemptions_kst" AS SELECT *, datetime("redeemed_at",'+9 hours') AS redeemed_at_kst FROM "voucher_redemptions"`,
     ],
   },
+  {
+    // 아담(101) 인사말(greeting) 문구 교체 — 옛 "샤갈!" 멘트를 무효화한다.
+    //  - VOICE_GREETING_OVERRIDES 의 아담 문구를 바꿨으므로, 옛 문구로 합성돼 있던
+    //    greeting 스톡 클립을 지워 다음 seed 때 새 문구로 재생성되게 한다 (#45 와 동일 패턴).
+    //  - findMissingStockTargets 가 (voice_profile_id|category|language) 로만 존재 여부를
+    //    보기 때문에, 행을 지워야 새 문구로 다시 만들어진다.
+    //  - 배포 후 POST /api/admin/seed-stock-clips 로 재생성한다 (reset 불필요 — 여기서 무효화됨).
+    //  - 이 greeting 을 참조하던 알람은 sound-only 로 떼어낸다.
+    id: 47,
+    name: 'refresh-adam-greeting-clip',
+    statements: [
+      `UPDATE alarms
+        SET mode = 'sound-only', wake_mode = 'sound_then_voice',
+            message_id = NULL, voice_profile_id = NULL, speaker_id = NULL,
+            raw_audio_url = NULL, raw_audio_duration_ms = NULL
+        WHERE message_id IN (
+          SELECT id FROM messages
+          WHERE COALESCE(is_preset, 0) = 1 AND category = 'greeting'
+            AND voice_profile_id = '70000000-0000-4000-9000-000000000101'
+        )`,
+      `DELETE FROM message_library WHERE message_id IN (
+        SELECT id FROM messages
+        WHERE COALESCE(is_preset, 0) = 1 AND category = 'greeting'
+          AND voice_profile_id = '70000000-0000-4000-9000-000000000101'
+      )`,
+      `DELETE FROM generated_audio_assets WHERE message_id IN (
+        SELECT id FROM messages
+        WHERE COALESCE(is_preset, 0) = 1 AND category = 'greeting'
+          AND voice_profile_id = '70000000-0000-4000-9000-000000000101'
+      )`,
+      `DELETE FROM messages
+        WHERE COALESCE(is_preset, 0) = 1 AND category = 'greeting'
+          AND voice_profile_id = '70000000-0000-4000-9000-000000000101'`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/stock-clips.ts
+++ b/packages/backend/src/lib/stock-clips.ts
@@ -26,8 +26,49 @@ export const STOCK_CLIP_PRESETS = [
   {
     category: 'morning',
     // 안내방송처럼 딱딱하지 않게, 옆에서 다정하게 깨워주는 자연스러운 한 마디.
+    // 가장 많이 쓰는 알람이라 한국어 외에 영어·일본어까지 미리 만들어 둔다.
     baseText: '좋은 아침이에요. 잘 잤어요? 천천히 기지개 켜고 오늘 하루도 산뜻하게 시작해 봐요.',
     languages: ['ko', 'en', 'ja'],
+  },
+  // 아래는 무료 플랜이 그대로 받아 쓰는 알람 스톡 클립. 앱의 카테고리
+  // (morning·lunch·evening·night·health·study·cheer·love) 와 동일하게 맞춰,
+  // 시스템 보이스마다 카테고리별 알람 음성을 하나씩 미리 합성해 둔다.
+  // 신규 카테고리는 한국어 우선으로 두고(영어·일본어는 추후 확장),
+  // morning(3개 언어) + 아래 7개 = 보이스당 알람 클립 10개가 채워진다.
+  {
+    category: 'lunch',
+    baseText: '점심시간이에요. 잠깐 멈추고 따뜻한 밥 한 끼 제대로 챙겨 먹어요. 오후도 든든하게 가봐요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'evening',
+    baseText: '오늘 하루도 정말 고생 많았어요. 이제 천천히 마무리하고 편하게 쉬러 가요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'night',
+    baseText: '벌써 밤이 깊었어요. 오늘은 여기까지만 하고, 편안하게 잘 준비를 해봐요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'health',
+    baseText: '물 한 잔 마실 시간이에요. 어깨도 쭉 펴고, 잠깐 몸을 챙겨줘요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'study',
+    baseText: '집중할 시간이에요. 딱 한 페이지만 펼쳐 봐요. 시작하면 금방 흐름을 탈 거예요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'cheer',
+    baseText: '잘하고 있어요. 지금까지도 충분히 잘 해왔으니까, 조금만 더 힘내봐요.',
+    languages: ['ko'],
+  },
+  {
+    category: 'love',
+    baseText: '오늘도 당신을 생각하고 있어요. 무리하지 말고, 끼니 잘 챙기면서 지내요.',
+    languages: ['ko'],
   },
   {
     category: STOCK_GREETING_CATEGORY,
@@ -43,9 +84,9 @@ export const STOCK_CLIP_PRESETS = [
  * 미리듣기에서 각 목소리의 개성이 드러나도록 톤을 음성별로 맞췄다.
  */
 export const VOICE_GREETING_OVERRIDES: Record<string, string> = {
-  // 아담(Adam) — 장난스러운 자기소개 톤. [excited] 태그로 들뜬 딜리버리 고정
+  // 아담(Adam) — 릴스/숏폼에서 유행한 들뜬 자기소개 톤. [excited] 태그로 딜리버리 고정
   // (Vertex autoTag 에 맡기지 않고 직접 박음. stripDeliveryTags 가 표시용에선 태그 제거).
-  pNInz6obpgDQGcFmaJgB: '[excited] 샤갈! 여러분! 저 됐어요! 저 알람톡 음성 됐어요! 자주 봐요!',
+  pNInz6obpgDQGcFmaJgB: '[excited] 여러분! 저 됐어요! 저 알람톡 음성 됐어요! 앞으로 자주 봐요!',
   // 미나·하준·소은 — 목소리 특징이나 알람 기능을 드러내지 않는 담백한 첫인사.
   aiUUgjHa4mpHf6UenZuf: '안녕하세요! 만나서 정말 반가워요. 앞으로 자주 봐요.',
   LKOcTG4J4tYTPR9DnLeM: '안녕하세요. 반가워요. 우리 앞으로 잘 지내봐요.',


### PR DESCRIPTION
## 변경

- `STOCK_CLIP_PRESETS` 에 앱 카테고리(lunch·evening·night·health·study·cheer·love) 알람 클립 추가
  - 시스템 보이스(아담·미나·하준·소은)당 알람 클립 **10개** (morning 3개 언어 + 7개 한국어)
- 아담(Adam) greeting 문구에서 "샤갈" 제거 → `여러분! 저 됐어요! 저 알람톡 음성 됐어요! 앞으로 자주 봐요!`
- 아담 greeting 교체에 따라 옛 클립 무효화 마이그레이션 **#47** 추가

## 배포 후 할 일
`POST /api/admin/seed-stock-clips?max=12` 를 `remaining`이 0이 될 때까지 반복 호출해 실제 오디오 생성.

## 검증
- `tsc --noEmit` 통과
- `migrations.test.ts` + `tts.test.ts` 72개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)