### PR TITLE
출시 전 감사: 음성파일 누수·보안·동시성·Android 안정성 수정

### DIFF
--- a/ELEVENLABS_API.md
+++ b/ELEVENLABS_API.md
@@ -1,0 +1,121 @@
+# ElevenLabs API 사용 현황
+
+AlarmTalk 백엔드(Cloudflare Workers)가 ElevenLabs로 호출하는 모든 API를 정리한 문서.
+
+- **Base URL**: `https://api.elevenlabs.io`
+- **인증**: 모든 요청 헤더에 `xi-api-key: <ELEVENLABS_API_KEY>`
+- **API 키**: 환경 변수 `ELEVENLABS_API_KEY` (Worker secret)
+- **클라이언트 래퍼**: `packages/backend/src/lib/elevenlabs.ts` 의 `ElevenLabsClient` 클래스 하나로 모든 호출을 감싼다.
+- **사용 모델**
+  - TTS: `eleven_v3` (기본값, `DEFAULT_TTS_MODEL_ID`)
+  - STT/화자분리: `scribe_v2`
+
+---
+
+## 1. Instant Voice Clone — 음성 클론 생성
+
+| 항목 | 값 |
+|------|-----|
+| 메서드 | `POST /v1/voices/add` |
+| 본문 | `multipart/form-data` (`files`, `name`, `remove_background_noise`) |
+| 응답 | `{ voice_id }` |
+| 래퍼 | `ElevenLabsClient.createInstantClone()` |
+
+**용도**: 사용자가 업로드한 60~120초 음성 샘플로 즉시 음성 프로필을 만든다. `remove_background_noise: true`로 배경 잡음 제거.
+
+**호출 경로**
+- `lib/voice-provider.ts` → `createEnrollmentAttempts()` 의 `enroll()`
+- `routes/voice-profile.ts` → `POST /clone` (유료 플랜 전용, 음성 프로필 1개 한도)
+
+---
+
+## 2. Text to Speech — 텍스트 음성 변환
+
+| 항목 | 값 |
+|------|-----|
+| 메서드 | `POST /v1/text-to-speech/{voiceId}` |
+| 본문 | JSON (`text`, `model_id`, `language_code`, 조건부 `voice_settings`) |
+| 헤더 | `Accept: audio/mpeg` |
+| 응답 | 오디오 바이너리 (`ArrayBuffer`, mp3) |
+| 래퍼 | `ElevenLabsClient.textToSpeech()` |
+
+**voice_settings** (모델이 `eleven_v3`가 **아닐** 때만 전송):
+- `stability` (기본 0.5)
+- `similarity_boost` (기본 0.82)
+- `style` (기본 0.25)
+- `speed` (기본 0.96)
+- `use_speaker_boost` (옵션)
+
+> `eleven_v3`는 voice_settings를 보내지 않고 `text` + `model_id` (+ `language_code`)만 전송한다.
+
+**지원 언어**: ko, en, ja, fr, it (`SUPPORTED_SYNTHESIS_LANGUAGES`)
+
+**호출 경로**
+- `lib/voice-provider.ts` → `createSynthesisAttempts()` 의 `synthesize()`
+- `routes/tts.ts` → `POST /generate`
+  - 생성 전 캐시(`generated_audio_assets.request_hash`) 확인 → **히트 시 ElevenLabs 호출 없이** R2 저장 오디오 재사용
+  - 시스템(스톡) 보이스는 전체 사용자가 캐시 공유 → 한계 비용 ≈ 0
+  - 무료 플랜은 시스템 보이스 + 프리셋 고정 문구만 허용, 일일 생성 한도(free 3회)
+
+---
+
+## 3. Speech to Text (화자 분리) — Diarization
+
+| 항목 | 값 |
+|------|-----|
+| 메서드 | `POST /v1/speech-to-text` |
+| 본문 | `multipart/form-data` (`file`, `model_id=scribe_v2`, `diarize=true`, `timestamps_granularity=word`, `tag_audio_events=false`) |
+| 응답 | 단어별 타임스탬프 + `speaker_id` → 화자별 세그먼트로 가공 |
+| 래퍼 | `ElevenLabsClient.diarize()` |
+
+**용도**: 업로드 음성에서 화자를 분리(최대 3명). 단어 간격 0.35초(`DIARIZATION_MERGE_GAP_SECONDS`) 이내는 같은 세그먼트로 병합.
+
+**호출 경로**
+- `routes/voice-upload.ts` → `POST /uploads/:uploadId/separate` (저장된 업로드 분리)
+- `routes/voice-upload.ts` → `POST /diarize` (즉석 업로드 분리)
+
+---
+
+## 4. Delete Voice — 음성 프로필 삭제
+
+| 항목 | 값 |
+|------|-----|
+| 메서드 | `DELETE /v1/voices/{voiceId}` |
+| 응답 | 없음 (void) |
+| 래퍼 | `ElevenLabsClient.deleteVoice()` |
+
+**용도**: 음성 프로필 삭제 시 ElevenLabs 쪽 보이스도 정리. 외부 삭제가 실패해도 로컬 DB 삭제는 진행(best-effort).
+
+**호출 경로**
+- `routes/voice-profile.ts` → `DELETE /:id`
+- `lib/audio-retention.ts` → 보존기간 만료/유료 해지 정리 크론
+
+---
+
+## 5. List Voices — 음성 목록 조회
+
+| 항목 | 값 |
+|------|-----|
+| 메서드 | `GET /v1/voices` |
+| 응답 | `{ voices: [{ voice_id, name }] }` |
+| 래퍼 | `ElevenLabsClient.listVoices()` |
+
+**용도**: 사용 가능한 보이스 목록 조회. (현재 클라이언트에 구현되어 있으며, 운영/디버깅 보조용)
+
+---
+
+## 요약 매트릭스
+
+| # | ElevenLabs API | 래퍼 메서드 | 주요 호출 위치 |
+|---|----------------|-------------|----------------|
+| 1 | `POST /v1/voices/add` | `createInstantClone` | voice-profile `/clone`, voice-provider enroll |
+| 2 | `POST /v1/text-to-speech/{id}` | `textToSpeech` | tts `/generate`, voice-provider synthesize |
+| 3 | `POST /v1/speech-to-text` | `diarize` | voice-upload `/separate`, `/diarize` |
+| 4 | `DELETE /v1/voices/{id}` | `deleteVoice` | voice-profile `/:id` 삭제, audio-retention 크론 |
+| 5 | `GET /v1/voices` | `listVoices` | (보조/운영) |
+
+## 비용·캐싱 메모
+
+- TTS는 **글자 수 과금**이라 재생성도 매번 차감된다. → `request_hash` 기반 캐시로 동일 (보이스 × 문구 × 언어 × 모델 × 포맷) 조합은 **단 한 번만** 생성.
+- 클론 생성은 보이스 슬롯을 소모 → `VOICE_LIMIT_REACHED` / `voice_add_edit_counter` 등 슬롯 소진 에러를 `VOICE_SLOT_EXHAUSTED`(503)로 변환.
+- 생성 오디오는 R2(`VOICE_BUCKET`)에 저장하고 DB(`generated_audio_assets`)에 메타·해시 기록.

--- a/LAUNCH_AUDIT.md
+++ b/LAUNCH_AUDIT.md
@@ -423,9 +423,12 @@
 - 코치마크 maxWidth / 시간피커 폰트스케일 / AlarmRow 말줄임+접근가능 삭제 / 온보딩 \n 제거
 - 데드코드 제거 / LazyColumn key / DateTimeFormatter 호이스팅 / base64 IO 디스패처 / filter remember
 
+### 2차 배치 (가족/캐릭터 레이스 + auth)
+- character /xp 논스 중복지급 차단(조건부 INSERT 예약), streak 마일스톤 중복 차단,
+  가족초대 좌석 초과 TOCTOU(원자적 조건부 INSERT) (`character-mutation.ts`, `family-invite.ts`)
+- auth 전용 엄격 레이트리밋(15/분, 별도 버킷)로 무차별 대입 방어 (`rateLimit.ts`, `index.ts`)
+
 ## ⏳ 남은 항목 (권장 다음 배치)
-- 가족 medium 레이스: character XP 중복지급, streak 보너스 중복, 가족초대 좌석 초과 TOCTOU (트랜잭션/멱등 필요)
-- auth 엔드포인트 레이트리밋 (medium)
 - `pending_deletion` fail-open: fail-closed 전환은 일시적 DB 오류 시 인증 장애 위험 → 신중한 결정 필요(의도적 보류)
 - 저위험 리팩토링: resolveUserPk 중복 통합, ownerIds 헬퍼, 공통 에러 헬퍼, family-alarm 중복
 - 대형 구조 리팩토링(AlarmTalkApp God-composable 분할, AlarmListScreen 70-param 분할, strings.xml i18n): 출시 직전 리스크로 보류

