### PR TITLE
fix(android): 약관 동의 화면을 온보딩보다 항상 먼저 노출

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -199,7 +199,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
 
     LoginPermissionGate(
         authSession = authSession,
-        enabled = authSession != null && !viewModel.showOnboarding,
+        enabled = authSession != null && viewModel.consentChecked && !viewModel.needsConsent &&
+            !viewModel.showOnboarding,
         permissions = permissions,
         onRequestPermission = ::requestPermission,
         onRequestAllPermissions = ::requestAllMissingPermissions,
@@ -437,7 +438,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
 
     Scaffold(
         bottomBar = {
-            if (authSession != null && !viewModel.showOnboarding && !viewModel.updateRequired &&
+            if (authSession != null && viewModel.consentChecked && !viewModel.needsConsent &&
+                !viewModel.showOnboarding && !viewModel.updateRequired &&
                 !viewModel.pendingDeletion && currentTab != null
             ) {
                 AlarmTalkBottomBar(
@@ -499,6 +501,12 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
               onRecover = viewModel::cancelAccountDeletion,
               onLogout = ::logout,
           )
+          return@Scaffold
+      }
+      // 동의 확인이 끝나기 전엔 온보딩·홈을 띄우지 않고 로딩으로 잡아둬, 동의가 필요한
+      // 사용자에게 다른 화면이 먼저 깜빡였다가 동의 화면이 끼어드는 일을 막는다.
+      if (!viewModel.consentChecked) {
+          ConsentCheckLoadingScreen(contentPadding = padding)
           return@Scaffold
       }
       if (viewModel.needsConsent) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/ConsentScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/ConsentScreen.kt
@@ -2,6 +2,7 @@ package com.alarmtalk.app
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -14,6 +15,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -126,6 +128,23 @@ internal fun ConsentScreen(
         ) {
             Text(if (busy) "처리 중…" else "동의하고 시작하기")
         }
+    }
+}
+
+/**
+ * 로그인 직후 서버에 필수 동의 여부를 확인하는 동안 잠깐 보여주는 로딩 화면.
+ * 이 게이트 덕분에 동의가 필요한 사용자에게 온보딩·홈이 먼저 깜빡이지 않고
+ * 동의 화면이 항상 먼저 뜬다.
+ */
+@Composable
+internal fun ConsentCheckLoadingScreen(contentPadding: PaddingValues) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -218,8 +218,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var showOnboarding by mutableStateOf(false)
         internal set
 
+    private val consentPrefs = application.getSharedPreferences("voice_alarm_consent", android.content.Context.MODE_PRIVATE)
+
     // 필수 개인정보/약관 동의가 아직 안 된 경우 true → 로그인 후 동의 화면을 띄운다.
     var needsConsent by mutableStateOf(false)
+        internal set
+
+    // 동의 확인이 끝났는지(서버 응답 또는 로컬 캐시로 확정). false 동안엔 온보딩·홈을 막아
+    // 동의 화면이 다른 화면보다 항상 먼저 뜨도록 한다.
+    var consentChecked by mutableStateOf(false)
         internal set
 
     // 탈퇴 유예(pending_deletion) 상태로 로그인하면 true → 복구/로그아웃만 가능한 화면을 띄운다.
@@ -271,6 +278,21 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             onboardingPrefs.edit().putStringSet("seen_users", seen).apply()
         }
         showOnboarding = false
+    }
+
+    // 이 기기에서 필수 동의를 마친 사용자 캐시. 재로그인/콜드스타트 시 서버 응답을 기다리는
+    // 로딩 없이 바로 통과시키되, 백그라운드 서버 재확인은 그대로 진행한다.
+    internal fun isConsentCachedDone(userId: String): Boolean {
+        if (userId.isBlank()) return false
+        val done = consentPrefs.getStringSet("consented_users", emptySet()) ?: emptySet()
+        return userId in done
+    }
+
+    internal fun rememberConsentDone(userId: String, done: Boolean) {
+        if (userId.isBlank()) return
+        val set = consentPrefs.getStringSet("consented_users", emptySet())?.toMutableSet() ?: mutableSetOf()
+        if (done) set += userId else set -= userId
+        consentPrefs.edit().putStringSet("consented_users", set).apply()
     }
 
     fun loadReceivedAlarmBadgeState() {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -357,6 +357,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         receivedAlarmSeenAtMillis = 0L
         registerEmailVerificationSentTo = null
         registerEmailVerified = null
+        // 세션이 비워지는 모든 경로(로그아웃/만료/탈퇴)에서 동의 게이트 상태도 함께 초기화한다.
+        // 특히 consentChecked 가 옛 세션의 true 로 남으면, 다음 로그인에서 동의 확인 전에
+        // 온보딩·홈·하단바가 먼저 뜰 수 있어 반드시 false 로 되돌린다.
+        needsConsent = false
+        consentChecked = false
+        pendingDeletion = false
     }
 
     fun ensureReceivedAlarmBadgeBaseline(alarms: List<AlarmEntity>) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -280,19 +280,35 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showOnboarding = false
     }
 
