### PR TITLE
docs(legal): 결제 거래 기록 DB 암호화 의무 검토 추가

### DIFF
--- a/docs/legal/compliance-notes.ko.md
+++ b/docs/legal/compliance-notes.ko.md
@@ -73,6 +73,46 @@
 - **비밀번호**는 일방향 해시여야 하며 절대 복호화 가능한 형태로 저장하면 안 된다(현재 준수).
 - 인증코드 등 검증만 필요한 값도 일방향 해시 권장(현재 준수).
 
+### 결제 거래 기록 DB 암호화 의무 검토 (인앱결제 IAP 구조)
+
+질문: 카드번호(PAN)·CVC·계좌번호는 **전혀 저장하지 않고**, Google Play/Apple 인앱결제(IAP)의
+구독 거래 검증 기록만 저장하는 `store_transactions` 테이블(컬럼: `user_id`, `provider`,
+`provider_transaction_id`(구매토큰/주문ID), `product_id`, `plan_key`, `expires_at`,
+`raw_payload`(Google: `latestOrderId` + `subscriptionState`만))을 **법적으로 암호화해야 하는가?**
+
+**결론: 법적 암호화 의무 없음.** 프레임워크별 근거는 다음과 같다.
+
+- **PCI-DSS** — PAN/CVC를 전자적으로 저장·처리·전송하지 않고 카드 처리를 PCI-DSS 준수
+  제3자(Google/Apple)에 전적으로 위탁하는 구조는 최소 범위인 **SAQ A** 조건을 충족하며,
+  카드데이터 취급에 관한 PCI scope에서 사실상 제외된다. SAQ A 원문 요건: *"The merchant does
+  not electronically store, process, or transmit any account data on merchant systems or
+  premises, but relies entirely on a TPSP(s) to handle all these functions."* IAP는 카드
+  가맹점(merchant of record)이 Google/Apple이므로 일반 SAQ A 가맹점보다도 범위 밖일 수 있다.
+- **개인정보의 안전성 확보조치 기준 제7조** — 저장 시 의무 암호화 대상은 고유식별정보·비밀번호·
+  바이오정보·**신용카드번호·계좌번호**다. `provider_transaction_id`(구매토큰/주문ID)·`product_id`·
+  `plan_key`·만료시각·`raw_payload`(주문ID+구독상태)는 **제7조 열거 어디에도 해당하지 않아**
+  법정 암호화 대상이 아니다. 암호화를 트리거하는 카드번호·계좌번호를 **애초에 저장하지 않으므로**
+  의무가 발생하지 않는다.
+- **전자상거래법 시행령 제6조** — 거래기록은 '**보존**' 의무(계약·청약철회 5년, 대금결제·재화공급
+  5년, 소비자불만·분쟁처리 3년, 표시·광고 6개월)일 뿐 '**암호화**' 의무가 아니다. 조문에
+  '암호화/보안/안전성' 문구가 없다. `provider_transaction_id`·만료시각 보관은 이 보존 의무
+  충족용이다(위 3절과 동일 맥락).
+- **신용정보법 / 전자금융거래법** — 이 법들은 PG·금융회사 등 **돈 흐름에 직접 끼는 사업자**를
+  규율한다. 영수증 검증만 하고 정산만 수령하는 앱 사업자에는 (해당 거래기록에 관한 한) 그
+  암호화 의무가 직접 적용되지 않는다. ⚠️ 단, 이 결론을 뒷받침하는 **1차 조항(전자금융거래법
+  제2조 정의·신용정보법 적용범위)의 정확한 인용은 미확정** — 출시 전 법무 검토 시 확인 권장.
+
+#### 본 서비스 결정
+- 결제 거래 기록 DB는 **법적 의무로서의 암호화 대상이 아니다.** 카드·계좌 정보를 절대 저장하지
+  않는 현재 설계를 유지하는 것이 의무 회피의 핵심이다.
+- `raw_payload`는 **민감정보 제외 원칙**을 유지한다(현재 Google 경로는 `latestOrderId` +
+  `subscriptionState`만 저장). 향후 영수증 원본을 통째로 적재하지 않는다.
+- `user_id`가 다른 보유정보와 결합(결합용이성, 법 제2조)해 개인정보로 평가되더라도 그 자체로
+  암호화 의무는 없으나, **접근통제·접근권한 관리·접속기록 보관** 등 일반 안전성 확보조치는
+  암호화와 별개로 적용된다.
+- (모범관행) 인프라 레벨 저장암호화(at-rest)·TLS 전송암호화는 의무가 아니라도 비용 없이 적용
+  가능하면 켜둔다.
+
 ## 5. 위치정보 — GPS 제거 결정
 
 근거: 위치정보의 보호 및 이용 등에 관한 법률(위치정보법).
@@ -101,3 +141,4 @@
 - 가명정보의 처리 (찾기쉬운 생활법령): https://easylaw.go.kr/CSP/CnpClsMain.laf?popMenu=ov&csmSeq=1257&ccfNo=2&cciNo=4&cnpClsNo=1
 - 위치정보의 보호 및 이용 등에 관한 법률 (국가법령정보센터): https://law.go.kr/LSW/lsInfoP.do?lsiSeq=125348
 - 전자상거래 등에서의 소비자보호에 관한 법률 시행령: https://law.go.kr/법령/전자상거래등에서의소비자보호에관한법률시행령
+- PCI DSS v4.0 SAQ A (PCI Security Standards Council): https://listings.pcisecuritystandards.org/documents/PCI-DSS-v4-0-SAQ-A.pdf


### PR DESCRIPTION
## 요약
인앱결제(IAP) 구조에서 카드번호·계좌번호를 저장하지 않는 `store_transactions` 테이블을 **법적으로 암호화해야 하는가**에 대한 검토 결과를 `docs/legal/compliance-notes.ko.md` 4절(암호화)에 정리.

**결론: 현재 구조에서 결제 거래 기록 DB 법적 암호화 의무 없음.**

## 프레임워크별 근거 (1차 출처 기반)
- **PCI-DSS**: PAN/CVC 미보관 + 카드처리 전적 위탁 → SAQ A 조건 충족, scope 사실상 제외
- **안전성 확보조치 기준 제7조**: 구매토큰/주문ID/product_id 등은 암호화 의무 대상(고유식별정보·카드번호·계좌번호) 아님
- **전자상거래법 시행령 제6조**: '보존' 의무(5년/5년/3년/6개월)일 뿐 '암호화' 의무 아님
- **신용정보법/전자금융거래법**: PG·금융회사 대상 (⚠️ 1차 조항 미확정 표기 — 출시 전 법무 검토 권장)

## 본 서비스 결정
- 카드/계좌 미저장 설계 유지가 의무 회피의 핵심
- `raw_payload` 민감정보 제외 원칙 유지
- user_id 결합용이성 시 접근통제 등 일반 안전성 조치는 별도 적용
- 출처에 PCI SSC SAQ A v4.0 추가

> 문서 변경만 있어 코드/배포 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)