### PR TITLE
feat(backend): 아담 인사말을 유행 멘트로 교체 + 보이스 단위 스톡 클립 재생성 옵션

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -133,12 +133,20 @@ app.post('/api/admin/seed-stock-clips', async (c) => {
   try {
     const max = Math.min(Math.max(parseInt(c.req.query('max') || '2', 10) || 2, 1), 12);
     const reset = ['1', 'true', 'yes'].includes((c.req.query('reset') || '').toLowerCase());
-    const { findMissingStockTargets, generateStockClip, deleteAllStockClips } = await import(
-      './lib/stock-clips'
-    );
+    // 특정 보이스(+카테고리)만 재생성하고 싶을 때: ?voice=<elevenlabs_voice_id>&category=greeting
+    // 해당 클립만 지우면 findMissingStockTargets 가 그것만 다시 채운다 (다른 클립·알람 영향 없음).
+    const voice = (c.req.query('voice') || '').trim();
+    const category = (c.req.query('category') || '').trim();
+    const { findMissingStockTargets, generateStockClip, deleteAllStockClips, deleteStockClips } =
+      await import('./lib/stock-clips');
     const db = getDB(c.env);
     let deleted = 0;
-    if (reset) {
+    if (voice) {
+      deleted = await deleteStockClips(db, c.env, {
+        elevenlabsVoiceId: voice,
+        category: category || undefined,
+      });
+    } else if (reset) {
       deleted = await deleteAllStockClips(db, c.env);
     }
     const missing = await findMissingStockTargets(db);

--- a/packages/backend/src/lib/stock-clips.ts
+++ b/packages/backend/src/lib/stock-clips.ts
@@ -86,7 +86,7 @@ export const STOCK_CLIP_PRESETS = [
 export const VOICE_GREETING_OVERRIDES: Record<string, string> = {
   // 아담(Adam) — 릴스/숏폼에서 유행한 들뜬 자기소개 톤. [excited] 태그로 딜리버리 고정
   // (Vertex autoTag 에 맡기지 않고 직접 박음. stripDeliveryTags 가 표시용에선 태그 제거).
-  pNInz6obpgDQGcFmaJgB: '[excited] 여러분! 저 됐어요! 저 알람톡 음성 됐어요! 앞으로 자주 봐요!',
+  pNInz6obpgDQGcFmaJgB: '[excited] 여러분! 저 됐어요! 알람톡 음성 됐어요! 반가워요!',
   // 미나·하준·소은 — 목소리 특징이나 알람 기능을 드러내지 않는 담백한 첫인사.
   aiUUgjHa4mpHf6UenZuf: '안녕하세요! 만나서 정말 반가워요. 앞으로 자주 봐요.',
   LKOcTG4J4tYTPR9DnLeM: '안녕하세요. 반가워요. 우리 앞으로 잘 지내봐요.',
@@ -179,21 +179,46 @@ export async function findMissingStockTargets(db: Client): Promise<StockClipTarg
   return targets;
 }
 
+/** 스톡 클립 삭제 필터. 비우면 전체(reset), 채우면 특정 보이스(+카테고리)만. */
+export interface DeleteStockClipsFilter {
+  /** elevenlabs_voice_id 로 특정 시스템 보이스만 한정. */
+  elevenlabsVoiceId?: string;
+  /** category 로 한정 (예: 'greeting'). elevenlabsVoiceId 와 함께 쓰면 보이스의 해당 클립만. */
+  category?: string;
+}
+
 /**
- * 기존 스톡 클립 전체 삭제 (문구를 바꿔 재생성할 때 사용). messages·
- * generated_audio_assets·message_library 행과 R2 오브젝트를 정리하고,
- * 혹시 이 클립을 참조하던 알람은 sound-only 로 떼어낸다. dev 반복용.
+ * 스톡 클립 삭제 (문구를 바꿔 재생성할 때 사용). 필터가 없으면 전체(reset),
+ * 있으면 특정 보이스(+카테고리)만 지운다. messages·generated_audio_assets·
+ * message_library 행과 R2 오브젝트를 정리하고, 혹시 이 클립을 참조하던 알람은
+ * sound-only 로 떼어낸다. dev 반복용.
  */
-export async function deleteAllStockClips(db: Client, env: Env): Promise<number> {
+export async function deleteStockClips(
+  db: Client,
+  env: Env,
+  filter: DeleteStockClipsFilter = {},
+): Promise<number> {
+  const conditions = [
+    'COALESCE(m.is_preset, 0) = 1',
+    `m.voice_profile_id IN (
+       SELECT id FROM voice_profiles
+       WHERE COALESCE(is_system, 0) = 1
+       ${filter.elevenlabsVoiceId ? 'AND elevenlabs_voice_id = ?' : ''}
+     )`,
+  ];
+  const selectArgs: string[] = [];
+  if (filter.elevenlabsVoiceId) selectArgs.push(filter.elevenlabsVoiceId);
+  if (filter.category) {
+    conditions.push('m.category = ?');
+    selectArgs.push(filter.category);
+  }
+
   const rows = await db.execute({
     sql: `SELECT m.id AS message_id, ga.audio_object_key AS audio_object_key
           FROM messages m
           LEFT JOIN generated_audio_assets ga ON ga.message_id = m.id
-          WHERE COALESCE(m.is_preset, 0) = 1
-            AND m.voice_profile_id IN (
-              SELECT id FROM voice_profiles WHERE COALESCE(is_system, 0) = 1
-            )`,
-    args: [],
+          WHERE ${conditions.join(' AND ')}`,
+    args: selectArgs,
   });
   const ids = Array.from(new Set(rows.rows.map((r) => String(r.message_id))));
   if (ids.length === 0) return 0;
@@ -229,6 +254,11 @@ export async function deleteAllStockClips(db: Client, env: Env): Promise<number>
   });
   await db.execute({ sql: `DELETE FROM messages WHERE id IN (${ph})`, args: ids });
   return ids.length;
+}
+
+/** 전체 스톡 클립 삭제 (reset). deleteStockClips 의 무필터 호출. */
+export async function deleteAllStockClips(db: Client, env: Env): Promise<number> {
+  return deleteStockClips(db, env);
 }
 
 /** 표시용 텍스트에서 [tag] 마커 제거 (앱에는 태그 없이 보여준다). */


### PR DESCRIPTION
## 무엇을
- 아담(Adam) greeting 인사말을 릴스/숏폼에서 유행한 들뜬 자기소개 톤으로 교체
  - `[excited] 여러분! 저 됐어요! 알람톡 음성 됐어요! 반가워요!`
- `seed-stock-clips` 어드민 엔드포인트에 **보이스 단위 타깃 재생성** 옵션 추가
  - `?voice=<elevenlabs_voice_id>&category=<cat>` → 전체 reset 없이 해당 클립만 삭제·재생성
  - `deleteStockClips(filter)` 신설, 기존 `deleteAllStockClips` 는 무필터 호출로 유지

## 왜
- 기존엔 아담 그리팅 클립이 한국어 오버라이드가 들어오기 전에 생성·캐시돼, 코드가 한국어여도 폰에선 옛 음성이 재생됨
- 텍스트만 바꿔선 캐시된 클립이 갱신되지 않아 재생성이 필요한데, 기존 도구는 전체 reset(모든 보이스×카테고리 재생성, 비용 + 알람 sound-only 분리)만 지원
- 보이스 단위 옵션으로 다른 클립·알람 영향 없이 아담 그리팅만 새 멘트로 재생성 가능

## 배포 후
develop 머지 → dev 자동 배포 후:
`POST /api/admin/seed-stock-clips?voice=pNInz6obpgDQGcFmaJgB&category=greeting&max=1` (dev 전용)

## 확인
- [x] `tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)