### PR TITLE
fix(backend): 출시 전 보안 감사 수정 — W1 (IDOR/SSRF/계정열거/시크릿 노출)

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -88,11 +88,25 @@ async function healthPayload(env: Env) {
 app.get('/', async (c) => c.json(await healthPayload(c.env)));
 app.get('/health', async (c) => c.json(await healthPayload(c.env)));
 
+// init-db / seed 는 파괴적 DDL + 유료 합성을 수행하므로 모든 환경에서 INIT_DB_SECRET 헤더를
+// 요구한다. 시크릿이 설정돼 있지 않으면(=의도적으로 비활성) 무조건 거부한다(404).
+// 헤더 비교는 상수시간(timingSafeEqualStr)으로 수행해 타이밍 오라클을 차단한다.
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  if (ab.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ab.length; i++) diff |= ab[i]! ^ bb[i]!;
+  return diff === 0;
+}
+
 function canRunInitDb(c: { env: Env; req: { header: (name: string) => string | undefined } }) {
-  if (c.env.ENVIRONMENT !== 'production') return true;
   const expected = c.env.INIT_DB_SECRET;
   if (!expected) return false;
-  return c.req.header('x-init-db-secret') === expected;
+  const provided = c.req.header('x-init-db-secret');
+  if (!provided) return false;
+  return timingSafeEqualStr(provided, expected);
 }
 
 // DB 초기화 엔드포인트 — Workers free plan caps subrequests per invocation
@@ -118,13 +132,9 @@ app.post('/api/init-db', async (c) => {
     await initDB(c.env);
     return c.json({ success: true, message: 'Database initialized' });
   } catch (err) {
-    return c.json(
-      {
-        error: 'DB init failed',
-        detail: err instanceof Error ? err.message : 'Unknown error',
-      },
-      500,
-    );
+    // SQL/Turso 내부 메시지를 클라이언트로 반사하지 않는다 — 서버 로그로만 남긴다.
+    logRouteError(c, err);
+    return c.json({ error: 'DB init failed' }, 500);
   }
 });
 
@@ -168,13 +178,9 @@ app.post('/api/admin/seed-stock-clips', async (c) => {
       remaining: missing.length - generated.length,
     });
   } catch (err) {
-    return c.json(
-      {
-        error: 'Stock clip seed failed',
-        detail: err instanceof Error ? err.message : 'Unknown error',
-      },
-      500,
-    );
+    // 합성/스토리지 내부 오류 메시지를 클라이언트로 반사하지 않는다 — 서버 로그로만 남긴다.
+    logRouteError(c, err);
+    return c.json({ error: 'Stock clip seed failed' }, 500);
   }
 });
 
@@ -255,6 +261,18 @@ async function scheduled(event: ScheduledEvent, env: Env): Promise<void> {
     await drainExternalDeletions(db, env);
   } catch (err) {
     logStructured('error', { at: 'scheduled.audio_retention', error: String(err) });
+  }
+
+  // 만료된 이메일 인증코드(PII) 정리 — 무한 보존 방지. expires_at 은 ISO 문자열로 기록되므로
+  // 동일 포맷으로 비교한다. 만료 후 72h 유예를 두고 일괄 삭제(저렴·멱등).
+  try {
+    const pruneBefore = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
+    await db.execute({
+      sql: 'DELETE FROM email_verification_codes WHERE expires_at < ?',
+      args: [pruneBefore],
+    });
+  } catch (err) {
+    logStructured('error', { at: 'scheduled.email_code_prune', error: String(err) });
   }
 
   // 구독 만료 / 결제일 도달 정리. 알람 푸시보다 먼저 처리해 plan 다운그레이드를 반영.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import type { Env, AppEnv } from './types';
 import { authMiddleware } from './middleware/auth';
+import { consentMiddleware } from './middleware/consent';
 import { loggerMiddleware } from './middleware/logger';
 import { rateLimitMiddleware, authRateLimitMiddleware } from './middleware/rateLimit';
 import { bodyLimitMiddleware } from './middleware/bodyLimit';
@@ -220,6 +221,9 @@ app.route('/api/billing/google', billingGoogleRtdn);
 // 인증이 필요한 라우트들
 const api = new Hono<AppEnv>();
 api.use('*', authMiddleware);