-    // 이 기기에서 필수 동의를 마친 사용자 캐시. 재로그인/콜드스타트 시 서버 응답을 기다리는
-    // 로딩 없이 바로 통과시키되, 백그라운드 서버 재확인은 그대로 진행한다.
+    // 이 기기에서 "현재 정책 버전" 기준으로 필수 동의를 마친 사용자 캐시.
+    // 재로그인/콜드스타트 시 서버 응답을 기다리는 로딩 없이 바로 통과시키되, 백그라운드
+    // 서버 재확인은 그대로 진행한다. 정책 버전이 올라가면(개정) 옛 버전 동의 캐시는 폐기해,
+    // 이미 동의했던 사용자라도 재동의가 필요할 땐 캐시로 게이트를 건너뛰지 않게 한다.
     internal fun isConsentCachedDone(userId: String): Boolean {
         if (userId.isBlank()) return false
+        // 현재 정책 버전을 한 번도 확인한 적 없으면(=서버 확인 전) 캐시로 통과시키지 않는다.
+        if (cachedPolicyVersion() == null) return false
         val done = consentPrefs.getStringSet("consented_users", emptySet()) ?: emptySet()
         return userId in done
     }
 
-    internal fun rememberConsentDone(userId: String, done: Boolean) {
+    // 직전에 서버에서 확인한 현재 정책 버전. 아직 확인 전이면 null.
+    internal fun cachedPolicyVersion(): String? =
+        consentPrefs.getString("current_policy_version", null)
+
+    // done=true 면 userId 를 "policyVersion 동의 완료" 캐시에 넣고, false 면 뺀다.
+    // policyVersion 이 캐시된 현재 버전과 다르면(정책 개정) 동의 캐시를 비우고 새 버전으로 시작한다.
+    internal fun rememberConsentDone(userId: String, done: Boolean, policyVersion: String) {
         if (userId.isBlank()) return
-        val set = consentPrefs.getStringSet("consented_users", emptySet())?.toMutableSet() ?: mutableSetOf()
+        val editor = consentPrefs.edit()
+        val set = if (cachedPolicyVersion() != policyVersion) {
+            editor.putString("current_policy_version", policyVersion)
+            mutableSetOf()
+        } else {
+            consentPrefs.getStringSet("consented_users", emptySet())?.toMutableSet() ?: mutableSetOf()
+        }
         if (done) set += userId else set -= userId
-        consentPrefs.edit().putStringSet("consented_users", set).apply()
+        editor.putStringSet("consented_users", set).apply()
     }
 
     fun loadReceivedAlarmBadgeState() {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -214,6 +214,7 @@ internal fun MainViewModel.logout(signOutGoogle: suspend () -> Unit = {}) {
         clearUserScopedRemoteState()
         authSession = null
         needsConsent = false
+        consentChecked = false
         pendingDeletion = false
         message = "로그아웃했어요"
         authBusy = false
@@ -459,16 +460,29 @@ internal fun MainViewModel.checkAppVersion() {
 // AlarmTalkApp 이 동의 화면을 띄운다. 네트워크 실패 시에는 앱 진입을 막지 않는다.
 internal fun MainViewModel.checkConsentStatus() {
     val session = authSession ?: return
+    val userId = session.user.id
+    // 이 기기에서 이미 동의를 마친 사용자는 로딩 없이 바로 통과시키고, 서버로 재확인만 한다.
+    // 처음 보는 사용자는 서버 응답이 올 때까지 consentChecked=false 로 두어, 동의 화면이
+    // 온보딩·홈보다 먼저 뜨도록 진입을 막는다.
+    if (isConsentCachedDone(userId)) {
+        needsConsent = false
+        consentChecked = true
+    } else {
+        consentChecked = false
+    }
     val authorization = com.alarmtalk.app.network.AlarmTalkApiClient.bearer(session.token)
     viewModelScope.launch {
         runCatching {
             api.consentStatus(authorization)
         }.onSuccess { status ->
             needsConsent = status.needsConsent
+            rememberConsentDone(userId, !status.needsConsent)
         }.onFailure { error ->
             Log.w(TAG, "Failed to check consent status", error)
-            needsConsent = false
+            // 캐시로 이미 통과시킨 게 아니면 네트워크 실패가 앱 진입을 막지 않게 한다.
+            if (!isConsentCachedDone(userId)) needsConsent = false
         }
+        consentChecked = true
     }
 }
 
@@ -497,6 +511,8 @@ internal fun MainViewModel.submitConsents(marketingAgreed: Boolean) {
             )
         }.onSuccess {
             needsConsent = false
+            consentChecked = true
+            rememberConsentDone(session.user.id, true)
             message = "동의가 완료됐어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to record consents", error)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -211,11 +211,8 @@ internal fun MainViewModel.logout(signOutGoogle: suspend () -> Unit = {}) {
             }
         }
         authSessionStore.clear()
-        clearUserScopedRemoteState()
+        clearUserScopedRemoteState() // 동의/탈퇴 게이트 상태(needsConsent·consentChecked·pendingDeletion)도 여기서 초기화된다
         authSession = null
-        needsConsent = false
-        consentChecked = false
-        pendingDeletion = false
         message = "로그아웃했어요"
         authBusy = false
     }
@@ -499,6 +496,10 @@ internal fun MainViewModel.submitConsents(marketingAgreed: Boolean) {
         return
     }
     val authorization = com.alarmtalk.app.network.AlarmTalkApiClient.bearer(session.token)
+    // 서버에 "현재 정책 버전"으로 기록되도록 직전 checkConsentStatus 가 저장한 버전을 함께 보낸다.
+    // version 을 비우면 백엔드가 "1" 로 기록해, 정책이 개정된 뒤엔 옛 버전으로 저장되어
+    // 계속 재동의를 요구받고 로컬 캐시(새 버전 만족)와 어긋난다.
+    val policyVersion = cachedPolicyVersion()
     viewModelScope.launch {
         authBusy = true
         runCatching {
@@ -506,20 +507,19 @@ internal fun MainViewModel.submitConsents(marketingAgreed: Boolean) {
                 authorization,
                 com.alarmtalk.app.network.RecordConsentsRequest(
                     consents = listOf(
-                        com.alarmtalk.app.network.ConsentItemRequest(type = "terms", agreed = true),
-                        com.alarmtalk.app.network.ConsentItemRequest(type = "privacy", agreed = true),
-                        com.alarmtalk.app.network.ConsentItemRequest(type = "age14", agreed = true),
-                        com.alarmtalk.app.network.ConsentItemRequest(type = "marketing", agreed = marketingAgreed),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "terms", agreed = true, version = policyVersion),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "privacy", agreed = true, version = policyVersion),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "age14", agreed = true, version = policyVersion),
+                        com.alarmtalk.app.network.ConsentItemRequest(type = "marketing", agreed = marketingAgreed, version = policyVersion),
                     ),
                 ),
             )
         }.onSuccess {
             needsConsent = false
             consentChecked = true
-            // 방금 동의한 사용자를 현재 정책 버전 캐시에 기록한다. 현재 버전은 직전 checkConsentStatus
-            // 가 저장해 둔 값(미동의 상태로 이 화면에 온 이상 존재한다). 모르면 다음 콜드스타트에서
-            // 서버로 재확인하므로 굳이 캐시하지 않는다.
-            cachedPolicyVersion()?.let { rememberConsentDone(session.user.id, true, it) }
+            // 방금 서버에 보낸 그 버전으로 로컬 캐시도 기록해 서버·클라 상태를 일치시킨다.
+            // 모르면(직전 status 실패) 다음 콜드스타트에서 서버로 재확인하므로 캐시하지 않는다.
+            policyVersion?.let { rememberConsentDone(session.user.id, true, it) }
             message = "동의가 완료됐어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to record consents", error)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -475,14 +475,18 @@ internal fun MainViewModel.checkConsentStatus() {
         runCatching {
             api.consentStatus(authorization)
         }.onSuccess { status ->
+            // 응답을 기다리는 사이 로그아웃/계정전환이 일어났으면, 옛 사용자의 결과로
+            // 현재(또는 빈) 세션의 동의 상태를 덮어쓰지 않는다.
+            if (authSession?.user?.id != userId) return@launch
             needsConsent = status.needsConsent
-            rememberConsentDone(userId, !status.needsConsent)
+            rememberConsentDone(userId, !status.needsConsent, status.policyVersion)
         }.onFailure { error ->
+            if (authSession?.user?.id != userId) return@launch
             Log.w(TAG, "Failed to check consent status", error)
             // 캐시로 이미 통과시킨 게 아니면 네트워크 실패가 앱 진입을 막지 않게 한다.
             if (!isConsentCachedDone(userId)) needsConsent = false
         }
-        consentChecked = true
+        if (authSession?.user?.id == userId) consentChecked = true
     }
 }
 
