### PR TITLE
ci: iOS 빌드 워크플로 자동 트리거 비활성화 (도입 보류)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,16 +1,15 @@
 name: iOS Build
 
 on:
-  push:
-    branches:
-      - develop
-      - main
-      - "feat/**"
-      - "fix/**"
-      - "ci/**"
-      - "refactor/**"
-  pull_request:
-    branches: [develop, main]
+  # iOS 도입 보류(2026-06) — 자동 빌드 비활성화. 출시하지 않을 앱을 매 push/PR 마다
+  # 유료 macOS 러너로 빌드하지 않도록 수동 트리거(workflow_dispatch)만 남긴다.
+  # iOS 재개 시 아래 push/pull_request 트리거를 복원하면 된다. (iOS 체크는 develop
+  # 브랜치 보호의 필수 상태 체크가 아니므로 비활성해도 PR 머지를 막지 않는다.)
+  #
+  # push:
+  #   branches: [develop, main, "feat/**", "fix/**", "ci/**", "refactor/**"]
+  # pull_request:
+  #   branches: [develop, main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
iOS 도입을 당분간 보류하므로 iOS 전용 CI(`ios-build.yml`)의 자동 트리거를 끕니다.

## 변경
- `ios-build.yml`: `push`/`pull_request` 트리거 제거 → `workflow_dispatch`(수동)만 남김.
- **코드·DB·백엔드 Apple 경로(`/auth/apple`·billing-apple·`apple_id` 컬럼)는 전부 보존** — iOS는 취소가 아니라 보류이며, 휴면 코드는 런타임 비용이 없고 Google 로그인/결제와 얽혀 있어 제거 시 위험만 큼.
- iOS 재개 시 주석 처리된 트리거 2줄만 복원하면 됨.

## 영향
- 매 push/PR 마다 돌던 유료 macOS 러너 빌드(iOS Simulator 빌드+유닛테스트) 중단 → CI 비용·시간 절감.
- iOS 체크는 develop 브랜치 보호의 **필수 상태 체크가 아니므로** 비활성화해도 PR 머지에 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)