--- a/LAUNCH_AUDIT.md
+++ b/LAUNCH_AUDIT.md
@@ -1,0 +1,431 @@
+# AlarmTalk 출시 전 감사 리포트
+
+생성: 멀티에이전트 감사(8개 차원, 적대적 검증) · 확정 54건, 기각 7건
+
+심각도: high 7 / medium 17 / low 30
+
+
+---
+
+## 심각도: HIGH
+
+
+### [be-auth-billing] Google OAuth login never checks email_verified, enabling email-based account takeover
+
+- **파일**: `packages/backend/src/lib/oauth.ts` :120-140 (verifyGoogleIdToken); consumed at packages/backend/src/routes/auth.ts:385-431
+- **설명**: verifyGoogleIdToken declares email_verified in ExternalTokenPayload (oauth.ts:4) but never reads it. /auth/google then links accounts by `WHERE google_id = ? OR email = ?` (auth.ts:396) and, when a row matches by email, overwrites that existing account's google_id with the caller's Google sub and issues a session for it (auth.ts:417-436). The same gap exists for Apple where `email` from the token is trusted unconditionally (auth.ts:540-554). Google explicitly requires verifying email_verified before trusting the email claim; without it, a Google identity whose email claim is unverified that collides with a victim's email+password account (users.email is UNIQUE, migrations.ts:163) can be linked to and take over the victim account. This is the canonical OAuth account-linking vulnerability.
+- **수정안**: In verifyGoogleIdToken, reject tokens where email_verified is not true (boolean true or string 'true') before returning the payload. For Apple, only trust payload.email when email_verified is true and never fall back to a client-supplied email for linking. Do not auto-link an OAuth identity to a pre-existing email+password account by email alone; require an explicit, authenticated link step.
+
+
+### [be-alarm-tts-voice] Daily TTS limit has a read-then-increment race that lets users burn unlimited paid ElevenLabs calls
+
+- **파일**: `packages/backend/src/routes/tts.ts` :642-653, 884-892, 961-964
+- **설명**: The free/plus daily cap is enforced by (1) reading `daily_tts_count` into an in-memory snapshot (lines 642-653), (2) re-checking that snapshot's `dailyLimitExceeded` boolean right before synthesis (lines 884-892), and (3) incrementing with `UPDATE users SET daily_tts_count = daily_tts_count + 1` only AFTER a successful synthesis (lines 961-964). There is no atomic slot reservation. If a user fires N concurrent /tts/generate requests, every request reads the same count (e.g. 2 < free limit 3), every one passes the guard, every one calls ElevenLabs textToSpeech, and only then does each increment. The cap of 3/day is trivially bypassed to N synthesis calls per burst. Each ElevenLabs v3 call costs real money, so this is a direct cost-blowup vector. The project's own docs/tech/backend-findings.ko.md:72-74 already documents this exact issue and proposes an atomic `UPDATE ... WHERE daily_tts_count < :limit` reservation, but the code still uses the non-atomic pattern.
+- **수정안**: Reserve the slot atomically BEFORE synthesis: `UPDATE users SET daily_tts_count = daily_tts_count + 1 WHERE (id=? OR google_id=?) AND daily_tts_count < :limit` and treat rowsAffected===0 as DAILY_TTS_LIMIT_EXCEEDED. On synthesis failure or cache hit, compensate by decrementing. This closes the concurrent-burst window that currently allows uncapped paid regeneration.
+
+
+### [be-alarm-tts-voice] Alarm create/update rejects system stock-clip message_id, breaking free-plan stock-clip alarms
+
+- **파일**: `packages/backend/src/routes/alarm-mutation.ts` :261-269
+- **설명**: Stock clips are stored as messages owned by SYSTEM_VOICE_LIBRARY_USER_ID ('70000000-0000-4000-9000-000000000001') with is_preset=1 (stock-clips.ts:308-325). The free plan is explicitly allowed to build TTS alarms from these stock clips: usesOnlySystemStockVoice() (alarm-mutation.ts:57-87) deliberately accepts a message_id that JOINs to a system voice. However, the actual alarm INSERT validation that runs when a client sends message_id only accepts messages the caller owns: `SELECT id FROM messages WHERE id = ? AND user_id IN (userPk, userId)` (lines 262-264). A system stock-clip message_id has user_id = SYSTEM_VOICE_LIBRARY_USER_ID, so this returns 0 rows and the request fails with 404 MESSAGE_NOT_FOUND. The same ownership-only check exists implicitly on PATCH (effectiveVoiceFields uses current.message_id, but a newly-provided system message_id is never re-validated as owned, and GET /tts/messages/:id/audio at tts.ts:1115-1122 DOES special-case is_preset+is_system — confirming the system anticipated stock message_ids flow through the alarm path). The two halves of the design disagree: usesOnlySystemStockVoice green-lights stock message_ids for plan gating, but the ownership SELECT blocks them. If the Android client attaches the stock-clip message_id (TtsApi StockClip exposes message_id and RemoteAlarmMapper sends ttsMessageId), free-plan stock-clip alarms cannot be created server-side.
+- **수정안**: In the message_id branch of alarm POST/PATCH, also accept system stock-clip messages: extend the validation to `... AND (user_id IN (?, ?) OR (COALESCE(is_preset,0)=1 AND EXISTS(SELECT 1 FROM voice_profiles vp WHERE vp.id = messages.voice_profile_id AND COALESCE(vp.is_system,0)=1)))`, mirroring the audio endpoint. Otherwise free users can preview a stock clip but cannot set an alarm with it.
+
+
+### [be-family-social-voucher] Family voucher redemption silently dissolves the redeemer's existing family group and downgrades its members
+
+- **파일**: `packages/backend/src/lib/voucher-redemption.ts` :242-260
+- **설명**: During redemption, cancelActiveSubscriptionsForUser(db, userPk, ...) is called before creating the new subscription (line 242). If the redeeming user currently OWNS a family plan group, cancelSubscriptionImmediate (billing-cancel.ts:151-192) detects ownerUserId===userPk and cascades: it cancels every other member's subscription, downgrades them all to free, and DELETEs all plan_group_members rows (billing-cancel.ts:169-191). So a family owner who redeems any INV/GIFT code (e.g. a friend's invite) instantly and irreversibly dissolves their own paid family group and strips all their members' access — with no warning and no confirmation surfaced by the voucher path. This is a data/access-loss footgun that orphans the owner's whole group.
+- **수정안**: Before cascading, detect when the redeemer owns an active group and either block the redemption with a clear error (must transfer ownership or dissolve first) or require an explicit confirm flag. At minimum, do not auto-destroy other members' subscriptions as a side effect of one user redeeming a code.
+
+
+### [voice-file-lifecycle] Deleting a TTS message leaves its R2 audio object orphaned forever
+
+- **파일**: `packages/backend/src/routes/tts.ts` :1221-1229
+- **설명**: tts.delete('/messages/:id') deletes the generated_audio_assets row (DELETE FROM generated_audio_assets WHERE message_id = ?) and the messages row, but never deletes the backing R2 object (generated_audio_assets.audio_object_key) nor enqueues it via enqueueExternalDeletion. Once the DB row is gone, the object key is no longer recorded anywhere, so neither the TTL cron (cleanupExpiredAudio only scans existing generated_audio_assets rows, audio-retention.ts:189-200) nor drainExternalDeletions can ever reach it. Compare with the sibling deleters that DO clean R2: alarm-mutation.ts:522-544 and voice-profile.ts:937-949 both delete the R2 object before dropping the asset row. This is the most common user action (deleting a saved message from the library), so on a real launch every message deletion permanently leaks one mp3 in the prod bucket voice-alarm-voices-prod.
+- **수정안**: Before deleting the generated_audio_assets rows, SELECT their audio_object_key WHERE message_id = ? AND audio_object_key IS NOT NULL and either call new R2VoiceStorage(c.env.VOICE_BUCKET).delete(key) (like alarm-mutation.ts) or enqueueExternalDeletion(db, 'r2_object', key) for the cron to drain. Also NULL/remove the message before relying on it being gone.
+
+
+### [voice-file-lifecycle] Raw alarm clips uploaded to R2 are never tracked in the DB, so unattached uploads leak permanently
+
+- **파일**: `packages/backend/src/routes/alarm-source.ts` :86-108
+- **설명**: POST /alarm/source writes the clip to R2 at raw-alarms/{userId}/{uuid} via bucket.put and returns the key, but writes NO database row at all. The object only becomes deletable if the client later creates/updates an alarm with raw_audio_url = r2://raw-alarms/... (then alarm DELETE at alarm-mutation.ts:505-513 can enqueue it). If the user uploads a recording and then abandons the flow (closes the app, picks a different clip, network error before alarm save) the object is orphaned: there is no DB row, and no cleanup path enumerates the bucket (grep shows zero .list() calls and cleanupExpiredAudio only scans voice_uploads + generated_audio_assets tables). These orphans accumulate with no TTL and no deleter. At launch scale this is unbounded R2 storage growth plus a GDPR gap (an abandoned upload survives even account deletion, because enqueueUserVoiceArtifacts in audio-retention.ts:88-98 only enqueues raw_audio_url values that are actually referenced by an alarms row).
+- **수정안**: Persist every raw-alarms upload in a tracking table (e.g. raw_alarm_uploads(id, user_id, object_key, created_at, attached INTEGER DEFAULT 0)) at upload time, mark attached=1 when an alarm adopts it, and extend cleanupExpiredAudio to enqueue R2 deletion for rows that are still unattached after a short TTL (e.g. 24-48h). Also enqueue these object_keys in enqueueUserVoiceArtifacts for account deletion.
+
+
+### [android-correctness] Alarm fire can crash the app (FGS start from background) when scheduled via the inexact fallback
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/AlarmReceiver.kt` :27
+- **설명**: AlarmReceiver.onReceive() calls RingingService.start(context, alarmId) (RingingService.kt:606-612), which does ContextCompat.startForegroundService() with NO try/catch anywhere in the chain. The app targets SDK 35, so Android 12+ FGS background-start restrictions apply. An exact-alarm broadcast (setAlarmClock) grants a temporary FGS-start exemption, but the inexact fallback used in AlarmScheduler.schedule() — alarmManager.setAndAllowWhileIdle() at AlarmScheduler.kt:46 — does NOT grant that exemption. The fallback is reachable in production: PermissionGate only blocks NEW alarm creation/enabling when exact-alarm permission is missing, but an already-enabled alarm stays scheduled, and reschedulePendingAlarms() (AlarmRepository.kt:478, run on BOOT_COMPLETED and app start) re-arms it through the same schedule() path. If the user revokes 'Alarms & reminders' after creating an alarm, the next fire arrives as a plain background broadcast and startForegroundService() throws ForegroundServiceStartNotAllowedException, which is uncaught inside a BroadcastReceiver → process crash → the alarm never rings and the app dies. This is exactly the 'alarm silently fails to fire' class of launch blocker.
+- **수정안**: Wrap the startForegroundService call (and the AlarmReceiver invocation) in try/catch for ForegroundServiceStartNotAllowedException. On failure, fall back to posting the full-screen-intent ringing notification directly (the RINGING_CHANNEL_ID notification already carries setFullScreenIntent), and/or re-check canScheduleExactAlarms() before relying on the inexact path. Also re-evaluate enabled alarms when exact-alarm permission state changes so users are told their alarms may be delayed/unreliable.
+
+
+---
+
+## 심각도: MEDIUM
+
+
+### [be-auth-billing] pending_deletion enforcement fails open if the user-resolution query throws
+
+- **파일**: `packages/backend/src/middleware/auth.ts` :89-152
+- **설명**: authMiddleware resolves the user row and enforces the pending_deletion gate inside a try block (lines 89-140). If the SELECT/INSERT throws for any reason, the catch (lines 141-150) sets userIdPK = verified.sub and calls await next() anyway, so the deletion_status check is skipped entirely. An account scheduled for deletion (which is supposed to be blocked from all APIs except GET/DELETE /user/me) would regain full API access on any transient DB error in this path, and the request proceeds with a best-effort PK that may not be the true users.id.
+- **수정안**: On user-resolution failure for an authenticated request, fail closed (return 503/500) rather than proceeding, or at minimum re-run the pending_deletion path-restriction before calling next(). Do not grant API access when the deletion gate cannot be evaluated.
+
+
+### [be-auth-billing] No dedicated rate limiting / brute-force protection on auth endpoints
+
+- **파일**: `packages/backend/src/index.ts` :42, 188; packages/backend/src/middleware/rateLimit.ts:24-25
+- **설명**: /api/auth (login, register, email-code, email-code/verify, google, apple) is mounted directly on app (index.ts:188) and is covered only by the single global rateLimitMiddleware (index.ts:42) of 60 req/min shared across ALL endpoints for the same IP key. There is no stricter per-route limit on credential login or on email-code verification. Login attempts return distinct codes (AUTH_INVALID_CREDENTIALS vs AUTH_OAUTH_ONLY) and email-code verification allows up to 5 attempts per code with unbounded code re-requests, so 60/min/IP is far too loose for password brute-force and code guessing at launch. The limiter is also per-isolate in-memory (rateLimit.ts:10-13), so the real global ceiling is multiplied by the number of live isolates.
+- **수정안**: Add a tight, separate limiter (e.g. 5-10/min per IP+email) to /auth/login, /auth/register, and /auth/email-code(/verify). Back it with Durable Objects or KV so the limit is global rather than per-isolate, as the file's own comment notes.
+
+
+### [be-auth-billing] No Apple/Google server-to-server billing notifications; entitlements only refreshed on client confirm or 5-min cron
+
+- **파일**: `packages/backend/src/routes/billing-apple.ts` :whole file; also billing-google.ts and index.ts:223-242
+- **설명**: Entitlement state is only created/refreshed when the client calls /billing/apple/confirm, /billing/google/confirm, or /billing/portone/complete, and downgraded by the local cron processSubscriptionExpiry (index.ts:237-242) which only acts once subscriptions.expires_at passes. There is no App Store Server Notifications V2 or Google Real-Time Developer Notifications (Pub/Sub) webhook (grep for webhook/notification/signedPayload finds none in billing). Consequences at launch: refunds, charge-backs, Apple/Google-side cancellations, billing retries, and grace-period transitions are not reflected until the client happens to re-confirm or the store-reported expiry elapses. A user who refunds keeps paid features until expiry; a renewal that the client never reports leaves the subscription to be force-cancelled by cron with deleteVoiceData=true at expiry even though it is still valid at the store.
+- **수정안**: Implement signed App Store Server Notifications V2 and Google RTDN webhook endpoints (verify Apple JWS signature chain and Google Pub/Sub auth), and drive entitlement grant/revoke from them. Until then, document the refund/cancellation lag as a known launch limitation and reconcile periodically via the server APIs already wired up here.
+
+
+### [be-alarm-tts-voice] System-voice cache hit returns another user's message_id, which downstream alarm creation will reject
+
+- **파일**: `packages/backend/src/routes/tts.ts` :853-882, 1289-1298
+- **설명**: For system (stock) voices, findCachedGeneratedAudio is called with anyUser:true (line 856-858), and the SQL drops the user filter entirely (`WHERE ${anyUser ? '' : 'ga.user_id IN (?, ?) AND '}ga.request_hash = ?`, line 1295). The returned cached.messageId is whichever user generated that (voice x text) pair first — typically the SYSTEM_VOICE_LIBRARY_USER_ID for true stock clips, but it can also be an ARBITRARY paid user who happened to synthesize the same custom text on a shared/system voice. The /tts/generate response then echoes that foreign message_id (line 861) as `message_id`. The caller is expected to use this message_id to attach an alarm, but POST /alarms only accepts owned message_ids (alarm-mutation.ts:262), so an alarm built from a cache-hit foreign message_id silently 404s. This is both a correctness break (cache hits behave differently from cache misses, which return the caller's own freshly-inserted message_id at line 973) and a minor info leak (one user learns another user's message UUID).
+- **수정안**: On a system-voice cache hit, do not return a foreign user's message_id. Either (a) insert a thin per-caller messages row pointing at the same audio_url and return that id, or (b) constrain the anyUser cache lookup to is_preset rows owned by SYSTEM_VOICE_LIBRARY_USER_ID so the returned message_id is always the canonical stock message, and make the alarm path accept it (see related finding).
+
+
+### [be-alarm-tts-voice] Voice clone has no upload byte-size cap before reading the full file into memory and sending to ElevenLabs
+
+- **파일**: `packages/backend/src/routes/voice-profile.ts` :686, 658-684
+- **설명**: POST /voice/clone validates durationMs (60-120s) but never validates the audio byte size. It calls `await audioFile.arrayBuffer()` (line 686) on the raw multipart file with no MAX_BYTES guard, unlike POST /voice/upload which caps at MAX_UPLOAD_BYTES = 25 MiB (voice-upload.ts:79-87) and POST /alarm/source which caps at 5 MiB (alarm-source.ts:76-84). A client can claim durationMs=90000 while uploading an arbitrarily large file; the whole buffer is loaded into the Worker's memory and forwarded to ElevenLabs createInstantClone. On Cloudflare Workers this risks hitting the 128 MB memory limit (request OOM / 1102) and forwards oversized payloads to a paid provider. durationMs is client-supplied and untrusted, so it is not a real size bound.
+- **수정안**: Add the same byte-size cap (e.g. 25 MiB) on the clone audio buffer before arrayBuffer()/enrollment, returning 413 AUDIO_FILE_TOO_LARGE. Do not trust durationMs as a size proxy.
+
+
+### [be-family-social-voucher] Character /xp endpoint grants XP twice on concurrent duplicate-nonce requests (no transaction, check-then-insert race)
+
+- **파일**: `packages/backend/src/routes/character-mutation.ts` :48-146
+- **설명**: POST /character/xp does NOT run inside a write transaction. The client_nonce idempotency is implemented as a non-atomic read-then-write: it SELECTs character_xp_logs for the nonce (lines 48-75), and only much later INSERTs the log row (lines 137-146). Between those two statements the character row is mutated with the granted XP/affection/streak via a bare UPDATE (lines 121-134). Two concurrent requests carrying the SAME client_nonce both see zero rows in the dedup SELECT, both apply the character UPDATE (double XP/affection/level), then both attempt the log INSERT. The unique index idx_character_xp_logs_nonce on (character_id, client_nonce) (migrations.ts:380-382) makes the SECOND insert throw, returning HTTP 500 — but the second character UPDATE already committed, so XP was granted twice. The unique index gives a false sense of safety; it only deduplicates the log, not the XP mutation.
+- **수정안**: Wrap the entire /xp handler body (dedup check, character UPDATE, log INSERT, milestone loop, stats update) in withWriteTransaction(db, ...). libSQL write transactions take a single-writer lock so the second concurrent request will serialize behind the first and its dedup SELECT will then see the committed log row. Additionally make the log INSERT the gating step (INSERT first; on unique-constraint failure, treat as duplicate and short-circuit) so the XP mutation can never run twice.
+
+
+### [be-family-social-voucher] Streak milestone bonus XP (up to 2000) can be double-granted via concurrent /xp requests
+
+- **파일**: `packages/backend/src/routes/character-mutation.ts` :148-189
+- **설명**: The milestone-bonus loop reads streak_achievements to check whether the milestone was already awarded (lines 150-154, 'SELECT id FROM streak_achievements WHERE character_id=? AND milestone=?'), then if absent applies the bonus XP and INSERTs the achievement row (lines 165-179). With no surrounding transaction, two concurrent alarm_completed requests that both reach a milestone (e.g. streak hits 7/30/90) both read zero existing achievements and both add the bonus XP (100/500/2000) to the character before either inserts. The unique index idx_streak_achievements_unique on (character_id, milestone) (migrations.ts:415-416) makes only the second INSERT fail with 500, but both XP additions already landed via separate UPDATEs (lines 165-173). streak_bonus_* events are cap-exempt (xpRules.ts:35-39) so the daily cap does not contain the leak.
+- **수정안**: Run the whole handler in a write transaction (same fix as the XP double-grant finding). The single-writer lock serializes the existence check + insert so the bonus is granted exactly once.
+
+
+### [be-family-social-voucher] Family invite acceptance has TOCTOU seat-overflow — group can exceed max_members
+
+- **파일**: `packages/backend/src/routes/family-invite.ts` :181-218
+- **설명**: POST /family/invites/:code/accept runs WITHOUT a transaction. It checks the live member count (SELECT COUNT(*) ... lines 197-201), compares to max_members (line 202), then INSERTs the new plan_group_members row (lines 206-211). plan_group_members has only UNIQUE(plan_group_id, user_id) (migrations.ts:307) — there is no DB constraint enforcing max_members. Two (or N) distinct users redeeming different valid pending invite codes for the same near-full group concurrently each read memberCount < max and each insert, overflowing the seat cap and yielding extra free family-plan seats. Unlike the voucher path (voucher-redemption.ts wraps capacity check + insert in withWriteTransaction), this invite path has no serialization. The earlier creation-time check in POST /invites (member+pending<=max, lines 57-72) does not prevent concurrent accepts.
+- **수정안**: Wrap the accept handler (count check, member insert, invite-status UPDATE) in withWriteTransaction so concurrent accepts serialize behind the single writer. Optionally re-verify count < max immediately before the insert inside the same transaction and fail with GROUP_FULL otherwise.
+
+
+### [voice-file-lifecycle] Replacing an alarm's raw_audio_url via PATCH orphans the previous R2 recording
+
+- **파일**: `packages/backend/src/routes/alarm-mutation.ts` :437-440
+- **설명**: The alarm PATCH handler overwrites raw_audio_url unconditionally (updates.push('raw_audio_url = ?')) without reading or cleaning up the previous value. When a user re-records their alarm voice clip, the old r2://raw-alarms/... object is replaced in the row and becomes unreferenced. Because raw-alarms objects are not tracked in any table (see the alarm-source finding) and no .list()-based GC exists, the previous object leaks forever. The DELETE path (lines 505-513) correctly guards and enqueues raw audio for deletion, but the PATCH/replace path was not given the same treatment.
+- **수정안**: In the PATCH handler, when body.raw_audio_url changes the stored value, first SELECT the current raw_audio_url; after the UPDATE, if the old r2:// value is no longer referenced by any alarm, enqueueExternalDeletion(db, 'r2_object', oldKey) — mirroring the DELETE handler logic.
+
+
+### [voice-file-lifecycle] TTL cleanup of generated_audio_assets leaves messages.audio_url pointing at a deleted R2 object
+
+- **파일**: `packages/backend/src/lib/audio-retention.ts` :189-207
+- **설명**: cleanupExpiredAudio enqueues the R2 object for deletion and DELETEs the generated_audio_assets row after 30 days, but does not NULL the matching messages.audio_url. Each generated message stores audio_url = r2://generated-tts/... (tts.ts:911,927) and keeps that pointer indefinitely (messages have no TTL). After the 30-day TTL fires, the message row survives in the user's library with a dangling r2:// URL whose object has been deleted, so GET /tts/messages/:id/audio returns 404 MESSAGE_AUDIO_NOT_FOUND (tts.ts:1149-1154) for a message the UI still lists. Unlike the notes endpoint, which self-heals by nulling the column on a missing object (notes.ts:218-223), the messages path does not, so the broken pointer persists. Not a storage leak, but a correctness/UX bug: previously-saved library messages silently stop playing.
+- **수정안**: When expiring a generated_audio_assets row, also run UPDATE messages SET audio_url = NULL WHERE id = <message_id> (or WHERE audio_url = 'r2://' || audio_object_key), and/or have GET /messages/:id/audio null the column on a missing object as notes.ts already does. Reconsider whether 30-day server retention should drop library messages at all.
+
+
+### [be-refactor-opt] repeat_days JSON parse + alarm mode inference duplicated between cron and /tick row-mapping
+
+- **파일**: `packages/backend/src/index.ts; packages/backend/src/routes/alarm-query.ts; packages/backend/src/routes/alarm-helpers.ts` :index.ts:280-298; alarm-query.ts:31-45; alarm-helpers.ts:27-52
+- **설명**: The scheduled() cron handler (index.ts:280-298) maps DB rows into ScheduledAlarm by inlining its own repeat_days JSON.parse IIFE (285-292) and mode inference (`r.mode === 'sound-only' ? 'sound-only' : 'tts'`, 294). The GET /tick handler (alarm-query.ts:31-45) builds the identical ScheduledAlarm from the identical SELECT columns, but routes the parsing through normalizeAlarmRow (alarm-helpers.ts:27) — a third place that parses repeat_days and infers mode. Three implementations of the same row→ScheduledAlarm transform that must stay in lockstep (they query the same columns: id,user_id,target_user_id,time,repeat_days,is_active,mode,voice_profile_id,speaker_id,timezone).
+- **수정안**: Add `rowToScheduledAlarm(row): ScheduledAlarm` (and/or `parseRepeatDays(raw): number[]`) in lib/scheduler.ts and call it from both index.ts:280 and alarm-query.ts:31. Removes the inline IIFE and the divergent mode-inference copies; one source of truth for the cron/tick contract.
+
+
+### [android-ui-ux] Time-picker wheels use fixed-dp row height (72.dp) with sp text — digits clip at large system font scale
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmTimePicker.kt` :54, 98, 123-126
+- **설명**: AlarmTimePickerCard hard-codes `itemHeight = 72.dp` and the wheel rows (DraggableTimeWheelColumn, AmPmWheelColumn) are clamped to `.height(itemHeight)` / `.height(itemHeight*3)` with `.clipToBounds()`. The digit glyphs inside are rendered with `MaterialTheme.typography.displayLarge` (~57sp, ~64sp line height) which DOES scale with the OS font-scale setting, while the dp row height does NOT. At the system 'large' font scale (~1.3x) the text line box (~83sp ≈ 83dp) exceeds the 72dp clipped row, so the top/bottom of the hour/minute digits get cut off on the single most important screen (alarm time set). There is no font-scale clamping anywhere (grep for fontScale/nonScaledSp returns nothing). Same pattern in AmPmWheelColumn.kt (hardcoded 38sp/32sp in 72dp rows — less severe but same class). The DraggableTimeWheelColumn.kt also relies on this (lines 102-105, 150-153, 171-174).
+- **수정안**: Make the row height scale with text: derive itemHeight from the resolved line height (e.g. `with(density){ displayLargeLineHeight.toDp() } + verticalPadding`), or size the row with `Modifier.heightIn(min = 72.dp)` and remove `clipToBounds()` from the selected-row cell, or cap fontScale just for the wheel via a `LocalDensity` override. Test at Settings > Display > Font size = Largest before launch.
+
+
+### [android-ui-ux] Swipe-to-delete is the only way to delete an alarm — inaccessible to TalkBack / motor-impaired users
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt` :201-374 (AlarmRow / DeleteRevealButton)
+- **설명**: AlarmRow reveals the delete action only via a horizontal `draggable` gesture; tapping the card opens the editor. The DeleteRevealButton is rendered behind the card and only becomes hittable after a successful drag. TalkBack users and users who cannot perform a precise horizontal swipe have no exposed affordance to delete an alarm from the list, and the row exposes no custom accessibility action. This is a Play Store accessibility gap for a core destructive operation.
+- **수정안**: Add a custom accessibility action (`Modifier.semantics { customActions = listOf(CustomAccessibilityAction("알람 삭제", { onDeleteAlarm(); true })) }`) on the AlarmRow, or expose a delete entry in the alarm editor / a long-press menu. Verify the editor offers delete; if not, this is the only delete path.
+
+
+### [android-correctness] No timezone/DST rescheduling — alarms fire at wrong wall-clock time after travel or DST change
+
+- **파일**: `apps/android-native/app/src/main/AndroidManifest.xml` :67-76
+- **설명**: Alarms persist an absolute fireAtMillis (AlarmEntity.fireAtMillis) computed once in the device's then-current timezone (AlarmTimeCalculator.nextFireAtMillis uses ZoneId.systemDefault()). BootCompletedReceiver only listens for BOOT_COMPLETED and MY_PACKAGE_REPLACED; there is no receiver for ACTION_TIMEZONE_CHANGED or ACTION_TIME_CHANGED (grep confirms zero references). reschedulePendingAlarms() only runs on boot and app-start. Consequently, if the user crosses a timezone or a DST transition occurs while the app is not opened, the stored fireAtMillis no longer maps to the intended local time and a 7:00 alarm fires up to an hour early/late (or at the old timezone's instant). For an alarm-clock app this is a serious correctness defect that users will perceive as 'the alarm went off at the wrong time'.
+- **수정안**: Register a receiver for android.intent.action.TIMEZONE_CHANGED (and ideally TIME_SET) that calls a recompute-and-reschedule routine which recalculates fireAtMillis from hour/minute/repeatDaysMask in the new zone and re-arms every enabled alarm. Reuse reschedulePendingAlarms but force recomputation (currently it keeps fireAtMillis as-is when it is still in the future, so it must be extended to recompute non-repeating alarms too).
+
+
+### [android-correctness] Dynamic/random-prompt voice refresh worker is never scheduled (dead code) — repeating dynamic alarms replay stale audio
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/sync/DynamicVoiceRefreshScheduler.kt` :21-46
+- **설명**: DynamicVoiceRefreshScheduler.ensurePeriodic()/runOnce() enqueue DynamicVoiceRefreshWorker, which calls AlarmRepository.refreshDueDynamicAlarmTalks() to regenerate fresh TTS for repeating 'random prompt' voice alarms. However, grep shows ensurePeriodic/runOnce are never called from anywhere (not Application.onCreate, not MainViewModel.init, not BootCompletedReceiver). Only RemoteAlarmSyncScheduler is wired. As a result the worker is never enqueued, refreshDueDynamicAlarmTalks runs nowhere, and a repeating dynamic-voice alarm keeps replaying the audio prepared at creation time every day (shouldRefreshDynamicVoice would return true, but nothing invokes it). The advertised 'fresh daily message / weather / fortune' behavior silently does not happen in the background.
+- **수정안**: Call DynamicVoiceRefreshScheduler.ensurePeriodic(this) in AlarmTalkApplication.onCreate (and runOnce on app start / boot when a session exists), mirroring the RemoteAlarmSyncScheduler wiring, or remove the feature if intentionally cut. Verify with a log that the worker actually runs.
+
+
+### [android-correctness] reverseGeocode (Android 13+) never resumes on geocoder error — coroutine hangs
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/location/WeatherLocationProvider.kt` :74-81
+- **설명**: On API 33+ the code uses geocoder.getFromLocation(lat, lon, 1) { addresses -> ... } supplying only the onGeocode callback of GeocodeListener. If geocoding fails, the framework invokes onError(...) (default no-op), so the suspendCancellableCoroutine continuation is never resumed and the coroutine suspends indefinitely until the surrounding scope is cancelled. This stalls the weather-location resolution used for dynamic prompts. Not a crash and gated by cancellation, but it can leak a hung coroutine and leave the dynamic-voice weather fetch silently pending.
+- **수정안**: Pass an object implementing GeocodeListener with both onGeocode and onError, resuming the continuation (e.g., with ''/'' or null) in onError. Optionally add a withTimeoutOrNull around the reverse-geocode call.
+
+
+### [android-refactor-opt] AlarmTalkApp is a 767-line God-composable reading ~25 ViewModel states at the top, forcing wide recomposition
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt` :43-67 (state reads), 91-174 (permission logic), 438-765 (Scaffold + NavHost)
+- **설명**: A single `AlarmTalkApp()` composable (767 lines) reads ~25 distinct ViewModel `State`-backed properties directly in its body (lines 43-67: alarms, message, authSession, authBusy, syncBusy, voiceProfiles, voiceProfileBusy, socialBusy, familyGroup, familyVoices, characterEvents, characterBusy, characterResponse, billingBusy, subscriptionResponse, vouchers, noteBusy, receivedNotes, themeMode, etc.). Because all of these are read in the same composable scope, ANY single state change (e.g. `billingBusy` flipping, a `message` snackbar, a sync busy toggle) recomposes the entire `AlarmTalkApp` body, which re-evaluates the whole `Scaffold`/`NavHost` and re-passes ~70 parameters to the active `AlarmListScreen`. The function also inlines the entire permission state machine (lines 91-174), Google sign-in handling (305-341), and all NavHost wiring. This is the single largest maintainability and recomposition-altitude problem in the UI layer.
+- **수정안**: Hoist cohesive slices into dedicated holders/composables: (1) extract the permission flow (missingRuntimePermissions/nextSettingsPermissionTarget/openPermissionSettings/requestPermission/bulk flow + its LaunchedEffect) into a `rememberPermissionFlowController()`; (2) wrap the per-tab refresh throttle LaunchedEffect (259-303) into its own effect-only composable; (3) give each NavHost screen a small state-class param instead of ~70 individual args. At minimum, read volatile states (message, *Busy flags) inside the narrowest child that needs them rather than at the top, so a busy-flag toggle doesn't recompose the NavHost.
+
+
+---
+
+## 심각도: LOW
+
+
+### [be-auth-billing] AUTH 401 path logs token error detail and client-id presence to console
+
+- **파일**: `packages/backend/src/middleware/auth.ts` :164-173
+- **설명**: On any verification failure the middleware does `console.log('[AUTH 401]', code, '|', message, '| GOOGLE_CLIENT_ID set:', !!c.env.GOOGLE_CLIENT_ID)`. The error message can include token-format/issuer/audience detail derived from attacker-supplied tokens, and the same raw message is returned to the client in the 401 body (line 173). This is inconsistent with the rest of the codebase which uses logStructured and deliberately avoids logging PII (see the comment at auth.ts:142-143). Verbose auth-error reflection aids token-forgery probing and leaks server config state into logs.
+- **수정안**: Replace the console.log with logStructured at warn level without echoing attacker-controlled token contents, drop the GOOGLE_CLIENT_ID-set hint, and return a generic error string to the client (keep only the stable error_code).
+
+
+### [be-auth-billing] Apple transaction JWS payload is decoded without verifying the signature chain
+
+- **파일**: `packages/backend/src/routes/billing-apple.ts` :113-122, 141-149
+- **설명**: decodeJwsPayload (lines 113-122) base64-decodes the signedTransactionInfo JWS payload without verifying its x5c certificate chain back to Apple's root. The code relies entirely on the response having been fetched over TLS directly from api.storekit.itunes.apple.com (comment line 113). That is acceptable only as long as the only data source is that exact TLS endpoint and the response envelope is otherwise trusted. It is fragile: any future reuse of decodeJwsPayload on client-supplied JWS (e.g. accepting a JWSTransaction from the app, or an S2S notification body) would accept a forged transaction because no signature is checked. Apple's guidance is to verify the JWS signature even for Server API responses.
+- **수정안**: Verify the JWS signature and x5c chain (to Apple's G3 root) before trusting bundleId/productId/expiresDate, so the verification is sound independent of where the JWS originates and is safe to reuse for future S2S notifications.
+
+
+### [be-auth-billing] Privileged test-code issuance is gated only by a JWT email claim, defaulting to a hardcoded personal Gmail
+
+- **파일**: `packages/backend/src/routes/billing-mutation.ts` :106-118, 324-327
+- **설명**: /billing/test-codes mints real paid invite/gift vouchers (up to 50 per call, up to 365-day expiry) and authorizes the caller solely by comparing c.get('userEmail') against TEST_CODE_ISSUER_EMAILS, which defaults to the hardcoded 'gyuwon05@gmail.com' when the env var is unset (line 107). userEmail is populated from the bearer token's email claim (auth.ts:82), including Google/Apple ID tokens. Anyone who controls the Google/Apple account for that email (or any address present in the allowlist) can issue unlimited free paid-plan vouchers. Email-claim-based authorization is weaker than a server-side role flag and the production default should not be a personal address.
+- **수정안**: Authorize privileged billing actions via a users.role/is_admin column checked server-side rather than a token email claim, remove the hardcoded personal-email default (fail closed if the allowlist is unset in production), and disable /test-codes entirely when ENVIRONMENT==='production'.
+
+
+### [be-auth-billing] Stub checkout/change-plan can grant paid plans with zero payment if BILLING_STUB_ENABLED is set in production
+
+- **파일**: `packages/backend/src/routes/billing-mutation.ts` :93-97, 233-322, 614-617
+- **설명**: /billing/checkout and /billing/change-plan create fully active paid subscriptions (and family plan groups + invite vouchers) with no payment verification whenever isBillingStubEnabled returns true. isBillingStubEnabled (lines 93-97) is true in any non-production environment and also true in production if BILLING_STUB_ENABLED is '1' or 'true'. A single misconfigured production env var therefore turns /checkout into a free-Plus/Family dispenser. There is no secondary guard (e.g. requiring a real provider confirm) behind these routes.
+- **수정안**: Before launch, hard-fail these stub routes in production unconditionally (assert ENVIRONMENT!=='production' regardless of BILLING_STUB_ENABLED) or remove the stub paths from the production build, and verify BILLING_STUB_ENABLED is unset in the production Worker config.
+
+
+### [be-alarm-tts-voice] POST /voice/diarize reads the full audio buffer before the paid-plan check, allowing unauthenticated-cost reads
+
+- **파일**: `packages/backend/src/routes/voice-upload.ts` :339-358
+- **설명**: In POST /voice/diarize the handler parses formData and calls `await audioFile.arrayBuffer()` (line 347) BEFORE checking hasPaidVoiceAccess (line 349). There is also no MIME-type check and no byte-size cap on this endpoint at all (unlike /upload and /uploads/:id/separate). A free-plan or abusive caller can repeatedly POST large bodies; the Worker buffers the entire payload into memory before the plan gate rejects it, and there is no upper bound on the file size that reaches diarize when the caller IS paid. This wastes Worker memory/CPU on requests that will be rejected and exposes the diarize path (a paid ElevenLabs scribe_v2 call) to oversized inputs.
+- **수정안**: Move the hasPaidVoiceAccess check before reading the buffer, and add MIME + byte-size validation matching /upload (audio/* only, <=25 MiB). Reject early to avoid buffering rejected payloads and to bound the size sent to the paid diarize provider.
+
+
+### [be-alarm-tts-voice] ElevenLabs failures throw raw upstream error text back to the client (HTTP 500 detail leak)
+
+- **파일**: `packages/backend/src/lib/elevenlabs.ts` :46-51, 80-86, 163-166
+- **설명**: Every ElevenLabsClient method throws `new Error(\`ElevenLabs API error ${status}: ${errorBody}\`)` where errorBody is the raw upstream response text. In /tts/generate the final catch returns `detail: err.message` (tts.ts:1036) in a 500 response; voice-profile clone returns `detail` (voice-profile.ts:752,772,782); voice-upload diarize returns `detail` (voice-upload.ts:228,373). The raw ElevenLabs error body can contain provider-internal identifiers, account/quota messaging, model names, and request context that should not be surfaced to end users at launch. It also conflates client-fixable vs internal errors under a generic 500.
+- **수정안**: Map known provider error classes to stable error_codes and a user-safe message; log the raw upstream body server-side only (it is already console.error'd at tts.ts:1001). Do not echo `detail` from upstream provider errors in production responses.
+
+
+### [be-alarm-tts-voice] Voice profile DELETE calls ElevenLabs with a possibly-empty API key and swallows all errors
+
+- **파일**: `packages/backend/src/routes/voice-profile.ts` :910-917
+- **설명**: On voice profile delete, `new ElevenLabsClient(c.env.ELEVENLABS_API_KEY)` is constructed and deleteVoice() is called inside a try/catch that silently swallows ANY error (the catch body is empty, line 915-917). If ELEVENLABS_API_KEY is unset/rotated, or the provider returns a transient 5xx, the cloned voice is NEVER removed from the ElevenLabs account, but the local row is soft-deleted regardless. Because cloned voices consume a finite ElevenLabs voice-slot quota (the code even handles VOICE_SLOT_EXHAUSTED on create, lines 767-776), orphaned remote voices accumulate and will eventually exhaust the paid quota, blocking all new clones for every user. There is no retry queue or deletion-pending marker for the remote voice (unlike R2 objects, which DO get enqueued for external deletion in alarm-mutation.ts:505-513).
+- **수정안**: On deleteVoice failure, enqueue the elevenlabs_voice_id for retried external deletion (mirroring enqueueExternalDeletion used for R2), and at minimum log the failure via logRouteError so orphaned provider voices can be reconciled before they exhaust the clone quota at launch.
+
+
+### [be-alarm-tts-voice] createSynthesisAttempts always uses output_format 'mp3' but never requests it from ElevenLabs, relying on the default
+
+- **파일**: `packages/backend/src/lib/elevenlabs.ts` :89-134
+- **설명**: voice-provider.ts hardcodes outputFormat:'mp3' and mimeType:'audio/mpeg' (lines 99,113-116) and the cache key is computed with outputFormat 'mp3' (tts.ts:846). But ElevenLabsClient.textToSpeech never sends an output_format query param / body field to the API; it only sets Accept: audio/mpeg (elevenlabs.ts:128) and trusts the provider default. If ElevenLabs changes its default sample rate/bitrate for eleven_v3, the stored bytes silently change format/quality while the cache key, audio_format column, and mimeType all still claim 'mp3' at the old assumptions. The cached object would then be served with a stale/incorrect format descriptor. This is fragile for a launch that caches audio long-term.
+- **수정안**: Explicitly pass `output_format` (e.g. mp3_44100_128) to the ElevenLabs TTS request and include the exact format string in the cache key, so the persisted audio format is pinned and self-consistent with the audio_format / mime_type columns and the cache identity.
+
+
+### [be-family-social-voucher] /xp endpoint is fully client-authoritative — XP/affection/streak can be farmed for arbitrary entitlements
+
+- **파일**: `packages/backend/src/routes/character-mutation.ts` :24-44
+- **설명**: POST /character/xp accepts the reward event verbatim from the request body with no server-side proof the event occurred. A client can POST {event:'friend_invited'} (50 XP, xpRules.ts:19) or {event:'alarm_completed'} repeatedly with fresh client_nonce values to farm XP up to the 200 daily cap, and can pass an attacker-chosen local_date to manufacture consecutive-day streaks (computeStreak only compares the client-supplied local_date to the stored last_wakeup_date — streak.ts:15-36). No alarm/friendship/family record is consulted to corroborate the event. Whether this is monetarily exploitable depends on whether character level/stage gates any paid feature or cosmetic; at minimum it corrupts leaderboards/achievements and trivializes milestone rewards.
+- **수정안**: Server-derive the event from durable state instead of trusting the body: for alarm_completed, require and verify an alarm/occurrence id owned by the user; for friend_invited, grant on the friendship-accept path server-side rather than via a client-declared event; clamp/validate local_date against server time (reject future dates and dates far from server 'today'). At minimum, rate-limit per event type.
+
+
+### [be-family-social-voucher] Gift accept is non-transactional with no pending-guard on UPDATE — duplicate library copies on concurrent accept
+
+- **파일**: `packages/backend/src/routes/gift.ts` :188-207
+- **설명**: PATCH /gift/:id/accept SELECTs the gift with status='pending' (lines 189-192), then UPDATEs status to 'accepted' WITHOUT an 'AND status=\'pending\'' guard (lines 198-201), then INSERTs into message_library (lines 203-207) — all outside a transaction. message_library has no unique constraint on (user_id, message_id) (migrations.ts:78-84). Two concurrent accept requests for the same pending gift both pass the SELECT and both INSERT a library row, so the recipient gets the gifted message duplicated in their library. Because rowsAffected of the unguarded UPDATE is not checked, a re-accept after the status already changed still proceeds to insert another library copy. Low monetary impact but a data-integrity/duplication bug at launch.
+- **수정안**: Wrap in withWriteTransaction; make the UPDATE conditional (UPDATE gifts SET status='accepted' WHERE id=? AND status='pending') and only insert into message_library when rowsAffected===1. Add a UNIQUE(user_id, message_id) index on message_library (with INSERT OR IGNORE) to make library inserts idempotent.
+
+
+### [voice-file-lifecycle] TTL preservation guard references a raw_audio_url relationship that no code path ever creates
+
+- **파일**: `packages/backend/src/lib/audio-retention.ts` :192-196
+- **설명**: cleanupExpiredAudio skips expiring a generated_audio_assets row when NOT EXISTS (SELECT 1 FROM alarms a WHERE a.raw_audio_url = 'r2://' || g.audio_object_key). This guard is dead: generated TTS objects use keys of the form generated-tts/{user}/{hash}.mp3 (audio-cache.ts:32-35), whereas alarms.raw_audio_url only ever holds raw-alarms/{user}/{uuid} keys uploaded via /alarm/source (alarm-source.ts:87). Alarms reference TTS audio indirectly through message_id, never by putting a generated-tts key into raw_audio_url. So the join condition can never match and the comment ('alarm raw_audio_url referencing object is preserved') is misleading. The practical risk is the opposite of a leak: a generated-tts object that IS still referenced by a live message is deleted at 30 days regardless (the guard does not check messages.audio_url), producing the dangling pointer described in the related finding.
+- **수정안**: Replace the alarms.raw_audio_url guard with a check against the actual consumer of generated TTS objects: NOT EXISTS (SELECT 1 FROM messages m WHERE m.audio_url = 'r2://' || g.audio_object_key) — so an object still backing a saved message is not deleted out from under it — or accept deletion and null the message pointer (see related finding).
+
+
+### [be-refactor-opt] Four duplicate resolveUserPk implementations (same SELECT id FROM users WHERE google_id=?)
+
+- **파일**: `packages/backend/src/lib/family-helpers.ts; packages/backend/src/routes/billing-helpers.ts; packages/backend/src/routes/character-helpers.ts; packages/backend/src/routes/notes.ts` :family-helpers.ts:3-12; billing-helpers.ts:43-52; character-helpers.ts:34-43; notes.ts:9-18
+- **설명**: The exact same helper that resolves a google sub to users.id is defined four separate times. character-helpers.ts:34 and notes.ts:9 are byte-for-byte copies of lib/family-helpers.ts:3 (both `(db, googleId) => SELECT id FROM users WHERE google_id = ?`). billing-helpers.ts:43 is a fourth copy that only differs by taking a Hono Context instead of (db, userId). This is pure copy-paste with no behavioral difference.
+- **수정안**: Keep one canonical `resolveUserPk(db, googleId)` in lib/family-helpers.ts. Delete the copies in character-helpers.ts and notes.ts and import from there. Replace billing-helpers.ts:resolveUserPk with a thin `resolveUserPk(c) = resolveUserPk(getDB(c.env), c.get('userId'))` wrapper (or have billing routes call the lib version directly). Removes ~30 lines and a divergence risk.
+
+
+### [be-refactor-opt] resolveUserPk re-queries users table even though auth middleware already put users.id in context (userIdPK)
+
+- **파일**: `packages/backend/src/routes/family-group.ts; packages/backend/src/routes/family-invite.ts; packages/backend/src/routes/notes.ts; packages/backend/src/routes/character-mutation.ts; packages/backend/src/routes/character-query.ts; packages/backend/src/routes/family-alarm.ts` :family-group.ts:21,109,156,224; family-invite.ts:24,102,140,241; notes.ts:24,91,142,193,241; family-alarm.ts:71,270
+- **설명**: authMiddleware already resolves the user row and stores users.id in c.set('userIdPK') (auth.ts:121, query `WHERE google_id=? OR apple_id=? OR id=?`). Yet ~20 handlers call `await resolveUserPk(db, userId)` unconditionally, issuing a second `SELECT id FROM users WHERE google_id=?` round-trip per request that returns the value already sitting in context. libSQL/Turso is a remote DB so each call is a network round-trip on the request hot path.
+- **수정안**: Add a shared `getUserPk(c): string` that returns `c.get('userIdPK')` (falling back to a query only if unset) and use it in all family-*/notes/character handlers. Eliminates one remote DB round-trip per request for the most-used routes; standardizes the userIdPK-vs-requery inconsistency that already exists across the codebase.
+
+
+### [be-refactor-opt] ownerIds/viewerIds tuple (userPk + userId) is reconstructed inline in 6+ handlers
+
+- **파일**: `packages/backend/src/routes/alarm-mutation.ts; packages/backend/src/routes/tts.ts; packages/backend/src/routes/alarm-query.ts; packages/backend/src/routes/voice-profile.ts` :alarm-mutation.ts:90-93; tts.ts:514-517,1044-1046,1093-1095,1170-1172; alarm-query.ts:10-12; voice-profile.ts:68-72,87-89
+- **설명**: The same 3-4 line preamble `const userId=c.get('userId'); const userPk=c.get('userIdPK')||userId; const ownerIds=[userPk,userId]` is copy-pasted in at least six handlers, and the dedup variant `Array.from(new Set([pk||sub, sub]))` is independently re-implemented as `viewerIds()` in alarm-query.ts:10 and `ownerIds()` in voice-profile.ts:68 with subtly different semantics (tuple-with-dupes vs Set-deduped).
+- **수정안**: Add one shared helper, e.g. `ownerIds(c): string[]` in a lib (returning the Set-deduped form) and use it everywhere. Replace the inline tuples and the two local helpers. Removes ~20 lines and unifies the dedup behavior so owner-check WHERE clauses are consistent.
+
+
+### [be-refactor-opt] 199 inline c.json({error, error_code}, status) calls with no shared error helper
+
+- **파일**: `packages/backend/src/routes (all)` :e.g. alarm-mutation.ts:113,129,267; alarm-query.ts:124,140; billing-mutation.ts (23 occurrences)
+- **설명**: Error responses are hand-written as `return c.json({ error: '...', error_code: '...' }, NNN)` in 199 places across 22 route files. There is no shared `apiError(c, status, code, message)` helper (confirmed: no errorResponse/jsonError/fail export exists). This bloats handlers, makes the error envelope easy to get inconsistent (some responses use `warning`/`message` keys instead, e.g. tts.ts:1187-1195), and any future change to the error shape requires touching ~200 call sites.
+- **수정안**: Introduce `apiError(c, status: ContentfulStatusCode, code: string, message: string)` returning `c.json({ error: message, error_code: code }, status)` and migrate call sites. Centralizes the envelope, shrinks handlers, and lets you add Sentry tagging / localization in one place.
+
+
+### [be-refactor-opt] Two family-alarm POST handlers duplicate ~60 lines of recipient validation
+
+- **파일**: `packages/backend/src/routes/family-alarm.ts` :38-110 (POST /alarms) vs 222-312 (POST /alarms/voice)
+- **설명**: POST /alarms and POST /alarms/voice repeat an almost identical preamble: recipient_user_id presence/trim, wake_at HH:mm regex check, resolveUserPk(sender), self-alarm check, assertSameGroup check, recipient SELECT (identical column list across both), allow_family_alarms check, normalizeRepeatDays, and isBlockedByFamilyAlarmQuietTime check. Roughly 60 lines are duplicated verbatim with identical error codes (RECIPIENT_REQUIRED, INVALID_WAKE_AT, USER_NOT_FOUND, SELF_ALARM, NOT_SAME_GROUP, RECIPIENT_NOT_FOUND, FAMILY_ALARM_DISABLED, FAMILY_ALARM_QUIET_TIME).
+- **수정안**: Extract `async function resolveFamilyAlarmTarget(db, senderUserId, body): Promise<{ ok:true; senderPk; recipient; recipientSettings; repeatDays; wakeAt } | { ok:false; status; body }>` and call it at the top of both handlers. Cuts ~60 duplicated lines and guarantees the two endpoints enforce identical recipient rules.
+
+
+### [be-refactor-opt] tts.ts is 1337 lines with the /generate handler ~530 lines of mixed routing + business logic
+
+- **파일**: `packages/backend/src/routes/tts.ts` :513-1042 (POST /generate); whole file 1-1337
+- **설명**: tts.ts is the largest backend file (1337 lines) but holds only 6 routes; the POST /generate handler alone spans ~530 lines (513-1042) and interleaves request-body normalization (a ~40-field snake_case/camelCase dual-key body type at 520-560), plan/quota logic, voice-profile resolution, dynamic-prompt/weather/relationship lookups, synthesis attempts, and caching. The file also carries many standalone helper functions (geocoding, preset picking, relationship-label resolution) that are not route-specific.
+- **수정안**: Split into tts-generate.ts (the /generate handler), tts-messages.ts (messages list/audio/delete), and move pure helpers (weather/geocode, preset pick, relationship-label/listener-title resolution, body-key normalization) into lib/tts-generation.ts. Improves reviewability and lets the dual-key body normalization be unit-tested in isolation.
+
+
+### [be-refactor-opt] Cron fans out alarm pushes sequentially (await sendAlarmPush in a loop)
+
+- **파일**: `packages/backend/src/index.ts` :310-313
+- **설명**: The scheduled() handler sends pushes for all firing alarms with `for (const alarm of firing) { await sendAlarmPush(...) }`. Each sendAlarmPush (fcm.ts:162) does a getTokensForUser DB query plus a sequential per-token FCM fetch, and the outer loop serializes every user. With many alarms firing in the same 5-minute window this latency stacks linearly and risks bumping the Workers subrequest/time budget, delaying later pushes. (The Google OAuth token itself is module-cached, so that part is fine.)
+- **수정안**: Batch the token lookup (single `SELECT user_id, token FROM push_tokens WHERE user_id IN (...)` for all firing target users) and dispatch FCM sends with bounded concurrency (e.g. Promise.all over chunks). Cuts wall-clock for multi-alarm ticks and reduces the chance of hitting Worker limits at scale.
+
+
+### [be-refactor-opt] Per-request inline TTS daily-limit map rebuilt on every /generate call
+
+- **파일**: `packages/backend/src/routes/tts.ts` :649
+- **설명**: Inside the hot POST /generate handler, the plan→limit table `const limits: Record<string, number> = { free: 3, plus: 9999, family: 9999 }` is reallocated on every request. Minor, but it sits on the busiest endpoint and the magic numbers (free=3, others effectively unlimited) are also implicitly duplicated by the daily-quota concept elsewhere.
+- **수정안**: Hoist to a module-level `const TTS_DAILY_LIMITS = { free: 3, plus: 9999, family: 9999 } as const;` (and consider deriving 'unlimited' from a sentinel). Trivial allocation win and a single place to tune quotas.
+
+
+### [be-refactor-opt] isValidUUID is an unused export (all callers use UUID_RE.test directly)
+
+- **파일**: `packages/backend/src/lib/validate.ts` :3-5
+- **설명**: validate.ts exports both UUID_RE and isValidUUID, but no production code calls isValidUUID — every route imports UUID_RE and calls UUID_RE.test(...) directly. The only reference to isValidUUID is its own unit test. It is effectively dead surface area.
+- **수정안**: Either delete isValidUUID (and its test) and standardize on UUID_RE.test, or, conversely, make isValidUUID the single public API and stop exporting the raw regex. Pick one to remove the redundant validation surface.
+
+
+### [android-ui-ux] Coach-mark / usage-guide cards have no maxWidth — stretch full-bleed on tablets, foldables, large screens
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt` :212-215 (CoachMarkOverlay), UsageGuideOverlay.kt 74-77
+- **설명**: Both first-run guide surfaces (CoachMarkCard in CoachMarkOverlay and the carousel card in UsageGuideOverlay) are laid out with `Modifier.fillMaxWidth().padding(horizontal = 20.dp/28.dp)` and NO `widthIn(max = …)`. On a tablet/foldable/large display the tip card stretches edge-to-edge (minus 20-28dp), producing very long line lengths and an unbalanced look on the exact screens the founder is worried about. The app already knows the right pattern — PlanGateDialog.kt L41 uses `.widthIn(max = 380.dp)` — but the coach marks don't follow it.
+- **수정안**: Add `.widthIn(max = 420.dp)` (and center with `Alignment.TopCenter`/horizontal arrangement) to the Surface in CoachMarkCard (CoachMarkOverlay.kt ~L213) and to the Surface in UsageGuideOverlay (~L75), matching PlanGateDialog. Cheap, high-visibility polish.
+
+
+### [android-ui-ux] AlarmRow label has no maxLines/ellipsis — long alarm names wrap and distort the list item
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt` :293-302
+- **설명**: In AlarmRow the `alarm.label` Text has no `maxLines`/`overflow`. The hero/quick cards (HomeCards.kt) and voice rows correctly cap with `maxLines = 1, overflow = Ellipsis`, but the primary alarm list item does not, so a long user-entered label wraps to multiple lines and unevenly grows the row next to the toggle. The time Text above it is also uncapped (less risky since it is fixed-format HH:MM).
+- **수정안**: Add `maxLines = 1, overflow = TextOverflow.Ellipsis` to the label Text (and ideally wrap the Column in `Modifier.weight(1f)` so it doesn't push the switch). Mirror the treatment already used in HomeCards.kt L116-117.
+
+
+### [android-ui-ux] Onboarding copy uses hardcoded \n line breaks — breaks awkwardly at large font scale / different widths
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/OnboardingScreen.kt` :49, 54, 59
+- **설명**: Onboarding page descriptions embed manual `\n` newlines (e.g. "녹음하거나 만든 목소리로\n내 알람을 울릴 수 있어요."). With a forced break plus natural wrapping at large font scale or narrow widths, lines can become lopsided or a single word can orphan to a third line, producing ragged centered text on the first screen new users see. LandingScreen.kt L127 has the same manual-break pattern.
+- **수정안**: Drop the manual `\n` and let `textAlign = Center` wrap naturally (the Column already has horizontal padding), or move strings to strings.xml so copy/wrapping can be tuned without code. If a controlled break is essential, verify it at Largest font scale.
+
+
+### [android-ui-ux] User-facing strings are hardcoded in Kotlin rather than strings.xml — no localization / RTL readiness
+
+- **파일**: `apps/android-native/app/src/main/res/values/strings.xml` :1-7
+- **설명**: strings.xml contains only app_name and two notification strings; every screen label, button, dialog title/body and coach-mark copy is hardcoded Korean inline (e.g. CoachMarkOverlay.kt L231 "가이드 N / M", AlarmListScreen.kt L55-72 guide copy, PermissionGate.kt L166-185). With no string resources there is no path to localization and no automatic RTL/bidi handling; a Play launch limited to Korean is fine short-term, but it blocks any future locale and means accessibility scanners can't pull labels from resources.
+- **수정안**: If a single-locale launch is intentional, document it as a deliberate scope decision. Otherwise begin extracting user-facing strings into strings.xml so they can be translated and so RTL layouts (start/end paddings are already used in most places) render correctly.
+
+
+### [android-refactor-opt] Audio base64 payloads decoded on the main thread before entering Dispatchers.IO (UI jank on every preview/clip tap)
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt, apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt` :VoiceProfileManagementPanel.kt:333, 578, 730; AlarmEditorScreen.kt:433, 471, 500, 774
+- **설명**: All audio preview/selection flows download a base64-encoded clip and decode it with `Base64.decode(response.audioBase64, Base64.DEFAULT)` while running on `scope = rememberCoroutineScope()` (Main dispatcher). The decode is performed OUTSIDE the subsequent `withContext(Dispatchers.IO){ audioStore.cacheGeneratedAudio(...) }` block — i.e. the CPU-bound base64 decode of a 1-2 minute voice clip (hundreds of KB to several MB) runs on the UI thread, then the already-decoded bytes are handed to IO. Evidence: VoiceProfileManagementPanel.kt line 333 `val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)` sits between the `onDownloadStockAudio(...)` call (332) and `withContext(Dispatchers.IO)` (334); identical ordering at lines 578 and 730, and at AlarmEditorScreen.kt 471, 500, 774. `scope` is `rememberCoroutineScope()` at VoiceProfileManagementPanel.kt:248 and AlarmEditorScreen.kt:164, which dispatches on Main. This causes a visible frame hitch each time a user taps a stock voice greeting or stock clip preview — a core, frequently-used flow at launch.
+- **수정안**: Move the `Base64.decode(...)` call inside the existing `withContext(Dispatchers.IO){ ... }` block (or wrap it in its own `withContext(Dispatchers.Default)`), so only the resulting `CachedAlarmAudio` crosses back to Main. Better, push the decode+cache entirely into AlarmAudioStore by adding a `cacheGeneratedAudioFromBase64(base64, format, ...)` helper that decodes on IO, and call that from all 7 sites to remove the duplicated decode logic at once.
+
+
+### [android-refactor-opt] AlarmListScreen is a single 70-parameter mega-dispatcher for 7 unrelated tab screens with inline lambdas allocated every composition
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt` :76-141 (signature), 195-381 (when(selectedTab) body); call site AlarmTalkApp.kt:529-627
+- **설명**: `AlarmListScreen` takes ~70 parameters (lines 77-140) and contains a `when (selectedTab)` (line 195) that renders 7 completely different screens (Home, Voices, Alarms, People, Messages, Growth, Billing) in one function. Every tab gets the full 70-arg surface even though e.g. the Billing tab needs none of the voice/alarm callbacks. Worse, the call site in AlarmTalkApp.kt passes many freshly-allocated lambdas on each composition — e.g. line 559 `onPromoteDraftVoice = { profileId -> viewModel.promoteDraftVoice(profileId); viewModel.loadVoiceProfiles() }`, 566 `onDownloadStockAudio = { messageId -> ... }`, 569, 590-603 (onCreateAlarm/onCreateFamilyAlarm/onToggleEnabled), 611, 615-626 (profileMenu). Non-method-reference lambdas are new instances each recomposition, so even with K2 strong-skipping these params compare unequal and the screen cannot skip — guaranteeing a full re-render of the active tab whenever AlarmTalkApp recomposes.
+- **수정안**: Split into per-tab composables (HomeTab, VoicesTab, AlarmsTab, etc.) routed directly in the NavHost, each taking only the state/callbacks it uses. Group the remaining callbacks into a small stable `@Immutable` actions holder (e.g. AlarmScreenActions) created once with `remember`, and wrap multi-statement call-site lambdas in `remember { }` (or move them into the ViewModel) so they are stable across recompositions and let strong-skipping actually skip.
+
+
+### [android-refactor-opt] DateTimeFormatter allocated per call in label utils (inconsistent with the codebase's own correct pattern)
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt` :87, 95, 105, 119, 124
+- **설명**: `formatFireTime` (87), `formatVoucherIssuedAt` (95), `formatNoteCreatedAt` (105) and `parseBackendTimestamp` (119, 124) each call `DateTimeFormatter.ofPattern(...)` on every invocation. `DateTimeFormatter` is immutable and thread-safe, so re-parsing the pattern string per call is pure waste. `parseBackendTimestamp` is the worst: it allocates up to three formatters per call, and it is invoked once per message timestamp via `formatNoteCreatedAt` while rendering message lists. The same module BillingCharacterPanel.kt already does this correctly with top-level vals (CharacterEventTimeFormatter/PassDateFormatter/PassShortDateFormatter at lines 409-416), so this is an internal inconsistency.
+- **수정안**: Hoist all four patterns to top-level `private val` DateTimeFormatter constants (e.g. `private val FireTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")`) and reference them, mirroring BillingCharacterPanel.kt. Zero behavior change, removes repeated parsing in list rendering.
+
+
+### [android-refactor-opt] Dead composables CountdownBanner and LegacyPanel are defined but never referenced
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListComponents.kt` :71-100 (CountdownBanner), 134-151 (LegacyPanel)
+- **설명**: `CountdownBanner(nextAlarm: AlarmEntity)` (lines 71-100) and `LegacyPanel(modifier, content)` (lines 134-151) are declared `internal fun` but a full-source search across apps/android-native/app/src/main finds no call sites other than their own definitions. They are dead code (the home screen now uses NextAlarmHeroCard instead of CountdownBanner). Dead UI code adds maintenance noise and ships unused bytecode.
+- **수정안**: Delete both composables. If kept intentionally for future use, annotate and document; otherwise remove to keep AlarmListComponents.kt focused.
+
+
+### [android-refactor-opt] LazyColumn items(sortedMembers) has no stable key — defeats item identity/animation and reuse
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt` :238
+- **설명**: `items(sortedMembers) { member -> MemberRow(...) }` (line 238) omits the `key` parameter, so Compose falls back to positional keys. When the member list changes (a member is removed via `pendingRemoveMember`, or sort order shifts), Compose cannot match items to their prior composition state and animations/reuse degrade. The sibling alarm list does this correctly: AlarmListScreen.kt:284 `items(sortedAlarms, key = { it.id })`. Each member has a stable `member.userId`.
+- **수정안**: Add a stable key: `items(sortedMembers, key = { it.userId }) { member -> ... }`, matching the alarm list pattern.
+
+
+### [android-refactor-opt] voiceProfiles.filter{} and bottom-bar receivedNotes.count{} recomputed every recomposition (not remembered)
+
+- **파일**: `apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt, apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt` :VoiceProfileManagementPanel.kt:300-301; AlarmTalkApp.kt:446
+- **설명**: In VoiceProfileManagementPanel the derived lists `systemVoices = voiceProfiles.filter { it.isSystem == true }` and `ownVoices = voiceProfiles.filter { it.isSystem != true }` (lines 300-301) are recomputed on every recomposition of this large, frequently-recomposing panel (see the 250ms waveform finding) instead of being wrapped in `remember(voiceProfiles)`. Similarly, AlarmTalkApp computes `unreadMessageCount = receivedNotes.count { it.readAt.isNullOrBlank() }` inline in the bottomBar lambda (line 446) on every Scaffold recomposition, whereas the analogous `unreadAlarmCount` is correctly memoized with `remember(alarms, ...)` at lines 71-76 — an inconsistency.
+- **수정안**: Wrap the filters in `remember(voiceProfiles) { ... }` and the unread count in `remember(receivedNotes) { receivedNotes.count { it.readAt.isNullOrBlank() } }`, mirroring the already-memoized `unreadAlarmCount`. Cheap, removes per-frame list scans during recording and snackbar/busy-flag churn.
+
+
+---
+
+# 적용 현황 (이번 작업에서 처리)
+
+## ✅ 수정 완료 + 검증됨
+
+### 백엔드 (1360 테스트 통과, typecheck/lint clean)
+- **음성파일 라이프사이클 전부 차단 (VF1~VF5)**
+  - VF1: 메시지 삭제 시 R2 오브젝트 삭제 큐 적재 (`tts.ts`)
+  - VF2: raw-alarms 업로드 추적 테이블(`raw_alarm_uploads`, migration 48) + 미연결 클립 TTL(2일) 정리 크론 + 계정삭제 정리 (`alarm-source.ts`, `audio-retention.ts`, `account-deletion.ts`)
+  - VF3: 알람 PATCH 녹음 교체 시 이전 R2 정리 (`alarm-mutation.ts`)
+  - VF4: TTL 정리 시 messages.audio_url 댕글링 포인터 NULL 처리 (`audio-retention.ts`)
+  - VF5: dead TTL 가드 → 활성 알람(message_id 경유)이 쓰는 TTS 보존(30일 후 무음 버그 수정)
+- **OAuth `email_verified` 강제** (Google+Apple) + Apple 클라이언트 이메일 fallback 제거 → 계정연동 탈취 차단 (`oauth.ts`, `auth.ts`)
+- **TTS 일일한도 원자적 예약** — read-then-increment 레이스 차단 + 실패 시 슬롯 복구 (`tts.ts`)
+- **스톡클립 message_id 알람 허용** — 무료플랜 스톡 알람 차단 버그 수정 (`alarm-mutation.ts`)
+- **바우처 그룹 자동해체 방지 가드** — 소유 그룹에 멤버 있으면 차단 (`voucher-redemption.ts`)
+- **화자분리 num_speakers 상한** — 1~3명 녹음 과분할 억제(정확도 개선) (`elevenlabs.ts`, `voice-upload.ts`)
+- **크론 알람 푸시 병렬화** — 청크 단위 allSettled (`index.ts`)
+
+### Android (assembleDevDebug 빌드 성공, 14건)
+- FGS 발화 크래시 가드 + 풀스크린 알림 폴백 / Geocoder 행 수정 / 동적보이스 새로고침 스케줄링 / 시간대·DST 재스케줄 리시버
+- 코치마크 maxWidth / 시간피커 폰트스케일 / AlarmRow 말줄임+접근가능 삭제 / 온보딩 \n 제거
+- 데드코드 제거 / LazyColumn key / DateTimeFormatter 호이스팅 / base64 IO 디스패처 / filter remember
+
+## ⏳ 남은 항목 (권장 다음 배치)
+- 가족 medium 레이스: character XP 중복지급, streak 보너스 중복, 가족초대 좌석 초과 TOCTOU (트랜잭션/멱등 필요)
+- auth 엔드포인트 레이트리밋 (medium)
+- `pending_deletion` fail-open: fail-closed 전환은 일시적 DB 오류 시 인증 장애 위험 → 신중한 결정 필요(의도적 보류)
+- 저위험 리팩토링: resolveUserPk 중복 통합, ownerIds 헬퍼, 공통 에러 헬퍼, family-alarm 중복
+- 대형 구조 리팩토링(AlarmTalkApp God-composable 분할, AlarmListScreen 70-param 분할, strings.xml i18n): 출시 직전 리스크로 보류

--- a/apps/android-native/app/src/main/AndroidManifest.xml
+++ b/apps/android-native/app/src/main/AndroidManifest.xml
@@ -71,6 +71,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <!-- 시간대(여행)·시스템 시각/DST 변경 시 알람 재예약을 위해 수신 -->
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
                 <action android:name="com.alarmtalk.app.action.DEBUG_RESTORE_ALARMS" />
             </intent-filter>
         </receiver>

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/AlarmReceiver.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/AlarmReceiver.kt
@@ -1,9 +1,12 @@
 package com.alarmtalk.app.alarm
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationManagerCompat
 import com.alarmtalk.app.alarm.AlarmContract.ACTION_ALARM_TRIGGER
 import com.alarmtalk.app.alarm.AlarmContract.EXTRA_ALARM_ID
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
@@ -24,7 +27,7 @@ class AlarmReceiver : BroadcastReceiver() {
         }
 
         Log.i(TAG, "Alarm received id=$alarmId")
-        RingingService.start(context, alarmId)
+        startRingingOrFallback(context, alarmId)
 
         val pendingResult = goAsync()
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
@@ -35,5 +38,39 @@ class AlarmReceiver : BroadcastReceiver() {
             }
             pendingResult.finish()
         }
+    }
+
+    /**
+     * 비정확 폴백(앱 백그라운드) 등으로 알람이 울릴 때, FGS(포그라운드 서비스) 시작이
+     * Android 12(API 31)+ 에서 ForegroundServiceStartNotAllowedException 으로 막힐 수 있다.
+     * 이 경우 서비스 대신 전체 화면 인텐트를 가진 울림 알림을 직접 게시해, 잠금 화면 위로
+     * 울림 화면이 뜨도록 폴백한다(알림 자체가 setFullScreenIntent 를 들고 있음).
+     */
+    private fun startRingingOrFallback(context: Context, alarmId: String) {
+        try {
+            RingingService.start(context, alarmId)
+        } catch (error: Exception) {
+            val isFgsBlocked = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                error is ForegroundServiceStartNotAllowedException
+            if (!isFgsBlocked) throw error
+            Log.w(TAG, "FGS start blocked; falling back to full-screen ringing notification id=$alarmId", error)
+            postRingingNotificationFallback(context, alarmId)
+        }
+    }
+
+    private fun postRingingNotificationFallback(context: Context, alarmId: String) {
+        runCatching {
+            NotificationChannels.ensure(context)
+            val notification = RingingNotificationFactory(context).build(alarmId)
+            NotificationManagerCompat.from(context).notify(RINGING_FALLBACK_NOTIFICATION_ID, notification)
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to post ringing notification fallback id=$alarmId", error)
+        }
+    }
+
+    private companion object {
+        // RingingService 의 RINGING_NOTIFICATION_ID(1001)와 동일한 슬롯을 재사용해
+        // 이후 서비스가 살아나면 같은 알림을 갱신/취소할 수 있게 한다.
+        const val RINGING_FALLBACK_NOTIFICATION_ID = 1001
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/BootCompletedReceiver.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/BootCompletedReceiver.kt
@@ -18,8 +18,12 @@ class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action ?: return
         val isDebuggable = context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+        // 부팅/업데이트뿐 아니라 시간대(여행)·시스템 시각/DST 변경 시에도 알람을 재예약한다.
+        // 그렇지 않으면 시간대 변경 후 알람이 잘못된 벽시계 시각에 울린다.
         val isRestoreAction = action == Intent.ACTION_BOOT_COMPLETED ||
             action == Intent.ACTION_MY_PACKAGE_REPLACED ||
+            action == Intent.ACTION_TIMEZONE_CHANGED ||
+            action == Intent.ACTION_TIME_CHANGED ||
             (isDebuggable && action == ACTION_DEBUG_RESTORE_ALARMS)
         if (!isRestoreAction) return
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import android.util.Log
 import com.alarmtalk.app.alarm.AlarmScheduler
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
+import com.alarmtalk.app.sync.DynamicVoiceRefreshScheduler
 import com.alarmtalk.app.network.TtsGenerateRequest
 import com.alarmtalk.app.network.AlarmTalkApi
 import com.alarmtalk.app.network.AlarmTalkApiClient
@@ -168,6 +169,8 @@ class AlarmRepository(
         // 새 알람을 저장한 뒤에 충돌 알람을 삭제해야, 둘이 같은 audioCacheKey 를
         // 공유할 때 캐시 음성이 보존된다(deleteAlarm 의 참조 카운트가 새 알람을 포함).
         conflict?.let { deleteAlarm(it.id) }
+        // 반복 랜덤 문구 알람이면 동적 음성 갱신 워커를 예약한다.
+        ensureDynamicVoiceRefreshScheduled(alarm)
         Log.i(TAG, "Created local alarm id=${alarm.id} fireAt=${alarm.fireAtMillis}")
         return alarm
     }
@@ -238,6 +241,8 @@ class AlarmRepository(
         alarmDao.upsert(updated)
         // 갱신본 저장 후 충돌 알람 삭제 — 공유 audioCacheKey 음성 보존.
         conflict?.let { deleteAlarm(it.id) }
+        // 수정으로 반복 랜덤 문구 알람이 됐을 수 있으니 동적 음성 갱신 워커를 재예약한다.
+        ensureDynamicVoiceRefreshScheduled(updated)
         Log.i(TAG, "Updated local alarm id=$alarmId enabled=${updated.enabled} fireAt=${updated.fireAtMillis}")
         return updated
     }
@@ -275,6 +280,8 @@ class AlarmRepository(
 
         if (enabled) alarmScheduler.schedule(updated)
         alarmDao.upsert(updated)
+        // 활성화된 반복 랜덤 문구 알람이면 동적 음성 갱신 워커를 예약한다.
+        if (enabled) ensureDynamicVoiceRefreshScheduled(updated)
         Log.i(TAG, "Alarm enabled changed id=$alarmId enabled=$enabled fireAt=${updated.fireAtMillis}")
         return updated
     }
@@ -650,6 +657,33 @@ class AlarmRepository(
         Instant.ofEpochMilli(nowMillis)
             .atZone(ZoneId.systemDefault())
             .toLocalDate()
+
+    /**
+     * 반복되는 랜덤 문구(동적 음성) 알람인지 판별한다.
+     * AlarmDao.getRepeatingDynamicAlarmTalks 의 조건과 동일하게 맞춘다.
+     */
+    private fun isRepeatingDynamicVoiceAlarm(alarm: AlarmEntity): Boolean =
+        alarm.enabled &&
+            alarm.repeatDaysMask != 0 &&
+            alarm.voiceRandomPrompt &&
+            alarm.playMode != AlarmPlayModes.ALARM_ONLY &&
+            !alarm.voiceProfileId.isNullOrBlank()
+
+    /**
+     * 반복 랜덤 문구 알람은 매번 새 음성으로 갱신돼야 한다. 알람 생성/수정/활성화 시
+     * 이 메서드를 호출해 DynamicVoiceRefreshWorker(WorkManager)를 예약한다.
+     * 이 wiring 이 없으면 반복 동적 알람이 과거에 캐시된 동일 음성만 재생한다.
+     */
+    private fun ensureDynamicVoiceRefreshScheduled(alarm: AlarmEntity) {
+        if (!isRepeatingDynamicVoiceAlarm(alarm)) return
+        runCatching {
+            DynamicVoiceRefreshScheduler.ensurePeriodic(context)
+            DynamicVoiceRefreshScheduler.runOnce(context)
+            Log.i(TAG, "Scheduled dynamic voice refresh for alarm id=${alarm.id}")
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to schedule dynamic voice refresh id=${alarm.id}", error)
+        }
+    }
 
     private fun shouldRefreshDynamicVoice(alarm: AlarmEntity, nowMillis: Long): Boolean {
         if (alarm.dynamicVoicePreparedForFireAtMillis == alarm.fireAtMillis) return false

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/location/WeatherLocationProvider.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/location/WeatherLocationProvider.kt
@@ -72,12 +72,32 @@ object WeatherLocationProvider {
             ?: return "" to ""
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             suspendCancellableCoroutine { continuation ->
-                geocoder.getFromLocation(latitude, longitude, 1) { addresses ->
-                    val address = addresses.firstOrNull()
-                    val country = address?.countryName?.trim().orEmpty()
-                    val city = (address?.adminArea ?: address?.locality)?.trim().orEmpty()
-                    if (continuation.isActive) continuation.resume(country to city)
+                // 비동기 콜백은 성공/에러/빈 결과 어느 경로로도 continuation 을 정확히 한 번만
+                // 재개해야 한다. resumed 가드가 없으면 onError 미처리로 코루틴이 영영 멈춘다.
+                val resumed = java.util.concurrent.atomic.AtomicBoolean(false)
+                fun finish(result: Pair<String, String>) {
+                    if (resumed.compareAndSet(false, true) && continuation.isActive) {
+                        continuation.resume(result)
+                    }
                 }
+                geocoder.getFromLocation(
+                    latitude,
+                    longitude,
+                    1,
+                    object : Geocoder.GeocodeListener {
+                        override fun onGeocode(addresses: MutableList<android.location.Address>) {
+                            val address = addresses.firstOrNull()
+                            val country = address?.countryName?.trim().orEmpty()
+                            val city = (address?.adminArea ?: address?.locality)?.trim().orEmpty()
+                            finish(country to city)
+                        }
+
+                        override fun onError(errorMessage: String?) {
+                            // 에러 시에도 반드시 재개(null 대용으로 빈 값) — 미재개 시 무한 대기.
+                            finish("" to "")
+                        }
+                    },
+                )
             }
         } else {
             @Suppress("DEPRECATION")

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListComponents.kt
@@ -2,7 +2,6 @@ package com.alarmtalk.app
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.alarmtalk.app.data.AlarmEntity
 
 @Composable
 internal fun AlarmsHeader(
@@ -68,38 +66,6 @@ internal fun AlarmsHeader(
 }
 
 @Composable
-internal fun CountdownBanner(nextAlarm: AlarmEntity) {
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.34f),
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "다음 알람",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = formatFireTime(nextAlarm.fireAtMillis),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold,
-            )
-        }
-    }
-}
-
-@Composable
 internal fun EmptyAlarmCard(onCreateAlarm: () -> Unit) {
     Card(
         shape = RoundedCornerShape(16.dp),
@@ -131,21 +97,3 @@ internal fun EmptyAlarmCard(onCreateAlarm: () -> Unit) {
     }
 }
 
-@Composable
-internal fun LegacyPanel(
-    modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    Card(
-        modifier = modifier,
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-    ) {
-        Column(
-            modifier = Modifier.padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            content = content,
-        )
-    }
-}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -77,6 +77,10 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
     val pendingCharacterEventCount = remember(characterEvents) {
         characterEvents.count { it.state == CharacterEventStates.PENDING }
     }
+    // 읽지 않은 메시지 수도 receivedNotes 가 바뀔 때만 계산(매 리컴포지션 재계산 방지).
+    val unreadMessageCount = remember(receivedNotes) {
+        receivedNotes.count { it.readAt.isNullOrBlank() }
+    }
     val permissionState = rememberPermissionStatusState()
     val permissions = permissionState.snapshot
     var bulkPermissionFlowActive by remember { mutableStateOf(false) }
@@ -443,7 +447,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                 AlarmTalkBottomBar(
                     selectedTab = selectedTab,
                     unreadAlarmCount = if (selectedTab == NativeTab.Alarms) 0 else unreadAlarmCount,
-                    unreadMessageCount = receivedNotes.count { it.readAt.isNullOrBlank() },
+                    unreadMessageCount = unreadMessageCount,
                     // 메시지는 커플/가족 전용 — 무료·개인 플랜은 잠금 표시.
                     messagesLocked = !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup),
                     onSelectTab = ::navigateToTab,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
@@ -1,5 +1,7 @@
 package com.alarmtalk.app
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -26,6 +28,8 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -45,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.data.AlarmEntity
@@ -197,6 +202,7 @@ internal fun PermissionRow(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun AlarmRow(
     alarm: AlarmEntity,
@@ -209,6 +215,8 @@ internal fun AlarmRow(
     var deleteRevealed by remember(alarm.id) { mutableStateOf(false) }
     var dragOffsetPx by remember(alarm.id) { mutableStateOf(0f) }
     val warningText = alarmRowWarningText(alarm)
+    // 스와이프 외에 접근성(TalkBack/지체장애) 대체 삭제 수단: 길게 눌러 메뉴 노출.
+    var menuExpanded by remember(alarm.id) { mutableStateOf(false) }
     val settledOffsetPx = if (deleteRevealed) -deleteWidthPx else 0f
     val currentOffsetPx = if (dragOffsetPx != 0f) dragOffsetPx else settledOffsetPx
     val deleteVisible = deleteRevealed || currentOffsetPx < -0.5f
@@ -243,16 +251,21 @@ internal fun AlarmRow(
         }
 
         Card(
-            onClick = {
-                if (!deleteRevealed) {
-                    onEditAlarm()
-                } else {
-                    deleteRevealed = false
-                    dragOffsetPx = 0f
-                }
-            },
             modifier = Modifier
                 .offset { IntOffset(currentOffsetPx.roundToInt(), 0) }
+                // 클릭=수정/펼침 해제, 길게 누르기=삭제 메뉴. 길게 누르기로 스와이프와 별개의
+                // 접근성 친화 삭제 경로를 제공한다.
+                .combinedClickable(
+                    onClick = {
+                        if (!deleteRevealed) {
+                            onEditAlarm()
+                        } else {
+                            deleteRevealed = false
+                            dragOffsetPx = 0f
+                        }
+                    },
+                    onLongClick = { menuExpanded = true },
+                )
                 .draggable(
                     state = dragState,
                     orientation = Orientation.Horizontal,
@@ -279,7 +292,9 @@ internal fun AlarmRow(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Column {
+                    // weight(1f) 로 스위치 공간을 남기고 라벨이 가질 폭을 확정해야
+                    // 긴 알람 이름이 ellipsis(말줄임)로 잘려 행 레이아웃이 깨지지 않는다.
+                    Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = "%02d:%02d".format(alarm.hour, alarm.minute),
                             style = MaterialTheme.typography.headlineLarge,
@@ -294,6 +309,9 @@ internal fun AlarmRow(
                             text = alarm.label,
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
+                            // 긴 이름이 여러 줄로 줄바꿈되며 행을 망가뜨리지 않도록 한 줄 말줄임 처리.
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             color = if (alarm.enabled) {
                                 MaterialTheme.colorScheme.onSurface
                             } else {
@@ -301,6 +319,7 @@ internal fun AlarmRow(
                             },
                         )
                     }
+                    Spacer(Modifier.width(8.dp))
                     AlarmTalkSwitch(
                         checked = alarm.enabled,
                         onCheckedChange = onToggleEnabled,
@@ -332,6 +351,26 @@ internal fun AlarmRow(
                     }
                 }
             }
+        }
+
+        // 길게 누르기로 열리는 접근성 대체 삭제 메뉴(스와이프 삭제는 그대로 유지).
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("삭제") },
+                onClick = {
+                    menuExpanded = false
+                    onDeleteAlarm()
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = null,
+                    )
+                },
+            )
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -430,8 +430,9 @@ internal fun AlarmEditorScreen(
                         random = false,
                     ),
                 )
-                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 withContext(Dispatchers.IO) {
+                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                    val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                     audioStore.cacheGeneratedAudio(
                         bytes = audioBytes,
                         format = response.audioFormat,
@@ -468,8 +469,9 @@ internal fun AlarmEditorScreen(
             previewingStockMessageId = clip.messageId
             runCatching {
                 val response = onDownloadStockAudio(clip.messageId)
-                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 withContext(Dispatchers.IO) {
+                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                    val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                     audioStore.cacheGeneratedAudio(
                         bytes = audioBytes,
                         format = response.audioFormat,
@@ -497,8 +499,9 @@ internal fun AlarmEditorScreen(
         scope.launch {
             runCatching {
                 val response = onDownloadStockAudio(clip.messageId)
-                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 withContext(Dispatchers.IO) {
+                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                    val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                     audioStore.cacheGeneratedAudio(
                         bytes = audioBytes,
                         format = response.audioFormat,
@@ -771,7 +774,6 @@ internal fun AlarmEditorScreen(
                         ).trimmedOrNull(),
                     ),
                 )
-                val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 val rawAudioUri = response.audioUrl ?: response.audioObjectKey?.let { "r2://$it" }
                 val cacheKey = AlarmAudioStore.ttsCacheKey(
                     profileId = profileId,
@@ -781,6 +783,8 @@ internal fun AlarmEditorScreen(
                     serverCacheKey = response.cacheKey,
                 )
                 val cachedAudio = withContext(Dispatchers.IO) {
+                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                    val audioBytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                     audioStore.cacheGeneratedAudio(
                         bytes = audioBytes,
                         format = response.audioFormat,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmTimePicker.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmTimePicker.kt
@@ -51,7 +51,10 @@ internal fun AlarmTimePickerCard(
     modifier: Modifier = Modifier,
 ) {
     val currentOnTimeChange by rememberUpdatedState(onTimeChange)
-    val itemHeight = 72.dp
+    // 휠 글자는 sp(폰트 스케일에 비례)인데 행 높이가 고정 dp 면 큰 글꼴 설정에서 숫자가 잘린다.
+    // 시스템 폰트 스케일에 맞춰 행 높이를 키우되, 과도한 확대는 1.5배로 제한해 레이아웃 균형을 유지한다.
+    val fontScale = LocalDensity.current.fontScale.coerceIn(1f, 1.5f)
+    val itemHeight = 72.dp * fontScale
     val verticalWheelPadding = 24.dp
     var workingHour by remember { mutableIntStateOf(hour) }
     var workingMinute by remember { mutableIntStateOf(minute) }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -211,8 +212,11 @@ private fun CoachMarkCard(
 
         Surface(
             modifier = Modifier
+                .align(Alignment.TopCenter)
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
+                // 태블릿/폴더블에서 카드가 화면 폭 전체로 늘어나지 않도록 최대 폭을 제한하고 가운데 정렬.
+                .widthIn(max = 480.dp)
                 .offset { IntOffset(0, offsetY.roundToInt()) }
                 .onSizeChanged { cardHeightPx = it.height }
                 // 첫 프레임에 높이를 모른 채 그려지는 깜빡임을 숨긴다.

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
@@ -235,7 +235,7 @@ internal fun MemberManagementScreen(
             )
         }
 
-        items(sortedMembers) { member ->
+        items(sortedMembers, key = { it.userId }) { member ->
             MemberRow(
                 member = member,
                 isMe = member.userId == currentUserId,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/OnboardingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/OnboardingScreen.kt
@@ -43,20 +43,21 @@ private data class OnboardingPage(
 )
 
 private val OnboardingPages = listOf(
+    // 큰 글꼴 배율에서 줄바꿈이 어색하게 깨지지 않도록 하드코딩된 \n 없이 자연 줄바꿈에 맡긴다.
     OnboardingPage(
         icon = Icons.Outlined.Mic,
         title = "좋아하는 목소리로 깨어나요",
-        description = "녹음하거나 만든 목소리로\n내 알람을 울릴 수 있어요.",
+        description = "녹음하거나 만든 목소리로 내 알람을 울릴 수 있어요.",
     ),
     OnboardingPage(
         icon = Icons.Outlined.Group,
         title = "소중한 사람들과 함께",
-        description = "목소리와 메시지를 주고받고\n서로의 아침을 챙길 수 있어요.",
+        description = "목소리와 메시지를 주고받고 서로의 아침을 챙길 수 있어요.",
     ),
     OnboardingPage(
         icon = Icons.Outlined.AutoAwesome,
         title = "알람을 끄며 함께 성장해요",
-        description = "하루를 시작할 때마다\n캐릭터의 성장 기록이 쌓여요.",
+        description = "하루를 시작할 때마다 캐릭터의 성장 기록이 쌓여요.",
     ),
 )
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
@@ -32,6 +32,17 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 
+// DateTimeFormatter 는 스레드 안전하며 불변이므로 호출마다 새로 만들 필요가 없다.
+// 코드베이스의 다른 곳(BillingCharacterPanel)과 동일하게 top-level val 로 1회만 할당한다.
+private val DateTimeMinuteFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+private val DotDateFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy.MM.dd")
+private val BackendSecondFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+private val BackendMinuteFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
 internal fun Context.canScheduleExactAlarms(): Boolean {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
     val am = getSystemService(AlarmManager::class.java) ?: return false
@@ -84,29 +95,26 @@ internal fun Context.startSettingsActivity(intent: Intent) {
 }
 
 internal fun formatFireTime(millis: Long): String {
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
     return Instant.ofEpochMilli(millis)
         .atZone(ZoneId.systemDefault())
-        .format(formatter)
+        .format(DateTimeMinuteFormatter)
 }
 
 internal fun formatVoucherIssuedAt(isoString: String?): String? {
     if (isoString.isNullOrBlank()) return null
-    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
     return runCatching {
         Instant.parse(isoString)
             .atZone(ZoneId.systemDefault())
-            .format(formatter)
+            .format(DotDateFormatter)
     }.getOrNull()
 }
 
 internal fun formatNoteCreatedAt(isoString: String?, zoneId: ZoneId = ZoneId.systemDefault()): String? {
     val value = isoString?.trim()?.takeIf { it.isNotBlank() } ?: return null
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
     val instant = parseBackendTimestamp(value)
     return instant
         ?.atZone(zoneId)
-        ?.format(formatter)
+        ?.format(DateTimeMinuteFormatter)
         ?: value
             .replace('T', ' ')
             .take(16)
@@ -116,12 +124,12 @@ internal fun formatNoteCreatedAt(isoString: String?, zoneId: ZoneId = ZoneId.sys
 private fun parseBackendTimestamp(value: String): Instant? =
     runCatching { Instant.parse(value) }.getOrNull()
         ?: runCatching {
-            LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            LocalDateTime.parse(value, BackendSecondFormatter)
                 .atZone(ZoneOffset.UTC)
                 .toInstant()
         }.getOrNull()
         ?: runCatching {
-            LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+            LocalDateTime.parse(value, BackendMinuteFormatter)
                 .atZone(ZoneOffset.UTC)
                 .toInstant()
         }.getOrNull()

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -297,8 +297,9 @@ internal fun VoiceProfileManagementPanel(
     // 지금 인사말 샘플을 재생 중인 기본 목소리 id (재생 아이콘 토글용).
     var playingGreetingVoiceId by remember { mutableStateOf<String?>(null) }
     // 시스템 스톡 보이스는 "내 목소리" 수 제한·관리 액션에서 제외한다.
-    val systemVoices = voiceProfiles.filter { it.isSystem == true }
-    val ownVoices = voiceProfiles.filter { it.isSystem != true }
+    // 매 리컴포지션마다 재계산하지 않도록 voiceProfiles 가 바뀔 때만 다시 분류한다.
+    val systemVoices = remember(voiceProfiles) { voiceProfiles.filter { it.isSystem == true } }
+    val ownVoices = remember(voiceProfiles) { voiceProfiles.filter { it.isSystem != true } }
     val isLimitReached = ownVoices.size >= MAX_VOICE_PROFILES
     val canCreateVoice = hasPaidVoiceAccess(subscriptionResponse)
     val canShareVoice = canShareVoiceWithOthers(subscriptionResponse, familyGroup, authSession)
@@ -330,8 +331,9 @@ internal fun VoiceProfileManagementPanel(
             playingGreetingVoiceId = profile.id
             runCatching {
                 val response = onDownloadStockAudio(clip.messageId)
-                val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 val cached = withContext(Dispatchers.IO) {
+                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                    val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                     audioStore.cacheGeneratedAudio(
                         bytes = bytes,
                         format = response.audioFormat,
@@ -575,8 +577,9 @@ internal fun VoiceProfileManagementPanel(
                     random = false,
                 ),
             )
-            val audioBytes = Base64.decode(ttsResponse.audioBase64, Base64.DEFAULT)
             val cached = withContext(Dispatchers.IO) {
+                // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                val audioBytes = Base64.decode(ttsResponse.audioBase64, Base64.DEFAULT)
                 audioStore.cacheGeneratedAudio(
                     bytes = audioBytes,
                     format = ttsResponse.audioFormat,
@@ -727,8 +730,9 @@ internal fun VoiceProfileManagementPanel(
                     random = false,
                 ),
             )
-            val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
             val cached = withContext(Dispatchers.IO) {
+                // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+                val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
                 audioStore.cacheGeneratedAudio(
                     bytes = bytes,
                     format = response.audioFormat,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -307,9 +307,17 @@ async function scheduled(event: ScheduledEvent, env: Env): Promise<void> {
     firing_ids: firing.map((a) => a.id),
   });
 
-  for (const alarm of firing) {
-    const targetUserId = alarm.target_user_id ?? alarm.user_id;
-    await sendAlarmPush(db, env, targetUserId, alarm.id, alarm.time);
+  // 알람 푸시를 순차(await in loop)로 보내면 동시에 울릴 알람이 많을 때 지연이
+  // 선형으로 쌓인다(마지막 사용자는 늦게 울림). Workers 의 subrequest 상한을
+  // 고려해 청크 단위로 병렬 전송하고, 한 건 실패가 나머지를 막지 않도록 allSettled.
+  const PUSH_CONCURRENCY = 10;
+  for (let i = 0; i < firing.length; i += PUSH_CONCURRENCY) {
+    const chunk = firing.slice(i, i + PUSH_CONCURRENCY);
+    await Promise.allSettled(
+      chunk.map((alarm) =>
+        sendAlarmPush(db, env, alarm.target_user_id ?? alarm.user_id, alarm.id, alarm.time),
+      ),
+    );
   }
 }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from 'hono/cors';
 import type { Env, AppEnv } from './types';
 import { authMiddleware } from './middleware/auth';
 import { loggerMiddleware } from './middleware/logger';
-import { rateLimitMiddleware } from './middleware/rateLimit';
+import { rateLimitMiddleware, authRateLimitMiddleware } from './middleware/rateLimit';
 import { bodyLimitMiddleware } from './middleware/bodyLimit';
 import { privateCache, noStore } from './middleware/cache';
 import { securityHeadersMiddleware } from './middleware/securityHeaders';
@@ -185,6 +185,8 @@ app.get('/api/app/version', noStore, async (c) => {
 });
 
 // 이메일+비밀번호 가입/로그인 (인증 미들웨어 미적용)
+// 무차별 대입 방어용 엄격 한도를 일반 한도와 별개 버킷으로 추가 적용한다.
+app.use('/api/auth/*', authRateLimitMiddleware);
 app.route('/api/auth', authRoutes);
 
 // 인증이 필요한 라우트들

--- a/packages/backend/src/lib/account-deletion.ts
+++ b/packages/backend/src/lib/account-deletion.ts
@@ -151,6 +151,13 @@ export async function purgeUserAccount(
       args: [userPk],
     });
 
+    // raw-alarms 업로드 추적 행 정리(R2 오브젝트는 위 enqueueUserVoiceArtifacts 가
+    // 이미 삭제 큐에 적재했다).
+    await tx.execute({
+      sql: `DELETE FROM raw_alarm_uploads WHERE user_id IN (?, ?)`,
+      args: [userPk, userId],
+    });
+
     await tx.execute({
       sql: `DELETE FROM generated_audio_assets
             WHERE user_id IN (?, ?)

--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -24,6 +24,9 @@ import { logStructured } from './logger';
 
 export const VOICE_UPLOAD_TTL_DAYS = 7;
 export const GENERATED_TTS_TTL_DAYS = 30;
+// 알람에 연결되지 않은 raw-alarms 업로드의 유예 시간. 업로드 직후 알람에 붙는
+// 정상 흐름은 보존하면서, 이탈로 버려진 클립만 정리할 만큼 넉넉하게 잡는다.
+export const RAW_ALARM_UPLOAD_TTL_DAYS = 2;
 
 const DRAIN_BATCH_SIZE = 10;
 const TTL_BATCH_SIZE = 10;
@@ -95,6 +98,15 @@ export async function enqueueUserVoiceArtifacts(
   for (const row of rawAlarms.rows) {
     const url = String(row.raw_audio_url ?? '');
     await enqueueExternalDeletion(tx, 'r2_object', url.replace(/^r2:\/\//, ''));
+  }
+
+  // 추적된 raw-alarms 업로드(알람에 연결되지 않은 것 포함) — 계정 삭제 시 함께 정리.
+  const rawTracked = await tx.execute({
+    sql: `SELECT object_key FROM raw_alarm_uploads WHERE user_id IN (${ph})`,
+    args: ownerIds,
+  });
+  for (const row of rawTracked.rows) {
+    await enqueueExternalDeletion(tx, 'r2_object', row.object_key as string);
   }
 }
 
@@ -185,7 +197,11 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
     });
   }
 
-  // 2) TTS 캐시 — 알람 raw_audio_url 이 참조 중인 오브젝트는 보존.
+  // 2) TTS 캐시 — 알람이 참조 중인 오브젝트는 보존한다.
+  //    알람은 (a) raw_audio_url 로 직접, 또는 (b) message_id → messages.audio_url 로
+  //    간접 참조할 수 있다. 두 경로를 모두 확인하지 않으면 활성 알람이 쓰는 TTS
+  //    오브젝트가 30일 후 삭제되어 알람이 무음이 된다(기존 가드는 (a)만 검사해
+  //    generated-tts 키를 한 번도 매칭하지 못하는 dead guard 였다).
   const generated = await db.execute({
     sql: `SELECT g.id, g.audio_object_key FROM generated_audio_assets g
           WHERE g.created_at <= ?
@@ -194,23 +210,60 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
               SELECT 1 FROM alarms a
               WHERE a.raw_audio_url = 'r2://' || g.audio_object_key
             )
+            AND NOT EXISTS (
+              SELECT 1 FROM alarms a
+              JOIN messages m ON m.id = a.message_id
+              WHERE m.audio_url = 'r2://' || g.audio_object_key
+            )
           ORDER BY g.created_at ASC
           LIMIT ?`,
     args: [generatedCutoff, TTL_BATCH_SIZE],
   });
   for (const row of generated.rows) {
-    await enqueueExternalDeletion(db, 'r2_object', row.audio_object_key as string);
+    const objectKey = row.audio_object_key as string;
+    await enqueueExternalDeletion(db, 'r2_object', objectKey);
+    // 라이브러리 메시지가 가리키던 포인터를 비워, 오브젝트 삭제 후 깨진 r2:// 참조
+    // (재생 시 404)가 라이브러리에 남지 않도록 한다.
+    await db.execute({
+      sql: `UPDATE messages SET audio_url = NULL WHERE audio_url = 'r2://' || ?`,
+      args: [objectKey],
+    });
     await db.execute({
       sql: 'DELETE FROM generated_audio_assets WHERE id = ?',
       args: [String(row.id)],
     });
   }
 
-  if (uploads.rows.length > 0 || generated.rows.length > 0) {
+  // 3) raw-alarms 직접 재생 클립 — 업로드 후 어떤 알람에도 연결되지 않은 채
+  //    TTL 이 지나면 정리한다. 알람이 raw_audio_url 로 참조 중이면 보존한다.
+  const rawUploadCutoff = new Date(
+    now.getTime() - RAW_ALARM_UPLOAD_TTL_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const rawUploads = await db.execute({
+    sql: `SELECT id, object_key FROM raw_alarm_uploads
+          WHERE created_at <= ?
+            AND NOT EXISTS (
+              SELECT 1 FROM alarms a
+              WHERE a.raw_audio_url = 'r2://' || raw_alarm_uploads.object_key
+            )
+          ORDER BY created_at ASC
+          LIMIT ?`,
+    args: [rawUploadCutoff, TTL_BATCH_SIZE],
+  });
+  for (const row of rawUploads.rows) {
+    await enqueueExternalDeletion(db, 'r2_object', row.object_key as string);
+    await db.execute({
+      sql: 'DELETE FROM raw_alarm_uploads WHERE id = ?',
+      args: [String(row.id)],
+    });
+  }
+
+  if (uploads.rows.length > 0 || generated.rows.length > 0 || rawUploads.rows.length > 0) {
     logStructured('info', {
       at: 'audio-retention.ttl',
       expired_uploads: uploads.rows.length,
       expired_generated: generated.rows.length,
+      expired_raw_uploads: rawUploads.rows.length,
     });
   }
 }

--- a/packages/backend/src/lib/elevenlabs.ts
+++ b/packages/backend/src/lib/elevenlabs.ts
@@ -2,6 +2,14 @@ const ELEVENLABS_BASE_URL = 'https://api.elevenlabs.io';
 const DEFAULT_TTS_MODEL_ID = 'eleven_v3';
 const DIARIZATION_MERGE_GAP_SECONDS = 0.35;
 const DEFAULT_AUDIO_MIME_TYPE = 'audio/wav';
+// 가족/연인 녹음은 보통 1~3명이다. 앱의 화자 처리 상한과 동일하게 맞춰 과분할을 막는다.
+const DEFAULT_MAX_DIARIZATION_SPEAKERS = 3;
+const SCRIBE_MAX_SPEAKERS = 32;
+
+function clampSpeakerCount(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_MAX_DIARIZATION_SPEAKERS;
+  return Math.max(1, Math.min(SCRIBE_MAX_SPEAKERS, Math.round(value)));
+}
 
 type TranscriptWord = {
   start?: number;
@@ -136,7 +144,7 @@ export class ElevenLabsClient {
   /** Speaker Diarization - 화자 분리 */
   async diarize(
     audioData: ArrayBuffer,
-    options?: AudioUploadOptions,
+    options?: AudioUploadOptions & { numSpeakers?: number; languageCode?: string | null },
   ): Promise<{
     speakers: DiarizedSpeaker[];
   }> {
@@ -151,6 +159,16 @@ export class ElevenLabsClient {
     formData.append('diarize', 'true');
     formData.append('timestamps_granularity', 'word');
     formData.append('tag_audio_events', 'false');
+    // num_speakers 를 지정하지 않으면 scribe 가 화자 수를 모델 최대치로 가정해
+    // 한두 명짜리 녹음을 여러 '유령 화자'로 과분할한다 → 분리 결과가 애매해진다.
+    // 앱이 실제로 지원하는 화자 수 상한으로 고정해 과분할을 억제한다(정확도 개선).
+    const numSpeakers = clampSpeakerCount(options?.numSpeakers ?? DEFAULT_MAX_DIARIZATION_SPEAKERS);
+    formData.append('num_speakers', String(numSpeakers));
+    // 언어를 알면 전사 정확도가 올라가 단어 타임스탬프(화자 분리의 입력)도 좋아진다.
+    // 모르면 생략해 자동 감지에 맡긴다(다국어 녹음 회귀 방지).
+    if (options?.languageCode) {
+      formData.append('language_code', options.languageCode);
+    }
 
     const res = await fetch(`${ELEVENLABS_BASE_URL}/v1/speech-to-text`, {
       method: 'POST',

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1125,6 +1125,28 @@ export const migrations: Migration[] = [
           AND voice_profile_id = '70000000-0000-4000-9000-000000000101'`,
     ],
   },
+  {
+    // raw-alarms 업로드 추적: POST /alarm/source 로 올린 직접 재생용 클립은 지금까지
+    // DB 에 기록되지 않아, 사용자가 알람에 연결하지 않고 흐름을 이탈하면 R2 에서
+    // 영구 고아로 남았다(TTL/GC 없음 + 계정 삭제로도 정리 안 됨). 업로드 시점에
+    // 행을 남겨, 일정 시간 뒤에도 어떤 알람에서도 참조되지 않으면 정리(삭제 큐 적재)한다.
+    id: 48,
+    name: 'track-raw-alarm-uploads',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS raw_alarm_uploads (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        object_key TEXT NOT NULL,
+        created_at TEXT DEFAULT (datetime('now'))
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_raw_alarm_uploads_key
+        ON raw_alarm_uploads(object_key)`,
+      `CREATE INDEX IF NOT EXISTS idx_raw_alarm_uploads_created
+        ON raw_alarm_uploads(created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_raw_alarm_uploads_user
+        ON raw_alarm_uploads(user_id)`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/oauth.ts
+++ b/packages/backend/src/lib/oauth.ts
@@ -135,6 +135,15 @@ export async function verifyGoogleIdToken(
   if (Number(payload.exp) < Date.now() / 1000) {
     throw new Error('Token expired');
   }
+  // email_verified 미검증 시 email 클레임을 신뢰하면 안 된다(OAuth 계정 연동 탈취
+  // 방지). 다운스트림이 email 로 기존 계정과 연동하므로, 검증된 이메일만 통과시킨다.
+  if (
+    payload.email !== undefined &&
+    payload.email_verified !== true &&
+    payload.email_verified !== 'true'
+  ) {
+    throw new Error('Google token email not verified');
+  }
 
   return { ...payload, exp: Number(payload.exp) };
 }
@@ -171,6 +180,16 @@ export async function verifyAppleIdToken(
     }
   } else {
     console.warn('[oauth] apple token verified without nonce check');
+  }
+
+  // Apple 도 email_verified 가 명시적으로 false 면 email 을 신뢰하지 않는다.
+  // (private-relay 포함 검증된 이메일은 'true'/true 로 온다.)
+  if (
+    payload.email !== undefined &&
+    payload.email_verified !== true &&
+    payload.email_verified !== 'true'
+  ) {
+    throw new Error('Apple token email not verified');
   }
 
   return { ...payload, exp: Number(payload.exp) };

--- a/packages/backend/src/lib/voucher-redemption.ts
+++ b/packages/backend/src/lib/voucher-redemption.ts
@@ -233,6 +233,27 @@ async function redeemVoucherCodeInTransaction(
     });
   }
 
+  // 방어 가드: 코드를 사용하면 redeemer 의 기존 구독이 취소되는데, redeemer 가
+  // *다른 멤버가 있는 가족 그룹의 소유자*라면 그 취소가 그룹을 해체하고 멤버들의
+  // 구독까지 강등시킨다(한 사람의 코드 사용이 남의 구독을 파괴). 이를 막기 위해
+  // 소유 그룹에 본인 외 멤버가 있으면 명확한 에러로 차단한다(소유권 이전/멤버
+  // 정리 후 재시도하도록 유도).
+  const ownedGroupRes = await db.execute({
+    sql: `SELECT COUNT(*) AS other_members
+          FROM plan_group_members m
+          JOIN plan_groups pg ON pg.id = m.plan_group_id
+          WHERE pg.owner_user_id = ? AND m.user_id != ?`,
+    args: [params.userPk, params.userPk],
+  });
+  const otherMembers = Number(ownedGroupRes.rows[0]?.other_members) || 0;
+  if (otherMembers > 0) {
+    throw new VoucherRedemptionError(
+      409,
+      'OWNS_ACTIVE_GROUP',
+      'You own a family group with other members. Transfer ownership or remove members before redeeming a new code.',
+    );
+  }
+
   await claimVoucherUse(db, {
     voucherId,
     userPk: params.userPk,

--- a/packages/backend/src/middleware/rateLimit.ts
+++ b/packages/backend/src/middleware/rateLimit.ts
@@ -43,30 +43,57 @@ function getKey(c: Context): string {
   return `ip:${ip}`;
 }
 
-export async function rateLimitMiddleware(c: Context, next: Next) {
-  cleanup();
+/**
+ * 레이트리밋 미들웨어 팩토리. prefix 로 버킷을 분리하면 동일 키(사용자/IP)에 대해
+ * 일반 한도와 별개의 더 엄격한 한도를 독립적으로 걸 수 있다.
+ */
+export function createRateLimitMiddleware(options?: {
+  windowMs?: number;
+  maxRequests?: number;
+  prefix?: string;
+}) {
+  const windowMs = options?.windowMs ?? WINDOW_MS;
+  const maxRequests = options?.maxRequests ?? MAX_REQUESTS;
+  const prefix = options?.prefix ?? '';
 
-  const key = getKey(c);
-  const now = Date.now();
-  let entry = store.get(key);
+  return async function rateLimit(c: Context, next: Next) {
+    cleanup();
 
-  if (!entry || entry.resetAt <= now) {
-    entry = { count: 0, resetAt: now + WINDOW_MS };
-    store.set(key, entry);
-  }
+    const key = `${prefix}${getKey(c)}`;
+    const now = Date.now();
+    let entry = store.get(key);
 
-  entry.count++;
+    if (!entry || entry.resetAt <= now) {
+      entry = { count: 0, resetAt: now + windowMs };
+      store.set(key, entry);
+    }
 
-  const remaining = Math.max(0, MAX_REQUESTS - entry.count);
-  c.header('X-RateLimit-Limit', String(MAX_REQUESTS));
-  c.header('X-RateLimit-Remaining', String(remaining));
-  c.header('X-RateLimit-Reset', String(Math.ceil(entry.resetAt / 1000)));
+    entry.count++;
 
-  if (entry.count > MAX_REQUESTS) {
-    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-    c.header('Retry-After', String(retryAfter));
-    return c.json({ error: 'Too many requests', retryAfter }, 429);
-  }
+    const remaining = Math.max(0, maxRequests - entry.count);
+    c.header('X-RateLimit-Limit', String(maxRequests));
+    c.header('X-RateLimit-Remaining', String(remaining));
+    c.header('X-RateLimit-Reset', String(Math.ceil(entry.resetAt / 1000)));
 
-  await next();
+    if (entry.count > maxRequests) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      c.header('Retry-After', String(retryAfter));
+      return c.json({ error: 'Too many requests', retryAfter }, 429);
+    }
+
+    await next();
+  };
 }
+
+export const rateLimitMiddleware = createRateLimitMiddleware();
+
+/**
+ * 인증 엔드포인트(로그인/회원가입/이메일코드/소셜) 전용 엄격 한도. 별도 prefix 버킷이라
+ * 일반 60/분 한도와 독립적으로 동작해 무차별 대입(brute-force)을 좁힌다.
+ * 정상 다단계 가입 흐름(코드요청→검증→가입)에 여유를 두되 비밀번호 추측은 제한.
+ */
+export const authRateLimitMiddleware = createRateLimitMiddleware({
+  windowMs: 60_000,
+  maxRequests: 15,
+  prefix: 'auth:',
+});

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -259,8 +259,24 @@ alarmMutation.post('/', async (c) => {
     });
     resolvedMessageId = placeholderMsgId;
   } else if (resolvedMessageId) {
+    // 본인 소유 메시지뿐 아니라 시스템 스톡 클립(is_preset=1 + 시스템 보이스)도
+    // 허용한다. 무료 플랜은 스톡 클립으로 알람을 만들 수 있어야 하는데, 기존
+    // 검증은 user_id 만 봐서 스톡 클립 알람을 404 로 막고 있었다
+    // (GET /tts/messages/:id/audio 의 허용 규칙과 일치시킨다).
     const msg = await db.execute({
-      sql: 'SELECT id FROM messages WHERE id = ? AND user_id IN (?, ?)',
+      sql: `SELECT id FROM messages
+            WHERE id = ?
+              AND (
+                user_id IN (?, ?)
+                OR (
+                  COALESCE(is_preset, 0) = 1
+                  AND EXISTS (
+                    SELECT 1 FROM voice_profiles vp
+                    WHERE vp.id = messages.voice_profile_id
+                      AND COALESCE(vp.is_system, 0) = 1
+                  )
+                )
+              )`,
       args: [resolvedMessageId, ...ownerIds],
     });
     if (msg.rows.length === 0) {
@@ -458,6 +474,26 @@ alarmMutation.patch('/:id', async (c) => {
     sql: `UPDATE alarms SET ${updates.join(', ')} WHERE id = ?`,
     args,
   });
+
+  // raw_audio_url 을 새 값으로 교체하면 이전 R2 녹음이 어떤 알람에서도 참조되지
+  // 않을 수 있다. DELETE 핸들러와 동일하게, 더 이상 쓰이지 않는 이전 오브젝트를
+  // 삭제 큐에 적재해 영구 고아를 막는다(교체 경로에는 기존에 이 정리가 없었다).
+  if (body.raw_audio_url !== undefined) {
+    const previousRawUrl = current.raw_audio_url;
+    if (
+      previousRawUrl?.startsWith('r2://') &&
+      previousRawUrl !== body.raw_audio_url
+    ) {
+      const stillReferenced = await db.execute({
+        sql: 'SELECT COUNT(*) AS cnt FROM alarms WHERE raw_audio_url = ?',
+        args: [previousRawUrl],
+      });
+      if (Number(typedRow<{ cnt: number }>(stillReferenced.rows[0]!).cnt ?? 0) === 0) {
+        const { enqueueExternalDeletion } = await import('../lib/audio-retention');
+        await enqueueExternalDeletion(db, 'r2_object', previousRawUrl.replace(/^r2:\/\//, ''));
+      }
+    }
+  }
 
   const updated = await db.execute({
     sql: `SELECT id, user_id, target_user_id, message_id, time, repeat_days,

--- a/packages/backend/src/routes/alarm-source.ts
+++ b/packages/backend/src/routes/alarm-source.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getFormFile } from '../lib/db-types';
+import { getDB } from '../lib/db';
 
 /**
  * Upload a short raw audio clip (≤30s) to be played directly when an alarm
@@ -93,6 +94,19 @@ alarmSource.post('/source', async (c) => {
       originalName: audioFile.name?.slice(0, 200) ?? '',
     },
   });
+
+  // 업로드를 추적 테이블에 기록한다. 이후 어떤 알람에도 연결되지 않은 채 TTL 이
+  // 지나면 retention 크론이 R2 삭제 큐에 적재해 고아 누수를 막는다(VF2).
+  try {
+    await getDB(c.env).execute({
+      sql: `INSERT OR IGNORE INTO raw_alarm_uploads (id, user_id, object_key)
+            VALUES (?, ?, ?)`,
+      args: [id, userId, objectKey],
+    });
+  } catch {
+    // 추적 행 기록 실패가 업로드 자체를 막진 않는다(클립은 이미 R2 에 저장됨).
+    // 최악의 경우 해당 클립이 추적되지 않을 뿐, 알람에 연결되면 정상 동작한다.
+  }
 
   // Return a relative URL the alarm-fire client can resolve against the
   // public bucket / signed-URL endpoint. Storing the bare object key keeps

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -537,9 +537,11 @@ auth.post('/apple', async (c) => {
       expectedNonceHash,
     );
     const appleId = apple.sub;
-    const email = (apple.email || parsed.data.email || `${appleId}@apple.local`)
-      .toLowerCase()
-      .trim();
+    // 계정 연동에 쓰이는 email 은 *검증된 토큰*의 email 만 신뢰한다. 클라이언트가
+    // 보낸 parsed.data.email 을 fallback 으로 쓰면, Apple 토큰에 email 이 없는
+    // (재로그인) 경우 공격자가 피해자 이메일을 주입해 기존 계정에 연동·탈취할 수
+    // 있다. 토큰에 email 이 없으면 충돌하지 않는 placeholder 로 둔다.
+    const email = (apple.email || `${appleId}@apple.local`).toLowerCase().trim();
     const name = parsed.data.name ?? apple.name ?? '';
 
     const existing = await db.execute({

--- a/packages/backend/src/routes/character-mutation.ts
+++ b/packages/backend/src/routes/character-mutation.ts
@@ -118,6 +118,47 @@ characterMutation.post('/xp', async (c) => {
   const newLevel = Math.max(current.level, computeLevelFromXp(newXp));
   const newStage = computeStageFromLevel(newLevel);
 
+  const logId = crypto.randomUUID();
+
+  // 논스가 있으면 캐릭터 갱신 *전에* 로그를 조건부 삽입으로 예약한다. 같은 논스의
+  // 동시 요청 중 단 하나만 삽입에 성공하고(나머지는 rowsAffected=0 → 중복 처리),
+  // check-then-insert 레이스에 의한 XP/affection 중복 지급을 막는다. (XP UPDATE 는
+  // 절대값 SET 이라 순서를 바꿔도 안전하다.)
+  if (clientNonce) {
+    const reserved = await db.execute({
+      sql: `INSERT INTO character_xp_logs
+              (id, character_id, event, client_nonce, granted_xp, affection_delta, capped)
+            SELECT ?, ?, ?, ?, ?, ?, ?
+            WHERE NOT EXISTS (
+              SELECT 1 FROM character_xp_logs
+              WHERE character_id = ? AND client_nonce = ?
+            )`,
+      args: [
+        logId, current.id, event, clientNonce,
+        totalGrantedXp, grant.affection, grant.xp.capped ? 1 : 0,
+        current.id, clientNonce,
+      ],
+    });
+    if ((reserved.rowsAffected ?? 0) === 0) {
+      // 동시 중복: 다른 요청이 같은 논스로 이미 지급 중/완료 → XP 미적용, 현재 상태 반환.
+      const [dupStats, dupAchievements] = await Promise.all([
+        loadStats(db, current.id),
+        loadAchievements(db, current.id),
+      ]);
+      return c.json({
+        ...serializeCharacter(current, dupStats, dupAchievements),
+        grant: {
+          event,
+          granted_xp: 0,
+          affection: 0,
+          capped: false,
+          remaining_cap: 0,
+          duplicated: true,
+        },
+      });
+    }
+  }
+
   await db.execute({
     sql: `UPDATE characters
           SET xp = ?, affection = ?, level = ?, stage = ?,
@@ -133,27 +174,39 @@ characterMutation.post('/xp', async (c) => {
     ],
   });
 
-  const logId = crypto.randomUUID();
-  await db.execute({
-    sql: `INSERT INTO character_xp_logs
-          (id, character_id, event, client_nonce, granted_xp, affection_delta, capped)
-          VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    args: [
-      logId, current.id, event, clientNonce,
-      totalGrantedXp, grant.affection,
-      grant.xp.capped ? 1 : 0,
-    ],
-  });
+  if (!clientNonce) {
+    // 논스가 없으면 예약하지 않았으므로 여기서 로그를 기록한다(중복 방지 대상 아님).
+    await db.execute({
+      sql: `INSERT INTO character_xp_logs
+            (id, character_id, event, client_nonce, granted_xp, affection_delta, capped)
+            VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        logId, current.id, event, clientNonce,
+        totalGrantedXp, grant.affection,
+        grant.xp.capped ? 1 : 0,
+      ],
+    });
+  }
 
   const milestoneGrants: Array<{ event: XpEvent; xp: number }> = [];
   for (const mEvent of milestoneEvents) {
-    const existing = await db.execute({
-      sql: 'SELECT id FROM streak_achievements WHERE character_id = ? AND milestone = ?',
-      args: [current.id, newStreak],
-    });
-    if (existing.rows.length > 0) continue;
-
     const mGrant = computeGrant(mEvent, newDailyXp);
+
+    // 마일스톤 보상도 조건부 삽입으로 예약한다 — 동시 요청이 같은 마일스톤을
+    // 중복 지급하지 않도록 (achievement INSERT 에 성공한 요청만 보상 적용).
+    const achReserved = await db.execute({
+      sql: `INSERT INTO streak_achievements (id, character_id, milestone, bonus_xp)
+            SELECT ?, ?, ?, ?
+            WHERE NOT EXISTS (
+              SELECT 1 FROM streak_achievements WHERE character_id = ? AND milestone = ?
+            )`,
+      args: [
+        crypto.randomUUID(), current.id, newStreak, mGrant.xp.grantedXp,
+        current.id, newStreak,
+      ],
+    });
+    if ((achReserved.rowsAffected ?? 0) === 0) continue;
+
     newXp += mGrant.xp.grantedXp;
     newDailyXp += mGrant.xp.grantedXp;
     totalGrantedXp += mGrant.xp.grantedXp;
@@ -170,12 +223,6 @@ characterMutation.post('/xp', async (c) => {
                 updated_at = datetime('now')
             WHERE id = ?`,
       args: [newXp, updatedLevel, updatedStage, mGrant.affection, newDailyXp, current.id],
-    });
-
-    await db.execute({
-      sql: `INSERT INTO streak_achievements (id, character_id, milestone, bonus_xp)
-            VALUES (?, ?, ?, ?)`,
-      args: [crypto.randomUUID(), current.id, newStreak, mGrant.xp.grantedXp],
     });
 
     await db.execute({

--- a/packages/backend/src/routes/family-invite.ts
+++ b/packages/backend/src/routes/family-invite.ts
@@ -203,12 +203,19 @@ familyInvite.post('/invites/:code/accept', async (c) => {
     return c.json({ error: `정원 초과 (최대 ${maxMembers}명)`, error_code: 'GROUP_FULL' }, 409);
   }
 
+  // 좌석을 원자적으로 삽입한다: 정원 미만일 때만 INSERT 되도록 한 문장으로 처리해
+  // 동시 수락 두 건이 모두 count<max 를 읽고 함께 들어가 정원을 넘기는 TOCTOU 를
+  // 막는다. rowsAffected=0 이면 그 사이 정원이 찼다는 뜻이므로 GROUP_FULL.
   const memberId = crypto.randomUUID();
-  await db.execute({
+  const insertRes = await db.execute({
     sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role)
-          VALUES (?, ?, ?, 'member')`,
-    args: [memberId, planGroupId, userPk],
+          SELECT ?, ?, ?, 'member'
+          WHERE (SELECT COUNT(*) FROM plan_group_members WHERE plan_group_id = ?) < ?`,
+    args: [memberId, planGroupId, userPk, planGroupId, maxMembers],
   });
+  if ((insertRes.rowsAffected ?? 0) === 0) {
+    return c.json({ error: `정원 초과 (최대 ${maxMembers}명)`, error_code: 'GROUP_FULL' }, 409);
+  }
 
   await db.execute({
     sql: `UPDATE plan_group_invites

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -623,6 +623,9 @@ tts.post('/generate', async (c) => {
 
   let dailyLimitExceeded = false;
   let freePlanRestricted = false;
+  // 일일 한도 값. null 이면 한도 미적용(레거시/유저행 없음 경로). 합성 직전
+  // 원자적 예약에서 사용한다.
+  let dailyLimit: number | null = null;
   const user = await db.execute({
     sql: 'SELECT * FROM users WHERE id = ? OR google_id = ? LIMIT 1',
     args: ownerIds,
@@ -639,6 +642,9 @@ tts.post('/generate', async (c) => {
       freePlanRestricted = true;
     }
 
+    const limits: Record<string, number> = { free: 3, plus: 9999, family: 9999 };
+    dailyLimit = limits[plan] ?? 3;
+
     if (u.daily_tts_reset_at !== today) {
       await db.execute({
         sql: `UPDATE users SET daily_tts_count = 0, daily_tts_reset_at = ? WHERE id = ? OR google_id = ?`,
@@ -646,8 +652,7 @@ tts.post('/generate', async (c) => {
       });
     } else {
       const count = Number(u.daily_tts_count);
-      const limits: Record<string, number> = { free: 3, plus: 9999, family: 9999 };
-      if (count >= (limits[plan] ?? 3)) {
+      if (count >= dailyLimit) {
         dailyLimitExceeded = true;
       }
     }
@@ -881,14 +886,27 @@ tts.post('/generate', async (c) => {
       }
     }
 
-    if (dailyLimitExceeded) {
-      return c.json(
-        {
-          error: 'Daily TTS generation limit exceeded.',
-          error_code: 'DAILY_TTS_LIMIT_EXCEEDED',
-        },
-        429,
-      );
+    // 원자적 슬롯 예약: 합성(과금) 직전에 daily_tts_count 를 조건부 증가시켜
+    // 동시 요청이 같은 카운트를 읽고 모두 통과하던 read-then-increment 레이스를
+    // 닫는다(유료 ElevenLabs 호출 무제한 소비 방지). 캐시 히트는 위에서 이미
+    // 반환되므로, 여기 도달했다는 건 실제 합성 경로다.
+    let reservedSlot = false;
+    if (dailyLimit !== null && Number.isFinite(dailyLimit)) {
+      const reservation = await db.execute({
+        sql: `UPDATE users SET daily_tts_count = daily_tts_count + 1
+              WHERE (id = ? OR google_id = ?) AND daily_tts_count < ?`,
+        args: [...ownerIds, dailyLimit],
+      });
+      reservedSlot = (reservation.rowsAffected ?? 0) > 0;
+      if (!reservedSlot) {
+        return c.json(
+          {
+            error: 'Daily TTS generation limit exceeded.',
+            error_code: 'DAILY_TTS_LIMIT_EXCEEDED',
+          },
+          429,
+        );
+      }
     }
 
     let lastError: unknown = noVoiceProviderError();
@@ -958,10 +976,7 @@ tts.post('/generate', async (c) => {
           });
         }
 
-        await db.execute({
-          sql: `UPDATE users SET daily_tts_count = daily_tts_count + 1 WHERE id = ? OR google_id = ?`,
-          args: ownerIds,
-        });
+        // 일일 카운트는 합성 직전 reservedSlot 예약에서 이미 원자적으로 증가됨.
 
         await db.execute({
           sql: `INSERT INTO message_library (id, user_id, message_id) VALUES (?, ?, ?)`,
@@ -994,6 +1009,16 @@ tts.post('/generate', async (c) => {
         if (err instanceof UnsupportedVoiceProviderError) continue;
         if (attempt !== attempts[attempts.length - 1]) continue;
       }
+    }
+
+    // 모든 합성 시도가 실패하면 예약한 슬롯을 되돌린다(실패한 호출이 한도를
+    // 깎지 않도록 — 슬롯 누수 방지).
+    if (reservedSlot) {
+      await db.execute({
+        sql: `UPDATE users SET daily_tts_count = MAX(0, daily_tts_count - 1)
+              WHERE id = ? OR google_id = ?`,
+        args: ownerIds,
+      });
     }
 
     throw lastError;
@@ -1217,6 +1242,21 @@ tts.delete('/messages/:id', async (c) => {
     sql: 'DELETE FROM message_library WHERE message_id = ? AND user_id IN (?, ?)',
     args: [id, ...ownerIds],
   });
+
+  // 메시지를 지우기 전에 백킹 R2 오브젝트를 삭제 큐에 적재한다. 큐에 넣지 않고
+  // generated_audio_assets 행만 지우면 object_key 가 어디에도 기록되지 않아
+  // R2 의 mp3 가 영구히 고아로 남는다(가장 흔한 사용자 동작인 메시지 삭제마다 누수).
+  const assetKeysRes = await db.execute({
+    sql: `SELECT audio_object_key FROM generated_audio_assets
+          WHERE message_id = ? AND user_id IN (?, ?) AND audio_object_key IS NOT NULL`,
+    args: [id, ...ownerIds],
+  });
+  if (assetKeysRes.rows.length > 0) {
+    const { enqueueExternalDeletion } = await import('../lib/audio-retention');
+    for (const row of assetKeysRes.rows) {
+      await enqueueExternalDeletion(db, 'r2_object', row.audio_object_key as string);
+    }
+  }
 
   await db.execute({
     sql: 'DELETE FROM generated_audio_assets WHERE message_id = ? AND user_id IN (?, ?)',

--- a/packages/backend/src/routes/voice-upload.ts
+++ b/packages/backend/src/routes/voice-upload.ts
@@ -212,6 +212,7 @@ voiceUpload.post('/uploads/:uploadId/separate', async (c) => {
     const diarized = await client.diarize(toArrayBuffer(stored.bytes), {
       mimeType: stored.meta.mimeType,
       fileName: stored.meta.originalName ?? upload.object_key,
+      numSpeakers: MAX_SPEAKERS,
     });
     result = {
       provider: 'elevenlabs',
@@ -355,6 +356,7 @@ voiceUpload.post('/diarize', async (c) => {
     const result = await client.diarize(audioBuffer, {
       mimeType: audioFile.type,
       fileName: audioFile.name,
+      numSpeakers: MAX_SPEAKERS,
     });
 
     return c.json({

--- a/packages/backend/test/auth-middleware.test.ts
+++ b/packages/backend/test/auth-middleware.test.ts
@@ -245,6 +245,7 @@ describe('authMiddleware — Google token', () => {
       name: 'Google User',
       picture: 'https://lh3.googleusercontent.com/photo.jpg',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -269,6 +270,7 @@ describe('authMiddleware — Google token', () => {
     const token = fakeToken({
       sub: 'g-user',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -290,6 +292,7 @@ describe('authMiddleware — Google token', () => {
     const payload = {
       sub: 'g-user',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: 'wrong-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -311,6 +314,7 @@ describe('authMiddleware — Google token', () => {
     const payload = {
       sub: 'g-user',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) - 3600,
     };
@@ -332,6 +336,7 @@ describe('authMiddleware — Google token', () => {
     const token = fakeToken({
       sub: 'g-user',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -352,6 +357,7 @@ describe('authMiddleware — Apple token', () => {
       sub: 'apple-user-001',
       email: 'user@privaterelay.appleid.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: ENV.APPLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -372,6 +378,7 @@ describe('authMiddleware — Apple token', () => {
       sub: 'apple-user-001',
       email: 'user@apple.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: ENV.APPLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) - 3600,
     };
@@ -388,6 +395,7 @@ describe('authMiddleware — Apple token', () => {
     const payload = {
       sub: 'apple-user-002',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: ENV.APPLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -411,6 +419,7 @@ describe('authMiddleware — Apple token', () => {
         sub: 'apple-user-mw-nonce',
         email: 'mw-nonce@apple.com',
         iss: 'https://appleid.apple.com',
+      email_verified: true,
         aud: ENV.APPLE_CLIENT_ID,
         exp: Math.floor(Date.now() / 1000) + 3600,
         nonce: 'a'.repeat(64),
@@ -472,6 +481,7 @@ describe('authMiddleware — 토큰 발급자 분기', () => {
     const payload = {
       sub: 'apple-u',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: ENV.APPLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     };

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -358,6 +358,7 @@ describe('POST /auth/google', () => {
       name: 'Google User',
       picture: 'https://lh3.googleusercontent.com/photo.jpg',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: ENV.GOOGLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -400,6 +401,7 @@ describe('POST /auth/google', () => {
       email: 'linked@gmail.com',
       name: 'Linked User',
       iss: 'accounts.google.com',
+      email_verified: true,
       aud: ENV.GOOGLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     };
@@ -474,6 +476,7 @@ describe('POST /auth/apple', () => {
       email: 'user@privaterelay.appleid.com',
       name: 'Apple User',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -516,6 +519,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-2',
       email: 'linked@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -564,6 +568,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-3',
       email: 'bad@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'other.bundle',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -587,6 +592,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-4',
       email: 'tampered@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
@@ -635,6 +641,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-nonce-ok',
       email: 'nonce-ok@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
       nonce: nonceHash,
@@ -673,6 +680,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-nonce-bad',
       email: 'nonce-bad@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
       nonce: wrongNonceHash,
@@ -700,6 +708,7 @@ describe('POST /auth/apple', () => {
         sub: 'apple-user-no-nonce',
         email: 'no-nonce@icloud.com',
         iss: 'https://appleid.apple.com',
+      email_verified: true,
         aud: 'com.voicealarm.nativeapp.ios',
         exp: Math.floor(Date.now() / 1000) + 3600,
       });
@@ -738,6 +747,7 @@ describe('POST /auth/apple', () => {
       sub: 'apple-user-token-has-nonce',
       email: 'token-nonce@icloud.com',
       iss: 'https://appleid.apple.com',
+      email_verified: true,
       aud: 'com.voicealarm.nativeapp.ios',
       exp: Math.floor(Date.now() / 1000) + 3600,
       nonce: nonceHash,

--- a/packages/backend/test/character-mutation.test.ts
+++ b/packages/backend/test/character-mutation.test.ts
@@ -254,14 +254,13 @@ describe('POST /characters/xp (characterMutation)', () => {
     };
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([charStreak29]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1); // UPDATE characters (main)
+    mockDB.pushResult([], 1); // INSERT xp_log (main)
+    mockDB.pushResult([], 1); // INSERT streak_achievements (조건부 예약, 성공)
+    mockDB.pushResult([], 1); // UPDATE characters (milestone)
+    mockDB.pushResult([], 1); // INSERT xp_log (milestone)
+    mockDB.pushResult([], 1); // ensureStatsRow
+    mockDB.pushResult([], 1); // UPDATE stats
     const refreshed = {
       ...charStreak29,
       xp: 505,
@@ -293,14 +292,13 @@ describe('POST /characters/xp (characterMutation)', () => {
     };
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([charStreak89]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1); // UPDATE characters (main)
+    mockDB.pushResult([], 1); // INSERT xp_log (main)
+    mockDB.pushResult([], 1); // INSERT streak_achievements (조건부 예약, 성공)
+    mockDB.pushResult([], 1); // UPDATE characters (milestone)
+    mockDB.pushResult([], 1); // INSERT xp_log (milestone)
+    mockDB.pushResult([], 1); // ensureStatsRow
+    mockDB.pushResult([], 1); // UPDATE stats
     const refreshed = {
       ...charStreak89,
       xp: 2005,
@@ -365,12 +363,14 @@ describe('POST /characters/xp (characterMutation)', () => {
     await buildApp().request(
       jsonReq('POST', '/characters/xp', { event: 'alarm_completed', local_date: '2026-04-25' }),
     );
+    // 마일스톤 중복 방지는 이제 조건부 INSERT(WHERE NOT EXISTS)에 내장됨.
+    // 존재 검사 바인딩(character_id, milestone)은 INSERT args 의 마지막 두 개.
     const milestoneCheck = mockDB.calls.find(
-      (c) => c.sql.includes('streak_achievements') && c.sql.includes('SELECT'),
+      (c) => c.sql.includes('streak_achievements') && c.sql.includes('NOT EXISTS'),
     );
     expect(milestoneCheck).toBeDefined();
-    expect(milestoneCheck!.args[0]).toBe('char-1');
-    expect(milestoneCheck!.args[1]).toBe(7);
+    expect(milestoneCheck!.args[4]).toBe('char-1');
+    expect(milestoneCheck!.args[5]).toBe(7);
   });
 
   it('milestone INSERT — streak_achievements에 정확한 값 저장', async () => {
@@ -382,14 +382,13 @@ describe('POST /characters/xp (characterMutation)', () => {
     };
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([charStreak6]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1); // UPDATE characters (main)
+    mockDB.pushResult([], 1); // INSERT xp_log (main)
+    mockDB.pushResult([], 1); // INSERT streak_achievements (조건부 예약, 성공)
+    mockDB.pushResult([], 1); // UPDATE characters (milestone)
+    mockDB.pushResult([], 1); // INSERT xp_log (milestone)
+    mockDB.pushResult([], 1); // ensureStatsRow
+    mockDB.pushResult([], 1); // UPDATE stats
     const refreshed = { ...charStreak6, xp: 105, current_streak: 7, daily_xp: 105 };
     mockDB.pushResult([refreshed]);
     mockDB.pushResult([]);
@@ -415,14 +414,13 @@ describe('POST /characters/xp (characterMutation)', () => {
     };
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([charStreak6]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1); // UPDATE characters (main)
+    mockDB.pushResult([], 1); // INSERT xp_log (main)
+    mockDB.pushResult([], 1); // INSERT streak_achievements (조건부 예약, 성공)
+    mockDB.pushResult([], 1); // UPDATE characters (milestone)
+    mockDB.pushResult([], 1); // INSERT xp_log (milestone)
+    mockDB.pushResult([], 1); // ensureStatsRow
+    mockDB.pushResult([], 1); // UPDATE stats
     const refreshed = { ...charStreak6, xp: 105, current_streak: 7, daily_xp: 105 };
     mockDB.pushResult([refreshed]);
     mockDB.pushResult([]);

--- a/packages/backend/test/character.test.ts
+++ b/packages/backend/test/character.test.ts
@@ -378,9 +378,8 @@ describe('POST /characters/xp', () => {
     mockDB.pushResult([charStreak6]);
     mockDB.pushResult([], 1);                   // UPDATE characters
     mockDB.pushResult([], 1);                   // INSERT xp_log
-    mockDB.pushResult([]);                      // milestone check: no existing achievement
+    mockDB.pushResult([], 1);                   // INSERT streak_achievements (조건부 예약, 성공)
     mockDB.pushResult([], 1);                   // UPDATE characters (milestone XP)
-    mockDB.pushResult([], 1);                   // INSERT streak_achievements
     mockDB.pushResult([], 1);                   // INSERT xp_log (milestone)
     mockDB.pushResult([], 1);                   // ensureStatsRow
     mockDB.pushResult([], 1);                   // UPDATE stats

--- a/packages/backend/test/code.test.ts
+++ b/packages/backend/test/code.test.ts
@@ -178,6 +178,7 @@ describe('POST /code/register voucher redemption', () => {
     pushVoucher();
     mockDB.pushResult([]); // duplicate redemption lookup
     pushPersonalPlan();
+    mockDB.pushResult([{ other_members: 0 }]); // owned-group guard
     mockDB.pushResult([], 1); // claim voucher use
     mockDB.pushResult([]); // existing active subscription
     mockDB.pushResult([], 1); // insert subscription
@@ -206,6 +207,7 @@ describe('POST /code/register voucher redemption', () => {
     pushVoucher();
     mockDB.pushResult([]);
     pushPersonalPlan();
+    mockDB.pushResult([{ other_members: 0 }]); // owned-group guard
     mockDB.pushResult([], 1); // claim voucher use
     mockDB.pushResult([
       {
@@ -243,6 +245,7 @@ describe('POST /code/register voucher redemption', () => {
     mockDB.pushResult([]);
     pushFamilyPlan();
     mockDB.pushResult([{ max_members: 6, member_count: 2 }]); // capacity precheck
+    mockDB.pushResult([{ other_members: 0 }]); // owned-group guard
     mockDB.pushResult([], 1); // claim voucher use
     mockDB.pushResult([]); // existing active subscription
     mockDB.pushResult([{ id: 'group-1', max_members: 6 }]); // issuer group

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -280,11 +280,12 @@ describe('DELETE /tts/messages/:id — 메시지 삭제', () => {
   });
 
   it('force=true로 연관 알람 있어도 삭제', async () => {
-    mockDB.pushResult([{ cnt: 2 }]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([{ cnt: 2 }]); // alarm check
+    mockDB.pushResult([], 1); // UPDATE alarms (detach)
+    mockDB.pushResult([], 1); // DELETE message_library
+    mockDB.pushResult([]); // SELECT audio_object_key
+    mockDB.pushResult([], 1); // DELETE generated_audio_assets
+    mockDB.pushResult([], 1); // DELETE messages
     const app = buildApp();
     const res = await app.request(jsonReq('DELETE', `/tts/messages/${M1}?force=true`));
     expect(res.status).toBe(200);
@@ -313,10 +314,11 @@ describe('DELETE /tts/messages/:id — 메시지 삭제', () => {
   });
 
   it('정상 삭제', async () => {
-    mockDB.pushResult([{ cnt: 0 }]);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([{ cnt: 0 }]); // alarm check
+    mockDB.pushResult([], 1); // DELETE message_library
+    mockDB.pushResult([]); // SELECT audio_object_key
+    mockDB.pushResult([], 1); // DELETE generated_audio_assets
+    mockDB.pushResult([], 1); // DELETE messages
     const app = buildApp();
     const res = await app.request(jsonReq('DELETE', `/tts/messages/${M1}`));
     expect(res.status).toBe(200);
@@ -411,6 +413,8 @@ describe('POST /tts/generate — edge cases', () => {
   it('ElevenLabs 실패 시 500 + detail 포함', async () => {
     mockDB.pushResult([{ plan: 'plus', daily_tts_count: 0, daily_tts_reset_at: today() }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
+    mockDB.pushResult([]); // cache lookup (miss)
+    mockDB.pushResult([], 1); // atomic daily-count reservation
     mockTextToSpeech.mockRejectedValue(new Error('ElevenLabs quota exceeded'));
     const app = buildApp();
     const res = await reqWithEnv(
@@ -426,6 +430,8 @@ describe('POST /tts/generate — edge cases', () => {
   it('ElevenLabs가 비-Error를 throw하면 detail "Unknown error"', async () => {
     mockDB.pushResult([{ plan: 'plus', daily_tts_count: 0, daily_tts_reset_at: today() }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
+    mockDB.pushResult([]); // cache lookup (miss)
+    mockDB.pushResult([], 1); // atomic daily-count reservation
     mockTextToSpeech.mockRejectedValue('raw string error');
     const app = buildApp();
     const res = await reqWithEnv(
@@ -463,6 +469,8 @@ describe('POST /tts/generate — edge cases', () => {
     const r2 = createMockR2Bucket();
     mockDB.pushResult([{ plan: 'plus', daily_tts_count: 0, daily_tts_reset_at: today() }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
+    mockDB.pushResult([]); // cache lookup (miss)
+    mockDB.pushResult([], 1); // atomic daily-count reservation
     mockTextToSpeech.mockResolvedValue(new Uint8Array([72, 101]).buffer);
     const app = buildApp();
     const res = await app.request(
@@ -975,30 +983,34 @@ describe('DELETE /tts/messages/:id — edge cases', () => {
   it('삭제 시 message_library부터 삭제 후 messages 삭제 (순서 검증)', async () => {
     mockDB.pushResult([{ cnt: 0 }]); // alarm check
     mockDB.pushResult([], 1); // DELETE message_library
+    mockDB.pushResult([]); // SELECT audio_object_key (정리할 R2 오브젝트 없음)
     mockDB.pushResult([], 1); // DELETE generated_audio_assets
     mockDB.pushResult([], 1); // DELETE messages
     const app = buildApp();
     await app.request(jsonReq('DELETE', `/tts/messages/${M1}`));
     expect(mockDB.calls[1].sql).toContain('DELETE FROM message_library');
-    expect(mockDB.calls[2].sql).toContain('DELETE FROM generated_audio_assets');
-    expect(mockDB.calls[3].sql).toContain('DELETE FROM messages');
+    expect(mockDB.calls[2].sql).toContain('SELECT audio_object_key');
+    expect(mockDB.calls[3].sql).toContain('DELETE FROM generated_audio_assets');
+    expect(mockDB.calls[4].sql).toContain('DELETE FROM messages');
   });
 
   it('삭제 SQL에 user_id 포함 (사용자 격리)', async () => {
     mockDB.pushResult([{ cnt: 0 }]);
     mockDB.pushResult([], 1);
+    mockDB.pushResult([]); // SELECT audio_object_key
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     const app = buildApp('user-99');
     await app.request(jsonReq('DELETE', `/tts/messages/${M1}`));
     expect(mockDB.calls[1].args).toContain('user-99');
-    expect(mockDB.calls[2].args).toContain('user-99');
     expect(mockDB.calls[3].args).toContain('user-99');
+    expect(mockDB.calls[4].args).toContain('user-99');
   });
 
   it('force=true이고 알람 0개여도 정상 삭제', async () => {
     mockDB.pushResult([{ cnt: 0 }]);
     mockDB.pushResult([], 1);
+    mockDB.pushResult([]); // SELECT audio_object_key
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     const app = buildApp();

--- a/packages/backend/test/voice-upload.test.ts
+++ b/packages/backend/test/voice-upload.test.ts
@@ -111,9 +111,13 @@ it('저장된 mp3 MIME 과 파일명을 ElevenLabs diarize 로 전달', async ()
   expect(mockDiarize).toHaveBeenCalledOnce();
   const [, optionsArg] = mockDiarize.mock.calls[0]! as [
     ArrayBuffer,
-    { mimeType?: string; fileName?: string },
+    { mimeType?: string; fileName?: string; numSpeakers?: number },
   ];
-  expect(optionsArg).toEqual({ mimeType: 'audio/mpeg', fileName: 'voice.mp3' });
+  expect(optionsArg).toEqual({
+    mimeType: 'audio/mpeg',
+    fileName: 'voice.mp3',
+    numSpeakers: 3,
+  });
 });
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## 개요
출시 전 멀티에이전트 감사(8개 차원 + 적대적 검증, 확정 54건)에서 발견한 출시 차단/고위험 항목을 수정하고, 실기기(에뮬레이터 2대)로 전 플로우를 검증했습니다. 자세한 내역은 `LAUNCH_AUDIT.md` 참고.

## 백엔드 (테스트 1360개 통과, typecheck/lint clean)
- **음성파일 누수 5건 차단(VF1~VF5)**: 메시지 삭제/녹음 교체/raw 업로드 R2 정리, TTL 댕글링 포인터, 활성 알람 TTS 보존, `raw_alarm_uploads` 추적(migration 48) + 정리 크론 + 계정삭제
- **OAuth `email_verified` 강제**(Google/Apple) + Apple 클라이언트 이메일 주입 차단
- **TTS 일일한도 원자적 예약**(과금 레이스 차단), 스톡클립 알람 허용(무료플랜 버그), 바우처 그룹 자동해체 가드
- **화자분리 `num_speakers` 상한**(과분할 억제, 정확도 개선)
- **동시성 레이스**: 캐릭터 XP·마일스톤 중복지급, 가족초대 좌석 TOCTOU
- **auth 무차별대입 레이트리밋**(15/분), 크론 푸시 병렬화

## Android (assembleDevDebug 빌드 성공, 14건)
- FGS 발화 크래시 가드 + 풀스크린 알림 폴백, 시간대/DST 재스케줄, 동적보이스 스케줄링, Geocoder 행 수정
- 코치마크 maxWidth, 시간피커 폰트스케일, AlarmRow 말줄임 + 접근가능 삭제, 온보딩 줄바꿈
- 데드코드 제거, LazyColumn key, formatter 호이스팅, base64 off-main-thread

## 검증
- 백엔드 `vitest` 1360 통과 · `tsc`/`eslint` clean
- Android `assembleDevDebug` 빌드 성공
- 실기기 라이브: 로그인→온보딩→권한→홈→코치마크→에디터→코드화면→알람 울리는 화면 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)