### PR TITLE
fix(security): 출시 감사 잔여 저위험 항목 보강

### DIFF
--- a/apps/android-native/app/src/main/AndroidManifest.xml
+++ b/apps/android-native/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- 정식 알람/시계 앱: USE_EXACT_ALARM 은 자동 부여·사용자 회수 불가라 정확 알람을
+         안정적으로 보장한다(SCHEDULE_EXACT_ALARM 회수 시 비정확 폴백으로 떨어지는 것 방지). -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -56,7 +56,10 @@ const ALLOWED_ORIGINS = [
 app.use(
   '*',
   cors({
-    origin: (origin) => (ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0]),
+    // 허용 목록에 없는 Origin 에는 ACAO 헤더를 설정하지 않아 브라우저가 차단하게 한다.
+    // (기본 origin 반사는 정책을 모호하게 만들고 localhost 출처를 프로덕션에 노출한다.
+    //  토큰 인증은 Authorization 헤더 기반이라 네이티브 앱 요청에는 CORS 영향 없음.)
+    origin: (origin) => (ALLOWED_ORIGINS.includes(origin) ? origin : undefined),
     allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
     allowHeaders: ['Content-Type', 'Authorization'],
     maxAge: 86400,

--- a/packages/backend/src/lib/account-deletion.ts
+++ b/packages/backend/src/lib/account-deletion.ts
@@ -30,15 +30,18 @@ export async function pseudonymizeBillingForRetention(
 ): Promise<void> {
   const pseudonym = await pseudonymizeUserId(userPk, salt);
   const retainUntil = new Date(now.getTime() + 5 * 365 * 24 * 60 * 60 * 1000).toISOString();
+  // 결제 금액(plans.price_krw)을 함께 보존해 전자상거래법상 '대금결제 기록'이 완전해지도록 한다.
   const subs = await tx.execute({
-    sql: `SELECT id, plan_id, status, starts_at, expires_at FROM subscriptions WHERE user_id = ?`,
+    sql: `SELECT s.id, s.plan_id, s.status, s.starts_at, s.expires_at, p.price_krw
+          FROM subscriptions s LEFT JOIN plans p ON p.id = s.plan_id
+          WHERE s.user_id = ?`,
     args: [userPk],
   });
   for (const row of subs.rows) {
     await tx.execute({
       sql: `INSERT INTO retained_billing_records
-              (id, pseudonym, plan_id, status, starts_at, expires_at, retained_reason, retain_until)
-            VALUES (?, ?, ?, ?, ?, ?, 'ecommerce_act_5y', ?)`,
+              (id, pseudonym, plan_id, status, starts_at, expires_at, amount_krw, retained_reason, retain_until)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'ecommerce_act_5y', ?)`,
       args: [
         crypto.randomUUID(),
         pseudonym,
@@ -46,6 +49,7 @@ export async function pseudonymizeBillingForRetention(
         (row.status as string | null) ?? null,
         (row.starts_at as string | null) ?? null,
         (row.expires_at as string | null) ?? null,
+        row.price_krw != null ? Number(row.price_krw) : null,
         retainUntil,
       ],
     });
@@ -112,6 +116,13 @@ export async function purgeUserAccount(
     await tx.execute({
       sql: `DELETE FROM subscriptions WHERE user_id = ?`,
       args: [userPk],
+    });
+    // 결제 검증 원본(store_transactions)도 함께 파기한다. user_id(원본 식별자)가 남으면
+    // 가명보존(retained_billing_records) 설계를 우회해 탈퇴자 직접식별자가 잔존한다
+    // (개인정보보호법 제21조). 보존이 필요한 거래 사실은 위 가명보존 레코드가 담는다.
+    await tx.execute({
+      sql: `DELETE FROM store_transactions WHERE user_id IN (?, ?)`,
+      args: [userPk, userId],
     });
 
     await tx.execute({

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -165,15 +165,10 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
           : message.includes('format')
             ? 'AUTH_MALFORMED_TOKEN'
             : 'AUTH_VERIFICATION_FAILED';
-    // eslint-disable-next-line no-console
-    console.log(
-      '[AUTH 401]',
-      code,
-      '|',
-      message,
-      '| GOOGLE_CLIENT_ID set:',
-      !!c.env.GOOGLE_CLIENT_ID,
-    );
+    // 검증 실패 상세(토큰 발급자/audience)·구성 단서(GOOGLE_CLIENT_ID 설정 여부)를
+    // 평문 콘솔에 남기면 토큰 위조 탐색에 악용될 수 있어, 코드만 구조화 로그로 남긴다.
+    const { logStructured } = await import('../lib/logger');
+    logStructured('warn', { at: 'auth.verify_failed', code });
     return c.json({ error: message, error_code: code }, 401);
   }
 }

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -91,6 +91,9 @@ interface TestCodeVoucher {
 }
 
 function isBillingStubEnabled(env: Partial<AppEnv['Bindings']> | undefined): boolean {
+  // production 에서는 BILLING_STUB_ENABLED 값과 무관하게 항상 비활성한다.
+  // (env 오설정 하나로 /checkout·/change-plan 이 무결제 유료지급 디스펜서가 되는 것 차단.)
+  if (env?.ENVIRONMENT === 'production') return false;
   if (env?.BILLING_STUB_ENABLED === 'true' || env?.BILLING_STUB_ENABLED === '1') return true;
   if (env?.BILLING_STUB_ENABLED === 'false' || env?.BILLING_STUB_ENABLED === '0') return false;
   return env?.ENVIRONMENT !== 'production';
@@ -104,7 +107,11 @@ function checkoutDisabledResponse() {
 }
 
 function allowedTestCodeIssuerEmails(env: Partial<AppEnv['Bindings']> | undefined): Set<string> {
-  const raw = env?.TEST_CODE_ISSUER_EMAILS?.trim() || 'gyuwon05@gmail.com';
+  // 발급자 화이트리스트는 TEST_CODE_ISSUER_EMAILS 로만 지정한다. 개인 이메일 하드코딩
+  // 폴백을 두면 env 누락·계정 탈취 시 단일 계정이 무제한 무료 유료코드 발급 권한을 갖게
+  // 되므로, 미설정이면 발급자 없음(fail-closed)으로 둔다.
+  const raw = env?.TEST_CODE_ISSUER_EMAILS?.trim();
+  if (!raw) return new Set();
   return new Set(
     raw
       .split(',')

--- a/packages/backend/test/billing-test-codes.test.ts
+++ b/packages/backend/test/billing-test-codes.test.ts
@@ -46,6 +46,15 @@ const PLAN_FAMILY = {
 
 function buildApp(email = 'gyuwon05@gmail.com') {
   const app = new Hono<AppEnv>();
+  // 발급자 화이트리스트는 이제 하드코딩 폴백 없이 TEST_CODE_ISSUER_EMAILS 로만 지정되므로
+  // 테스트도 env 를 명시 설정한다(미설정 시 fail-closed → 403).
+  app.use('*', async (c, next) => {
+    (c as unknown as { env: Record<string, unknown> }).env = {
+      ...((c.env as Record<string, unknown>) ?? {}),
+      TEST_CODE_ISSUER_EMAILS: 'gyuwon05@gmail.com',
+    };
+    await next();
+  });
   app.use('*', fakeAuthMiddleware('google-admin', email));
   app.route('/billing', billingMutation);
   return app;


### PR DESCRIPTION
출시 감사(`LAUNCH_AUDIT.md`)에서 미처리로 남았거나 커버되지 않은 **저위험 보안/정합성 항목**을 보강합니다. 모든 HIGH/MEDIUM 은 이미 develop(#481/#482)에 반영되어 있어 본 PR 은 잔여 lows 입니다.

## 변경
- **billing/test-codes**: 발급자 화이트리스트의 하드코딩 개인 이메일(`gyuwon05@gmail.com`) 폴백 제거 → `TEST_CODE_ISSUER_EMAILS` 미설정 시 **fail-closed**. (env 누락/계정 탈취로 단일 계정이 무제한 무료 유료코드를 발급하는 위험 차단)
- **billing stub**: `/checkout`·`/change-plan` stub 을 **production 에서 `BILLING_STUB_ENABLED` 값과 무관하게 무조건 비활성**(env 오설정 하나로 무결제 유료지급 디스펜서가 되는 것 차단).
- **CORS**: 허용 목록에 없는 Origin 에 ACAO 헤더를 설정하지 않음(기본 origin 반사·localhost 노출 제거). 토큰은 Authorization 헤더 기반이라 네이티브 앱 영향 없음.
- **auth 401 로그**: console.log 의 토큰 detail·`GOOGLE_CLIENT_ID` 설정여부 노출 제거 → 코드만 구조화 로그.
- **계정 영구파기**: `store_transactions`(탈퇴자 원본 `user_id`) 함께 파기(개인정보보호법 제21조 잔존 방지) + `retained_billing_records` 에 결제 금액(`price_krw`) 보존(전자상거래법 5년 기록 완전화).
- **android**: `USE_EXACT_ALARM` 선언 — 자동 부여·회수 불가라 `SCHEDULE_EXACT_ALARM` 회수 시 비정확 폴백으로 떨어지는 것 방지.

## 검증
- 백엔드 typecheck clean, **66 파일 / 1373 테스트 통과**, lint clean. (billing-test-codes 테스트는 issuer env 를 명시 설정하도록 갱신)

## 의도적 보류(사유)
- Apple JWS x5c 체인 검증: 현재 TLS-직접조회라 미악용·구현 위험 → 방어계층으로 후속.
- Google tokeninfo→JWKS: 현재 동작·가치 대비 위험 낮음.
- PortOne `payment_id` 사용자 귀속: 결제 생성 시 customData 클라이언트 연동 필요.
- elevenlabs 타임아웃·캐시 복합UNIQUE: Perso 전환 후 무의미/조건부 저영향.
- 배터리 최적화 예외 UI, 위치권한 제거, 대형 리팩토링: 출시 직전 리스크로 후속 배치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)