+// 서버측 동의 강제(B4) — authMiddleware 직후에 둬 userIdPK 를 사용한다. 데이터 수집
+// 라우트는 일반 필수 동의가 없으면 403. 면제 경로는 consentMiddleware 내부에서 통과.
+api.use('*', consentMiddleware);
 api.use('*', rateLimitMiddleware);
 api.use('*', async (c, next) => {
   const mw = c.req.method === 'GET' ? privateCache : noStore;

--- a/packages/backend/src/lib/account-deletion.ts
+++ b/packages/backend/src/lib/account-deletion.ts
@@ -65,6 +65,20 @@ export async function purgeUserAccount(
   userPk: string | null,
   userId: string,
 ): Promise<void> {
+  // userPk(users.id) 를 해석하지 못한 채 진행하면 PK 로 연결된 자식 PII(클론 음성·
+  // 결제·노트 등)가 고아로 남는다. 사용자 행이 실제로 존재하는데 userPk 만 null 이면
+  // 해석 실패이므로 소리 없이 users 만 지우지 말고 throw 해 호출부에서 롤백되게 한다.
+  if (!userPk) {
+    const orphanGuard = await tx.execute({
+      sql: `SELECT id FROM users WHERE google_id = ? OR apple_id = ? OR id = ? LIMIT 1`,
+      args: [userId, userId, userId],
+    });
+    if (orphanGuard.rows.length > 0) {
+      throw new Error(
+        `purgeUserAccount: userPk unresolved for existing user (userId=${userId}); aborting to avoid orphaning child PII`,
+      );
+    }
+  }
   if (userPk) {
     const userIds = [userPk, userId];
     // 클론 voice/R2 오디오의 외부 삭제 참조를 행 삭제 *전에* 큐에 적재한다.

--- a/packages/backend/src/lib/audio-loader.ts
+++ b/packages/backend/src/lib/audio-loader.ts
@@ -10,36 +10,107 @@ export function uint8ToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+const MAX_AUDIO_URL_LENGTH = 2048;
+
+/**
+ * R2 객체 키 네임스페이스. 보이스/녹음 원본은 voices/{userId}/...,
+ * 생성 TTS 캐시는 generated-tts/{userId}/... 형태로 저장된다
+ * (r2-storage.ts, audio-cache.ts 참고). 키의 둘째 path segment 가 소유자 id.
+ */
+const R2_USER_PREFIXES = ['voices/', 'generated-tts/'] as const;
+
+export type AudioAccess =
+  /**
+   * 신뢰된 호출자(예: tts.ts). audio_url 이 서버 측 DB(generated_audio_assets,
+   * messages.audio_url)에서 온 것이라 이미 소유권 검증을 거쳤다. r2:// 키
+   * 네임스페이스만 강제하고 별도 소유자 매칭은 하지 않는다.
+   */
+  | { kind: 'trusted' }
+  /**
+   * 클라이언트가 제공한 audio_url(예: notes.audio_url, alarm.raw_audio_url).
+   * r2:// 키의 소유자 segment 가 ownerIds 중 하나와 일치해야 한다.
+   */
+  | { kind: 'owner'; ownerIds: string[] };
+
+/**
+ * 클라이언트가 제공할 수 있는 audio_url 의 형식만 1차 검증한다.
+ * (스킴/길이) — 소유권/SSRF 검증은 loadAudioBytes 에서 수행한다.
+ * https 등 임의 원격 호스트 프록시는 SSRF 위험이라 더 이상 허용하지 않는다.
+ */
+export function isStoredAudioUrl(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_AUDIO_URL_LENGTH &&
+    value.startsWith('r2://')
+  );
+}
+
+function r2KeyOwner(objectKey: string): string | null {
+  for (const prefix of R2_USER_PREFIXES) {
+    if (objectKey.startsWith(prefix)) {
+      const rest = objectKey.slice(prefix.length);
+      const slash = rest.indexOf('/');
+      if (slash <= 0) return null;
+      return decodeURIComponent(rest.slice(0, slash));
+    }
+  }
+  return null;
+}
+
+/**
+ * r2:// 키가 access 정책에 따라 허용되는지 판정한다.
+ * - trusted: 알려진 사용자 네임스페이스(voices/, generated-tts/) 키만 허용.
+ * - owner: 위에 더해 키에 박힌 소유자 id 가 호출자(ownerIds)와 일치해야 함.
+ *   → 타인 네임스페이스(r2://voices/{victim}/...) 추측을 통한 cross-tenant
+ *     읽기(IDOR)를 차단한다.
+ */
+export function isR2KeyAuthorized(objectKey: string, access: AudioAccess): boolean {
+  const owner = r2KeyOwner(objectKey);
+  if (owner === null) return false;
+  if (access.kind === 'owner') {
+    return access.ownerIds.some((id) => id != null && id === owner);
+  }
+  return true;
+}
+
 export async function loadAudioBytes(
   c: Context<AppEnv>,
   audioUrl: string,
+  access: AudioAccess = { kind: 'trusted' },
 ): Promise<{ bytes: Uint8Array; format: string } | null> {
-  let bytes: Uint8Array;
-  let format = audioFormatFromUrl(audioUrl);
+  const fallbackFormat = audioFormatFromUrl(audioUrl);
   const voiceBucket = c.env?.VOICE_BUCKET;
 
-  if (audioUrl.startsWith('r2://')) {
-    if (!voiceBucket) return null;
-    const objectKey = audioUrl.slice('r2://'.length);
-    const stored = await new R2VoiceStorage(voiceBucket).get(objectKey);
-    if (!stored) return null;
-    bytes = stored.bytes;
-    format = audioFormatFromMime(stored.meta.mimeType) ?? format;
-  } else if (audioUrl.startsWith('https://')) {
-    const audioRes = await fetch(audioUrl);
-    if (!audioRes.ok) return null;
-    bytes = new Uint8Array(await audioRes.arrayBuffer());
-    format = audioFormatFromMime(audioRes.headers.get('content-type')) ?? format;
-  } else if (voiceBucket) {
-    const stored = await new R2VoiceStorage(voiceBucket).get(audioUrl);
-    if (!stored) return null;
-    bytes = stored.bytes;
-    format = audioFormatFromMime(stored.meta.mimeType) ?? format;
-  } else {
+  if (typeof audioUrl !== 'string' || audioUrl.length > MAX_AUDIO_URL_LENGTH) {
     return null;
   }
 
-  return { bytes, format };
+  // 임의 https:// (또는 그 외 원격) URL 프록시를 전면 차단한다. 정당한 오디오는
+  // 항상 내부 R2(r2://) 에 저장되므로, 사용자 제공 호스트로의 아웃바운드 fetch
+  // (SSRF)를 허용할 이유가 없다.
+  let objectKey: string;
+  if (audioUrl.startsWith('r2://')) {
+    objectKey = audioUrl.slice('r2://'.length);
+  } else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(audioUrl)) {
+    // r2:// 가 아닌 스킴 부착 URL(https://, http://, file:// 등)은 거부.
+    return null;
+  } else {
+    // 스킴 없는 값은 곧 R2 객체 키로 취급(레거시 저장 형식).
+    objectKey = audioUrl;
+  }
+
+  if (!objectKey || !isR2KeyAuthorized(objectKey, access)) {
+    return null;
+  }
+  if (!voiceBucket) return null;
+  const stored = await new R2VoiceStorage(voiceBucket).get(objectKey);
+  if (!stored) return null;
+
+  return {
+    bytes: stored.bytes,
+    format: audioFormatFromMime(stored.meta.mimeType) ?? fallbackFormat,
+  };
 }
 
 function audioFormatFromMime(mimeType: string | null | undefined): string | null {

--- a/packages/backend/src/lib/consent.ts
+++ b/packages/backend/src/lib/consent.ts
@@ -1,0 +1,77 @@
+/**
+ * 동의(consent) 설정의 단일 진실 공급원 + 서버측 동의 충족 판정 헬퍼 (B4).
+ *
+ * 개인정보보호법 제22조에 따라 동의 사실을 (유형, 정책 버전, 동의 여부, 시각)으로
+ * 누적 보관한다. user_consents 테이블의 동일 (user_id, consent_type) 최신 행이
+ * 현재 동의 상태이며, 이력은 INSERT 로만 누적된다.
+ *
+ * 동의 유형
+ *  - terms            이용약관 (일반 필수)
+ *  - privacy          개인정보 수집·이용 (일반 필수)
+ *  - age14            만 14세 이상 (일반 필수)
+ *  - marketing        광고성 정보 수신 (선택)
+ *  - voice_biometric  음성(생체정보) 처리 — 음성 클론/등록 시 별도 필수.
+ *                     클론된 목소리는 개인을 식별·재현할 수 있는 **생체정보**로 분류한다
+ *                     (법적 문구는 후속 wave 에서 정비).
+ *  - overseas_transfer 국외 이전 — 크로스보더 TTS/번역(Vertex)이 텍스트를 국외로
+ *                     전송하므로 해당 경로 사용 시 별도 필수.
+ */
+import type { Client } from '@libsql/client/web';
+
+export const CONSENT_TYPES = [
+  'terms',
+  'privacy',
+  'age14',
+  'marketing',
+  'voice_biometric',
+  'overseas_transfer',
+] as const;
+
+export type ConsentType = (typeof CONSENT_TYPES)[number];
+
+/** POST /user/consents 로 기록 가능한 유형 집합. */
+export const ALLOWED_CONSENT_TYPES = new Set<string>(CONSENT_TYPES);
+
+/** 가입/일반 이용에 반드시 필요한 필수 동의. marketing(선택)·민감동의는 제외. */
+export const GENERAL_REQUIRED_CONSENTS = ['terms', 'privacy', 'age14'] as const;
+
+/** 특정 민감 기능(생체 음성, 국외 이전)에서만 추가로 요구되는 동의. */
+export const SENSITIVE_REQUIRED_CONSENTS = ['voice_biometric', 'overseas_transfer'] as const;
+
+/** 동의 상태 조회/충족 판정에 쓰는 일반 필수 동의 목록(GET /consents/status 호환). */
+export const REQUIRED_CONSENT_TYPES = GENERAL_REQUIRED_CONSENTS;
+
+/** 처리방침/약관 버전. 정책 개정 시 이 값을 올려 기존 가입자 재동의를 유도한다. */
+export const CURRENT_POLICY_VERSION = '1';
+
+/**
+ * requiredTypes 중 하나라도 (미기록 | 미동의 | 현재 정책버전과 불일치) 이면 true.
+ * user_consents 의 유형별 최신 1건만 보고 판정한다 (created_at DESC, rowid DESC).
+ */
+export async function needsConsent(
+  db: Client,
+  userIdPK: string,
+  requiredTypes: readonly string[],
+): Promise<boolean> {
+  if (requiredTypes.length === 0) return false;
+  const res = await db.execute({
+    // created_at 은 초 단위라 같은 초에 토글하면 동점이 된다. rowid(삽입 순서)를
+    // 보조 정렬로 두어 같은 초여도 항상 마지막 삽입을 최신으로 선택한다.
+    sql: `SELECT consent_type, policy_version, agreed
+          FROM user_consents WHERE user_id = ? ORDER BY created_at DESC, rowid DESC`,
+    args: [userIdPK],
+  });
+  const latest = new Map<string, { agreed: boolean; version: string }>();
+  for (const row of res.rows) {
+    const type = String(row.consent_type);
+    if (latest.has(type)) continue; // 유형별 최신 1건만
+    latest.set(type, {
+      agreed: Number(row.agreed) === 1,
+      version: String(row.policy_version),
+    });
+  }
+  return requiredTypes.some((type) => {
+    const cur = latest.get(type);
+    return !cur || !cur.agreed || cur.version !== CURRENT_POLICY_VERSION;
+  });
+}

--- a/packages/backend/src/lib/email-verification.ts
+++ b/packages/backend/src/lib/email-verification.ts
@@ -2,6 +2,11 @@ import type { Env } from '../types';
 
 export const EMAIL_VERIFICATION_TTL_SECONDS = 10 * 60;
 export const EMAIL_VERIFICATION_MAX_ATTEMPTS = 5;
+// 재발송 쿨다운: 동일 이메일로 이 시간 안에 이미 코드를 발급했다면 새 코드를
+// 보내지 않고(이메일 폭탄/Resend 비용 남용 방지) 기존 코드를 그대로 둔다.
+export const EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS = 60;
+// 동일 이메일 1일 발급 상한(IP 와 무관). 초과 시 추가 발송하지 않는다.
+export const EMAIL_VERIFICATION_DAILY_CAP = 10;
 
 export function normalizeAuthEmail(email: string): string {
   return email.toLowerCase().trim();

--- a/packages/backend/src/lib/jwt.ts
+++ b/packages/backend/src/lib/jwt.ts
@@ -2,6 +2,10 @@ export interface AppJwtPayload {
   sub: string;
   email: string;
   name?: string;
+  // 토큰 세대(epoch). 발급 시 users.token_epoch 를 박아 넣고, authMiddleware 가
+  // 현재 users.token_epoch 와 비교해 더 낮으면 폐기(TOKEN_REVOKED)된 것으로 본다.
+  // 클레임이 없는 토큰(레거시)은 0 으로 간주한다.
+  epoch?: number;
   iss: string;
   aud: string;
   iat: number;
@@ -44,7 +48,7 @@ async function getKey(secret: string, usage: 'sign' | 'verify'): Promise<CryptoK
 }
 
 export async function signAppJwt(
-  payload: { sub: string; email: string; name?: string },
+  payload: { sub: string; email: string; name?: string; epoch?: number },
   secret: string,
   ttlSeconds: number = DEFAULT_TTL_SECONDS,
 ): Promise<string> {
@@ -55,6 +59,7 @@ export async function signAppJwt(
     sub: payload.sub,
     email: payload.email,
     name: payload.name,
+    epoch: payload.epoch ?? 0,
     iss: ISSUER,
     aud: AUDIENCE,
     iat: now,
@@ -96,6 +101,9 @@ export async function verifyAppJwt(token: string, secret: string): Promise<AppJw
   if (payload.iss !== ISSUER) throw new Error('Invalid issuer');
   if (payload.aud !== AUDIENCE) throw new Error('Token audience mismatch');
   if (payload.exp < Math.floor(Date.now() / 1000)) throw new Error('Token expired');
+
+  // epoch 클레임이 없는(레거시) 토큰은 0 으로 정규화해 호출자가 항상 숫자를 받게 한다.
+  payload.epoch = typeof payload.epoch === 'number' ? payload.epoch : 0;
 
   return payload;
 }

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1205,6 +1205,18 @@ export const migrations: Migration[] = [
       `CREATE VIEW IF NOT EXISTS "users_kst" AS SELECT *, datetime("created_at",'+9 hours') AS created_at_kst, datetime("updated_at",'+9 hours') AS updated_at_kst, datetime("last_active_at",'+9 hours') AS last_active_at_kst, datetime("deletion_requested_at",'+9 hours') AS deletion_requested_at_kst, datetime("deletion_purge_at",'+9 hours') AS deletion_purge_at_kst FROM "users"`,
     ],
   },
+  {
+    // 토큰 폐기(revocation) / 전 기기 로그아웃 지원 (B5).
+    //  - users.token_epoch: 발급된 앱 JWT 의 유효 세대(epoch). 로그아웃(POST /auth/logout)
+    //    이나 향후 비밀번호 재설정 시 이 값을 +1 한다. authMiddleware 는 JWT 의 epoch
+    //    클레임(기본 0)이 users.token_epoch 보다 작으면 TOKEN_REVOKED(401)로 거부한다.
+    //    이로써 탈취·유출된 기존 토큰을 만료 전에도 즉시 무효화할 수 있다.
+    id: 51,
+    name: 'user-token-epoch',
+    statements: [
+      `ALTER TABLE users ADD COLUMN token_epoch INTEGER NOT NULL DEFAULT 0`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/password.ts
+++ b/packages/backend/src/lib/password.ts
@@ -2,6 +2,14 @@ import bcrypt from 'bcryptjs';
 
 const BCRYPT_ROUNDS = 10;
 
+/**
+ * 존재하지 않는 사용자로 로그인 시도 시, 실제 비밀번호 검증과 동일한 비용의
+ * bcrypt 비교를 수행해 타이밍으로 계정 존재 여부가 새지 않게 하기 위한 고정 더미
+ * 해시. 어떤 평문과도 일치하지 않는다(BCRYPT_ROUNDS 와 동일한 cost=10).
+ */
+export const DUMMY_BCRYPT_HASH =
+  '$2a$10$CwTycUXWue0Thq9StjUM0uJ8DvY8Rc0G2qY9C2bq8N3w1qS8m9b2K';
+
 export function applyPepper(password: string, pepper: string): string {
   return `${password}::${pepper ?? ''}`;
 }

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,19 +1,20 @@
 /**
  * 인증 미들웨어. 모든 보호 라우트(`/api/*`)는 이 미들웨어를 통과한다.
  *
- * Firebase 없이 Bearer 토큰을 직접 검증한다. 토큰의 `iss`(발급자)를 보고
- * 세 가지 경로로 분기한다:
- *  - 자체 발급 앱 JWT(APP_JWT_ISSUER)  → verifyAppJwt
- *  - Google ID Token                   → verifyGoogleIdToken
- *  - Apple ID Token                    → verifyAppleIdToken
+ * **앱 JWT 전용(B5).** 과거에는 Google/Apple ID Token 을 Bearer 로 직접 받아
+ * 검증했으나, provider ID 토큰을 그대로 통과시키면 (a) 폐기/로그아웃 불가
+ * (token_epoch 가 없음) (b) audience/만료가 provider 정책에 종속되는 문제가 있다.
+ * 이제 provider 토큰은 오직 /auth/google · /auth/apple 교환 엔드포인트에서만
+ * 쓰이고, 그 외 모든 보호 라우트는 자체 발급 앱 JWT(APP_JWT_ISSUER) 만 받는다.
  *
  * 검증 후 `users` 행을 해석(없으면 즉석 생성)해 `userIdPK`(FK 기준 식별자)를
- * 컨텍스트에 심고, 탈퇴 유예(pending_deletion) 계정은 본인조회/철회 외 API를 막는다.
+ * 컨텍스트에 심고, (1) JWT epoch < users.token_epoch 이면 폐기된 토큰으로 보아
+ * 401(TOKEN_REVOKED), (2) 탈퇴 유예(pending_deletion) 계정은 본인조회/철회 외
+ * API 를 막는다.
  */
 import type { Context, Next } from 'hono';
 import type { AppEnv } from '../types';
-import { verifyAppJwt, APP_JWT_ISSUER } from '../lib/jwt';
-import { decodeJwtPayload, verifyAppleIdToken, verifyGoogleIdToken } from '../lib/oauth';
+import { verifyAppJwt } from '../lib/jwt';
 
 interface TokenPayload {
   sub: string;
@@ -23,11 +24,11 @@ interface TokenPayload {
   iss: string;
   aud: string;
   exp: number;
+  epoch: number;
 }
 
 /**
- * Google / Apple ID Token 검증 미들웨어
- * Firebase 없이 직접 검증
+ * 앱 JWT 전용 인증 미들웨어 (provider ID 토큰 직접 수용 제거됨).
  */
 export async function authMiddleware(c: Context<AppEnv>, next: Next) {
   const authHeader = c.req.header('Authorization');
@@ -47,34 +48,20 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
   }
 
   try {
-    const payload = decodeJwtPayload(token);
-
-    let verified: TokenPayload;
-
-    if (payload.iss === APP_JWT_ISSUER) {
-      const app = await verifyAppJwt(token, c.env.JWT_SECRET);
-      verified = {
-        sub: app.sub,
-        email: app.email,
-        name: app.name,
-        picture: undefined,
-        iss: app.iss,
-        aud: app.aud,
-        exp: app.exp,
-      };
-    } else if (payload.iss === 'https://appleid.apple.com') {
-      if (!c.env.APPLE_CLIENT_ID) {
-        throw new Error('Apple client ID is not configured');
-      }
-      verified = await verifyAppleIdToken(token, c.env.APPLE_CLIENT_ID);
-    } else if (
-      payload.iss === 'accounts.google.com' ||
-      payload.iss === 'https://accounts.google.com'
-    ) {
-      verified = await verifyGoogleIdToken(token, c.env.GOOGLE_CLIENT_ID);
-    } else {
-      throw new Error('Invalid token issuer');
-    }
+    // 앱 JWT 만 수용한다. provider(Apple/Google) ID 토큰은 여기서 거부되고,
+    // /auth/google·/auth/apple 교환 라우트(authMiddleware 비적용)에서만 처리된다.
+    // verifyAppJwt 가 iss/aud/exp/서명을 모두 검증하며 실패 시 throw → 401.
+    const app = await verifyAppJwt(token, c.env.JWT_SECRET);
+    const verified: TokenPayload = {
+      sub: app.sub,
+      email: app.email,
+      name: app.name,
+      picture: undefined,
+      iss: app.iss,
+      aud: app.aud,
+      exp: app.exp,
+      epoch: app.epoch ?? 0,
+    };
 
     // Legacy convention: most routes still query `WHERE google_id = ?`, so
     // `userId` keeps that meaning (the JWT sub).
@@ -89,36 +76,49 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
     try {
       const { getDB } = await import('../lib/db');
       const db = getDB(c.env);
-      const isApple = verified.iss === 'https://appleid.apple.com';
+      // 앱 JWT 의 sub 은 발급 시점의 loginSub(google_id ?? apple_id ?? id)이므로,
+      // 세 컬럼 모두에 대해 매칭한다. provider 사용자는 /auth 교환 단계에서 이미
+      // 행이 생성돼 있어 아래 fallback INSERT 는 사실상 이메일/레거시 경로의 안전망이다.
       const found = await db.execute({
-        sql: 'SELECT id, deletion_status FROM users WHERE google_id = ? OR apple_id = ? OR id = ?',
-        args: [verified.sub, isApple ? verified.sub : null, verified.sub],
+        sql: 'SELECT id, deletion_status, token_epoch FROM users WHERE google_id = ? OR apple_id = ? OR id = ?',
+        args: [verified.sub, verified.sub, verified.sub],
       });
       let pk: string;
       let deletionStatus = 'active';
+      let tokenEpoch = 0;
       if (found.rows.length > 0) {
         pk = String(found.rows[0]!.id);
         deletionStatus = String(found.rows[0]!.deletion_status ?? 'active');
+        tokenEpoch = Number(found.rows[0]!.token_epoch ?? 0);
       } else {
         // 최초 인증 시 users 행을 즉석에서 생성한다. 동일 사용자의 동시 첫 요청이
         // 둘 다 INSERT 를 시도해도 중복키 예외로 죽지 않도록 ON CONFLICT DO NOTHING
         // 으로 멱등화한다. 신규 계정은 id = sub 이므로 경쟁 상황에서도 pk 는 일관된다.
         await db.execute({
-          sql: `INSERT INTO users (id, google_id, apple_id, email, name, picture)
-                VALUES (?, ?, ?, ?, ?, ?)
+          sql: `INSERT INTO users (id, google_id, email, name, picture)
+                VALUES (?, ?, ?, ?, ?)
                 ON CONFLICT DO NOTHING`,
           args: [
             verified.sub,
             verified.sub,
-            isApple ? verified.sub : null,
             verified.email || `${verified.sub}@unknown`,
             verified.name || null,
             verified.picture || null,
           ],
         });
         pk = verified.sub;
+        // 갓 만든 행의 token_epoch 는 DEFAULT 0. 토큰 epoch 도 0(또는 그 이상)이라 통과.
       }
       c.set('userIdPK', pk);
+
+      // 토큰 폐기 검사(B5): JWT epoch 가 현재 users.token_epoch 보다 낮으면, 로그아웃
+      // (전 기기) 또는 비밀번호 재설정으로 무효화된 구(舊) 토큰이다. 만료 전이라도 거부.
+      if (verified.epoch < tokenEpoch) {
+        return c.json(
+          { error: 'Token has been revoked', error_code: 'TOKEN_REVOKED' },
+          401,
+        );
+      }
 
       // 탈퇴 유예(pending_deletion) 계정은 본인정보 조회(GET /user/me)와 탈퇴 철회
       // (DELETE /user/me/deletion) 외의 인증 API 사용을 차단한다(개인정보보호법 제21조,

--- a/packages/backend/src/middleware/consent.ts
+++ b/packages/backend/src/middleware/consent.ts
@@ -1,0 +1,75 @@
+/**
+ * 서버측 동의 강제 미들웨어 (B4). authMiddleware 다음에 실행되며 userIdPK 를 사용한다.
+ *
+ * 데이터 수집/처리성 라우트에 대해 일반 필수 동의(GENERAL_REQUIRED_CONSENTS)가
+ * 충족되지 않았으면 403 CONSENT_REQUIRED 로 막는다. 클라이언트는 온보딩에서
+ * POST /user/consents 로 동의를 기록한 뒤 진입한다.
+ *
+ * 면제(EXEMPT) 경로 — 동의 없이도 통과해야 하는 라우트:
+ *  - /auth/*                      (로그인/교환/로그아웃)
+ *  - /api/health, '/'             (헬스체크)
+ *  - GET /user/me                 (본인정보 조회)
+ *  - /user/consents*              (동의 기록/조회/상태 — 동의 자체를 하러 오는 경로)
+ *  - DELETE /user/me, /user/me/deletion (탈퇴/철회)
+ *  - GET /app/version             (버전 정책)
+ *  - /holiday                     (공휴일, 비인증)
+ *
+ * pending_deletion 면제와 동일한 스타일(경로/메서드 매칭)로 작성한다.
+ */
+import type { Context, Next } from 'hono';
+import type { AppEnv } from '../types';
+import { GENERAL_REQUIRED_CONSENTS, needsConsent } from '../lib/consent';
+
+function isExempt(path: string, method: string): boolean {
+  // '/api' prefix 가 있을 수도/없을 수도 있어 정규화 후 정확한 path-segment 로 매칭한다.
+  // (substring 매칭은 향후 '/.../auth/...' 같은 데이터 라우트를 실수로 면제할 위험이 있어 지양.)
+  const p = path.startsWith('/api/') ? path.slice(4) : path === '/api' ? '/' : path;
+
+  // 인증/교환/로그아웃
+  if (p === '/auth' || p.startsWith('/auth/')) return true;
+  // 헬스체크
+  if (p === '/' || p === '/health') return true;
+  // 버전 정책
+  if (p === '/app/version') return true;
+  // 공휴일(비인증)
+  if (p === '/holiday' || p.startsWith('/holiday/')) return true;
+  // 동의 기록/조회/상태(동의 자체를 하러 오는 경로)
+  if (p === '/user/consents' || p.startsWith('/user/consents/')) return true;
+  // 본인정보 조회(GET /user/me)
+  if (method === 'GET' && p === '/user/me') return true;
+  // 탈퇴/철회: DELETE /user/me, POST·DELETE /user/me/deletion
+  if (p === '/user/me/deletion') return true;
+  if (method === 'DELETE' && p === '/user/me') return true;
+
+  return false;
+}
+
+export async function consentMiddleware(c: Context<AppEnv>, next: Next) {
+  if (isExempt(c.req.path, c.req.method)) {
+    return next();
+  }
+
+  const userIdPK = c.get('userIdPK');
+  if (!userIdPK) {
+    // authMiddleware 가 먼저 돌아 userIdPK 를 심어야 한다. 없으면 구성 오류 — fail-closed.
+    return c.json(
+      { error: 'Consent state unavailable', error_code: 'CONSENT_STATE_UNAVAILABLE' },
+      403,
+    );
+  }
+
+  const { getDB } = await import('../lib/db');
+  const db = getDB(c.env);
+  if (await needsConsent(db, userIdPK, GENERAL_REQUIRED_CONSENTS)) {
+    return c.json(
+      {
+        error: 'Required consents are missing',
+        error_code: 'CONSENT_REQUIRED',
+        required: GENERAL_REQUIRED_CONSENTS,
+      },
+      403,
+    );
+  }
+
+  return next();
+}

--- a/packages/backend/src/middleware/sentry.ts
+++ b/packages/backend/src/middleware/sentry.ts
@@ -9,11 +9,22 @@ export const sentryMiddleware = createMiddleware<AppEnv>(async (c, next) => {
     return;
   }
 
+  // RTDN 웹훅 등은 ?token=<secret> 쿼리로 인증한다. Toucan 에 원본 요청을 그대로 넘기면
+  // 500 발생 시 쿼리스트링(=시크릿)이 Sentry 로 전송된다. 요청 URL 에서 쿼리스트링을 제거한
+  // 사본을 넘기고, allowedSearchParams 도 명시적으로 비활성화해 어떤 쿼리 파라미터도 캡처되지
+  // 않게 한다(인증 메커니즘 자체는 건드리지 않음 — 라우트 핸들러는 원본 c.req 를 그대로 사용).
+  const sanitizedUrl = new URL(c.req.raw.url);
+  sanitizedUrl.search = '';
+  const sanitizedRequest = new Request(sanitizedUrl.toString(), c.req.raw);
+
   const sentry = new Toucan({
     dsn,
-    request: c.req.raw,
+    request: sanitizedRequest,
     context: c.executionCtx,
     environment: c.env.ENVIRONMENT || 'production',
+    requestDataOptions: {
+      allowedSearchParams: false,
+    },
   });
 
   c.set('sentry', sentry);

--- a/packages/backend/src/routes/alarm-helpers.ts
+++ b/packages/backend/src/routes/alarm-helpers.ts
@@ -1,4 +1,5 @@
 import { UUID_RE } from '../lib/validate';
+import { isStoredAudioUrl } from '../lib/audio-loader';
 
 export const ALARM_MODES = ['sound-only', 'tts'] as const;
 export type AlarmMode = (typeof ALARM_MODES)[number];
@@ -6,7 +7,6 @@ export const VIBRATION_PATTERNS = ['default', 'strong', 'none'] as const;
 export type VibrationPattern = (typeof VIBRATION_PATTERNS)[number];
 export const WAKE_MODES = ['sound_then_voice', 'voice_only'] as const;
 export type WakeMode = (typeof WAKE_MODES)[number];
-const MAX_REMOTE_AUDIO_URL_LENGTH = 2048;
 
 export type AlarmRow = Record<string, unknown> & {
   repeat_days?: unknown;
@@ -106,8 +106,8 @@ export function validateAlarmFields(body: {
   }
 
   if (body.raw_audio_url !== undefined && body.raw_audio_url !== null) {
-    if (typeof body.raw_audio_url !== 'string' || !isEncryptedRemoteAudioUrl(body.raw_audio_url.trim())) {
-      return { error: 'raw_audio_url must be r2:// or https://', error_code: 'INVALID_RAW_AUDIO_URL' };
+    if (typeof body.raw_audio_url !== 'string' || !isStoredAudioUrl(body.raw_audio_url.trim())) {
+      return { error: 'raw_audio_url must be a stored r2:// object', error_code: 'INVALID_RAW_AUDIO_URL' };
     }
   }
 
@@ -160,9 +160,4 @@ export function validateAlarmFields(body: {
   }
 
   return null;
-}
-
-export function isEncryptedRemoteAudioUrl(value: string): boolean {
-  return value.length <= MAX_REMOTE_AUDIO_URL_LENGTH &&
-    (value.startsWith('r2://') || value.startsWith('https://'));
 }

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -86,6 +86,56 @@ async function usesOnlySystemStockVoice(
   return false;
 }
 
+/**
+ * message_id 가 호출자(ownerIds) 소유이거나 시스템 스톡 프리셋인지 확인한다.
+ * POST 생성 경로(아래)와 GET /tts/messages/:id/audio 의 허용 규칙과 동일하게
+ * 맞춰, PATCH 에서 타인 메시지 id 를 알람에 끼워 넣는 IDOR 을 막는다.
+ */
+async function messageBelongsToCaller(
+  db: ReturnType<typeof getDB>,
+  messageId: string,
+  ownerIds: [string, string],
+): Promise<boolean> {
+  const msg = await db.execute({
+    sql: `SELECT 1 FROM messages
+          WHERE id = ?
+            AND (
+              user_id IN (?, ?)
+              OR (
+                COALESCE(is_preset, 0) = 1
+                AND EXISTS (
+                  SELECT 1 FROM voice_profiles vp
+                  WHERE vp.id = messages.voice_profile_id
+                    AND COALESCE(vp.is_system, 0) = 1
+                )
+              )
+            )
+          LIMIT 1`,
+    args: [messageId, ...ownerIds],
+  });
+  return msg.rows.length > 0;
+}
+
+/**
+ * voice_profile_id 가 호출자 소유이거나 시스템 보이스인지 확인한다.
+ * 타인 voice_profile_id 를 알람에 기록하는 IDOR 을 막는다.
+ */
+async function voiceProfileBelongsToCaller(
+  db: ReturnType<typeof getDB>,
+  voiceProfileId: string,
+  ownerIds: [string, string],
+): Promise<boolean> {
+  const vp = await db.execute({
+    sql: `SELECT 1 FROM voice_profiles
+          WHERE id = ?
+            AND deleted_at IS NULL
+            AND (user_id IN (?, ?) OR COALESCE(is_system, 0) = 1)
+          LIMIT 1`,
+    args: [voiceProfileId, ...ownerIds],
+  });
+  return vp.rows.length > 0;
+}
+
 alarmMutation.post('/', async (c) => {
   const userId = c.get('userId');
   const resolvedUserPk = c.get('userIdPK');
@@ -263,23 +313,7 @@ alarmMutation.post('/', async (c) => {
     // 허용한다. 무료 플랜은 스톡 클립으로 알람을 만들 수 있어야 하는데, 기존
     // 검증은 user_id 만 봐서 스톡 클립 알람을 404 로 막고 있었다
     // (GET /tts/messages/:id/audio 의 허용 규칙과 일치시킨다).
-    const msg = await db.execute({
-      sql: `SELECT id FROM messages
-            WHERE id = ?
-              AND (
-                user_id IN (?, ?)
-                OR (
-                  COALESCE(is_preset, 0) = 1
-                  AND EXISTS (
-                    SELECT 1 FROM voice_profiles vp
-                    WHERE vp.id = messages.voice_profile_id
-                      AND COALESCE(vp.is_system, 0) = 1
-                  )
-                )
-              )`,
-      args: [resolvedMessageId, ...ownerIds],
-    });
-    if (msg.rows.length === 0) {
+    if (!(await messageBelongsToCaller(db, resolvedMessageId, ownerIds))) {
       return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);
     }
   }
@@ -404,6 +438,29 @@ alarmMutation.patch('/:id', async (c) => {
         error_code: 'VOICE_FEATURE_REQUIRES_PAID_PLAN',
       },
       403,
+    );
+  }
+
+  // IDOR 방어: PATCH 로 새 message_id / voice_profile_id 를 기록하기 전에,
+  // POST 생성 경로와 동일한 소유권/프리셋 검증을 다시 수행한다. 이 검증이
+  // 없으면 호출자가 타인 소유 message_id(타인 음성 클립)나 voice_profile_id 를
+  // 자기 알람에 끼워 넣어 cross-tenant 리소스를 참조/재생할 수 있다.
+  const ownerIds = [resolvedUserPk || userId, userId] as [string, string];
+  if (
+    body.message_id !== undefined &&
+    body.message_id !== null &&
+    !(await messageBelongsToCaller(db, body.message_id, ownerIds))
+  ) {
+    return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);
+  }
+  if (
+    body.voice_profile_id !== undefined &&
+    body.voice_profile_id !== null &&
+    !(await voiceProfileBelongsToCaller(db, body.voice_profile_id, ownerIds))
+  ) {
+    return c.json(
+      { error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' },
+      404,
     );
   }
 

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { Client } from '@libsql/client/web';
-import type { Env } from '../types';
+import type { Env, AppEnv } from '../types';
+import { authMiddleware } from '../middleware/auth';
 import { getDB } from '../lib/db';
 import { logRouteError } from '../lib/logger';
 import { typedRow } from '../lib/db-types';
@@ -293,7 +294,12 @@ auth.post('/register', async (c) => {
 
     await consumeEmailVerificationCode(db, verification.id);
 
-    const token = await signAppJwt({ sub: id, email: normalizedEmail, name }, c.env.JWT_SECRET);
+    // 신규 가입자는 token_epoch 가 항상 0 이지만(방금 INSERT), 폐기 로직과 일관되게
+    // 명시적으로 박아 둔다.
+    const token = await signAppJwt(
+      { sub: id, email: normalizedEmail, name, epoch: 0 },
+      c.env.JWT_SECRET,
+    );
 
     return c.json(
       {
@@ -338,7 +344,7 @@ auth.post('/login', async (c) => {
 
   try {
     const result = await db.execute({
-      sql: `SELECT id, google_id, email, password_hash, name, plan,
+      sql: `SELECT id, google_id, email, password_hash, name, plan, token_epoch,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows, dynamic_prompt_settings_json
@@ -362,6 +368,7 @@ auth.post('/login', async (c) => {
       password_hash: string | null;
       name: string | null;
       plan: 'free' | 'plus' | 'family' | null;
+      token_epoch: number | string | null;
     }>(result.rows[0]!);
 
     // OAuth 전용 계정(비밀번호 없음)도 더미 해시로 동일 비용 비교 후 동일 응답을
@@ -380,7 +387,12 @@ auth.post('/login', async (c) => {
     }
 
     const token = await signAppJwt(
-      { sub: row.id, email: row.email, name: row.name ?? undefined },
+      {
+        sub: row.id,
+        email: row.email,
+        name: row.name ?? undefined,
+        epoch: Number(row.token_epoch ?? 0),
+      },
       c.env.JWT_SECRET,
     );
 
@@ -433,7 +445,7 @@ auth.post('/google', async (c) => {
     const name = google.name ?? '';
 
     const existing = await db.execute({
-      sql: `SELECT id, google_id, email, name, plan,
+      sql: `SELECT id, google_id, email, name, plan, token_epoch,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows, dynamic_prompt_settings_json
@@ -445,6 +457,7 @@ auth.post('/google', async (c) => {
 
     let userId: string;
     let plan: 'free' | 'plus' | 'family';
+    let tokenEpoch = 0;
 
     if (existing.rows.length > 0) {
       const row = typedRow<
@@ -454,10 +467,12 @@ auth.post('/google', async (c) => {
           email: string;
           name: string | null;
           plan: 'free' | 'plus' | 'family' | null;
+          token_epoch: number | string | null;
         } & Record<string, unknown>
       >(existing.rows[0]!);
       userId = row.id;
       plan = row.plan ?? 'free';
+      tokenEpoch = Number(row.token_epoch ?? 0);
 
       await db.execute({
         sql: `UPDATE users
@@ -476,7 +491,7 @@ auth.post('/google', async (c) => {
     }
 
     const token = await signAppJwt(
-      { sub: googleId, email, name: name || undefined },
+      { sub: googleId, email, name: name || undefined, epoch: tokenEpoch },
       c.env.JWT_SECRET,
     );
 
@@ -593,7 +608,7 @@ auth.post('/apple', async (c) => {
     const name = parsed.data.name ?? apple.name ?? '';
 
     const existing = await db.execute({
-      sql: `SELECT id, google_id, apple_id, email, name, plan,
+      sql: `SELECT id, google_id, apple_id, email, name, plan, token_epoch,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows, dynamic_prompt_settings_json
@@ -607,6 +622,7 @@ auth.post('/apple', async (c) => {
     let loginSub: string;
     let plan: 'free' | 'plus' | 'family';
     let resolvedName: string;
+    let tokenEpoch = 0;
 
     if (existing.rows.length > 0) {
       const row = typedRow<
@@ -617,12 +633,14 @@ auth.post('/apple', async (c) => {
           email: string;
           name: string | null;
           plan: 'free' | 'plus' | 'family' | null;
+          token_epoch: number | string | null;
         } & Record<string, unknown>
       >(existing.rows[0]!);
       userId = row.id;
       loginSub = row.google_id ?? appleId;
       plan = row.plan ?? 'free';
       resolvedName = name || row.name || '';
+      tokenEpoch = Number(row.token_epoch ?? 0);
 
       await db.execute({
         sql: `UPDATE users
@@ -647,7 +665,7 @@ auth.post('/apple', async (c) => {
     }
 
     const token = await signAppJwt(
-      { sub: loginSub, email, name: resolvedName || undefined },
+      { sub: loginSub, email, name: resolvedName || undefined, epoch: tokenEpoch },
       c.env.JWT_SECRET,
     );
 
@@ -771,5 +789,32 @@ auth.get('/me', async (c) => {
     return c.json(jsonError('AUTH_INVALID_TOKEN', detail), 401);
   }
 });
+
+// POST /auth/logout — 전 기기 로그아웃(sign-out-all-devices). authMiddleware 를 통과한
+// 사용자의 users.token_epoch 를 +1 하여, 현재까지 발급된 모든 앱 JWT(이전 epoch)를
+// 즉시 폐기한다. 다음 로그인 시 새 epoch 가 박힌 토큰이 발급된다.
+// NOTE: 비밀번호 재설정 라우트는 아직 없다. 추가될 경우, 재설정 성공 시에도 반드시
+//       동일하게 token_epoch 를 +1 하여 유출된 기존 세션을 무효화해야 한다.
+// authMiddleware 가 userIdPK/userId 를 심으므로 별도 AppEnv 서브앱으로 마운트한다.
+const logout = new Hono<AppEnv>();
+logout.use('*', authMiddleware);
+logout.post('/', async (c) => {
+  const userPk = c.get('userIdPK');
+  const userId = c.get('userId');
+  const db = getDB(c.env);
+  try {
+    await db.execute({
+      sql: `UPDATE users
+            SET token_epoch = token_epoch + 1, updated_at = datetime('now')
+            WHERE id = ? OR google_id = ? OR apple_id = ?`,
+      args: [userPk ?? userId, userId, userId],
+    });
+    return c.json({ success: true });
+  } catch (err) {
+    logRouteError(c, err);
+    return c.json(jsonError('AUTH_LOGOUT_FAILED', 'Logout failed'), 500);
+  }
+});
+auth.route('/logout', logout);
 
 export default auth;

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -4,7 +4,7 @@ import type { Env } from '../types';
 import { getDB } from '../lib/db';
 import { logRouteError } from '../lib/logger';
 import { typedRow } from '../lib/db-types';
-import { hashPassword, verifyPassword } from '../lib/password';
+import { DUMMY_BCRYPT_HASH, hashPassword, verifyPassword } from '../lib/password';
 import { signAppJwt, verifyAppJwt } from '../lib/jwt';
 import {
   RegisterRequestSchema,
@@ -21,7 +21,9 @@ import {
   dynamicPromptSettingsFromRow,
 } from '../lib/dynamic-prompt-settings';
 import {
+  EMAIL_VERIFICATION_DAILY_CAP,
   EMAIL_VERIFICATION_MAX_ATTEMPTS,
+  EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
   EMAIL_VERIFICATION_TTL_SECONDS,
   emailVerificationExpiresAt,
   generateEmailVerificationCode,
@@ -137,13 +139,49 @@ auth.post('/email-code', async (c) => {
   const email = normalizeAuthEmail(parsed.data.email);
   const db = getDB(c.env);
 
+  // 모든 분기에서 동일한 성공 응답을 돌려준다(계정 열거 방지). debug_code 는 코드를
+  // 실제로 새로 발송했을 때만 포함한다(쿨다운/상한/기존가입으로 미발송 시 생략).
+  const successResponse = (debugCode?: string) =>
+    c.json({
+      success: true,
+      expires_in_seconds: EMAIL_VERIFICATION_TTL_SECONDS,
+      ...(debugCode && shouldExposeDebugEmailCode(c.env) ? { debug_code: debugCode } : {}),
+    });
+
   try {
     const existing = await db.execute({
       sql: 'SELECT id FROM users WHERE email = ?',
       args: [email],
     });
+    // 이미 가입된 이메일이라도 409(AUTH_EMAIL_TAKEN)로 회원 여부를 노출하지 않고
+    // 동일한 성공 응답을 반환한다. 코드도 보내지 않는다.
     if (existing.rows.length > 0) {
-      return c.json(jsonError('AUTH_EMAIL_TAKEN', 'Email is already registered'), 409);
+      return successResponse();
+    }
+
+    const nowMs = Date.now();
+    // 최근 발급 이력 조회: (a) 쿨다운 내 미만료 코드가 있으면 재발송하지 않고
+    // 동일 응답, (b) 최근 24시간 발급 건수가 일일 상한을 넘으면 미발송.
+    const recent = await db.execute({
+      sql: `SELECT strftime('%Y-%m-%dT%H:%M:%fZ', created_at) AS created_at, expires_at
+            FROM email_verification_codes
+            WHERE email = ? AND purpose = ?
+              AND created_at >= datetime('now', '-1 day')
+            ORDER BY created_at DESC`,
+      args: [email, EMAIL_VERIFICATION_PURPOSE_REGISTER],
+    });
+
+    const cooldownActive = recent.rows.some((r) => {
+      const created = Date.parse(String(r.created_at ?? ''));
+      const expires = Date.parse(String(r.expires_at ?? ''));
+      if (!Number.isFinite(created)) return false;
+      const withinCooldown =
+        nowMs - created < EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000;
+      const stillValid = Number.isFinite(expires) ? expires > nowMs : false;
+      return withinCooldown && stillValid;
+    });
+    if (cooldownActive || recent.rows.length >= EMAIL_VERIFICATION_DAILY_CAP) {
+      return successResponse();
     }
 
     const code = generateEmailVerificationCode();
@@ -160,11 +198,7 @@ auth.post('/email-code', async (c) => {
 
     await sendEmailVerificationCode(c.env, email, code);
 
-    return c.json({
-      success: true,
-      expires_in_seconds: EMAIL_VERIFICATION_TTL_SECONDS,
-      ...(shouldExposeDebugEmailCode(c.env) ? { debug_code: code } : {}),
-    });
+    return successResponse(code);
   } catch (err) {
     logRouteError(c, err);
     const detail = err instanceof Error ? err.message : String(err);
@@ -222,14 +256,9 @@ auth.post('/register', async (c) => {
   const db = getDB(c.env);
 
   try {
-    const existing = await db.execute({
-      sql: 'SELECT id FROM users WHERE email = ?',
-      args: [normalizedEmail],
-    });
-    if (existing.rows.length > 0) {
-      return c.json(jsonError('AUTH_EMAIL_TAKEN', 'Email is already registered'), 409);
-    }
-
+    // 계정 열거 방지: 이미 가입된 이메일이라도 409(AUTH_EMAIL_TAKEN)로 회원 여부를
+    // 노출하지 않는다. 가입된 이메일에는 /auth/email-code 가 코드를 발급하지 않으므로
+    // 아래 인증 코드 검증이 게이트 역할을 한다(미가입자만 유효 코드를 보유).
     const verification = await checkEmailVerificationCode(
       db,
       c.env,
@@ -238,6 +267,19 @@ auth.post('/register', async (c) => {
     );
     if (!verification.ok) {
       return c.json(jsonError(verification.code, verification.message), verification.status);
+    }
+
+    // 인증 코드를 통과했더라도(이론상 경쟁 상태) 이미 존재하는 이메일이면 generic
+    // 코드 무효 응답으로 통일한다 — 회원 가입 여부를 별도 코드로 노출하지 않는다.
+    const existing = await db.execute({
+      sql: 'SELECT id FROM users WHERE email = ?',
+      args: [normalizedEmail],
+    });
+    if (existing.rows.length > 0) {
+      return c.json(
+        jsonError('AUTH_EMAIL_CODE_INVALID', 'Invalid email verification code'),
+        400,
+      );
     }
 
     const id = crypto.randomUUID();
@@ -304,7 +346,12 @@ auth.post('/login', async (c) => {
       args: [normalizedEmail],
     });
 
+    // 계정 열거(account enumeration) 방지: 존재하지 않는 이메일·OAuth 전용 계정·
+    // 비밀번호 불일치를 모두 동일한 응답(AUTH_INVALID_CREDENTIALS, 401)으로 처리한다.
+    // 또한 사용자가 없을 때도 고정 더미 해시로 bcrypt 비교를 수행해, 존재 여부가
+    // 응답 시간(타이밍 오라클)으로 새지 않게 한다.
     if (result.rows.length === 0) {
+      await verifyPassword(password, DUMMY_BCRYPT_HASH, c.env.PASSWORD_PEPPER);
       return c.json(jsonError('AUTH_INVALID_CREDENTIALS', 'Invalid email or password'), 401);
     }
 
@@ -317,12 +364,11 @@ auth.post('/login', async (c) => {
       plan: 'free' | 'plus' | 'family' | null;
     }>(result.rows[0]!);
 
-    if (!row.password_hash) {
-      return c.json(jsonError('AUTH_OAUTH_ONLY', 'This account uses OAuth sign-in'), 401);
-    }
-
-    const ok = await verifyPassword(password, row.password_hash, c.env.PASSWORD_PEPPER);
-    if (!ok) {
+    // OAuth 전용 계정(비밀번호 없음)도 더미 해시로 동일 비용 비교 후 동일 응답을
+    // 반환한다. 별도 error_code 로 가입 방식을 노출하면 계정 열거에 악용된다.
+    const passwordHash = row.password_hash ?? DUMMY_BCRYPT_HASH;
+    const ok = await verifyPassword(password, passwordHash, c.env.PASSWORD_PEPPER);
+    if (!row.password_hash || !ok) {
       return c.json(jsonError('AUTH_INVALID_CREDENTIALS', 'Invalid email or password'), 401);
     }
 
@@ -472,6 +518,9 @@ auth.post('/google', async (c) => {
       },
     });
   } catch (err) {
+    // 검증 실패 상세(err.message)는 서버에만 로깅하고, 클라이언트에는 provider/검증
+    // 내부 정보를 반영하지 않는 안정적인 generic 메시지만 반환한다(정보 노출 방지).
+    logRouteError(c, err);
     const detail = err instanceof Error ? err.message : String(err);
     const status =
       detail.includes('Google token') ||
@@ -481,7 +530,7 @@ auth.post('/google', async (c) => {
       detail.includes('Token')
         ? 401
         : 500;
-    return c.json(jsonError('AUTH_GOOGLE_FAILED', detail), status);
+    return c.json(jsonError('AUTH_GOOGLE_FAILED', 'Google sign-in failed'), status);
   }
 });
 
@@ -644,9 +693,12 @@ auth.post('/apple', async (c) => {
       },
     });
   } catch (err) {
+    // 검증 실패 상세(err.message)는 서버에만 로깅하고, 클라이언트에는 provider/검증
+    // 내부 정보를 반영하지 않는 안정적인 generic 메시지만 반환한다(정보 노출 방지).
+    logRouteError(c, err);
     const detail = err instanceof Error ? err.message : String(err);
     if (detail.includes('nonce mismatch')) {
-      return c.json(jsonError('AUTH_APPLE_NONCE_MISMATCH', detail), 401);
+      return c.json(jsonError('AUTH_APPLE_NONCE_MISMATCH', 'Apple sign-in nonce mismatch'), 401);
     }
     const status =
       detail.includes('Apple token') ||
@@ -660,7 +712,7 @@ auth.post('/apple', async (c) => {
       detail.includes('format')
         ? 401
         : 500;
-    return c.json(jsonError('AUTH_APPLE_FAILED', detail), status);
+    return c.json(jsonError('AUTH_APPLE_FAILED', 'Apple sign-in failed'), status);
   }
 });
 

--- a/packages/backend/src/routes/notes.ts
+++ b/packages/backend/src/routes/notes.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
-import { loadAudioBytes, uint8ToBase64 } from '../lib/audio-loader';
+import { loadAudioBytes, uint8ToBase64, isStoredAudioUrl } from '../lib/audio-loader';
 
 const notes = new Hono<AppEnv>();
-const MAX_NOTE_AUDIO_URL_LENGTH = 2048;
 
 async function resolveUserPk(
   db: ReturnType<typeof getDB>,
@@ -37,8 +36,8 @@ notes.post('/', async (c) => {
   if (text.length > 500) return c.json({ error: 'text 는 최대 500자입니다', error_code: 'TEXT_TOO_LONG' }, 400);
   if (receiverId === senderPk) return c.json({ error: '자기 자신에게는 보낼 수 없습니다', error_code: 'SELF_NOTE' }, 400);
 
-  if (audioUrl && !isValidAudioUrl(audioUrl)) {
-    return c.json({ error: 'audio_url must be r2:// or https://', error_code: 'INVALID_AUDIO_URL' }, 400);
+  if (audioUrl && !isStoredAudioUrl(audioUrl)) {
+    return c.json({ error: 'audio_url must be a stored r2:// object', error_code: 'INVALID_AUDIO_URL' }, 400);
   }
 
   const receiverRes = await db.execute({
@@ -194,7 +193,11 @@ notes.get('/:id/audio', async (c) => {
   if (!userPk) return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
 
   const noteRes = await db.execute({
-    sql: 'SELECT id, sender_id, receiver_id, text, audio_url FROM notes WHERE id = ?',
+    sql: `SELECT n.id, n.sender_id, n.receiver_id, n.text, n.audio_url,
+                 s.google_id AS sender_google_id, s.apple_id AS sender_apple_id
+          FROM notes n
+          LEFT JOIN users s ON s.id = n.sender_id
+          WHERE n.id = ?`,
     args: [noteId],
   });
   if (noteRes.rows.length === 0) {
@@ -213,7 +216,21 @@ notes.get('/:id/audio', async (c) => {
     return c.json({ error: 'Note has no stored audio', error_code: 'NOTE_AUDIO_MISSING' }, 404);
   }
 
-  const loaded = await loadAudioBytes(c, audioUrl);
+  // 음성 쪽지의 R2 오브젝트는 발신자가 만든 것이므로, 키의 소유자 segment 가
+  // 발신자(users.id PK 또는 JWT sub = google_id/apple_id)와 일치해야만 로드한다.
+  // 그래야 타인 네임스페이스(r2://voices/{victim}/...) 키를 쪽지에 끼워 넣어
+  // 생체 음성을 빼내는 cross-tenant 읽기(IDOR)를 막을 수 있다.
+  // (Apple 전용 계정은 키가 apple_id 로 네임스페이스되므로 apple_id 도 허용.)
+  const senderGoogleId =
+    typeof note.sender_google_id === 'string' ? note.sender_google_id : null;
+  const senderAppleId =
+    typeof note.sender_apple_id === 'string' ? note.sender_apple_id : null;
+  const ownerIds = [
+    senderId,
+    ...(senderGoogleId ? [senderGoogleId] : []),
+    ...(senderAppleId ? [senderAppleId] : []),
+  ];
+  const loaded = await loadAudioBytes(c, audioUrl, { kind: 'owner', ownerIds });
   if (!loaded) {
     if (audioUrl.startsWith('r2://')) {
       await db.execute({
@@ -263,13 +280,5 @@ notes.patch('/:id/read', async (c) => {
 
   return c.json({ success: true, read_at: now });
 });
-
-function isValidAudioUrl(audioUrl: string): boolean {
-  return audioUrl.length <= MAX_NOTE_AUDIO_URL_LENGTH &&
-    (
-      audioUrl.startsWith('r2://') ||
-      audioUrl.startsWith('https://')
-    );
-}
 
 export default notes;

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -23,6 +23,7 @@ import {
 } from '../lib/vertex-translate';
 import { loadTtsPresets, type TtsPreset } from '../lib/tts-presets';
 import { isPaidVoicePlan } from './billing-helpers';
+import { needsConsent } from '../lib/consent';
 import {
   type DynamicPromptSettings,
   EMPTY_DYNAMIC_PROMPT_SETTINGS,
@@ -701,6 +702,24 @@ tts.post('/generate', async (c) => {
 
   try {
     const requestedLanguage = normalizeSynthesisLanguage(body.language);
+
+    // 국외 이전 동의(B4): 동적 문구 생성(wake_weather/wake_fortune 등)과 번역은
+    // 텍스트를 국외(Google Vertex)로 전송하므로 overseas_transfer 동의가 필요하다.
+    // 동의가 없으면 해당 크로스보더 경로를 차단(403)한다. 프리셋·동일언어 비번역
+    // 합성은 국외 이전이 없어 게이트 대상이 아니다.
+    const willUseCrossBorder =
+      body.translate === true || (randomRequested && randomContext !== 'preset');
+    if (willUseCrossBorder && (await needsConsent(db, userPk, ['overseas_transfer']))) {
+      return c.json(
+        {
+          error: 'Overseas transfer consent is required for translation or dynamic generation.',
+          error_code: 'CONSENT_REQUIRED',
+          consent: 'overseas_transfer',
+        },
+        403,
+      );
+    }
+
     if (randomRequested && randomContext !== 'preset') {
       const alarmHour = optionalInt(body.alarm_hour ?? body.alarmHour, 0, 23);
       const alarmMinute = optionalInt(body.alarm_minute ?? body.alarmMinute, 0, 59);

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -315,9 +315,12 @@ user.delete('/me', async (c) => {
   const db = getDB(c.env);
 
   try {
+    // apple_id 도 함께 매칭한다. Apple 로그인 사용자의 JWT sub 는 google_id 가 아닌
+    // apple_id 컬럼에만 저장돼 있을 수 있어, 누락하면 userPk 가 null 이 되어 자식
+    // PII(생체 음성 등)가 고아로 남는다(auth.ts:94 의 조회 조건과 동일하게 맞춤).
     const userRes = await db.execute({
-      sql: `SELECT id FROM users WHERE google_id = ? OR id = ? LIMIT 1`,
-      args: [userId, userId],
+      sql: `SELECT id FROM users WHERE google_id = ? OR apple_id = ? OR id = ? LIMIT 1`,
+      args: [userId, userId, userId],
     });
     const userPk = userRes.rows.length > 0 ? String(userRes.rows[0]!.id) : null;
 
@@ -521,22 +524,28 @@ user.get('/search', async (c) => {
   const db = getDB(c.env);
   const q = (c.req.query('q') || '').trim();
 
-  if (q.length < 2) {
+  // PII 하베스팅 방지: 너무 짧은 질의로 광범위하게 긁지 못하도록 최소 4자를 요구한다.
+  if (q.length < 4) {
     return c.json({ users: [] });
   }
 
   try {
+    // 부분 문자열('%q%') 대신 접두(prefix) 매칭만 허용해 무차별 수집을 줄인다.
+    // LIKE 와일드카드(%,_) 는 리터럴로 이스케이프한다.
+    const escaped = q.replace(/[\\%_]/g, (ch) => `\\${ch}`);
     const result = await db.execute({
-      sql: `SELECT google_id, email, name, picture FROM users
-            WHERE google_id != ? AND email LIKE ?
+      sql: `SELECT google_id, name, picture FROM users
+            WHERE google_id != ? AND email LIKE ? ESCAPE '\\'
             LIMIT 10`,
-      args: [userId, `%${q}%`],
+      args: [userId, `${escaped}%`],
     });
 
     return c.json({
+      // 다른 사용자의 email 은 절대 반환하지 않는다(PII). iOS/Android 의
+      // UserSearchResult.email 은 옵셔널이라 null 로 두어도 디코딩이 깨지지 않는다.
       users: result.rows.map((r) => ({
         id: r.google_id,
-        email: r.email,
+        email: null,
         name: r.name,
         picture: r.picture,
       })),

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -15,6 +15,11 @@ import {
   dynamicPromptSettingsFromRow,
   validateDynamicPromptSettings,
 } from '../lib/dynamic-prompt-settings';
+import {
+  ALLOWED_CONSENT_TYPES,
+  REQUIRED_CONSENT_TYPES,
+  CURRENT_POLICY_VERSION,
+} from '../lib/consent';
 
 const user = new Hono<AppEnv>();
 
@@ -342,14 +347,8 @@ user.delete('/me', async (c) => {
   }
 });
 
-// 동의 기록 (개인정보보호법 제22조). 가입/이용 중 동의 사실을 누적 INSERT 로 보관한다.
-// consent_type: 'terms'(이용약관·필수), 'privacy'(개인정보·필수), 'marketing'(마케팅·선택),
-// 'age14'(만14세이상·필수). 동일 (user_id, consent_type) 최신 행이 현재 동의 상태.
-const ALLOWED_CONSENT_TYPES = new Set(['terms', 'privacy', 'marketing', 'age14']);
-// 가입/이용에 반드시 필요한 필수 동의. marketing(광고성 정보 수신) 은 선택이라 제외.
-const REQUIRED_CONSENT_TYPES = ['terms', 'privacy', 'age14'] as const;
-// 처리방침/약관 버전. 정책을 개정하면 이 값을 올려 기존 가입자 재동의를 유도한다.
-const CURRENT_POLICY_VERSION = '1';
+// 동의 설정(ALLOWED/REQUIRED/CURRENT_POLICY_VERSION)과 충족 판정 헬퍼(needsConsent)는
+// lib/consent.ts 로 일원화됐다(라우트 게이트 미들웨어와 공유). 여기서는 import 해 사용한다.
 const DELETION_GRACE_DAYS = 30;
 
 user.post('/consents', async (c) => {
@@ -378,7 +377,7 @@ user.post('/consents', async (c) => {
       version:
         typeof item.version === 'string' && item.version.trim()
           ? item.version.trim().slice(0, 40)
-          : '1',
+          : CURRENT_POLICY_VERSION,
       agreed: item.agreed === true || item.agreed === 1 || item.agreed === '1',
     });
   }
@@ -437,6 +436,8 @@ user.get('/consents/status', async (c) => {
   const userPk = c.get('userIdPK');
   const db = getDB(c.env);
   try {
+    // 미충족 유형 목록(missing)은 응답에 그대로 노출하므로 직접 계산하되, needs_consent
+    // 종합 판정은 게이트 미들웨어와 동일한 needsConsent 헬퍼로 일관성을 보장한다.
     const res = await db.execute({
       sql: `SELECT consent_type, policy_version, agreed
             FROM user_consents WHERE user_id = ? ORDER BY created_at DESC, rowid DESC`,

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -9,6 +9,7 @@ import { R2VoiceStorage } from '../lib/r2-storage';
 import { createEnrollmentAttempts, UnsupportedVoiceProviderError } from '../lib/voice-provider';
 import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import { isPaidVoicePlan } from './billing-helpers';
+import { needsConsent } from '../lib/consent';
 
 const voiceProfile = new Hono<AppEnv>();
 const MAX_VOICE_PROFILES = 1;
@@ -583,6 +584,19 @@ voiceProfile.post('/clone', async (c) => {
   let insertedProfileId: string | null = null;
 
   try {
+    // 생체정보(음성 클론) 별도 동의 필수(B4). 클론된 목소리는 개인을 식별·재현할 수
+    // 있는 생체정보이므로 voice_biometric 동의가 없으면 클로닝을 차단한다.
+    if (await needsConsent(db, userPk, ['voice_biometric'])) {
+      return c.json(
+        {
+          error: 'Voice biometric consent is required to clone a voice.',
+          error_code: 'CONSENT_REQUIRED',
+          consent: 'voice_biometric',
+        },
+        403,
+      );
+    }
+
     if (resolvedUserPk) {
       const userPlan = await db.execute({
         sql: 'SELECT plan FROM users WHERE id = ? OR google_id = ? LIMIT 1',

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -749,6 +749,95 @@ describe('PATCH /alarms/:id', () => {
     expect(updateCall!.args).toContain('sound-only');
   });
 
+  it('IDOR: 타인/미존재 message_id 로 수정 시 404 MESSAGE_NOT_FOUND', async () => {
+    const foreignMsg = '10000000-0000-4000-8000-0000000000aa';
+    // existing alarm → 존재 (소유자 본인)
+    mockDB.pushResult([{
+      id: ID.alarm,
+      message_id: ID.message,
+      mode: 'tts',
+      wake_mode: 'sound_then_voice',
+      voice_profile_id: null,
+      speaker_id: null,
+      raw_audio_url: null,
+      user_plan: 'personal',
+    }]);
+    // messageBelongsToCaller → 소유/프리셋 아님 (0 rows)
+    mockDB.pushResult([]);
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, { message_id: foreignMsg }),
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()).error_code).toBe('MESSAGE_NOT_FOUND');
+    // 소유권 미통과 시 UPDATE 가 실행되면 안 됨
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(false);
+  });
+
+  it('IDOR: 본인 소유 message_id 로 수정은 허용', async () => {
+    mockDB.pushResult([{
+      id: ID.alarm,
+      message_id: null,
+      mode: 'tts',
+      wake_mode: 'sound_then_voice',
+      voice_profile_id: null,
+      speaker_id: null,
+      raw_audio_url: null,
+      user_plan: 'personal',
+    }]);
+    // messageBelongsToCaller → 소유 확인 (1 row)
+    mockDB.pushResult([{ '1': 1 }]);
+    // UPDATE
+    mockDB.pushResult([], 1);
+    // SELECT updated
+    mockDB.pushResult([{
+      id: ID.alarm,
+      user_id: 'user-1',
+      target_user_id: null,
+      message_id: ID.message,
+      time: '07:30',
+      repeat_days: '[]',
+      is_active: 1,
+      snooze_minutes: 5,
+      mode: 'tts',
+      vibration_pattern: 'default',
+      wake_mode: 'sound_then_voice',
+      voice_profile_id: null,
+      speaker_id: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-02',
+    }]);
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, { message_id: ID.message }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(true);
+  });
+
+  it('IDOR: 타인/미존재 voice_profile_id 로 수정 시 404 VOICE_PROFILE_NOT_FOUND', async () => {
+    const foreignVp = '50000000-0000-4000-8000-0000000000aa';
+    mockDB.pushResult([{
+      id: ID.alarm,
+      message_id: ID.message,
+      mode: 'tts',
+      wake_mode: 'sound_then_voice',
+      voice_profile_id: null,
+      speaker_id: null,
+      raw_audio_url: null,
+      user_plan: 'personal',
+    }]);
+    // voiceProfileBelongsToCaller → 0 rows
+    mockDB.pushResult([]);
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, { voice_profile_id: foreignVp }),
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()).error_code).toBe('VOICE_PROFILE_NOT_FOUND');
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(false);
+  });
+
   it('voice_profile_id null 로 해제', async () => {
     mockDB.pushResult([{ id: ID.alarm }]);
     mockDB.pushResult([], 1);

--- a/packages/backend/test/alarm.test.ts
+++ b/packages/backend/test/alarm.test.ts
@@ -385,6 +385,7 @@ describe('PATCH /alarm/:id — 알람 수정', () => {
     const voiceProfileId = '40000000-0000-4000-8000-0000000000aa';
     const speakerId = '50000000-0000-4000-8000-0000000000bb';
     mockDB.pushResult([{ id: ID.alarm }]); // existing
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller → 소유 확인
     mockDB.pushResult([], 1); // update
     mockDB.pushResult([
       {

--- a/packages/backend/test/auth-logout.test.ts
+++ b/packages/backend/test/auth-logout.test.ts
@@ -1,0 +1,141 @@
+// B5: POST /auth/logout 가 token_epoch 를 +1 하고, 이후 옛 epoch 토큰이
+// authMiddleware 에서 TOKEN_REVOKED(401)로 거부되는지 검증.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv, Env } from '../src/types';
+
+const mockVerifyAppJwt = vi.fn();
+vi.mock('../src/lib/jwt', () => ({
+  verifyAppJwt: (...args: unknown[]) => mockVerifyAppJwt(...args),
+  signAppJwt: vi.fn(),
+  APP_JWT_ISSUER: 'voice-alarm',
+}));
+
+// 사용자 행 상태(token_epoch)를 변수로 제어한다. UPDATE 는 epoch 를 증가시킨다.
+let userTokenEpoch = 0;
+const dbCalls: Array<{ sql: string; args: unknown[] }> = [];
+vi.mock('../src/lib/db', () => ({
+  getDB: () => ({
+    execute: async (q: { sql: string; args?: unknown[] }) => {
+      dbCalls.push({ sql: q.sql, args: q.args ?? [] });
+      if (/UPDATE users\s+SET token_epoch = token_epoch \+ 1/i.test(q.sql)) {
+        userTokenEpoch += 1;
+        return { rows: [], rowsAffected: 1 };
+      }
+      if (/SELECT id, deletion_status, token_epoch FROM users/i.test(q.sql)) {
+        return {
+          rows: [{ id: 'pk-1', deletion_status: 'active', token_epoch: userTokenEpoch }],
+          rowsAffected: 0,
+        };
+      }
+      return { rows: [], rowsAffected: 0 };
+    },
+  }),
+}));
+
+import authRoutes from '../src/routes/auth';
+
+const ENV: Env = {
+  ELEVENLABS_API_KEY: 'x',
+  TURSO_DATABASE_URL: 'x',
+  TURSO_AUTH_TOKEN: 'x',
+  GOOGLE_CLIENT_ID: 'x',
+  APPLE_CLIENT_ID: 'a',
+  JWT_SECRET: 'test-secret-32-chars-or-longer!',
+  PASSWORD_PEPPER: 'pepper',
+  ENVIRONMENT: 'test',
+};
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route('/api/auth', authRoutes);
+  return app;
+}
+
+function encodePart(obj: Record<string, unknown>): string {
+  return btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+function token(): string {
+  return `${encodePart({ alg: 'RS256', typ: 'JWT' })}.${encodePart({ iss: 'voice-alarm', sub: 'user-1' })}.sig`;
+}
+function call(method: string, path: string) {
+  return buildApp().request(
+    new Request(`http://localhost${path}`, {
+      method,
+      headers: { Authorization: `Bearer ${token()}` },
+    }),
+    undefined,
+    ENV,
+  );
+}
+
+beforeEach(() => {
+  userTokenEpoch = 0;
+  dbCalls.length = 0;
+  mockVerifyAppJwt.mockReset();
+});
+
+describe('POST /auth/logout — 전 기기 로그아웃 (B5)', () => {
+  it('authMiddleware 통과 후 token_epoch 를 +1 하고 success 반환', async () => {
+    // logout 은 authMiddleware 를 거치므로 앱 JWT(epoch 0)를 검증 통과시킨다.
+    mockVerifyAppJwt.mockResolvedValue({
+      sub: 'user-1',
+      email: 'u@test.com',
+      name: 'U',
+      iss: 'voice-alarm',
+      aud: 'voice-alarm-clients',
+      epoch: 0,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const res = await call('POST', '/api/auth/logout');
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(userTokenEpoch).toBe(1);
+    expect(
+      dbCalls.some((c) => /UPDATE users\s+SET token_epoch = token_epoch \+ 1/i.test(c.sql)),
+    ).toBe(true);
+  });
+
+  it('인증 헤더 없으면 401 (authMiddleware 차단)', async () => {
+    const res = await buildApp().request(
+      new Request('http://localhost/api/auth/logout', { method: 'POST' }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(userTokenEpoch).toBe(0);
+  });
+});
+
+describe('authMiddleware — 로그아웃 후 옛 토큰 폐기 (B5)', () => {
+  it('로그아웃으로 epoch 가 오르면 이전 epoch 토큰은 TOKEN_REVOKED', async () => {
+    // 1) 로그아웃: epoch 0 토큰으로 통과 → users.token_epoch 1 로 증가.
+    mockVerifyAppJwt.mockResolvedValue({
+      sub: 'user-1',
+      email: 'u@test.com',
+      iss: 'voice-alarm',
+      aud: 'voice-alarm-clients',
+      epoch: 0,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const logoutRes = await call('POST', '/api/auth/logout');
+    expect(logoutRes.status).toBe(200);
+    expect(userTokenEpoch).toBe(1);
+
+    // 2) 동일한 옛 토큰(epoch 0)으로 보호 라우트 진입 시도 → 폐기됨.
+    const { authMiddleware } = await import('../src/middleware/auth');
+    const guarded = new Hono<AppEnv>();
+    guarded.use('*', authMiddleware);
+    guarded.get('/api/alarm', (c) => c.json({ ok: true }));
+    const res = await guarded.request(
+      new Request('http://localhost/api/alarm', {
+        headers: { Authorization: `Bearer ${token()}` },
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect((await res.json()).error_code).toBe('TOKEN_REVOKED');
+  });
+});

--- a/packages/backend/test/auth-middleware.test.ts
+++ b/packages/backend/test/auth-middleware.test.ts
@@ -64,44 +64,6 @@ function fakeToken(payload: Record<string, unknown>): string {
   return `${header}.${body}.fakesignature`;
 }
 
-function encodeBytes(bytes: Uint8Array): string {
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
-async function signedAppleToken(payload: Record<string, unknown>): Promise<string> {
-  const kid = crypto.randomUUID();
-  const keyPair = (await crypto.subtle.generateKey(
-    {
-      name: 'RSASSA-PKCS1-v1_5',
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: 'SHA-256',
-    },
-    true,
-    ['sign', 'verify'],
-  )) as CryptoKeyPair;
-  const publicJwk = await crypto.subtle.exportKey('jwk', keyPair.publicKey);
-  const header = encodeJwtPart({ alg: 'RS256', kid, typ: 'JWT' });
-  const body = encodeJwtPart(payload);
-  const unsigned = `${header}.${body}`;
-  const signature = await crypto.subtle.sign(
-    { name: 'RSASSA-PKCS1-v1_5' },
-    keyPair.privateKey,
-    new TextEncoder().encode(unsigned),
-  );
-
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: async () => ({ keys: [{ ...publicJwk, kid, alg: 'RS256', use: 'sig' }] }),
-  }) as unknown as typeof fetch;
-
-  return `${unsigned}.${encodeBytes(new Uint8Array(signature))}`;
-}
-
 const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
@@ -144,6 +106,8 @@ describe('authMiddleware — Authorization header 검증', () => {
   });
 
   it('토큰이 3파트가 아니면 401 AUTH_MALFORMED_TOKEN', async () => {
+    // 실서버의 verifyAppJwt 는 파트 수가 3 이 아니면 "Invalid token format" 을 던진다.
+    mockVerifyAppJwt.mockRejectedValue(new Error('Invalid token format'));
     const app = buildApp();
     const res = await reqWithEnv(app, req('Bearer not-a-jwt'));
     expect(res.status).toBe(401);
@@ -152,6 +116,7 @@ describe('authMiddleware — Authorization header 검증', () => {
   });
 
   it('토큰이 2파트만 있으면 401 AUTH_MALFORMED_TOKEN', async () => {
+    mockVerifyAppJwt.mockRejectedValue(new Error('Invalid token format'));
     const app = buildApp();
     const res = await reqWithEnv(app, req('Bearer part1.part2'));
     expect(res.status).toBe(401);
@@ -269,237 +234,72 @@ describe('authMiddleware — App JWT (voice-alarm issuer)', () => {
   });
 });
 
-describe('authMiddleware — Google token', () => {
-  it('유효한 Google 토큰 시 context에 사용자 정보 설정', async () => {
-    const payload = {
+// B5: provider(Google/Apple) ID 토큰을 Bearer 로 직접 들고 오는 경로는 제거됐다.
+// 이제 authMiddleware 는 자체 발급 앱 JWT 만 받으며, 모든 토큰은 verifyAppJwt 로만
+// 검증된다. provider 토큰 교환은 /auth/google·/auth/apple 에서만 이뤄진다.
+describe('authMiddleware — provider ID 토큰 직접 수용 거부 (app-JWT-only)', () => {
+  it('Google ID 토큰을 직접 들고 오면 verifyAppJwt 가 거부 → 401', async () => {
+    const token = fakeToken({
       sub: 'google-user-123',
-      email: 'user@gmail.com',
-      name: 'Google User',
-      picture: 'https://lh3.googleusercontent.com/photo.jpg',
       iss: 'accounts.google.com',
-      email_verified: true,
-      aud: 'test-google-client-id',
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = fakeToken(payload);
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    }) as unknown as typeof fetch;
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.userId).toBe('google-user-123');
-    expect(body.userEmail).toBe('user@gmail.com');
-    expect(body.userName).toBe('Google User');
-    expect(body.userPicture).toBe('https://lh3.googleusercontent.com/photo.jpg');
-  });
-
-  it('Google API가 에러 반환하면 401', async () => {
-    const token = fakeToken({
-      sub: 'g-user',
-      iss: 'accounts.google.com',
-      email_verified: true,
       aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 400,
-      json: async () => ({ error: 'Invalid token' }),
-    }) as unknown as typeof fetch;
+    // 앱 JWT 가 아니므로 서명 검증 실패를 흉내낸다(실서버의 verifyAppJwt 와 동일 결과).
+    mockVerifyAppJwt.mockRejectedValue(new Error('Signature verification failed'));
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
 
     const app = buildApp();
     const res = await reqWithEnv(app, req(`Bearer ${token}`));
     expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error_code).toBe('AUTH_VERIFICATION_FAILED');
+    // provider 검증 경로가 사라졌으므로 외부 JWKS fetch 는 호출되지 않는다.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // 모든 토큰은 앱 JWT 검증으로만 흐른다.
+    expect(mockVerifyAppJwt).toHaveBeenCalledWith(token, ENV.JWT_SECRET);
   });
 
-  it('Google 토큰 audience 불일치 시 AUTH_AUDIENCE_MISMATCH', async () => {
-    const payload = {
-      sub: 'g-user',
-      iss: 'accounts.google.com',
-      email_verified: true,
-      aud: 'wrong-client-id',
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = fakeToken(payload);
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    }) as unknown as typeof fetch;
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error_code).toBe('AUTH_AUDIENCE_MISMATCH');
-  });
-
-  it('Google 토큰 만료 시 AUTH_TOKEN_EXPIRED', async () => {
-    const payload = {
-      sub: 'g-user',
-      iss: 'accounts.google.com',
-      email_verified: true,
-      aud: 'test-google-client-id',
-      exp: Math.floor(Date.now() / 1000) - 3600,
-    };
-    const token = fakeToken(payload);
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    }) as unknown as typeof fetch;
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error_code).toBe('AUTH_TOKEN_EXPIRED');
-  });
-
-  it('fetch 네트워크 에러 시 401', async () => {
+  it('Apple ID 토큰을 직접 들고 오면 verifyAppJwt 가 거부 → 401', async () => {
     const token = fakeToken({
-      sub: 'g-user',
-      iss: 'accounts.google.com',
-      email_verified: true,
-      aud: 'test-google-client-id',
+      sub: 'apple-user-001',
+      iss: 'https://appleid.apple.com',
+      aud: ENV.APPLE_CLIENT_ID,
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
-
-    globalThis.fetch = vi
-      .fn()
-      .mockRejectedValue(new Error('Network error')) as unknown as typeof fetch;
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(401);
-  });
-});
-
-describe('authMiddleware — Apple token', () => {
-  it('유효한 Apple 토큰 시 context에 사용자 정보 설정', async () => {
-    const payload = {
-      sub: 'apple-user-001',
-      email: 'user@privaterelay.appleid.com',
-      iss: 'https://appleid.apple.com',
-      email_verified: true,
-      aud: ENV.APPLE_CLIENT_ID,
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = await signedAppleToken(payload);
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.userId).toBe('apple-user-001');
-    expect(body.userEmail).toBe('user@privaterelay.appleid.com');
-    expect(body.userName).toBe('');
-    expect(body.userPicture).toBe('');
-  });
-
-  it('Apple 토큰 만료 시 AUTH_TOKEN_EXPIRED', async () => {
-    const payload = {
-      sub: 'apple-user-001',
-      email: 'user@apple.com',
-      iss: 'https://appleid.apple.com',
-      email_verified: true,
-      aud: ENV.APPLE_CLIENT_ID,
-      exp: Math.floor(Date.now() / 1000) - 3600,
-    };
-    const token = await signedAppleToken(payload);
+    mockVerifyAppJwt.mockRejectedValue(new Error('Invalid issuer'));
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
 
     const app = buildApp();
     const res = await reqWithEnv(app, req(`Bearer ${token}`));
     expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error_code).toBe('AUTH_TOKEN_EXPIRED');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockVerifyAppJwt).toHaveBeenCalled();
   });
 
-  it('Apple 토큰 email 없으면 빈 문자열', async () => {
-    const payload = {
-      sub: 'apple-user-002',
-      iss: 'https://appleid.apple.com',
-      email_verified: true,
-      aud: ENV.APPLE_CLIENT_ID,
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = await signedAppleToken(payload);
-
-    const app = buildApp();
-    const res = await reqWithEnv(app, req(`Bearer ${token}`));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.userId).toBe('apple-user-002');
-    expect(body.userEmail).toBe('');
-  });
-
-  // 회귀: Authorization 헤더로 직접 Apple id_token 을 들고 오는 경로는
-  // nonce 비교가 불가능하므로 (raw nonce 가 없음) 기존 동작이 유지되어야 한다.
-  // 즉 토큰에 nonce 클레임이 있어도 미들웨어는 통과시킨다.
-  it('토큰에 nonce 클레임이 있어도 미들웨어는 nonce 검사 없이 통과한다', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const payload = {
-        sub: 'apple-user-mw-nonce',
-        email: 'mw-nonce@apple.com',
-        iss: 'https://appleid.apple.com',
-      email_verified: true,
-        aud: ENV.APPLE_CLIENT_ID,
-        exp: Math.floor(Date.now() / 1000) + 3600,
-        nonce: 'a'.repeat(64),
-      };
-      const token = await signedAppleToken(payload);
-
-      const app = buildApp();
-      const res = await reqWithEnv(app, req(`Bearer ${token}`));
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body.userId).toBe('apple-user-mw-nonce');
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-});
-
-describe('authMiddleware — 토큰 발급자 분기', () => {
-  it('알 수 없는 issuer는 거부한다', async () => {
-    const payload = {
+  it('알 수 없는 issuer 토큰도 앱 JWT 검증 실패로 401', async () => {
+    const token = fakeToken({
       sub: 'user-unknown',
       iss: 'https://unknown-issuer.example.com',
-      aud: 'test-google-client-id',
       exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = fakeToken(payload);
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    }) as unknown as typeof fetch;
+    });
+    mockVerifyAppJwt.mockRejectedValue(new Error('Invalid issuer'));
 
     const app = buildApp();
     const res = await reqWithEnv(app, req(`Bearer ${token}`));
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error_code).toBe('AUTH_INVALID_ISSUER');
-    expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(mockVerifyAppJwt).not.toHaveBeenCalled();
   });
 
-  it('voice-alarm issuer는 앱 JWT 경로', async () => {
+  it('voice-alarm issuer(앱 JWT)는 정상 통과', async () => {
     const token = fakeToken({ iss: 'voice-alarm', sub: 'u1', email: 'e@t.com' });
     mockVerifyAppJwt.mockResolvedValue({
       sub: 'u1',
       email: 'e@t.com',
       iss: 'voice-alarm',
       aud: 'voice-alarm-clients',
+      epoch: 0,
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
 
@@ -508,22 +308,51 @@ describe('authMiddleware — 토큰 발급자 분기', () => {
     expect(res.status).toBe(200);
     expect(mockVerifyAppJwt).toHaveBeenCalled();
   });
+});
 
-  it('appleid.apple.com issuer는 Apple JWKS 검증 경로', async () => {
-    const payload = {
-      sub: 'apple-u',
-      iss: 'https://appleid.apple.com',
-      email_verified: true,
-      aud: ENV.APPLE_CLIENT_ID,
+describe('authMiddleware — 토큰 폐기(token_epoch) 검사 (B5)', () => {
+  it('JWT epoch < users.token_epoch 이면 401 TOKEN_REVOKED', async () => {
+    const token = fakeToken({ iss: 'voice-alarm', sub: 'user-1' });
+    mockVerifyAppJwt.mockResolvedValue({
+      sub: 'user-1',
+      email: 'test@test.com',
+      name: 'Test',
+      iss: 'voice-alarm',
+      aud: 'voice-alarm-clients',
+      epoch: 0,
       exp: Math.floor(Date.now() / 1000) + 3600,
-    };
-    const token = await signedAppleToken(payload);
+    });
+    // 사용자의 현재 token_epoch 가 토큰의 epoch(0)보다 크다 → 폐기된 토큰.
+    mockDbExecute.mockResolvedValue({
+      rows: [{ id: 'pk-1', deletion_status: 'active', token_epoch: 1 }],
+      rowsAffected: 0,
+    });
+
+    const app = buildApp();
+    const res = await reqWithEnv(app, req(`Bearer ${token}`));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error_code).toBe('TOKEN_REVOKED');
+  });
+
+  it('JWT epoch >= users.token_epoch 이면 통과', async () => {
+    const token = fakeToken({ iss: 'voice-alarm', sub: 'user-1' });
+    mockVerifyAppJwt.mockResolvedValue({
+      sub: 'user-1',
+      email: 'test@test.com',
+      name: 'Test',
+      iss: 'voice-alarm',
+      aud: 'voice-alarm-clients',
+      epoch: 2,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    mockDbExecute.mockResolvedValue({
+      rows: [{ id: 'pk-1', deletion_status: 'active', token_epoch: 2 }],
+      rowsAffected: 0,
+    });
 
     const app = buildApp();
     const res = await reqWithEnv(app, req(`Bearer ${token}`));
     expect(res.status).toBe(200);
-    expect(globalThis.fetch).toHaveBeenCalled();
-    expect(mockVerifyAppJwt).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -105,8 +105,9 @@ function registerBody(email: string, password = 'superSecret1', name = '김규�
 
 describe('POST /auth/email-code', () => {
   it('신규 이메일에 6자리 인증 코드를 발급한다', async () => {
-    mockDB.pushResult([]);
-    mockDB.pushResult([], 1);
+    mockDB.pushResult([]); // existing user lookup (none)
+    mockDB.pushResult([]); // recent codes (none → no cooldown/cap)
+    mockDB.pushResult([], 1); // INSERT
 
     const app = buildApp();
     const res = await app.request(
@@ -119,10 +120,11 @@ describe('POST /auth/email-code', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.debug_code).toMatch(/^\d{6}$/);
-    expect(mockDB.calls[1]?.args[1]).toBe('kim@test.com');
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
+    expect(insertCall?.args[1]).toBe('kim@test.com');
   });
 
-  it('이미 가입된 이메일에는 인증 코드를 보내지 않는다', async () => {
+  it('이미 가입된 이메일에도 동일한 성공 응답을 반환한다(회원 여부 비노출)', async () => {
     mockDB.pushResult([{ id: 'u-1' }]);
 
     const app = buildApp();
@@ -132,9 +134,64 @@ describe('POST /auth/email-code', () => {
       ENV,
     );
 
-    expect(res.status).toBe(409);
+    // 계정 열거 방지: 409/AUTH_EMAIL_TAKEN 대신 신규 이메일과 동일한 성공 응답.
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error_code).toBe('AUTH_EMAIL_TAKEN');
+    expect(body.success).toBe(true);
+    expect(body.error_code).toBeUndefined();
+    // 코드를 발송/삽입하지 않으므로 debug_code 도 없다.
+    expect(body.debug_code).toBeUndefined();
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
+    expect(insertCall).toBeUndefined();
+  });
+
+  it('쿨다운 내 재요청은 새 코드를 보내지 않고 동일 응답을 반환한다', async () => {
+    mockDB.pushResult([]); // existing user lookup (none)
+    // 최근(쿨다운 내) 미만료 코드가 존재
+    mockDB.pushResult([
+      {
+        created_at: new Date(Date.now() - 5 * 1000).toISOString(),
+        expires_at: new Date(Date.now() + 9 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/email-code', { email: 'cooldown@test.com' }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.debug_code).toBeUndefined();
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
+    expect(insertCall).toBeUndefined();
+  });
+
+  it('일일 발급 상한 초과 시 새 코드를 보내지 않는다', async () => {
+    mockDB.pushResult([]); // existing user lookup (none)
+    // 24시간 내 발급 건수가 상한(10) 이상 — 모두 만료된 오래된 코드라도 카운트
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      created_at: new Date(Date.now() - (i + 2) * 60 * 1000).toISOString(),
+      expires_at: new Date(Date.now() - (i + 1) * 60 * 1000).toISOString(),
+    }));
+    mockDB.pushResult(rows);
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/email-code', { email: 'capped@test.com' }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.debug_code).toBeUndefined();
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
+    expect(insertCall).toBeUndefined();
   });
 });
 
@@ -179,10 +236,10 @@ describe('POST /auth/email-code/verify', () => {
 
 describe('POST /auth/register', () => {
   it('신규 가입 성공 → 201 + 토큰 반환', async () => {
-    mockDB.pushResult([]);
-    await pushValidEmailVerification('kim@test.com');
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    await pushValidEmailVerification('kim@test.com'); // 1) 코드 검증 SELECT
+    mockDB.pushResult([]); // 2) 기존 이메일 SELECT (없음)
+    mockDB.pushResult([], 1); // 3) INSERT users
+    mockDB.pushResult([], 1); // 4) consume code UPDATE
 
     const app = buildApp();
     const res = await app.request(
@@ -199,8 +256,9 @@ describe('POST /auth/register', () => {
     expect(insertCall?.args[0]).toBe(body.user.id);
   });
 
-  it('중복 이메일 → 409', async () => {
-    mockDB.pushResult([{ id: 'u-1' }]);
+  it('중복 이메일은 회원 여부를 노출하지 않고 generic 코드 무효 응답을 반환한다', async () => {
+    await pushValidEmailVerification('kim@test.com'); // 코드 검증 통과
+    mockDB.pushResult([{ id: 'u-1' }]); // 기존 이메일 존재
 
     const app = buildApp();
     const res = await app.request(
@@ -208,9 +266,12 @@ describe('POST /auth/register', () => {
       undefined,
       ENV,
     );
-    expect(res.status).toBe(409);
+    // 계정 열거 방지: 409/AUTH_EMAIL_TAKEN 대신 generic AUTH_EMAIL_CODE_INVALID(400).
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error_code).toBe('AUTH_EMAIL_TAKEN');
+    expect(body.error_code).toBe('AUTH_EMAIL_CODE_INVALID');
+    const insertCall = mockDB.calls.find((call) => call.sql.includes('INSERT INTO users'));
+    expect(insertCall).toBeUndefined();
   });
 
   it('약한 비밀번호 → 400', async () => {
@@ -325,7 +386,7 @@ describe('POST /auth/login', () => {
     expect(res.status).toBe(401);
   });
 
-  it('OAuth 전용 계정(비밀번호 없음) → 401 OAUTH_ONLY', async () => {
+  it('OAuth 전용 계정(비밀번호 없음) → 401 generic (가입 방식 비노출)', async () => {
     mockDB.pushResult([
       {
         id: 'u-1',
@@ -344,9 +405,27 @@ describe('POST /auth/login', () => {
       undefined,
       ENV,
     );
+    // 계정 열거 방지: AUTH_OAUTH_ONLY 로 가입 방식을 노출하지 않고 generic 응답.
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error_code).toBe('AUTH_OAUTH_ONLY');
+    expect(body.error_code).toBe('AUTH_INVALID_CREDENTIALS');
+  });
+
+  it('존재하지 않는 사용자도 generic 응답 + 더미 bcrypt 비교 수행', async () => {
+    mockDB.pushResult([]); // 사용자 없음
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/login', {
+        email: 'ghost@test.com',
+        password: 'superSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    // 존재하지 않는 이메일과 비밀번호 불일치가 동일한 error_code 를 반환한다.
+    expect(body.error_code).toBe('AUTH_INVALID_CREDENTIALS');
   });
 });
 
@@ -776,8 +855,8 @@ describe('GET /auth/me', () => {
   });
 
   it('가입 후 받은 토큰으로 /auth/me 호출 성공', async () => {
-    mockDB.pushResult([]);
     await pushValidEmailVerification('kim@test.com');
+    mockDB.pushResult([]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
@@ -831,8 +910,8 @@ describe('GET /auth/me', () => {
   });
 
   it('삭제된 사용자 토큰 → 404 AUTH_USER_NOT_FOUND', async () => {
-    mockDB.pushResult([]);
     await pushValidEmailVerification('ghost@test.com');
+    mockDB.pushResult([]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
@@ -860,8 +939,8 @@ describe('GET /auth/me', () => {
   });
 
   it('/me 응답의 null name/plan → 기본값 매핑', async () => {
-    mockDB.pushResult([]);
     await pushValidEmailVerification('null-test@test.com');
+    mockDB.pushResult([]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
 
@@ -896,10 +975,10 @@ describe('GET /auth/me', () => {
 
 describe('POST /auth/register — 엣지 케이스', () => {
   it('이메일 대소문자 정규화 (KIM@Test.COM → kim@test.com)', async () => {
-    mockDB.pushResult([]);
-    await pushValidEmailVerification('kim@test.com');
-    mockDB.pushResult([], 1);
-    mockDB.pushResult([], 1);
+    await pushValidEmailVerification('kim@test.com'); // 1) 코드 검증 SELECT
+    mockDB.pushResult([]); // 2) 기존 이메일 SELECT
+    mockDB.pushResult([], 1); // 3) INSERT
+    mockDB.pushResult([], 1); // 4) consume
 
     const app = buildApp();
     const res = await app.request(
@@ -911,7 +990,7 @@ describe('POST /auth/register — 엣지 케이스', () => {
     const body = await res.json();
     expect(body.user.email).toBe('kim@test.com');
 
-    const insertCall = mockDB.calls[2];
+    const insertCall = mockDB.calls.find((call) => call.sql.includes('INSERT INTO users'));
     expect(insertCall?.args[1]).toBe('kim@test.com');
   });
 
@@ -946,14 +1025,15 @@ describe('POST /auth/register — 엣지 케이스', () => {
   });
 
   it('DB INSERT 실패 → 500 AUTH_REGISTER_FAILED', async () => {
-    mockDB.pushResult([]);
-    await pushValidEmailVerification('fail@test.com');
+    await pushValidEmailVerification('fail@test.com'); // 1) 코드 검증 SELECT
+    mockDB.pushResult([]); // 2) 기존 이메일 SELECT (없음)
 
     const originalExecute = mockDB.client.execute;
     let callCount = 0;
     mockDB.client.execute = async (query: { sql: string; args: (string | number | null)[] }) => {
       callCount++;
       if (callCount === 3) {
+        // 3) INSERT INTO users 단계에서 실패
         throw new Error('DB connection lost');
       }
       return originalExecute(query);

--- a/packages/backend/test/consent.test.ts
+++ b/packages/backend/test/consent.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv, Env } from '../src/types';
+import { createMockDB } from './helpers';
+import {
+  needsConsent,
+  GENERAL_REQUIRED_CONSENTS,
+  SENSITIVE_REQUIRED_CONSENTS,
+  ALLOWED_CONSENT_TYPES,
+  CURRENT_POLICY_VERSION,
+} from '../src/lib/consent';
+
+// consentMiddleware 가 getDB 로 user_consents 를 조회한다. 게이트 테스트에서 동의 상태를
+// 제어하기 위해 mock 한다. vi.mock 은 파일 상단으로 호이스트되며 factory 는 'mock' 으로
+// 시작하는 변수만 참조할 수 있어 mockConsentRows 로 명명한다.
+let mockConsentRows: Array<{ consent_type: string; policy_version: string; agreed: number }> = [];
+vi.mock('../src/lib/db', () => ({
+  getDB: () => ({
+    execute: async (q: { sql: string }) => {
+      if (/FROM user_consents/i.test(q.sql)) {
+        return { rows: mockConsentRows, rowsAffected: 0 };
+      }
+      return { rows: [], rowsAffected: 0 };
+    },
+  }),
+}));
+
+const ENV: Env = {
+  ELEVENLABS_API_KEY: 'x',
+  TURSO_DATABASE_URL: 'x',
+  TURSO_AUTH_TOKEN: 'x',
+  GOOGLE_CLIENT_ID: 'x',
+  JWT_SECRET: 'test-secret-32-chars-or-longer!',
+  PASSWORD_PEPPER: 'pepper',
+  ENVIRONMENT: 'test',
+};
+
+function consentRow(type: string, agreed = 1, version = CURRENT_POLICY_VERSION) {
+  return { consent_type: type, policy_version: version, agreed };
+}
+
+describe('lib/consent — config', () => {
+  it('새 민감 동의 유형(voice_biometric/overseas_transfer)이 ALLOWED 에 포함', () => {
+    expect(ALLOWED_CONSENT_TYPES.has('voice_biometric')).toBe(true);
+    expect(ALLOWED_CONSENT_TYPES.has('overseas_transfer')).toBe(true);
+  });
+  it('일반/민감 필수 목록이 분리돼 있다', () => {
+    expect([...GENERAL_REQUIRED_CONSENTS]).toEqual(['terms', 'privacy', 'age14']);
+    expect([...SENSITIVE_REQUIRED_CONSENTS]).toEqual(['voice_biometric', 'overseas_transfer']);
+  });
+});
+
+describe('lib/consent — needsConsent', () => {
+  let mockDB: ReturnType<typeof createMockDB>;
+  beforeEach(() => {
+    mockDB = createMockDB();
+    // needsConsent 가 user_consents 를 조회하므로 missing 모드로 두고 직접 결과를 push 한다.
+    mockDB.setConsentMissing(true);
+  });
+
+  it('필수 동의가 모두 기록·동의·최신버전이면 false', async () => {
+    mockDB.pushResult([
+      consentRow('terms'),
+      consentRow('privacy'),
+      consentRow('age14'),
+    ]);
+    expect(await needsConsent(mockDB.client as never, 'pk-1', GENERAL_REQUIRED_CONSENTS)).toBe(false);
+  });
+
+  it('한 유형이라도 미기록이면 true', async () => {
+    mockDB.pushResult([consentRow('terms'), consentRow('privacy')]);
+    expect(await needsConsent(mockDB.client as never, 'pk-1', GENERAL_REQUIRED_CONSENTS)).toBe(true);
+  });
+
+  it('미동의(agreed=0)이면 true', async () => {
+    mockDB.pushResult([
+      consentRow('terms'),
+      consentRow('privacy'),
+      consentRow('age14', 0),
+    ]);
+    expect(await needsConsent(mockDB.client as never, 'pk-1', GENERAL_REQUIRED_CONSENTS)).toBe(true);
+  });
+
+  it('정책 버전이 현재와 다르면 true', async () => {
+    mockDB.pushResult([
+      consentRow('terms'),
+      consentRow('privacy'),
+      consentRow('age14', 1, '0'),
+    ]);
+    expect(await needsConsent(mockDB.client as never, 'pk-1', GENERAL_REQUIRED_CONSENTS)).toBe(true);
+  });
+
+  it('동일 유형 최신 1건만 본다 (가장 먼저 온 행이 최신)', async () => {
+    // ORDER BY created_at DESC, rowid DESC → 첫 행이 최신. 최신이 동의면 통과.
+    mockDB.pushResult([
+      consentRow('terms', 1),
+      consentRow('terms', 0), // 과거 미동의 이력 — 무시돼야 함
+      consentRow('privacy'),
+      consentRow('age14'),
+    ]);
+    expect(await needsConsent(mockDB.client as never, 'pk-1', GENERAL_REQUIRED_CONSENTS)).toBe(false);
+  });
+
+  it('빈 requiredTypes 는 항상 false (쿼리 없이)', async () => {
+    expect(await needsConsent(mockDB.client as never, 'pk-1', [])).toBe(false);
+  });
+});
+
+// ---- consentMiddleware (라우트 게이트) ----
+import { consentMiddleware } from '../src/middleware/consent';
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  // authMiddleware 대체: userIdPK 를 심는다.
+  app.use('*', async (c, next) => {
+    c.set('userId', 'user-1');
+    c.set('userIdPK', 'pk-1');
+    await next();
+  });
+  app.use('*', consentMiddleware);
+  app.get('/api/alarm', (c) => c.json({ ok: 'data-route' }));
+  app.post('/api/voice/clone', (c) => c.json({ ok: 'clone' }));
+  app.get('/api/user/me', (c) => c.json({ ok: 'me' }));
+  app.get('/api/user/consents/status', (c) => c.json({ ok: 'status' }));
+  app.post('/api/user/consents', (c) => c.json({ ok: 'record' }));
+  app.delete('/api/user/me/deletion', (c) => c.json({ ok: 'cancel-deletion' }));
+  app.get('/api/app/version', (c) => c.json({ ok: 'version' }));
+  app.get('/api/holiday', (c) => c.json({ ok: 'holiday' }));
+  return app;
+}
+
+function call(method: string, path: string) {
+  return buildApp().request(
+    new Request(`http://localhost${path}`, { method }),
+    undefined,
+    ENV,
+  );
+}
+
+describe('consentMiddleware — 데이터 라우트 게이트 (B4)', () => {
+  beforeEach(() => {
+    mockConsentRows = [];
+  });
+
+  it('필수 동의 없으면 데이터 라우트 403 CONSENT_REQUIRED', async () => {
+    mockConsentRows = [];
+    const res = await call('GET', '/api/alarm');
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('CONSENT_REQUIRED');
+  });
+
+  it('필수 동의 기록 후 데이터 라우트 통과', async () => {
+    mockConsentRows = [
+      consentRow('terms'),
+      consentRow('privacy'),
+      consentRow('age14'),
+    ];
+    const res = await call('GET', '/api/alarm');
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe('data-route');
+  });
+
+  it.each([
+    ['GET', '/api/user/me'],
+    ['GET', '/api/user/consents/status'],
+    ['POST', '/api/user/consents'],
+    ['DELETE', '/api/user/me/deletion'],
+    ['GET', '/api/app/version'],
+    ['GET', '/api/holiday'],
+  ])('면제 경로 %s %s 는 동의 없이도 통과', async (method, path) => {
+    mockConsentRows = [];
+    const res = await call(method, path);
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -31,14 +31,52 @@ export function createMockDB() {
     transactions.commits = 0;
     transactions.rollbacks = 0;
     transactions.closes = 0;
+    consentResultsAllowMissing = false;
   }
 
   function clearResults() {
     results.length = 0;
   }
 
+  // 동의 게이트(B4)용 기본 응답. needsConsent / consentMiddleware 가 user_consents 를
+  // 조회하는데, 기존 라우트 단위 테스트들은 이 부수 쿼리를 위해 결과를 push 하지 않는다.
+  // 결과 큐를 소비하지 않고(=기존 push 순서/인덱스 보존), 모든 필수 동의를 '동의함'으로
+  // 합성해 돌려준다. 동의 미충족 시나리오를 검증하려면 consentResultsAllowMissing 를
+  // false 로 두고 직접 user_consents 결과를 push 하면 된다.
+  let consentResultsAllowMissing = false;
+  const CONSENT_TYPES_FOR_MOCK = [
+    'terms',
+    'privacy',
+    'age14',
+    'voice_biometric',
+    'overseas_transfer',
+  ];
+  function setConsentMissing(missing: boolean) {
+    consentResultsAllowMissing = missing;
+  }
+
   const client = {
     execute: async (query: { sql: string; args: (string | number | null)[] }) => {
+      // user_consents 조회 처리:
+      //  - 기본(consentResultsAllowMissing=false): 큐 소비/ calls 기록 없이 모든 필수
+      //    동의를 '동의함'으로 합성해 돌려준다. 기존 라우트 테스트의 push 순서·calls[N]
+      //    인덱스 단언을 보존하기 위한 부수 쿼리 격리.
+      //  - missing 모드(true): 동의 상태를 테스트가 직접 제어하도록 큐에서 결과를
+      //    꺼내 반환한다(동의 미충족/부분 동의 시나리오 검증용). calls 에는 기록한다.
+      if (/FROM user_consents/i.test(query.sql)) {
+        if (consentResultsAllowMissing) {
+          calls.push({ sql: query.sql, args: query.args });
+          return results.shift() ?? { rows: [], rowsAffected: 0 };
+        }
+        return {
+          rows: CONSENT_TYPES_FOR_MOCK.map((t) => ({
+            consent_type: t,
+            policy_version: '1',
+            agreed: 1,
+          })),
+          rowsAffected: 0,
+        };
+      }
       calls.push({ sql: query.sql, args: query.args });
       return results.shift() ?? { rows: [], rowsAffected: 0 };
     },
@@ -68,7 +106,7 @@ export function createMockDB() {
     },
   };
 
-  return { client, calls, pushResult, reset, clearResults, transactions };
+  return { client, calls, pushResult, reset, clearResults, transactions, setConsentMissing };
 }
 
 export function fakeAuthMiddleware(userId = 'user-1', email = 'user@test.com') {

--- a/packages/backend/test/init-db-guard.test.ts
+++ b/packages/backend/test/init-db-guard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// initDB 가 호출되면 성공하지만, 가드(404)에서 막히면 호출 자체가 없어야 한다.
+const initDBMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => ({
+    execute: vi.fn().mockResolvedValue({ rows: [] }),
+  }),
+  initDB: initDBMock,
+}));
+
+import app from '../src/index';
+
+const baseEnv = {
+  TURSO_DATABASE_URL: 'mock',
+  TURSO_AUTH_TOKEN: 'mock',
+} as never;
+
+function post(path: string, env: Record<string, unknown>, headers: Record<string, string> = {}) {
+  return app.fetch(new Request(`http://localhost${path}`, { method: 'POST', headers }), env as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/init-db — secret guard (FIX 8)', () => {
+  it('비프로덕션이라도 시크릿 미설정이면 404 (익명 차단)', async () => {
+    const res = await post('/api/init-db', { ...baseEnv, ENVIRONMENT: 'development' });
+    expect(res.status).toBe(404);
+    expect(initDBMock).not.toHaveBeenCalled();
+  });
+
+  it('시크릿 설정돼 있어도 헤더 없으면 404', async () => {
+    const res = await post('/api/init-db', {
+      ...baseEnv,
+      ENVIRONMENT: 'development',
+      INIT_DB_SECRET: 's3cret',
+    });
+    expect(res.status).toBe(404);
+    expect(initDBMock).not.toHaveBeenCalled();
+  });
+
+  it('잘못된 헤더면 404', async () => {
+    const res = await post(
+      '/api/init-db',
+      { ...baseEnv, ENVIRONMENT: 'development', INIT_DB_SECRET: 's3cret' },
+      { 'x-init-db-secret': 'wrong' },
+    );
+    expect(res.status).toBe(404);
+    expect(initDBMock).not.toHaveBeenCalled();
+  });
+
+  it('production 도 동일하게 시크릿 헤더 요구', async () => {
+    const res = await post('/api/init-db', {
+      ...baseEnv,
+      ENVIRONMENT: 'production',
+      INIT_DB_SECRET: 's3cret',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('올바른 시크릿 헤더면 통과해 initDB 실행', async () => {
+    const res = await post(
+      '/api/init-db',
+      { ...baseEnv, ENVIRONMENT: 'development', INIT_DB_SECRET: 's3cret' },
+      { 'x-init-db-secret': 's3cret' },
+    );
+    expect(res.status).toBe(200);
+    expect(initDBMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /api/admin/seed-stock-clips — shares same guard (FIX 8)', () => {
+  it('시크릿 미설정이면 404', async () => {
+    const res = await post('/api/admin/seed-stock-clips', {
+      ...baseEnv,
+      ENVIRONMENT: 'development',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('헤더 없으면 404', async () => {
+    const res = await post('/api/admin/seed-stock-clips', {
+      ...baseEnv,
+      ENVIRONMENT: 'development',
+      INIT_DB_SECRET: 's3cret',
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('init-db error body does not leak internals (FIX 9)', () => {
+  it('initDB 가 SQL 내부 메시지로 throw 해도 detail 을 반사하지 않는다', async () => {
+    initDBMock.mockRejectedValueOnce(new Error('SQLITE_ERROR: near "FROM": syntax error'));
+    const res = await post(
+      '/api/init-db',
+      { ...baseEnv, ENVIRONMENT: 'development', INIT_DB_SECRET: 's3cret' },
+      { 'x-init-db-secret': 's3cret' },
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('DB init failed');
+    expect(body.detail).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain('SQLITE_ERROR');
+  });
+});

--- a/packages/backend/test/integration-smoke.test.ts
+++ b/packages/backend/test/integration-smoke.test.ts
@@ -71,8 +71,23 @@ describe('Health & Public Routes', () => {
     expect(body.presets.length).toBeGreaterThan(0);
   });
 
-  it('POST /api/init-db → 200 DB 초기화', async () => {
+  it('POST /api/init-db → 시크릿 미설정(비프로덕션)이면 404 (익명 차단)', async () => {
+    // FIX 8: canRunInitDb 는 모든 환경에서 x-init-db-secret 를 요구한다.
+    // INIT_DB_SECRET 가 설정돼 있지 않으면 비프로덕션이라도 거부한다.
     const res = await fetchApp('POST', '/api/init-db');
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api/init-db → 올바른 시크릿 헤더면 200 DB 초기화', async () => {
+    const request = new Request('http://localhost/api/init-db', {
+      method: 'POST',
+      headers: { 'x-init-db-secret': 'init-secret' },
+    });
+    const res = await worker.fetch(
+      request,
+      { ...ENV, INIT_DB_SECRET: 'init-secret' },
+      {} as ExecutionContext,
+    );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.success).toBe(true);

--- a/packages/backend/test/jwt.test.ts
+++ b/packages/backend/test/jwt.test.ts
@@ -36,4 +36,16 @@ describe('appJwt', () => {
   it('빈 시크릿으로 서명 거부', async () => {
     await expect(signAppJwt({ sub: 'u1', email: 'u@test.com' }, '')).rejects.toThrow();
   });
+
+  it('epoch 클레임을 박아 넣고 검증 시 그대로 반환 (B5)', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com', epoch: 3 }, SECRET);
+    const payload = await verifyAppJwt(token, SECRET);
+    expect(payload.epoch).toBe(3);
+  });
+
+  it('epoch 미지정 시 기본 0 으로 서명/검증', async () => {
+    const token = await signAppJwt({ sub: 'u1', email: 'u@test.com' }, SECRET);
+    const payload = await verifyAppJwt(token, SECRET);
+    expect(payload.epoch).toBe(0);
+  });
 });

--- a/packages/backend/test/notes.test.ts
+++ b/packages/backend/test/notes.test.ts
@@ -581,22 +581,51 @@ describe('GET /notes/sent — 페이지네이션', () => {
   });
 });
 
+function createMockR2Bucket(initial: Record<string, Uint8Array> = {}) {
+  const store = new Map<string, Uint8Array>();
+  for (const [k, v] of Object.entries(initial)) store.set(k, v);
+  const bucket = {
+    put: async () => {},
+    get: async (key: string) => {
+      const bytes = store.get(key);
+      if (!bytes) return null;
+      return {
+        customMetadata: { mimeType: 'audio/mpeg', userId: 'sender', sizeBytes: String(bytes.byteLength) },
+        httpMetadata: { contentType: 'audio/mpeg' },
+        size: bytes.byteLength,
+        uploaded: new Date('2026-05-01T00:00:00Z'),
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      };
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+  };
+  return { bucket: bucket as unknown as R2Bucket, store };
+}
+
+const envWith = (bucket: R2Bucket) => ({ VOICE_BUCKET: bucket }) as unknown as AppEnv['Bindings'];
+
 describe('GET /notes/:id/audio', () => {
-  it('returns note audio as base64', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(
-      new Uint8Array([65, 66]).buffer,
-      { headers: { 'content-type': 'audio/mpeg' } },
-    )));
+  it('returns note audio as base64 for a sender-owned r2 key', async () => {
+    const key = 'voices/pk2/clip.mp3';
+    const r2 = createMockR2Bucket({ [key]: new Uint8Array([65, 66]) });
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([{
       id: 'n1',
       sender_id: 'pk2',
       receiver_id: 'pk1',
       text: 'hello',
-      audio_url: 'https://cdn.example.com/audio.mp3',
+      audio_url: `r2://${key}`,
+      sender_google_id: 'sender-google-2',
     }]);
     const app = buildApp();
-    const res = await app.request(new Request('http://localhost/notes/n1/audio'));
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.note_id).toBe('n1');
@@ -604,23 +633,119 @@ describe('GET /notes/:id/audio', () => {
     expect(body.audio_format).toBe('mp3');
   });
 
-  it('clears stale r2 audio_url when stored note audio is gone', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 404 })));
+  it('loads a key embedding the sender google_id namespace', async () => {
+    const key = 'voices/sender-google-2/clip.mp3';
+    const r2 = createMockR2Bucket({ [key]: new Uint8Array([65, 66]) });
     mockDB.pushResult([{ id: 'pk1' }]);
     mockDB.pushResult([{
       id: 'n1',
       sender_id: 'pk2',
       receiver_id: 'pk1',
       text: 'hello',
-      audio_url: 'r2://generated/missing.mp3',
+      audio_url: `r2://${key}`,
+      sender_google_id: 'sender-google-2',
     }]);
     const app = buildApp();
-    const res = await app.request(new Request('http://localhost/notes/n1/audio'));
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('loads a key embedding the sender apple_id namespace (Apple-only account)', async () => {
+    // Apple 전용 계정은 R2 키가 apple_id 로 네임스페이스되므로 google_id 없이도 로드돼야 한다.
+    const key = 'voices/sender-apple-9/clip.mp3';
+    const r2 = createMockR2Bucket({ [key]: new Uint8Array([65, 66]) });
+    mockDB.pushResult([{ id: 'pk1' }]);
+    mockDB.pushResult([{
+      id: 'n1',
+      sender_id: 'pk2',
+      receiver_id: 'pk1',
+      text: 'hello',
+      audio_url: `r2://${key}`,
+      sender_google_id: null,
+      sender_apple_id: 'sender-apple-9',
+    }]);
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a cross-tenant r2 key even if the object exists', async () => {
+    // 공격자가 자기 쪽지에 피해자 네임스페이스 키를 끼워 넣은 상황.
+    const victimKey = 'voices/victim-pk/secret.mp3';
+    const r2 = createMockR2Bucket({ [victimKey]: new Uint8Array([1, 2, 3]) });
+    mockDB.pushResult([{ id: 'pk1' }]);
+    mockDB.pushResult([{
+      id: 'n1',
+      sender_id: 'pk2',
+      receiver_id: 'pk1',
+      text: 'hello',
+      audio_url: `r2://${victimKey}`,
+      sender_google_id: 'sender-google-2',
+    }]);
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()).error_code).toBe('NOTE_AUDIO_NOT_FOUND');
+  });
+
+  it('rejects an arbitrary https audio host (SSRF guard)', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const r2 = createMockR2Bucket();
+    mockDB.pushResult([{ id: 'pk1' }]);
+    mockDB.pushResult([{
+      id: 'n1',
+      sender_id: 'pk2',
+      receiver_id: 'pk1',
+      text: 'hello',
+      audio_url: 'https://attacker.example.com/audio.mp3',
+      sender_google_id: 'sender-google-2',
+    }]);
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
+    expect(res.status).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears stale r2 audio_url when stored note audio is gone', async () => {
+    const key = 'voices/pk2/missing.mp3';
+    const r2 = createMockR2Bucket(); // object absent
+    mockDB.pushResult([{ id: 'pk1' }]);
+    mockDB.pushResult([{
+      id: 'n1',
+      sender_id: 'pk2',
+      receiver_id: 'pk1',
+      text: 'hello',
+      audio_url: `r2://${key}`,
+      sender_google_id: 'sender-google-2',
+    }]);
+    const app = buildApp();
+    const res = await app.request(
+      new Request('http://localhost/notes/n1/audio'),
+      undefined,
+      envWith(r2.bucket),
+    );
     expect(res.status).toBe(404);
     expect((await res.json()).error_code).toBe('NOTE_AUDIO_NOT_FOUND');
     const update = mockDB.calls.find((call) => call.sql.startsWith('UPDATE notes SET audio_url = NULL'));
     expect(update).toBeDefined();
-    expect(update!.args).toEqual(['n1', 'r2://generated/missing.mp3']);
+    expect(update!.args).toEqual(['n1', `r2://${key}`]);
   });
 
   it('forbids users outside the note sender and receiver', async () => {
@@ -630,7 +755,8 @@ describe('GET /notes/:id/audio', () => {
       sender_id: 'pk2',
       receiver_id: 'pk3',
       text: 'hello',
-      audio_url: 'https://cdn.example.com/audio.mp3',
+      audio_url: 'r2://voices/pk2/clip.mp3',
+      sender_google_id: 'sender-google-2',
     }]);
     const app = buildApp();
     const res = await app.request(new Request('http://localhost/notes/n1/audio'));

--- a/packages/backend/test/password.test.ts
+++ b/packages/backend/test/password.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { hashPassword, verifyPassword, applyPepper } from '../src/lib/password';
+import {
+  hashPassword,
+  verifyPassword,
+  applyPepper,
+  DUMMY_BCRYPT_HASH,
+} from '../src/lib/password';
 
 describe('password hashing', () => {
   it('같은 비밀번호라도 해시가 매번 달라야 한다 (salt 무작위)', async () => {
@@ -32,5 +37,12 @@ describe('password hashing', () => {
 
   it('applyPepper 는 페퍼를 비밀번호 뒤에 붙인다', () => {
     expect(applyPepper('pw', 'sauce')).toBe('pw::sauce');
+  });
+
+  it('DUMMY_BCRYPT_HASH 는 유효한 bcrypt 해시이며 어떤 평문과도 일치하지 않는다', async () => {
+    // 타이밍 오라클 방지를 위해 사용자 부재 시 비교하는 더미 해시.
+    expect(DUMMY_BCRYPT_HASH).toMatch(/^\$2[aby]\$\d{2}\$/);
+    expect(await verifyPassword('superSecret1', DUMMY_BCRYPT_HASH, 'pepper-test')).toBe(false);
+    expect(await verifyPassword('', DUMMY_BCRYPT_HASH, '')).toBe(false);
   });
 });

--- a/packages/backend/test/scheduled-prune.test.ts
+++ b/packages/backend/test/scheduled-prune.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// scheduled() 가 호출하는 모든 동적 import 를 no-op 으로 만들어 cron 본문만 검증한다.
+vi.mock('../src/lib/audio-retention', () => ({
+  cleanupExpiredAudio: vi.fn().mockResolvedValue(undefined),
+  drainExternalDeletions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/lib/billing-cancel', () => ({
+  processSubscriptionExpiry: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/lib/account-deletion', () => ({
+  purgeUserAccount: vi.fn().mockResolvedValue(undefined),
+  pseudonymizeBillingForRetention: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/lib/transactions', () => ({
+  withWriteTransaction: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/lib/fcm', () => ({
+  sendAlarmPush: vi.fn().mockResolvedValue(undefined),
+}));
+
+const executeMock = vi.hoisted(() =>
+  vi.fn().mockImplementation((arg: unknown) => {
+    void arg;
+    return Promise.resolve({ rows: [] });
+  }),
+);
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => ({ execute: executeMock }),
+  initDB: vi.fn(),
+}));
+
+import worker from '../src/index';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('scheduled() — email_verification_codes prune (FIX 10)', () => {
+  it('만료 후 72h 경과 코드를 파라미터 바인딩으로 삭제한다', async () => {
+    const now = new Date('2026-06-22T00:00:00.000Z');
+    const env = {
+      TURSO_DATABASE_URL: 'mock',
+      TURSO_AUTH_TOKEN: 'mock',
+      PASSWORD_PEPPER: 'pep',
+    } as never;
+
+    await worker.scheduled(
+      { scheduledTime: now.getTime(), cron: '*/5 * * * *' } as never,
+      env,
+    );
+
+    const pruneCall = executeMock.mock.calls.find(
+      (call) =>
+        typeof call[0] === 'object' &&
+        call[0] !== null &&
+        typeof (call[0] as { sql?: string }).sql === 'string' &&
+        (call[0] as { sql: string }).sql.includes('DELETE FROM email_verification_codes'),
+    );
+
+    expect(pruneCall).toBeDefined();
+    const stmt = pruneCall![0] as { sql: string; args: unknown[] };
+    // 파라미터 바인딩(인라인 금지)
+    expect(stmt.sql).toContain('expires_at < ?');
+    expect(Array.isArray(stmt.args)).toBe(true);
+    // expires_at 은 ISO 문자열로 기록되므로 ISO 문자열로 비교한다.
+    const expected = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
+    expect(stmt.args[0]).toBe(expected);
+  });
+});

--- a/packages/backend/test/sentry.test.ts
+++ b/packages/backend/test/sentry.test.ts
@@ -3,10 +3,14 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../src/types';
 
 const captureExceptionMock = vi.hoisted(() => vi.fn());
+const toucanCtorMock = vi.hoisted(() => vi.fn());
 
 vi.mock('toucan-js', () => ({
   Toucan: class {
     captureException = captureExceptionMock;
+    constructor(opts: unknown) {
+      toucanCtorMock(opts);
+    }
   },
 }));
 
@@ -87,6 +91,39 @@ describe('sentryMiddleware', () => {
     const res = await app.fetch(req, env, fakeCtx as never);
     expect(res.status).toBe(500);
     expect(captureExceptionMock).toHaveBeenCalledWith(testError);
+  });
+
+  it('query string secrets are stripped before reaching Toucan', async () => {
+    const { app, env } = buildApp('https://key@sentry.io/123');
+    app.get('/api/billing/google', (c) => c.json({ ok: true }));
+
+    const req = new Request('http://localhost/api/billing/google?token=super-secret');
+    const res = await app.fetch(req, env, fakeCtx as never);
+    expect(res.status).toBe(200);
+
+    expect(toucanCtorMock).toHaveBeenCalled();
+    const opts = toucanCtorMock.mock.calls[0][0] as {
+      request: Request;
+      requestDataOptions?: { allowedSearchParams?: unknown };
+    };
+    // Toucan 으로 넘어가는 요청 URL 에 쿼리스트링(시크릿)이 없어야 한다.
+    expect(opts.request.url).not.toContain('token');
+    expect(opts.request.url).not.toContain('super-secret');
+    expect(new URL(opts.request.url).search).toBe('');
+    // 어떤 쿼리 파라미터도 캡처되지 않도록 명시적으로 비활성화한다.
+    expect(opts.requestDataOptions?.allowedSearchParams).toBe(false);
+  });
+
+  it('sanitized request preserves method and path for Toucan', async () => {
+    const { app, env } = buildApp('https://key@sentry.io/123');
+    app.get('/api/x', (c) => c.json({ ok: true }));
+
+    const req = new Request('http://localhost/api/x?a=1');
+    await app.fetch(req, env, fakeCtx as never);
+
+    const opts = toucanCtorMock.mock.calls[0][0] as { request: Request };
+    expect(opts.request.method).toBe('GET');
+    expect(new URL(opts.request.url).pathname).toBe('/api/x');
   });
 
   it('onError without DSN does not call captureException', async () => {

--- a/packages/backend/test/user.test.ts
+++ b/packages/backend/test/user.test.ts
@@ -279,12 +279,14 @@ describe('PATCH /user/plan', () => {
 });
 
 describe('GET /user/search', () => {
-  it('검색어 2자 미만이면 빈 배열', async () => {
+  it('검색어 4자 미만이면 빈 배열 (PII 하베스팅 방지)', async () => {
     const app = buildApp();
-    const res = await app.request(jsonReq('GET', '/user/search?q=a'));
+    const res = await app.request(jsonReq('GET', '/user/search?q=abc'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.users).toEqual([]);
+    // DB 를 건드리지 않는다.
+    expect(mockDB.calls).toHaveLength(0);
   });
 
   it('검색어 없으면 빈 배열', async () => {
@@ -294,24 +296,46 @@ describe('GET /user/search', () => {
     expect((await res.json()).users).toEqual([]);
   });
 
-  it('이메일 검색 결과 반환', async () => {
+  it('검색 결과에서 email 은 노출하지 않는다 (null)', async () => {
     mockDB.pushResult([
-      { google_id: 'u-2', email: 'friend@test.com', name: 'Friend', picture: '' },
+      { google_id: 'u-2', name: 'Friend', picture: '' },
     ]);
     const app = buildApp();
     const res = await app.request(jsonReq('GET', '/user/search?q=friend'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.users).toHaveLength(1);
-    expect(body.users[0].email).toBe('friend@test.com');
+    expect(body.users[0]).toMatchObject({ id: 'u-2', name: 'Friend', picture: '' });
+    // email 키는 존재하지만 항상 null (클라이언트 옵셔널 디코딩 호환).
+    expect(body.users[0].email).toBeNull();
+    // SELECT 에 email 컬럼이 포함되지 않는다.
+    expect(mockDB.calls[0].sql).not.toContain('email,');
+    expect(mockDB.calls[0].sql).toContain('SELECT google_id, name, picture');
+  });
+
+  it('접두(prefix) 매칭만 사용한다 (substring %q% 아님)', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    await app.request(jsonReq('GET', '/user/search?q=friend'));
+    // LIKE 인자는 'friend%' 형태(접두). 앞에 % 가 붙지 않는다.
+    expect(mockDB.calls[0].args[1]).toBe('friend%');
+  });
+
+  it('LIKE 와일드카드(%,_) 는 이스케이프된다', async () => {
+    mockDB.pushResult([]);
+    const app = buildApp();
+    await app.request(jsonReq('GET', '/user/search?q=a%25b_c'));
+    // q = 'a%b_c' → 'a\%b\_c%' 로 이스케이프, ESCAPE 절 사용.
+    expect(mockDB.calls[0].args[1]).toBe('a\\%b\\_c%');
+    expect(mockDB.calls[0].sql).toContain("ESCAPE '\\'");
   });
 
   it('자기 자신은 제외', async () => {
     mockDB.pushResult([
-      { google_id: 'u-2', email: 'other@test.com', name: 'Other', picture: '' },
+      { google_id: 'u-2', name: 'Other', picture: '' },
     ]);
     const app = buildApp();
-    await app.request(jsonReq('GET', '/user/search?q=test'));
+    await app.request(jsonReq('GET', '/user/search?q=testuser'));
     expect(mockDB.calls[0].args[0]).toBe('user-1');
   });
 
@@ -354,6 +378,31 @@ describe('DELETE /user/me', () => {
     expect(friendshipCall?.args).toEqual(['pk-1', 'user-1', 'pk-1', 'user-1']);
     const giftCall = mockDB.calls.find((c) => c.sql.includes('DELETE FROM gifts'));
     expect(giftCall?.args).toEqual(['pk-1', 'user-1', 'pk-1', 'user-1', 'pk-1', 'user-1']);
+  });
+
+  it('userPk 조회에 apple_id 도 포함한다 (legacy Apple 계정 고아 방지)', async () => {
+    mockDB.pushResult([{ id: 'pk-apple' }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('DELETE', '/user/me'));
+    expect(res.status).toBe(200);
+    const lookup = mockDB.calls.find(
+      (c) => c.sql.includes('SELECT id FROM users') && c.sql.includes('apple_id'),
+    );
+    expect(lookup).toBeDefined();
+    // google_id / apple_id / id 세 컬럼 모두로 매칭한다.
+    expect(lookup?.sql).toContain('apple_id = ?');
+    expect(lookup?.args).toEqual(['user-1', 'user-1', 'user-1']);
+  });
+
+  it('userPk 미해석인데 사용자 행이 존재하면 throw → 500 (고아 PII 방지)', async () => {
+    // 1) SELECT id FROM users (DELETE 핸들러) → 미해석(null)
+    mockDB.pushResult([]);
+    // 2) purgeUserAccount 의 orphan guard SELECT → 사용자 행 존재
+    mockDB.pushResult([{ id: 'ghost-pk' }]);
+    const app = buildApp();
+    const res = await app.request(jsonReq('DELETE', '/user/me'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error_code).toBe('DELETE_ACCOUNT_FAILED');
   });
 
   it('DB 에러 → 500 DELETE_ACCOUNT_FAILED', async () => {

--- a/packages/backend/test/voice-profile.test.ts
+++ b/packages/backend/test/voice-profile.test.ts
@@ -286,6 +286,31 @@ describe('GET /:id/stats — 통계 (voice-profile)', () => {
 /*  POST /vp/clone — 음성 클론                                         */
 /* ------------------------------------------------------------------ */
 describe('POST /clone — 음성 클론 (voice-profile)', () => {
+  it('voice_biometric 동의 없으면 403 CONSENT_REQUIRED (B4)', async () => {
+    // 생체정보(음성 클론) 별도 동의 미충족 시 클로닝을 차단한다. 동의 쿼리는
+    // missing 모드로 두고 빈 결과(미동의)를 돌려준다.
+    mockDB.setConsentMissing(true);
+    mockDB.pushResult([]); // user_consents 조회 결과: 동의 없음
+    const res = await req(buildApp(), cloneForm(new Uint8Array([1, 2, 3]), '엄마 목소리'));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error_code).toBe('CONSENT_REQUIRED');
+    expect(body.consent).toBe('voice_biometric');
+    // 동의 게이트에서 막혔으므로 ElevenLabs 클론은 호출되지 않는다.
+    expect(mockCreateInstantClone).not.toHaveBeenCalled();
+  });
+
+  it('voice_biometric 동의가 있으면 클로닝 진행 (B4)', async () => {
+    // 기본 모드(setConsentMissing 미설정): 헬퍼가 모든 동의를 합성 충족 → 통과.
+    mockDB.pushResult([{ count: 0 }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockCreateInstantClone.mockResolvedValue({ voice_id: 'elv-consent-ok' });
+    const res = await req(buildApp(), cloneForm(new Uint8Array([1, 2]), '엄마 목소리'));
+    expect(res.status).toBe(201);
+    expect(mockCreateInstantClone).toHaveBeenCalledOnce();
+  });
+
   it('프로필 1개 이상이면 403 VOICE_LIMIT_REACHED', async () => {
     mockDB.pushResult([{ count: 1 }]);
     const res = await req(buildApp(), cloneForm(new Uint8Array([1, 2, 3]), '테스트'));


### PR DESCRIPTION
## 개요
출시 전 다중 에이전트 보안·법무 감사(21 에이전트 + 적대적 검증 + dev 라이브 프로빙)에서 도출된 **백엔드 blocker·quick-win 1차(W1)** 수정. 적대적 리뷰 + 추가 보강(apple_id/ISO/상수시간) 반영.

**검증:** 백엔드 테스트 1426 통과(무관한 `/friend` latency flake 2건 제외 — 로컬 머신 부하), typecheck·eslint 통과. 보안 테스트 225 + notes 55 통과.

## 수정 (감사 ID)
- **B3 IDOR**: `PATCH /alarm` 의 `message_id`·`voice_profile_id` 소유권 재검증(POST와 동일 헬퍼) — 타인 메시지/음성 첨부·열람 차단.
- **B2 SSRF/교차테넌트**: `loadAudioBytes` r2:// 만 허용 + 키 owner segment(발신자 PK/google_id/**apple_id**) 일치 강제, https 프록시 제거. `note/alarm audio_url` 검증 `isStoredAudioUrl` 통일 → 타인 생체 음성 탈취 + Worker SSRF 차단.
- **init-db/seed**: 전 환경 `x-init-db-secret` 요구(상수시간 비교), 에러 원문 미반사.
- **계정열거**: 로그인 실패 generic화 + dummy bcrypt 타이밍 평준화, email-code/register 멤버십 미노출.
- **email-code**: per-email 60s 쿨다운 + 일일 상한, 만료 코드 크론 정리(72h).
- **계정삭제**: `userPk` 조회에 `apple_id` 포함(레거시 Apple 자식 PII 고아화 방지) + null 시 fail-loud.
- **user-search**: 타인 이메일 미반환, 최소 4자 prefix, LIKE 와일드카드 이스케이프.
- 공급자 로그인 에러 원문 미반사, **RTDN 시크릿 쿼리스트링 Sentry 캡처 차단**.

## 후속 (같은 브랜치에 스택 예정)
- **W2**: B5 토큰 폐기/로그아웃 + authMiddleware 앱-JWT 제한, B4 서버 동의 미들웨어 + 음성=생체정보 동의타입.
- **W3**: 법무 문서(Vertex/사주 itemize/생체 분류/FCM·PortOne/정책버전 bump). *B1: 출시=Perso 유지(ElevenLabs 미추가).*
- **W4**: 앱 하드닝(iOS Keychain/파일보호, Android FLAG_SECURE/암호화).

## 미수행(사용자 결정)
- **B6 시크릿 로테이션**: 사용자 요청으로 스킵.