@@ -512,7 +516,10 @@ internal fun MainViewModel.submitConsents(marketingAgreed: Boolean) {
         }.onSuccess {
             needsConsent = false
             consentChecked = true
-            rememberConsentDone(session.user.id, true)
+            // 방금 동의한 사용자를 현재 정책 버전 캐시에 기록한다. 현재 버전은 직전 checkConsentStatus
+            // 가 저장해 둔 값(미동의 상태로 이 화면에 온 이상 존재한다). 모르면 다음 콜드스타트에서
+            // 서버로 재확인하므로 굳이 캐시하지 않는다.
+            cachedPolicyVersion()?.let { rememberConsentDone(session.user.id, true, it) }
             message = "동의가 완료됐어요"
         }.onFailure { error ->
             Log.e(TAG, "Failed to record consents", error)


### PR DESCRIPTION
## 배경
로그인 직후 서비스 약관 동의 화면이 **나중에** 뜨는 문제가 있었습니다.

- `checkOnboardingFor()`는 로컬(동기)이라 `showOnboarding`이 즉시 true가 되는데,
  `checkConsentStatus()`는 네트워크(비동기)라 `needsConsent`가 늦게 true가 됨
  → 온보딩/홈이 먼저 그려졌다가 동의 화면이 끼어드는 깜빡임 발생
- `bottomBar` 조건에 동의 상태가 빠져 있어 동의 화면 아래에 하단 nav가 깔림

## 변경
1. **동의 화면이 항상 먼저** — `consentChecked` 상태 추가. 동의 확인이 끝나기 전엔
   온보딩/홈을 띄우지 않고 짧은 로딩 화면(`ConsentCheckLoadingScreen`)으로 잡아둠
   → `로딩 → 동의 → 온보딩 → 앱` 순서 보장
2. **콜드스타트 회귀 방지** — 이미 동의를 마친 사용자는 로컬 캐시(`voice_alarm_consent`,
   기존 온보딩 prefs와 동일 패턴)로 즉시 통과시키고 서버 재확인만 백그라운드로.
   처음 보는/미동의 사용자만 응답 대기. 네트워크 실패 시 진입을 막지 않음
3. **동의/로딩 중 하단 nav·권한 게이트 숨김** — `bottomBar`, `LoginPermissionGate` 조건에
   `consentChecked && !needsConsent` 반영

## 변경 파일
- `MainViewModel.kt`, `MainViewModelAuthActions.kt`, `ConsentScreen.kt`, `AlarmTalkApp.kt`

## 테스트
- dev 디버그 빌드 통과, 실기기(SM, R3CW300EZBA) 설치/실행 확인
- 동의 필요 계정으로 신규 로그인 시 동의 화면이 온보딩보다 먼저 뜨고 하단 nav가 없는지 추가 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)