### PR TITLE
feat(landing): Quiet Frequency 스크롤 모션 재디자인 + 브랜드 블루 통일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ dumpsys-*.txt
 articles/
 !articles/alarmtalk_pt_onepage.html
 
+# Local audit/QA scratch — screenshots, i18n gen scripts, raw data (not shared)
+.audit-shots/
+
 # Test audio files (사용자가 로컬에 두는 음성 파일들 - 커밋 금지)
 test/*
 !test/.gitkeep

--- a/apps/landing/app/[locale]/opengraph-image.tsx
+++ b/apps/landing/app/[locale]/opengraph-image.tsx
@@ -41,7 +41,7 @@ export default async function OpengraphImage() {
           padding: "64px",
           backgroundColor: "#FAF9F5",
           backgroundImage:
-            "radial-gradient(circle at 14% 22%, rgba(217,119,87,0.16), transparent 44%), radial-gradient(circle at 88% 24%, rgba(94,155,125,0.12), transparent 46%)",
+            "radial-gradient(circle at 14% 22%, rgba(23,95,176,0.16), transparent 44%), radial-gradient(circle at 88% 24%, rgba(94,155,125,0.12), transparent 46%)",
           color: "#1F1E1C",
           fontFamily: "system-ui, -apple-system, sans-serif",
         }}
@@ -91,7 +91,7 @@ export default async function OpengraphImage() {
               }}
             >
               <span>you</span>
-              <span style={{ color: "#c25d3a" }}>love</span>
+              <span style={{ color: "#175fb0" }}>love</span>
               <span>.</span>
             </div>
             <div

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -31,14 +31,14 @@
   --color-text-dim: #8a8377;
   --color-text-faint: #aaa395;
 
-  /* accent — Claude coral / clay */
-  --color-accent: #d97757;
-  --color-accent-strong: #c25d3a;
-  --color-accent-soft: rgba(217, 119, 87, 0.1);
-  --color-accent-fg: #2a1206;
+  /* accent — brand blue, unified with the native apps (#175FB0) */
+  --color-accent: #175fb0;
+  --color-accent-strong: #124e8c;
+  --color-accent-soft: rgba(23, 95, 176, 0.1);
+  --color-accent-fg: #06243c;
   --color-mint: #5e9b7d;
   --color-rose: #db7e63;
-  --color-indigo-deep: #f0e4da;
+  --color-indigo-deep: #d6e9ff;
 
   /* typography */
   --font-sans:
@@ -122,8 +122,8 @@
   .bg-aurora {
     background-color: var(--color-bg);
     background-image:
-      radial-gradient(ellipse 80% 50% at 50% -10%, rgba(217, 119, 87, 0.1), transparent 60%),
-      radial-gradient(ellipse 60% 45% at 100% 0%, rgba(217, 119, 87, 0.06), transparent 55%),
+      radial-gradient(ellipse 80% 50% at 50% -10%, rgba(23, 95, 176, 0.1), transparent 60%),
+      radial-gradient(ellipse 60% 45% at 100% 0%, rgba(23, 95, 176, 0.06), transparent 55%),
       radial-gradient(ellipse 55% 40% at 0% 25%, rgba(94, 155, 125, 0.05), transparent 55%);
   }
 
@@ -179,7 +179,7 @@
     height: 52px;
     padding: 0 1.75rem;
     font-size: 15px;
-    box-shadow: 0 1px 2px rgba(120, 60, 35, 0.18), 0 8px 24px rgba(217, 119, 87, 0.22);
+    box-shadow: 0 1px 2px rgba(15, 50, 90, 0.18), 0 8px 24px rgba(23, 95, 176, 0.22);
   }
   .btn-primary:hover {
     background: var(--color-accent-strong);

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -1,6 +1,8 @@
+/* remote @import must precede the Tailwind import so it stays first after the
+   Tailwind plugin inlines its rules (otherwise CSS nesting order warns). */
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@500;600;700&display=swap");
 @import "tailwindcss";
 @import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
-@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@500;600;700&display=swap");
 
 @theme {
   /* warm gray ramp — paper-like, slightly toasted */
@@ -57,6 +59,10 @@
   --shadow-card: 0 1px 2px rgba(60, 50, 35, 0.04), 0 18px 44px rgba(90, 75, 55, 0.08);
   --shadow-elevated: 0 1px 3px rgba(60, 50, 35, 0.05), 0 34px 80px rgba(90, 75, 55, 0.14);
   --shadow-hairline: inset 0 0 0 1px rgba(40, 35, 25, 0.04);
+
+  /* motion — single house easing token (mirrors the inline curve in .btn / fadeup
+     and every JS motion config so the whole site feels authored, not random) */
+  --ease-paper: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @layer base {
@@ -242,5 +248,52 @@
 }
 
 .animate-fadeup {
-  animation: fadeup 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: fadeup 0.6s var(--ease-paper) both;
+}
+
+/* lightweight ambient loops — cheaper than JS for purely decorative motion.
+   The reduced-motion media query below neutralizes all of these. */
+@keyframes bob {
+  0%, 100% { transform: translateY(0); opacity: 0.85; }
+  50% { transform: translateY(5px); opacity: 1; }
+}
+
+.animate-bob {
+  animation: bob 2.4s var(--ease-paper) infinite;
+}
+
+@keyframes drift {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(10px, -12px); }
+}
+
+.animate-drift {
+  animation: drift 12s ease-in-out infinite;
+}
+.animate-drift-slow {
+  animation: drift 16s ease-in-out infinite reverse;
+}
+
+/* Accessibility dual-safety-net: a global reduced-motion reset that pairs with the
+   JS-level useReducedMotion() gate inside the motion primitives. Final (visible)
+   states are always preserved — only the movement is removed. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Restore the final visible state of every motion-revealed node from CSS alone,
+     independent of JS/hydration timing (mirrors the <noscript> override). This is
+     what guarantees reduced-motion users never see the baked opacity:0 initial. */
+  [data-reveal] {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+    clip-path: none !important;
+  }
 }

--- a/apps/landing/app/layout.tsx
+++ b/apps/landing/app/layout.tsx
@@ -15,6 +15,11 @@ export default function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <body className="bg-aurora min-h-screen">
+        {/* No-JS safety net: motion primitives bake their hidden initial state into
+            the static HTML; without JS this forces every revealed element visible. */}
+        <noscript>
+          <style>{`[data-reveal]{opacity:1!important;transform:none!important;clip-path:none!important;filter:none!important}`}</style>
+        </noscript>
         <div className="grain" aria-hidden="true" />
         <div className="bg-grid pointer-events-none absolute inset-x-0 top-0 -z-0 h-[640px]" />
         <div className="relative z-10">{children}</div>

--- a/apps/landing/components/motion/count-up.tsx
+++ b/apps/landing/components/motion/count-up.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { animate, useInView } from "motion/react";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+// Slight overshoot-then-settle for the "odometer" feel.
+const EASE_BACK: [number, number, number, number] = [0.34, 1.56, 0.64, 1];
+
+type Mode = "number" | "odometer" | "text";
+
+type Props = {
+  /** Target value for number / odometer modes. */
+  to?: number;
+  /** Start value (defaults: 0 for number, a small roll for odometer). */
+  from?: number;
+  /** Literal string for text mode (no counting — a blur settle instead). */
+  text?: string;
+  prefix?: string;
+  suffix?: string;
+  durationMs?: number;
+  mode?: Mode;
+  className?: string;
+};
+
+/**
+ * In-view number ticker. SSR renders the FINAL value (SEO / no-JS safe); when the
+ * element scrolls into view and motion is allowed, it counts from `from` to `to`.
+ * Reduced-motion → the final value, instantly. Only transform/opacity/filter
+ * animate (never layout properties) and the digits sit in a fixed-width box, so
+ * the count never causes layout shift. `text` mode does a one-shot blur settle.
+ */
+export function CountUp({
+  to = 0,
+  from,
+  text,
+  prefix = "",
+  suffix = "",
+  durationMs = 1000,
+  mode = "number",
+  className,
+}: Props) {
+  const reduced = usePrefersReducedMotion();
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true, margin: "0px 0px -12% 0px" });
+
+  const start = from ?? (mode === "odometer" ? (to === 0 ? 9 : 0) : 0);
+
+  useEffect(() => {
+    if (reduced || !inView) return;
+    const node = ref.current;
+    if (!node) return;
+
+    if (mode === "text") {
+      const controls = animate(0, 1, {
+        duration: durationMs / 1000,
+        ease: EASE,
+        onUpdate: (t) => {
+          // filter + opacity only — never letter-spacing (would reflow siblings).
+          node.style.filter = `blur(${(1 - t) * 4}px)`;
+          node.style.opacity = String(0.4 + t * 0.6);
+        },
+        onComplete: () => {
+          node.style.filter = "";
+          node.style.opacity = "";
+        },
+      });
+      return () => controls.stop();
+    }
+
+    const controls = animate(start, to, {
+      duration: durationMs / 1000,
+      ease: mode === "odometer" ? EASE_BACK : EASE,
+      onUpdate: (v) => {
+        node.textContent = `${prefix}${Math.round(v)}`;
+      },
+    });
+    return () => controls.stop();
+  }, [inView, reduced, mode, start, to, durationMs, prefix]);
+
+  if (mode === "text") {
+    return (
+      <span ref={ref} className={className}>
+        {text ?? ""}
+      </span>
+    );
+  }
+
+  // Digits live in a fixed-width, right-aligned box so 0→60 (1→2 glyphs) never
+  // shifts the trailing unit. SSR shows the final value.
+  return (
+    <span className={className}>
+      <span
+        ref={ref}
+        style={{
+          display: "inline-block",
+          minWidth: `${(prefix + String(to)).length}ch`,
+          textAlign: "right",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {prefix}
+        {to}
+      </span>
+      {suffix}
+    </span>
+  );
+}

--- a/apps/landing/components/motion/living-waveform.tsx
+++ b/apps/landing/components/motion/living-waveform.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { motion } from "motion/react";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+type Mode = "breathe" | "playOnce";
+
+type Props = {
+  /** Per-bar levels, 0..1. */
+  bars: number[];
+  mode?: Mode;
+  /** Color of active ("played") bars. */
+  color?: string;
+  /** Color of bars at/after `playedTo` (defaults to `color`). */
+  restColor?: string;
+  /** Index up to which bars are "active"/played (undefined = all active). */
+  playedTo?: number;
+  /** Breathe amplitude as a fraction of height (0.12 = ±12%). */
+  amplitude?: number;
+  /** Breathe loop period in seconds. */
+  period?: number;
+  /** Bar width in px, or "flex" to fill the row evenly. */
+  barWidth?: number | "flex";
+  gapPx?: number;
+  minPx?: number;
+  spanPx?: number;
+  align?: "center" | "end";
+  /** Per-level opacity (used when activeOpacity is not set): base + level*scale. */
+  opacityBase?: number;
+  opacityScale?: number;
+  /** Fixed opacities by played state (overrides the per-level formula). */
+  activeOpacity?: number;
+  restOpacity?: number;
+  radius?: number;
+  className?: string;
+  style?: CSSProperties;
+};
+
+/**
+ * The signature "voice you can see" motif — pure div bars (no canvas) driven by
+ * Framer. `breathe` runs a slow per-bar sine loop while in view (a traveling wave);
+ * `playOnce` raises bars left→right once, the colored "played" portion reading like
+ * a playhead sweep. Decorative + aria-hidden. Reduced-motion / no-JS → the exact
+ * static bar heights the component renders today (never empty).
+ */
+export function LivingWaveform({
+  bars,
+  mode = "breathe",
+  color = "var(--color-accent)",
+  restColor,
+  playedTo,
+  amplitude = 0.12,
+  period = 4,
+  barWidth = 1.5,
+  gapPx = 1.5,
+  minPx = 5,
+  spanPx = 22,
+  align = "center",
+  opacityBase = 1,
+  opacityScale = 0,
+  activeOpacity,
+  restOpacity,
+  radius = 9999,
+  className,
+  style,
+}: Props) {
+  const reduced = usePrefersReducedMotion();
+  const n = bars.length;
+  const flex = barWidth === "flex";
+
+  return (
+    <div
+      aria-hidden="true"
+      className={className}
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        alignItems: align === "center" ? "center" : "flex-end",
+        justifyContent: flex ? "space-between" : "space-between",
+        gap: `${gapPx}px`,
+        ...style,
+      }}
+    >
+      {bars.map((raw, i) => {
+        const level = Math.max(0, Math.min(1, raw));
+        const height = minPx + level * spanPx;
+        const isActive = playedTo == null || i < playedTo;
+        const barColor = isActive ? color : (restColor ?? color);
+        const opacity =
+          activeOpacity != null
+            ? isActive
+              ? activeOpacity
+              : (restOpacity ?? 1)
+            : opacityBase + level * opacityScale;
+
+        const barStyle: CSSProperties = {
+          height: `${height}px`,
+          width: flex ? undefined : `${barWidth}px`,
+          flex: flex ? "1 1 0%" : undefined,
+          backgroundColor: barColor,
+          opacity,
+          borderRadius: radius,
+          transformOrigin: mode === "breathe" ? "center" : "bottom",
+        };
+
+        if (reduced) {
+          return <span key={i} style={barStyle} />;
+        }
+
+        if (mode === "playOnce") {
+          return (
+            <motion.span
+              key={i}
+              data-reveal
+              style={barStyle}
+              initial={{ scaleY: 0 }}
+              whileInView={{ scaleY: 1 }}
+              viewport={{ once: true, margin: "0px 0px -10% 0px" }}
+              transition={{ duration: 0.5, ease: EASE, delay: i * 0.012 }}
+            />
+          );
+        }
+
+        return (
+          <motion.span
+            key={i}
+            style={barStyle}
+            initial={{ scaleY: 1 }}
+            whileInView={{
+              scaleY: [1 - amplitude, 1 + amplitude, 1 - amplitude],
+            }}
+            viewport={{ once: false }}
+            transition={{
+              duration: period,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: (i / n) * period,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/landing/components/motion/magnetic.tsx
+++ b/apps/landing/components/motion/magnetic.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
+import { useRef } from "react";
+import { motion, useMotionValue, useSpring } from "motion/react";
+import {
+  useCoarsePointer,
+  usePrefersReducedMotion,
+} from "./use-prefers-reduced-motion";
+
+const clamp = (v: number, max: number) => Math.max(-max, Math.min(max, v));
+
+type Props = {
+  children: ReactNode;
+  /** Max pull toward the cursor in px. */
+  strength?: number;
+  className?: string;
+};
+
+/**
+ * Subtle magnetic pull toward the cursor for a single CTA. No-ops on touch
+ * (coarse pointer) and under reduced-motion, rendering a plain inline wrapper.
+ */
+export function Magnetic({ children, strength = 6, className }: Props) {
+  const reduced = usePrefersReducedMotion();
+  const coarse = useCoarsePointer();
+  const ref = useRef<HTMLSpanElement>(null);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const sx = useSpring(x, { stiffness: 150, damping: 15 });
+  const sy = useSpring(y, { stiffness: 150, damping: 15 });
+
+  const cls = ["inline-flex", className].filter(Boolean).join(" ");
+
+  if (reduced || coarse) {
+    return <span className={cls}>{children}</span>;
+  }
+
+  const onMove = (event: ReactPointerEvent<HTMLSpanElement>) => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const dx = event.clientX - (r.left + r.width / 2);
+    const dy = event.clientY - (r.top + r.height / 2);
+    x.set(clamp((dx / (r.width / 2)) * strength, strength));
+    y.set(clamp((dy / (r.height / 2)) * strength, strength));
+  };
+
+  const onLeave = () => {
+    x.set(0);
+    y.set(0);
+  };
+
+  return (
+    <motion.span
+      ref={ref}
+      className={cls}
+      style={{ x: sx, y: sy }}
+      onPointerMove={onMove}
+      onPointerLeave={onLeave}
+    >
+      {children}
+    </motion.span>
+  );
+}

--- a/apps/landing/components/motion/reveal-group.tsx
+++ b/apps/landing/components/motion/reveal-group.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { CSSProperties, ElementType, ReactNode } from "react";
+import { motion, type Variants } from "motion/react";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+import { REVEAL_VARIANTS, type RevealVariant } from "./reveal";
+
+const containerVariants = (stagger: number, delay: number): Variants => ({
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: stagger, delayChildren: delay },
+  },
+});
+
+type GroupProps = {
+  as?: ElementType;
+  stagger?: number;
+  delay?: number;
+  /** "view" = animate when scrolled into view (default); "mount" = on load (for
+   *  above-the-fold groups so the LCP region isn't gated on an observer). */
+  trigger?: "view" | "mount";
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+};
+
+/**
+ * Staggered container for grids and lists. The parent orchestrates timing; each
+ * <RevealItem> inherits the entrance via Framer variant propagation, so the children
+ * need no individual triggers. Reduced-motion / no-JS behave exactly like <Reveal>.
+ *
+ * NOTE: <RevealItem> is a separate named export (not RevealGroup.Item) on purpose —
+ * a static compound property would be stripped across the server→client boundary,
+ * so server components importing it would see `undefined`.
+ */
+export function RevealGroup({
+  as = "div",
+  stagger = 0.08,
+  delay = 0.05,
+  trigger = "view",
+  className,
+  style,
+  children,
+}: GroupProps) {
+  const reduced = usePrefersReducedMotion();
+
+  if (reduced) {
+    const Plain = as;
+    return (
+      <Plain className={className} style={style}>
+        {children}
+      </Plain>
+    );
+  }
+
+  const MotionTag = (motion as unknown as Record<string, ElementType>)[
+    as as string
+  ];
+
+  const triggerProps =
+    trigger === "mount"
+      ? { animate: "visible" }
+      : {
+          whileInView: "visible",
+          viewport: { once: true, margin: "0px 0px -12% 0px" },
+        };
+
+  return (
+    <MotionTag
+      className={className}
+      style={style}
+      variants={containerVariants(stagger, delay)}
+      initial="hidden"
+      {...triggerProps}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+
+type ItemProps = {
+  as?: ElementType;
+  variant?: RevealVariant;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+};
+
+export function RevealItem({
+  as = "div",
+  variant = "rise",
+  className,
+  style,
+  children,
+}: ItemProps) {
+  const reduced = usePrefersReducedMotion();
+
+  if (reduced) {
+    const Plain = as;
+    return (
+      <Plain className={className} style={style}>
+        {children}
+      </Plain>
+    );
+  }
+
+  const MotionTag = (motion as unknown as Record<string, ElementType>)[
+    as as string
+  ];
+
+  return (
+    <MotionTag
+      className={className}
+      style={style}
+      data-reveal
+      variants={REVEAL_VARIANTS[variant]}
+      custom={0}
+    >
+      {children}
+    </MotionTag>
+  );
+}
+

--- a/apps/landing/components/motion/reveal.tsx
+++ b/apps/landing/components/motion/reveal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { CSSProperties, ElementType, ReactNode } from "react";
+import { motion, type Variants } from "motion/react";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+// House easing token (mirrors --ease-paper in globals.css).
+const EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+export type RevealVariant = "rise" | "focus" | "wipe";
+
+// Each `visible` is a function of a custom delay so a single entrance can be
+// offset without overriding its duration/easing.
+export const REVEAL_VARIANTS: Record<RevealVariant, Variants> = {
+  rise: {
+    hidden: { opacity: 0, y: 16 },
+    visible: (d = 0) => ({
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.6, ease: EASE, delay: d },
+    }),
+  },
+  focus: {
+    hidden: { opacity: 0, y: 20, filter: "blur(1.2px)", scale: 1.005 },
+    visible: (d = 0) => ({
+      opacity: 1,
+      y: 0,
+      filter: "blur(0px)",
+      scale: 1,
+      transition: { duration: 0.7, ease: EASE, delay: d },
+    }),
+  },
+  wipe: {
+    hidden: { opacity: 0, clipPath: "inset(0 100% 0 0)" },
+    visible: (d = 0) => ({
+      opacity: 1,
+      clipPath: "inset(0 0 0 0)",
+      transition: { duration: 0.8, ease: EASE, delay: d },
+    }),
+  },
+};
+
+type RevealProps = {
+  as?: ElementType;
+  variant?: RevealVariant;
+  /** Seconds to delay the entrance. */
+  delay?: number;
+  /** "view" = animate when scrolled into view (default); "mount" = animate on load. */
+  trigger?: "view" | "mount";
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+/**
+ * The workhorse entrance. Renders an element that animates in once (on scroll or on
+ * mount). Safety:
+ *  - reduced-motion → renders a plain element in its final visible state, no motion.
+ *  - no-JS → the `data-reveal` attribute is forced visible by the <noscript> override
+ *    in the root layout, so SSR content is never stuck hidden.
+ *  - only transform / opacity / clip-path / filter animate → CLS-safe.
+ */
+export function Reveal({
+  as = "div",
+  variant = "rise",
+  delay = 0,
+  trigger = "view",
+  className,
+  style,
+  children,
+}: RevealProps) {
+  const reduced = usePrefersReducedMotion();
+
+  if (reduced) {
+    const Plain = as;
+    return (
+      <Plain className={className} style={style}>
+        {children}
+      </Plain>
+    );
+  }
+
+  // motion's proxy resolves any intrinsic tag at runtime; the cast keeps it generic.
+  const MotionTag = (motion as unknown as Record<string, ElementType>)[
+    as as string
+  ];
+
+  const shared = {
+    className,
+    style,
+    "data-reveal": true,
+    variants: REVEAL_VARIANTS[variant],
+    custom: delay,
+    initial: "hidden" as const,
+  };
+
+  if (trigger === "mount") {
+    return (
+      <MotionTag {...shared} animate="visible">
+        {children}
+      </MotionTag>
+    );
+  }
+
+  return (
+    <MotionTag
+      {...shared}
+      whileInView="visible"
+      viewport={{ once: true, margin: "0px 0px -12% 0px" }}
+    >
+      {children}
+    </MotionTag>
+  );
+}

--- a/apps/landing/components/motion/use-prefers-reduced-motion.ts
+++ b/apps/landing/components/motion/use-prefers-reduced-motion.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+/**
+ * SSR-stable reduced-motion flag. motion v12's useReducedMotion resolves the real
+ * preference synchronously on the FIRST client render, which would diverge from the
+ * server (where it is always false) and cause a hydration mismatch on every revealed
+ * node. So we return `false` on SSR + the first client render (matching the server
+ * markup) and only apply the real preference after mount. Reduced-motion users stay
+ * visible in the meantime via the `[data-reveal]` rule inside the
+ * `@media (prefers-reduced-motion: reduce)` block in globals.css.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const reduced = useReducedMotion() ?? false;
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted && reduced;
+}
+
+/**
+ * True on coarse pointers (touch). SSR-stable (false until mounted). Used to no-op
+ * pointer-tracking effects like <Magnetic> on phones/tablets.
+ */
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(pointer: coarse)");
+    setCoarse(mq.matches);
+    const onChange = (event: MediaQueryListEvent) => setCoarse(event.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return coarse;
+}

--- a/apps/landing/components/motion/use-scroll-progress.ts
+++ b/apps/landing/components/motion/use-scroll-progress.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useScroll, useSpring, type MotionValue } from "motion/react";
+
+type ScrollProgress = {
+  /** Raw window scroll offset in px (for threshold checks). */
+  scrollY: MotionValue<number>;
+  /** Spring-smoothed 0→1 page scroll progress (for the coral voice-spine). */
+  progress: MotionValue<number>;
+};
+
+/**
+ * The single scroll subscriber for the page. One useScroll instance feeds both the
+ * header's scroll-state threshold and the coral "voice-spine" fill, keeping the page
+ * to one continuous scroll listener.
+ */
+export function useScrollProgress(): ScrollProgress {
+  const { scrollY, scrollYProgress } = useScroll();
+  const progress = useSpring(scrollYProgress, { stiffness: 60, damping: 20 });
+  return { scrollY, progress };
+}

--- a/apps/landing/components/phone-preview.tsx
+++ b/apps/landing/components/phone-preview.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, Mic, AlarmClock, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { BrandMark } from "./brand-mark";
+import { LivingWaveform } from "./motion/living-waveform";
 
 const WAVEFORM = [
   0.18, 0.24, 0.16, 0.34, 0.28, 0.52, 0.38, 0.7, 0.42, 0.6, 0.32, 0.56, 0.24,
@@ -80,19 +81,20 @@ export function PhonePreview() {
                 07:30
               </p>
 
-              {/* mini waveform */}
-              <div className="mt-4 flex h-[28px] items-center justify-between gap-[1.5px]">
-                {WAVEFORM.map((level, i) => (
-                  <span
-                    key={i}
-                    className="block w-[1.5px] rounded-full"
-                    style={{
-                      height: `${5 + level * 22}px`,
-                      backgroundColor: CORAL,
-                      opacity: 0.45 + level * 0.55,
-                    }}
-                  />
-                ))}
+              {/* mini waveform — the signature, now quietly breathing */}
+              <div className="mt-4 h-[28px]">
+                <LivingWaveform
+                  bars={WAVEFORM}
+                  mode="breathe"
+                  color={CORAL}
+                  barWidth={1.5}
+                  gapPx={1.5}
+                  minPx={5}
+                  spanPx={22}
+                  amplitude={0.12}
+                  opacityBase={0.45}
+                  opacityScale={0.55}
+                />
               </div>
 
               <div className="mt-4 flex items-center justify-between">

--- a/apps/landing/components/phone-preview.tsx
+++ b/apps/landing/components/phone-preview.tsx
@@ -10,9 +10,9 @@ const WAVEFORM = [
   0.28,
 ];
 
-// Phone screen keeps the app's native dark UI (a real product shot), recolored
-// to the brand coral so it reads as one family with the warm light page.
-const CORAL = "#ec8c6c";
+// Phone screen mirrors the app's native dark UI, tinted to the brand blue so it
+// reads as one family with the light page (matches the native app's accent).
+const ACCENT = "#6ba8f0";
 const SAGE = "#8fbf9e";
 const SCREEN_TEXT = "#f7f4ee";
 const SCREEN_MUTED = "#b0a89c";
@@ -27,7 +27,7 @@ export function PhonePreview() {
       {/* warm glow behind device */}
       <div
         aria-hidden="true"
-        className="absolute -inset-x-12 -top-10 -bottom-6 -z-10 rounded-[60px] bg-[radial-gradient(circle_at_50%_30%,rgba(217,119,87,0.20),transparent_60%)] blur-2xl"
+        className="absolute -inset-x-12 -top-10 -bottom-6 -z-10 rounded-[60px] bg-[radial-gradient(circle_at_50%_30%,rgba(23,95,176,0.20),transparent_60%)] blur-2xl"
       />
 
       {/* device bezel — 9:19.5 portrait */}
@@ -86,7 +86,7 @@ export function PhonePreview() {
                 <LivingWaveform
                   bars={WAVEFORM}
                   mode="breathe"
-                  color={CORAL}
+                  color={ACCENT}
                   barWidth={1.5}
                   gapPx={1.5}
                   minPx={5}
@@ -106,7 +106,7 @@ export function PhonePreview() {
                     {t("alarmEdit")}
                   </p>
                 </div>
-                <ArrowRight className="h-3.5 w-3.5 shrink-0" style={{ color: CORAL }} />
+                <ArrowRight className="h-3.5 w-3.5 shrink-0" style={{ color: ACCENT }} />
               </div>
             </div>
 
@@ -120,14 +120,14 @@ export function PhonePreview() {
               <QuickCard
                 icon={<Mic className="h-3.5 w-3.5" strokeWidth={2.2} />}
                 label={t("quickVoice")}
-                accentBg="#3a2a22"
-                accentFg="#f4d8c9"
+                accentBg="#16304d"
+                accentFg="#cfe3ff"
               />
               <QuickCard
                 icon={<AlarmClock className="h-3.5 w-3.5" strokeWidth={2.2} />}
                 label={t("quickAlarm")}
-                accentBg="#33291c"
-                accentFg="#f2e2c4"
+                accentBg="#1b3147"
+                accentFg="#d4e6ff"
               />
             </div>
 
@@ -174,7 +174,7 @@ export function PhonePreview() {
                 >
                   <span
                     className="block h-1 w-1 rounded-full"
-                    style={{ backgroundColor: tab.active ? CORAL : "transparent" }}
+                    style={{ backgroundColor: tab.active ? ACCENT : "transparent" }}
                   />
                   <span
                     className="whitespace-nowrap text-[9.5px] font-semibold"

--- a/apps/landing/components/sections/faq.tsx
+++ b/apps/landing/components/sections/faq.tsx
@@ -1,4 +1,6 @@
 import { useTranslations } from "next-intl";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
 
 export function Faq() {
   const t = useTranslations("faq");
@@ -7,13 +9,20 @@ export function Faq() {
   return (
     <section id="faq" className="relative">
       <div className="mx-auto max-w-4xl px-5 py-24 md:px-8 lg:py-32">
-        <h2 className="text-[34px] font-bold leading-[1.12] tracking-[-0.02em] text-text sm:text-[44px]">
+        <Reveal
+          as="h2"
+          className="text-[34px] font-bold leading-[1.12] tracking-[-0.02em] text-text sm:text-[44px]"
+        >
           {t("headline")}
-        </h2>
+        </Reveal>
 
-        <div className="mt-12 divide-y divide-line overflow-hidden rounded-3xl border border-line bg-surface">
+        <RevealGroup
+          className="mt-12 divide-y divide-line overflow-hidden rounded-3xl border border-line bg-surface"
+          stagger={0.06}
+        >
           {items.map((i) => (
-            <details
+            <RevealItem
+              as="details"
               key={i}
               className="group p-6 transition open:bg-raised md:p-7"
             >
@@ -41,12 +50,12 @@ export function Faq() {
                   </svg>
                 </span>
               </summary>
-              <p className="mt-4 max-w-3xl text-[14.5px] leading-[1.65] text-text-muted">
+              <p className="mt-4 max-w-3xl text-[14.5px] leading-[1.65] text-text-muted group-open:animate-fadeup">
                 {t(`items.${i}.a`)}
               </p>
-            </details>
+            </RevealItem>
           ))}
-        </div>
+        </RevealGroup>
       </div>
     </section>
   );

--- a/apps/landing/components/sections/feature-section.tsx
+++ b/apps/landing/components/sections/feature-section.tsx
@@ -1,5 +1,7 @@
 import { Check } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
 
 type Props = {
   namespace: "voice" | "shared" | "language";
@@ -20,38 +22,55 @@ export function FeatureSection({ namespace, reverse, visual, id }: Props) {
           }`}
         >
           <div className={`${reverse ? "lg:[direction:ltr]" : ""}`}>
-            <span className="inline-flex w-fit whitespace-nowrap rounded-full border border-accent/25 bg-accent-soft px-3 py-1.5 text-[11.5px] font-bold uppercase tracking-[0.12em] text-accent">
-              {t("eyebrow")}
-            </span>
-            <h2 className="mt-5 text-[34px] font-bold leading-[1.1] tracking-[-0.025em] text-text sm:text-[44px]">
-              {t("headline1")}
-              <br />
-              <span className="text-text">{t("headline2")}</span>
-            </h2>
-            <p className="mt-6 max-w-xl text-[16px] leading-[1.7] text-text-muted">
-              {t("description")}
-            </p>
-            <ul className="mt-7 space-y-3">
+            <RevealGroup stagger={0.08}>
+              <RevealItem
+                as="span"
+                className="inline-flex w-fit whitespace-nowrap rounded-full border border-accent/25 bg-accent-soft px-3 py-1.5 text-[11.5px] font-bold uppercase tracking-[0.12em] text-accent"
+              >
+                {t("eyebrow")}
+              </RevealItem>
+              <RevealItem
+                as="h2"
+                className="mt-5 text-[34px] font-bold leading-[1.1] tracking-[-0.025em] text-text sm:text-[44px]"
+              >
+                {t("headline1")}
+                <br />
+                <span className="text-text">{t("headline2")}</span>
+              </RevealItem>
+              <RevealItem
+                as="p"
+                className="mt-6 max-w-xl text-[16px] leading-[1.7] text-text-muted"
+              >
+                {t("description")}
+              </RevealItem>
+            </RevealGroup>
+
+            <RevealGroup as="ul" className="mt-7 space-y-3" stagger={0.07}>
               {(["bullet1", "bullet2", "bullet3"] as const).map((key) => (
-                <li key={key} className="flex items-start gap-3">
+                <RevealItem
+                  as="li"
+                  key={key}
+                  className="flex items-start gap-3"
+                >
                   <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full bg-accent-soft text-accent">
                     <Check className="h-3 w-3" strokeWidth={3} />
                   </span>
                   <span className="text-[14.5px] leading-[1.6] text-text">
                     {t(key)}
                   </span>
-                </li>
+                </RevealItem>
               ))}
-            </ul>
+            </RevealGroup>
           </div>
 
-          <div
+          <Reveal
+            variant="focus"
             className={`flex items-center justify-center ${
               reverse ? "lg:[direction:ltr]" : ""
             }`}
           >
             {visual}
-          </div>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/apps/landing/components/sections/feature-visuals.tsx
+++ b/apps/landing/components/sections/feature-visuals.tsx
@@ -1,7 +1,18 @@
 import { Mic, Heart, Languages, Send, ArrowRight } from "lucide-react";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
+import { LivingWaveform } from "../motion/living-waveform";
 
 const CARD =
   "rounded-[28px] border border-line bg-surface p-6 shadow-[0_24px_60px_rgba(90,75,55,0.10)]";
+
+// 48-bar recording waveform; bars 0..31 are the "played" (coral) portion.
+const VOICE_BARS = [
+  0.2, 0.3, 0.5, 0.4, 0.7, 0.55, 0.85, 0.45, 0.6, 0.8, 0.4, 0.55, 0.75, 0.5,
+  0.35, 0.65, 0.9, 0.6, 0.45, 0.7, 0.5, 0.85, 0.55, 0.4, 0.7, 0.6, 0.45, 0.8,
+  0.35, 0.55, 0.7, 0.5, 0.85, 0.4, 0.6, 0.75, 0.45, 0.65, 0.5, 0.4, 0.6, 0.8,
+  0.45, 0.55, 0.7, 0.5, 0.35, 0.55,
+];
 
 // Visual for "voice" — recording UI
 export function VoiceVisual() {
@@ -18,30 +29,22 @@ export function VoiceVisual() {
             00:08
           </span>
         </div>
-        <div className="mt-6 grid h-16 grid-cols-[repeat(48,_minmax(0,1fr))] items-center gap-[2px]">
-          {Array.from({ length: 48 }).map((_, i) => {
-            const heights = [
-              0.2, 0.3, 0.5, 0.4, 0.7, 0.55, 0.85, 0.45, 0.6, 0.8, 0.4, 0.55,
-              0.75, 0.5, 0.35, 0.65, 0.9, 0.6, 0.45, 0.7, 0.5, 0.85, 0.55, 0.4,
-              0.7, 0.6, 0.45, 0.8, 0.35, 0.55, 0.7, 0.5, 0.85, 0.4, 0.6, 0.75,
-              0.45, 0.65, 0.5, 0.4, 0.6, 0.8, 0.45, 0.55, 0.7, 0.5, 0.35, 0.55,
-            ];
-            const h = heights[i] ?? 0.4;
-            const played = i < 32;
-            return (
-              <span
-                key={i}
-                className="block w-full rounded-full"
-                style={{
-                  height: `${h * 100}%`,
-                  backgroundColor: played
-                    ? "var(--color-accent)"
-                    : "var(--color-line)",
-                  opacity: played ? 0.9 : 1,
-                }}
-              />
-            );
-          })}
+        {/* the signature playback sweep */}
+        <div className="mt-6 h-16">
+          <LivingWaveform
+            bars={VOICE_BARS}
+            mode="playOnce"
+            playedTo={32}
+            color="var(--color-accent)"
+            restColor="var(--color-line)"
+            barWidth="flex"
+            gapPx={2}
+            minPx={2}
+            spanPx={62}
+            align="end"
+            activeOpacity={0.9}
+            restOpacity={1}
+          />
         </div>
         <div className="mt-6 flex items-center justify-between">
           <span className="text-[12.5px] text-text-muted">&ldquo;늦지 않게 일어나자.&rdquo;</span>
@@ -75,9 +78,9 @@ export function SharedVisual() {
             가족 공유
           </span>
         </div>
-        <div className="mt-5 space-y-2.5">
+        <RevealGroup className="mt-5 space-y-2.5" stagger={0.08} delay={0.1}>
           {profiles.map((p) => (
-            <div
+            <RevealItem
               key={p.name}
               className="flex items-center gap-3 rounded-2xl border border-line bg-raised p-3.5"
             >
@@ -94,9 +97,9 @@ export function SharedVisual() {
                 <p className="truncate text-[11px] text-text-muted">{p.from}</p>
               </div>
               <ArrowRight className="h-4 w-4 shrink-0 text-text-dim" />
-            </div>
+            </RevealItem>
           ))}
-        </div>
+        </RevealGroup>
       </div>
     </div>
   );
@@ -116,12 +119,22 @@ export function LanguageVisual() {
           <span className="inline-flex h-6 items-center rounded-full bg-accent-soft px-2 text-[10.5px] font-bold uppercase tracking-wider text-accent">
             EN · 원어민 발음
           </span>
-          <p className="mt-3 text-[15px] font-semibold text-text">
+          {/* transcript "plays" left-to-right, then the source line fades in */}
+          <Reveal
+            as="p"
+            variant="wipe"
+            delay={0.15}
+            className="mt-3 text-[15px] font-semibold text-text"
+          >
             &ldquo;Don&rsquo;t oversleep — today matters.&rdquo;
-          </p>
-          <p className="mt-2 text-[12px] text-text-muted">
+          </Reveal>
+          <Reveal
+            as="p"
+            delay={0.55}
+            className="mt-2 text-[12px] text-text-muted"
+          >
             늦잠 자지 마. 오늘이 중요한 날이야.
-          </p>
+          </Reveal>
         </div>
         <div className="mt-3 flex items-center justify-between rounded-2xl border border-line bg-raised p-3.5">
           <div>

--- a/apps/landing/components/sections/feature-visuals.tsx
+++ b/apps/landing/components/sections/feature-visuals.tsx
@@ -18,7 +18,7 @@ const VOICE_BARS = [
 export function VoiceVisual() {
   return (
     <div className="relative w-full max-w-[420px]">
-      <div className="absolute -inset-4 -z-10 rounded-[40px] bg-[radial-gradient(circle_at_50%_30%,rgba(217,119,87,0.12),transparent_60%)] blur-2xl" />
+      <div className="absolute -inset-4 -z-10 rounded-[40px] bg-[radial-gradient(circle_at_50%_30%,rgba(23,95,176,0.12),transparent_60%)] blur-2xl" />
       <div className={CARD}>
         <div className="flex items-center justify-between">
           <span className="whitespace-nowrap text-[12px] font-semibold uppercase tracking-[0.12em] text-text-muted">
@@ -50,7 +50,7 @@ export function VoiceVisual() {
           <span className="text-[12.5px] text-text-muted">&ldquo;늦지 않게 일어나자.&rdquo;</span>
           <button
             type="button"
-            className="grid h-12 w-12 place-items-center rounded-full bg-accent text-white shadow-[0_8px_20px_rgba(217,119,87,0.28)]"
+            className="grid h-12 w-12 place-items-center rounded-full bg-accent text-white shadow-[0_8px_20px_rgba(23,95,176,0.28)]"
           >
             <Mic className="h-5 w-5" strokeWidth={2.2} />
           </button>
@@ -63,13 +63,13 @@ export function VoiceVisual() {
 // Visual for "shared" — voice library cards
 export function SharedVisual() {
   const profiles = [
-    { name: "엄마", from: "공유 받음 · 7일 전", color: "#db7e63" },
+    { name: "엄마", from: "공유 받음 · 7일 전", color: "#5e8fbf" },
     { name: "지수 (커플)", from: "공유 받음 · 어제", color: "#7fb096" },
     { name: "친구 민준", from: "공유 받음 · 3일 전", color: "#e0b15e" },
   ];
   return (
     <div className="relative w-full max-w-[420px]">
-      <div className="absolute -inset-4 -z-10 rounded-[40px] bg-[radial-gradient(circle_at_50%_30%,rgba(217,119,87,0.1),transparent_60%)] blur-2xl" />
+      <div className="absolute -inset-4 -z-10 rounded-[40px] bg-[radial-gradient(circle_at_50%_30%,rgba(23,95,176,0.1),transparent_60%)] blur-2xl" />
       <div className={CARD}>
         <div className="flex items-center justify-between">
           <span className="text-[16px] font-bold text-text">공유 음성</span>

--- a/apps/landing/components/sections/hero.tsx
+++ b/apps/landing/components/sections/hero.tsx
@@ -1,7 +1,10 @@
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { PhonePreview } from "../phone-preview";
 import { StoreBadges } from "../store-badges";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
+import { Magnetic } from "../motion/magnetic";
 
 export function Hero() {
   const t = useTranslations("hero");
@@ -9,37 +12,63 @@ export function Hero() {
   return (
     <section className="relative">
       <div className="mx-auto grid max-w-6xl items-center gap-16 px-5 pb-20 pt-12 md:px-8 lg:grid-cols-[1.1fr_0.9fr] lg:gap-12 lg:pb-28 lg:pt-20">
-        <div className="flex flex-col">
-          <span className="inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-full border border-line bg-surface px-3.5 py-1.5 text-[12px] font-medium text-text-muted">
+        {/* Left column — staggered on-load entrance. Text stays server-rendered;
+            only the thin Reveal/Magnetic wrappers are client. */}
+        <RevealGroup className="flex flex-col" stagger={0.07} delay={0.05} trigger="mount">
+          <RevealItem
+            as="span"
+            className="inline-flex w-fit items-center gap-2 whitespace-nowrap rounded-full border border-line bg-surface px-3.5 py-1.5 text-[12px] font-medium text-text-muted"
+          >
             <span className="h-1.5 w-1.5 rounded-full bg-mint" />
             {t("badge")}
-          </span>
+          </RevealItem>
 
-          <h1 className="mt-7 text-[44px] font-bold leading-[1.04] tracking-[-0.03em] text-text sm:text-[60px] lg:text-[72px]">
+          <RevealItem
+            as="h1"
+            className="mt-7 text-[44px] font-bold leading-[1.04] tracking-[-0.03em] text-text sm:text-[60px] lg:text-[72px]"
+          >
             {t("headline1")}
             <br />
             <span className="text-accent">{t("headline2")}</span>
-          </h1>
+          </RevealItem>
 
-          <p className="mt-7 max-w-[540px] text-[17px] leading-[1.65] text-text-muted sm:text-[18px]">
+          <RevealItem
+            as="p"
+            className="mt-7 max-w-[540px] text-[17px] leading-[1.65] text-text-muted sm:text-[18px]"
+          >
             {t("description")}
-          </p>
+          </RevealItem>
 
-          <div className="mt-10 flex flex-col gap-4">
+          <RevealItem as="div" className="mt-10 flex flex-col gap-4">
             <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-              <a href="#waitlist" className="group btn btn-primary">
-                {t("ctaPrimary")}
-                <ArrowRight className="ml-2 h-4 w-4 transition group-hover:translate-x-0.5" />
-              </a>
+              <Magnetic>
+                <a href="#waitlist" className="group btn btn-primary">
+                  {t("ctaPrimary")}
+                  <ArrowRight className="ml-2 h-4 w-4 transition group-hover:translate-x-0.5" />
+                </a>
+              </Magnetic>
               <StoreBadges />
             </div>
             <p className="text-[13px] text-text-faint">{t("ctaNote")}</p>
-          </div>
-        </div>
+          </RevealItem>
 
-        <div className="flex items-center justify-center">
+          <RevealItem as="div" className="mt-8">
+            <span className="animate-bob inline-flex items-center gap-1.5 text-[12px] font-medium uppercase tracking-[0.14em] text-text-faint">
+              {t("scrollHint")}
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            </span>
+          </RevealItem>
+        </RevealGroup>
+
+        {/* Phone — "powers on" after the text settles. */}
+        <Reveal
+          variant="focus"
+          delay={0.42}
+          trigger="mount"
+          className="flex items-center justify-center"
+        >
           <PhonePreview />
-        </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/apps/landing/components/sections/quotes.tsx
+++ b/apps/landing/components/sections/quotes.tsx
@@ -1,5 +1,7 @@
 import { Quote } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
 
 type QuoteItem = { body: string; author: string; role: string };
 
@@ -9,28 +11,36 @@ export function Quotes() {
 
   return (
     <section className="relative">
-      <div className="hairline" />
+      <Reveal variant="wipe" as="div" className="hairline" />
       <div className="mx-auto max-w-6xl px-5 py-24 md:px-8 lg:py-28">
         <div className="max-w-3xl">
-          <span className="eyebrow">{t("eyebrow")}</span>
-          <h2 className="mt-6 text-[32px] font-bold leading-[1.15] tracking-[-0.02em] text-text sm:text-[40px]">
+          <Reveal as="span" className="eyebrow">
+            {t("eyebrow")}
+          </Reveal>
+          <Reveal
+            as="h2"
+            delay={0.06}
+            className="mt-6 text-[32px] font-bold leading-[1.15] tracking-[-0.02em] text-text sm:text-[40px]"
+          >
             {t("headline")}
-          </h2>
-          <p className="mt-5 text-[16px] leading-[1.65] text-text-muted">
+          </Reveal>
+          <Reveal
+            as="p"
+            delay={0.12}
+            className="mt-5 text-[16px] leading-[1.65] text-text-muted"
+          >
             {t("description")}
-          </p>
+          </Reveal>
         </div>
 
-        <ul className="mt-12 grid gap-4 lg:grid-cols-3">
+        <RevealGroup as="ul" className="mt-12 grid gap-4 lg:grid-cols-3" stagger={0.1}>
           {items.map((item, i) => (
-            <li
+            <RevealItem
+              as="li"
               key={`${item.author}-${i}`}
               className="card relative flex flex-col p-7 lg:p-8"
             >
-              <Quote
-                className="h-5 w-5 text-accent"
-                aria-hidden="true"
-              />
+              <Quote className="h-5 w-5 text-accent" aria-hidden="true" />
               <p className="mt-5 text-[15.5px] leading-[1.7] text-text">
                 {item.body}
               </p>
@@ -47,11 +57,17 @@ export function Quotes() {
                   </span>
                 </div>
               </div>
-            </li>
+            </RevealItem>
           ))}
-        </ul>
+        </RevealGroup>
 
-        <p className="mt-10 text-[12.5px] text-text-faint">{t("disclaimer")}</p>
+        <Reveal
+          as="p"
+          delay={0.1}
+          className="mt-10 text-[12.5px] text-text-faint"
+        >
+          {t("disclaimer")}
+        </Reveal>
       </div>
     </section>
   );

--- a/apps/landing/components/sections/scenarios.tsx
+++ b/apps/landing/components/sections/scenarios.tsx
@@ -1,4 +1,6 @@
 import { useTranslations } from "next-intl";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
 
 export function Scenarios() {
   const t = useTranslations("scenarios");
@@ -8,25 +10,39 @@ export function Scenarios() {
     <section id="voices" className="relative">
       <div className="mx-auto max-w-6xl px-5 py-24 md:px-8 lg:py-32">
         <div className="max-w-2xl">
-          <h2 className="text-[34px] font-bold leading-[1.1] tracking-[-0.025em] text-text sm:text-[44px]">
+          <Reveal
+            as="h2"
+            className="text-[34px] font-bold leading-[1.1] tracking-[-0.025em] text-text sm:text-[44px]"
+          >
             {t("headline")}
-          </h2>
-          <p className="mt-5 text-[16px] leading-[1.65] text-text-muted">
+          </Reveal>
+          <Reveal
+            as="p"
+            delay={0.08}
+            className="mt-5 text-[16px] leading-[1.65] text-text-muted"
+          >
             {t("description")}
-          </p>
+          </Reveal>
         </div>
 
-        <div className="mt-12 grid gap-4 sm:grid-cols-2">
+        <RevealGroup
+          className="mt-12 grid gap-4 sm:grid-cols-2"
+          stagger={0.08}
+        >
           {items.map((i) => (
-            <article
+            <RevealItem
+              as="article"
               key={i}
-              className="card group relative p-7 transition hover:border-line"
+              className="card group relative p-7 transition hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
             >
               <div className="flex items-center gap-3">
                 <span className="inline-flex h-7 items-center whitespace-nowrap rounded-full border border-line bg-raised px-2.5 text-[11.5px] font-semibold text-text-muted">
                   {t(`items.${i}.tag`)}
                 </span>
-                <span className="h-px flex-1 bg-line-soft" />
+                {/* divider that wipes coral on hover */}
+                <span className="relative h-px flex-1 overflow-hidden bg-line-soft">
+                  <span className="absolute inset-0 origin-left scale-x-0 bg-accent transition-transform duration-300 ease-out group-hover:scale-x-100" />
+                </span>
               </div>
               <h3 className="mt-5 text-[20px] font-bold leading-snug tracking-[-0.015em] text-text">
                 {t(`items.${i}.title`)}
@@ -34,9 +50,9 @@ export function Scenarios() {
               <p className="mt-3 text-[15px] leading-[1.65] text-text-muted">
                 {t(`items.${i}.body`)}
               </p>
-            </article>
+            </RevealItem>
           ))}
-        </div>
+        </RevealGroup>
       </div>
     </section>
   );

--- a/apps/landing/components/sections/site-footer.tsx
+++ b/apps/landing/components/sections/site-footer.tsx
@@ -2,6 +2,7 @@
 import { Link } from "@/i18n/navigation";
 import { BrandMark } from "../brand-mark";
 import { LocaleSwitcher } from "../locale-switcher";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
 
 export function SiteFooter() {
   const t = useTranslations("footer");
@@ -11,8 +12,12 @@ export function SiteFooter() {
     <footer className="relative">
       <div className="hairline" />
       <div className="mx-auto max-w-6xl px-5 py-14 md:px-8 lg:py-20">
-        <div className="flex flex-col gap-12 lg:flex-row lg:items-start lg:justify-between">
-          <div className="max-w-sm">
+        <RevealGroup
+          as="div"
+          stagger={0.08}
+          className="flex flex-col gap-12 lg:flex-row lg:items-start lg:justify-between"
+        >
+          <RevealItem as="div" className="max-w-sm">
             <Link
               href="/"
               aria-label="AlarmTalk"
@@ -29,9 +34,9 @@ export function SiteFooter() {
             <div className="mt-6">
               <LocaleSwitcher />
             </div>
-          </div>
+          </RevealItem>
 
-          <div className="grid grid-cols-2 gap-10 sm:grid-cols-3">
+          <RevealItem as="div" className="grid grid-cols-2 gap-10 sm:grid-cols-3">
             <div>
               <p className="whitespace-nowrap text-[11px] font-semibold uppercase tracking-[0.12em] text-text-faint">
                 {t("product")}
@@ -127,8 +132,8 @@ export function SiteFooter() {
                 </li>
               </ul>
             </div>
-          </div>
-        </div>
+          </RevealItem>
+        </RevealGroup>
 
         <div className="mt-14 flex flex-col gap-3 border-t border-line pt-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="whitespace-nowrap text-[12.5px] text-text-faint">

--- a/apps/landing/components/sections/trust.tsx
+++ b/apps/landing/components/sections/trust.tsx
@@ -1,4 +1,20 @@
 import { useTranslations } from "next-intl";
+import { Reveal } from "../motion/reveal";
+import { RevealGroup, RevealItem } from "../motion/reveal-group";
+import { CountUp } from "../motion/count-up";
+
+type Metric =
+  | { mode: "number" | "odometer"; to: number; suffix: string }
+  | { mode: "text"; text: string };
+
+// Split a localized metric ("60초" / "60s" / "TTS" / "0") into a number + its
+// locale suffix so the count animates while the unit stays in i18n.
+function parseMetric(raw: string): Metric {
+  const m = raw.match(/^(\d+)(.*)$/);
+  if (!m) return { mode: "text", text: raw };
+  const to = parseInt(m[1], 10);
+  return { mode: to === 0 ? "odometer" : "number", to, suffix: m[2] };
+}
 
 export function Trust() {
   const t = useTranslations("trust");
@@ -7,27 +23,55 @@ export function Trust() {
   return (
     <section className="relative">
       <div className="mx-auto max-w-6xl px-5 py-16 md:px-8 lg:py-20">
-        <h2 className="max-w-2xl text-[28px] font-bold leading-[1.18] tracking-[-0.02em] text-text sm:text-[36px]">
+        <Reveal
+          as="h2"
+          className="max-w-2xl text-[28px] font-bold leading-[1.18] tracking-[-0.02em] text-text sm:text-[36px]"
+        >
           {t("headline")}
-        </h2>
+        </Reveal>
+        {/* coral wipe underline — ties Trust to the voice-spine */}
+        <Reveal
+          as="div"
+          variant="wipe"
+          delay={0.15}
+          className="mt-5 h-[2px] w-14 rounded-full bg-accent"
+        />
 
-        <div className="mt-10 grid gap-px overflow-hidden rounded-3xl border border-line bg-line lg:grid-cols-3">
-          {items.map((i) => (
-            <div key={i} className="flex flex-col gap-4 bg-surface p-7 lg:p-8">
-              <div className="flex items-baseline gap-1.5">
-                <span className="whitespace-nowrap text-[48px] font-bold leading-none tracking-[-0.03em] text-accent sm:text-[56px]">
-                  {t(`items.${i}.metric`)}
-                </span>
-                <span className="whitespace-nowrap text-[14px] font-semibold text-text-muted">
-                  {t(`items.${i}.title`)}
-                </span>
-              </div>
-              <p className="text-[14.5px] leading-[1.65] text-text-muted">
-                {t(`items.${i}.body`)}
-              </p>
-            </div>
-          ))}
-        </div>
+        <RevealGroup
+          className="mt-10 grid gap-px overflow-hidden rounded-3xl border border-line bg-line lg:grid-cols-3"
+          stagger={0.08}
+        >
+          {items.map((i) => {
+            const metric = parseMetric(t(`items.${i}.metric`));
+            return (
+              <RevealItem
+                key={i}
+                className="flex flex-col gap-4 bg-surface p-7 lg:p-8"
+              >
+                <div className="flex items-baseline gap-1.5">
+                  <span className="whitespace-nowrap text-[48px] font-bold leading-none tracking-[-0.03em] text-accent sm:text-[56px]">
+                    {metric.mode === "text" ? (
+                      <CountUp mode="text" text={metric.text} durationMs={700} />
+                    ) : (
+                      <CountUp
+                        mode={metric.mode}
+                        to={metric.to}
+                        suffix={metric.suffix}
+                        durationMs={900}
+                      />
+                    )}
+                  </span>
+                  <span className="whitespace-nowrap text-[14px] font-semibold text-text-muted">
+                    {t(`items.${i}.title`)}
+                  </span>
+                </div>
+                <p className="text-[14.5px] leading-[1.65] text-text-muted">
+                  {t(`items.${i}.body`)}
+                </p>
+              </RevealItem>
+            );
+          })}
+        </RevealGroup>
       </div>
     </section>
   );

--- a/apps/landing/components/sections/waitlist.tsx
+++ b/apps/landing/components/sections/waitlist.tsx
@@ -1,13 +1,25 @@
-﻿"use client";
+"use client";
 
 import { useState, type FormEvent } from "react";
 import { ArrowRight, Check, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { motion } from "motion/react";
+import { Reveal } from "../motion/reveal";
+import { Magnetic } from "../motion/magnetic";
+import { LivingWaveform } from "../motion/living-waveform";
+import { usePrefersReducedMotion } from "../motion/use-prefers-reduced-motion";
 
 type Status = "idle" | "loading" | "success" | "error";
 
+// short coral flourish — the voice-spine resolving where the journey begins
+const SPINE_BARS = [
+  0.3, 0.5, 0.4, 0.7, 0.55, 0.85, 0.5, 0.65, 0.9, 0.6, 0.45, 0.7, 0.5, 0.8,
+  0.4, 0.6,
+];
+
 export function Waitlist() {
   const t = useTranslations("waitlist");
+  const reduced = usePrefersReducedMotion();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<Status>("idle");
 
@@ -33,18 +45,34 @@ export function Waitlist() {
   return (
     <section id="waitlist" className="relative">
       <div className="mx-auto max-w-5xl px-5 py-24 md:px-8 lg:py-32">
-        <div className="card-raised relative overflow-hidden p-10 sm:p-14">
+        <Reveal
+          as="div"
+          variant="focus"
+          className="card-raised relative overflow-hidden p-10 sm:p-14"
+        >
           <div
             aria-hidden="true"
-            className="absolute -right-32 -top-32 h-80 w-80 rounded-full bg-accent/15 blur-3xl"
+            className="animate-drift absolute -right-32 -top-32 h-80 w-80 rounded-full bg-accent/15 blur-3xl"
           />
           <div
             aria-hidden="true"
-            className="absolute -bottom-32 -left-32 h-80 w-80 rounded-full bg-indigo-deep/40 blur-3xl"
+            className="animate-drift-slow absolute -bottom-32 -left-32 h-80 w-80 rounded-full bg-indigo-deep/40 blur-3xl"
           />
 
           <div className="relative grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
             <div>
+              <div className="mb-5 h-6 w-40">
+                <LivingWaveform
+                  bars={SPINE_BARS}
+                  mode="playOnce"
+                  color="var(--color-accent)"
+                  barWidth="flex"
+                  gapPx={3}
+                  minPx={2}
+                  spanPx={20}
+                  align="end"
+                />
+              </div>
               <h2 className="text-[32px] font-bold leading-[1.12] tracking-[-0.025em] text-text sm:text-[40px]">
                 {t("headline1")}
                 <br />
@@ -59,7 +87,7 @@ export function Waitlist() {
               <label htmlFor="waitlist-email" className="sr-only">
                 Email
               </label>
-              <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="relative flex flex-col gap-2 sm:flex-row">
                 <input
                   id="waitlist-email"
                   type="email"
@@ -75,25 +103,46 @@ export function Waitlist() {
                   }}
                   className="h-[52px] flex-1 rounded-full border border-line bg-bg px-5 text-[15px] text-text placeholder:text-text-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60"
                 />
-                <button
-                  type="submit"
-                  disabled={status === "loading" || status === "success"}
-                  className="btn btn-primary disabled:cursor-not-allowed disabled:opacity-70"
-                >
-                  {status === "loading" ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : status === "success" ? (
-                    <>
-                      <Check className="mr-2 h-4 w-4" />
-                      {t("ctaSuccess")}
-                    </>
-                  ) : (
-                    <>
-                      {t("cta")}
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </>
-                  )}
-                </button>
+                <Magnetic>
+                  <button
+                    type="submit"
+                    disabled={status === "loading" || status === "success"}
+                    className="btn btn-primary disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {status === "loading" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : status === "success" ? (
+                      <>
+                        <motion.span
+                          className="mr-2 inline-flex"
+                          initial={reduced ? false : { scale: 0 }}
+                          animate={reduced ? undefined : { scale: 1 }}
+                          transition={{ type: "spring", stiffness: 300, damping: 14 }}
+                        >
+                          <Check className="h-4 w-4" />
+                        </motion.span>
+                        {t("ctaSuccess")}
+                      </>
+                    ) : (
+                      <>
+                        {t("cta")}
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </>
+                    )}
+                  </button>
+                </Magnetic>
+
+                {/* mint success flash — mint = safe / trusted */}
+                {status === "success" && !reduced && (
+                  <motion.div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 rounded-full"
+                    style={{ backgroundColor: "var(--color-mint)" }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: [0, 0.18, 0] }}
+                    transition={{ duration: 1, ease: "easeOut" }}
+                  />
+                )}
               </div>
               <p
                 role="status"
@@ -112,7 +161,7 @@ export function Waitlist() {
               </p>
             </form>
           </div>
-        </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/apps/landing/components/site-header.tsx
+++ b/apps/landing/components/site-header.tsx
@@ -1,14 +1,42 @@
+"use client";
+
 import { useTranslations } from "next-intl";
+import { motion, useTransform } from "motion/react";
 import { Link } from "@/i18n/navigation";
 import { BrandMark } from "./brand-mark";
 import { MobileMenu } from "./mobile-menu";
+import { Magnetic } from "./motion/magnetic";
+import { useScrollProgress } from "./motion/use-scroll-progress";
 
 export function SiteHeader() {
   const t = useTranslations("nav");
+  const { scrollY, progress } = useScrollProgress();
+
+  // Scroll-linked, not class-toggled, so the chrome fades in smoothly.
+  const bgOpacity = useTransform(scrollY, [0, 48], [0, 0.85]);
+  const backdropFilter = useTransform(
+    scrollY,
+    [0, 48],
+    ["saturate(140%) blur(0px)", "saturate(140%) blur(12px)"],
+  );
 
   return (
-    <header className="relative z-30">
+    <header className="sticky top-0 z-30">
+      {/* translucent backdrop that fades in on scroll */}
+      <motion.div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-surface"
+        style={{ opacity: bgOpacity, backdropFilter, WebkitBackdropFilter: backdropFilter }}
+      />
+      {/* faint static hairline */}
       <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-line to-transparent" />
+      {/* coral voice-spine — page scroll progress; resolves at the Waitlist */}
+      <motion.div
+        aria-hidden="true"
+        className="absolute inset-x-0 bottom-0 h-px origin-left bg-accent"
+        style={{ scaleX: progress }}
+      />
+
       <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-5 md:px-8">
         <Link
           href="/"
@@ -55,9 +83,13 @@ export function SiteHeader() {
         </nav>
 
         <div className="flex items-center gap-2">
-          <Link href="/#waitlist" className="btn btn-primary btn-sm hidden sm:inline-flex">
-            {t("cta")}
-          </Link>
+          <div className="hidden sm:block">
+            <Magnetic>
+              <Link href="/#waitlist" className="btn btn-primary btn-sm">
+                {t("cta")}
+              </Link>
+            </Magnetic>
+          </div>
           <MobileMenu />
         </div>
       </div>

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "lucide-react": "^1.18.0",
+    "motion": "^12.40.0",
     "next": "^16.2.9",
     "next-intl": "^4.13.0",
     "pretendard": "^1.3.9",

--- a/docs/design/landing-quiet-frequency-prompts.md
+++ b/docs/design/landing-quiet-frequency-prompts.md
@@ -1,0 +1,61 @@
+# 랜딩 재디자인 "Quiet Frequency" — 크래프트된 프롬프트 모음
+
+스크롤 구동 모션 라이브러리(animmasterlib / reactbits / Aceternity / Magic UI / Motion Primitives / Framer Motion)를 참고해, 기존 "Claude paper" 브랜드에 맞춰 재사용한 프롬프트 9종. 실제 구현(`apps/landing`)을 이 프롬프트들이 구동했다. 새 컴포넌트를 추가하거나 다른 프로젝트에 이식할 때 그대로 재사용 가능.
+
+공통 제약(모든 프롬프트에 적용): Next.js 16 App Router · React 19 · Tailwind v4 · next-intl(ko/en/ja) · 정적 export(`output:'export'`, 클라이언트 모션만) · SEO/JSON-LD/hreflang 무손상 · `prefers-reduced-motion` 폴백 필수 · 새 i18n 키 금지(기존 키 재사용) · transform/opacity/clip-path/filter만 애니메이트 · coral `#d97757`는 유일한 채도색.
+
+---
+
+## 1. 모션 프리미티브 라이브러리
+**참고:** Motion Primitives (motion-primitives.com) + Framer Motion (`motion/react`)
+
+> `apps/landing/components/motion/` 폴더에 재사용 모션 프리미티브 세트를 만들어줘. Motion Primitives의 in-view reveal/stagger 패턴을 참고하되, 의존성은 `motion/react`(Framer Motion)만 쓴다. 파일: `reveal.tsx`(`<Reveal>`), `reveal-group.tsx`(`<RevealGroup>`+`<RevealItem>`), `count-up.tsx`(`<CountUp>`), `magnetic.tsx`(`<Magnetic>`), `use-prefers-reduced-motion.ts`. 모두 `'use client'`. `<Reveal>` props `{ as?, variant?: 'rise'|'focus'|'wipe', delay?, trigger?: 'view'|'mount' }`: whileInView + viewport `{ once:true, margin:'0px 0px -12% 0px' }`. rise={opacity:[0,1],y:[16,0]} 0.6s; focus={opacity:[0,1],y:[20,0],filter:['blur(1.2px)','blur(0px)'],scale:[1.005,1]} 0.7s; wipe={opacity:[0,1],clipPath:['inset(0 100% 0 0)','inset(0 0 0 0)']} 0.8s origin-left. 모든 ease는 `var(--ease-paper)`=cubic-bezier(0.16,1,0.3,1)에 대응하는 `[0.16,1,0.3,1]`. 제약: (1) LCP 보호 — 정적 HTML은 콘텐츠가 DOM에 존재(SEO), 위쪽은 `trigger='mount'`로 마운트 시 진입. (2) reduced-motion — `useReducedMotion()`을 **mounted 게이트**로 감싸 SSR/첫 클라이언트 렌더는 false(서버와 일치), 마운트 후에만 실제 값 적용. reduced면 자식을 즉시 최종 상태로. (3) transform/opacity/clip-path/filter만 → CLS 0. (4) 색은 토큰만. `<Magnetic>`: 포인터 추적 ≤6px + spring(150,15) 복귀; `matchMedia('(pointer: coarse)')` 또는 reduced-motion이면 정적 버튼으로 no-op. 모든 hook은 early-return 전에 호출. `<RevealItem>`은 `<RevealGroup>`의 정적 프로퍼티가 아니라 **독립 named export**로 — compound 프로퍼티는 RSC 서버→클라이언트 경계에서 stripping되어 서버 컴포넌트에서 undefined가 된다. trilingual i18n 유지(텍스트는 서버 부모가 렌더, 얇은 client leaf로 통과).
+
+## 2. LivingWaveform — 시그니처 호흡/재생 파형
+**참고:** Aceternity UI(오디오 파형 모션) → Framer Motion 재구현
+
+> `apps/landing/components/motion/living-waveform.tsx`(`'use client'`)를 만들어줘. Aceternity류 '살아있는 오디오 파형' 느낌을 참고하되 canvas 금지 — 순수 div bar + Framer(정적 export·저사양 안드로이드 페인트 비용 최소화). props `{ bars: number[], mode:'breathe'|'playOnce', color?, restColor?, amplitude?=0.12, playedTo?, barWidth?, gapPx?, minPx?, spanPx?, align?, ... }`. breathe: 각 bar가 scaleY를 무한 사인 루프로 ±amplitude 진동, phase=i*(2π/n), period 4s, 좌→우 traveling wave. playOnce: 마운트/in-view 시 좌→우로 솟고(stagger 12ms/bar), playedTo 인덱스까지 active 컬러가 쓸고 지나간 뒤 정지. 적용: (1) phone-preview의 40-bar → breathe, (2) feature-visuals VoiceVisual 48-bar(played=i<32) → playOnce, playedTo=32, active=`var(--color-accent)`/rest=`var(--color-line)`. 기본 color는 `var(--color-accent)`. reduced-motion이면 루프/스윕 끄고 정적 bar 높이 그대로(빈 화면 금지 — 이게 폴백). playOnce bar엔 `data-reveal` 부여(noscript/reduced CSS가 풀어줌). aria-hidden.
+
+## 3. Hero 진입 + Scroll 힌트
+**참고:** Magic UI(스태거 히어로) + Framer Motion
+
+> `apps/landing/components/sections/hero.tsx`를 서버 컴포넌트로 두되 `<RevealGroup trigger="mount">`/`<RevealItem>`로 Magic UI풍 스태거 진입 적용(라이브러리 추가 없이). 기존 2-컬럼 DOM·next-intl 키 변경 금지. 순서(70ms 스태거): badge → h1(text-accent 2번째 줄 포함, **기존 `<br/>`에서만** 줄바꿈 — 음절 분해 금지, KO/JA keep-all) → description → CTA row → StoreBadges → scrollHint. PhonePreview는 `<Reveal variant="focus" trigger="mount" delay={0.42}>` + 기존 glow로 '전원 켜짐'. primary CTA는 `<Magnetic>`. ctaNote 아래 'Scroll' 힌트: 기존 `t('scrollHint')`(ko/en/ja 모두 'Scroll') + `.animate-bob`(CSS). 위쪽이라 `trigger='mount'`로 마운트 즉시 진입(IO 대기 X). trilingual i18n 유지.
+
+## 4. Header 스크롤 상태 + 코랄 voice-spine
+**참고:** reactbits.dev(스크롤 진행/sticky 헤더) + Framer Motion `useScroll`
+
+> `apps/landing/components/site-header.tsx`에 reactbits류 스크롤 진행 헤더를 입혀줘(`'use client'`, JSON-LD·hreflang·정적 export 무손상). `useScrollProgress`(단일 `useScroll` 구독). scrollY>24px부터 헤더 배경 surface/85% + backdrop-blur를 '스크롤 연동'으로(클래스 토글 아님). 하단에 코랄 voice-spine: 1px 코랄 바, scaleX=페이지 진행도(0→1), origin-left, aria-hidden — 페이지 관통 연결선이며 Waitlist에서 파형으로 종결. 헤더 `sticky top-0`, 높이 고정(CLS 0). primary CTA는 `<Magnetic>`. nav 텍스트는 기존 next-intl 키.
+
+## 5. Trust 카운트업 지표
+**참고:** Magic UI NumberTicker + Framer Motion
+
+> `apps/landing/components/sections/trust.tsx`(서버 컴포넌트 유지)에서 지표를 `<CountUp>`으로. 로케일 metric 문자열("60초"/"60s"/"60秒"/"TTS"/"0")을 **숫자+접미사로 파싱**해 i18n 유지. '60': number 0→60 ~900ms; '0': odometer(9→0 짧게 굴러 안착); 'TTS': text 모드(blur+opacity 세틀, **letter-spacing 금지** — reflow). 숫자는 고정폭 inline-block(min-width=자릿수 ch, tabular-nums) → 자릿수 변해도 CLS 0. 헤딩 `<Reveal>`, 타일 `<RevealGroup>`(80ms), 헤딩 밑 coral 1px wipe 언더라인. reduced-motion이면 최종값 즉시.
+
+## 6. Feature 비주얼 — 재생 파형 + 자막 wipe
+**참고:** Motion Primitives(in-view reveal) + Framer Motion
+
+> `feature-section.tsx`/`feature-visuals.tsx`에 in-view 1회성 reveal(핀 고정 없이 '제품이 스스로 시연'). 기존 3개 교차 레이아웃·DOM·reading order·next-intl 유지(SEO). 텍스트 컬럼(eyebrow/h2/description/bullets)은 `<RevealGroup>`(80ms). visual은 `<Reveal variant="focus">`. VoiceVisual: 48-bar → `<LivingWaveform mode="playOnce" playedTo={32}>`(녹음 재생 스윕). SharedVisual: 3개 프로필 row를 내부 `<RevealGroup>`(y14,70ms) deal-in. LanguageVisual: EN 문장 `<Reveal variant="wipe">`(좌→우 transcript) 뒤 KR 원문 fade, mint 아이콘은 조용히. 전부 1회성 intersection. reduced-motion이면 최종 상태(=오늘 화면).
+
+## 7. Scenarios / Quotes / FAQ / Footer 차분한 reveal
+**참고:** Motion Primitives(stagger) + Framer Motion; FAQ는 네이티브 `<details>` 유지
+
+> 네 섹션을 차분한 reveal만 추가(쇼스토퍼 금지). scenarios: 헤딩 `<Reveal>`, 2×2 카드 `<RevealGroup>`(80ms, flat), hover에서만 tag divider가 coral 좌→우 wipe(CSS group-hover). quotes: 헤딩 `<Reveal>`, 카드 `<RevealGroup>`, 상단 `.hairline`은 enter 시 wipe(Quote 글리프엔 **중첩 Reveal 금지** — 이중 옵저버, 그룹 entrance에 함께 타게). faq: 네이티브 `<details>`/`<summary>` 그대로(no-JS·FAQPage JSON-LD 의존), `<RevealGroup>`(60ms), 답변은 `group-open:animate-fadeup`(CSS, JS 불필요). footer: 컬럼 `<RevealGroup>`(60ms) fade-up. 전부 reduced-motion이면 즉시 최종 상태, 색은 토큰만, trilingual i18n 유지.
+
+## 8. Waitlist 성공 비트 + spine 종결
+**참고:** reactbits.dev(성공 마이크로 인터랙션) + Framer Motion(이미 client)
+
+> `apps/landing/components/sections/waitlist.tsx`(이미 `'use client'`)에 마무리 모션. 폼 로직·next-intl 키 유지. 카드 `<Reveal variant="focus">`. 기존 blur blob 2개는 `.animate-drift`/`.animate-drift-slow`(CSS ~12–16s 사인). headline 앞에 짧은 coral `<LivingWaveform mode="playOnce">`(spine 종착점). submit 버튼 `<Magnetic>`. SUCCESS BEAT(유일한 축하): 성공 시 Check 아이콘 spring pop(scale0→1, stiffness300) + 입력 영역 soft MINT(`--color-mint`) 틴트 플래시(mint=안전/신뢰, coral 아님). reduced-motion/pointer:coarse면 전부 no-op·즉시 최종 상태.
+
+## 9. 전역 토큰 + reduced-motion 미디어쿼리 (직접 작성)
+**참고:** `globals.css` — 라이브러리 아님
+
+> `apps/landing/app/globals.css` 수정. (1) `@theme`에 `--ease-paper: cubic-bezier(0.16,1,0.3,1)` 추가, 모든 JS 모션 config가 이와 일치. (2) 경량 CSS 장식 키프레임 `.animate-bob`(scroll 힌트), `.animate-drift`(blob). (3) 파일 하단에 `@media (prefers-reduced-motion: reduce)` 블록: `*`의 animation/transition을 ~0으로, **그리고 `[data-reveal]{opacity:1!important;transform:none!important;filter:none!important;clip-path:none!important}`** — JS 하이드레이션 타이밍과 무관하게 CSS만으로 최종 가시 상태 복원(JS `usePrefersReducedMotion()` 게이트와 이중 안전망). (4) 폰트 remote `@import`는 `@import "tailwindcss"` **앞**으로(Tailwind 인라인 후 순서 경고 방지). 팔레트·폰트·radii·shadow 토큰은 변경 금지. 루트 layout에 `<noscript>`로 `[data-reveal]` 강제 표시(no-JS 안전망).
+
+---
+
+### 검증 체크리스트 (구현 후)
+- `tsc --noEmit` · `next build`(output:export) 통과, 26페이지 프리렌더
+- 빌드 산출물에서 헤드라인 텍스트·JSON-LD·hreflang 존재(SEO)
+- 빌드 CSS에 `[data-reveal]{opacity:1!important}` reduced-motion 규칙 존재
+- 서버 컴포넌트가 client hook을 호출하지 않음(client 컴포넌트 렌더는 OK)
+- 어드버서리얼 멀티 리뷰(RSC 경계 / 성능·a11y·reduced-motion / 브랜드·i18n)

--- a/docs/design/landing-quiet-frequency-prompts.md
+++ b/docs/design/landing-quiet-frequency-prompts.md
@@ -2,7 +2,9 @@
 
 스크롤 구동 모션 라이브러리(animmasterlib / reactbits / Aceternity / Magic UI / Motion Primitives / Framer Motion)를 참고해, 기존 "Claude paper" 브랜드에 맞춰 재사용한 프롬프트 9종. 실제 구현(`apps/landing`)을 이 프롬프트들이 구동했다. 새 컴포넌트를 추가하거나 다른 프로젝트에 이식할 때 그대로 재사용 가능.
 
-공통 제약(모든 프롬프트에 적용): Next.js 16 App Router · React 19 · Tailwind v4 · next-intl(ko/en/ja) · 정적 export(`output:'export'`, 클라이언트 모션만) · SEO/JSON-LD/hreflang 무손상 · `prefers-reduced-motion` 폴백 필수 · 새 i18n 키 금지(기존 키 재사용) · transform/opacity/clip-path/filter만 애니메이트 · coral `#d97757`는 유일한 채도색.
+공통 제약(모든 프롬프트에 적용): Next.js 16 App Router · React 19 · Tailwind v4 · next-intl(ko/en/ja) · 정적 export(`output:'export'`, 클라이언트 모션만) · SEO/JSON-LD/hreflang 무손상 · `prefers-reduced-motion` 폴백 필수 · 새 i18n 키 금지(기존 키 재사용) · transform/opacity/clip-path/filter만 애니메이트 · 브랜드 액센트는 `var(--color-accent)`(블루 #175FB0, 네이티브 앱과 통일) 단일 채도색.
+
+> 참고: 브랜드 색은 **블루(#175FB0)** 로 통일됨. 아래 프롬프트 본문의 코랄(#d97757/#ec8c6c) 하드코딩 언급은 작성 당시 값으로, 현재 구현은 토큰 `var(--color-accent)`(=블루)을 따른다.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "version": "0.1.0",
       "dependencies": {
         "lucide-react": "^1.18.0",
+        "motion": "^12.40.0",
         "next": "^16.2.9",
         "next-intl": "^4.13.0",
         "pretendard": "^1.3.9",
@@ -4081,6 +4082,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4710,6 +4738,47 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",


### PR DESCRIPTION
## 요약
랜딩에 스크롤 구동 모션 레이어("Quiet Frequency")를 얹고, 브랜드 색을 네이티브 앱과 동일한 블루(#175FB0)로 통일했습니다. 기존 콘텐츠·레이아웃·i18n은 그대로 두고 모션과 색만 입혔습니다.

## 변경
- **모션 프리미티브 5종** (motion/framer, `apps/landing/components/motion/`): `Reveal`/`RevealGroup`·`RevealItem`/`CountUp`/`LivingWaveform`/`Magnetic` + `useScrollProgress`
- **섹션**: Hero 스태거 진입·폰 focus, Header sticky+voice-spine, Trust 카운트업, Feature 재생 파형·자막 wipe, Scenarios/Quotes/FAQ(네이티브 details 유지)/Footer reveal, Waitlist 성공 비트
- **브랜드 색 코랄→블루 통일**: globals.css 토큰 + aurora/버튼 그림자/폰 목업/feature 글로우/OG 이미지 하드코딩 전부. 폰 목업이 실제 블루 앱과 일치(‘코랄 위장’ 해소)
- **안전장치**: reduced-motion 이중망(JS 게이트 + `@media [data-reveal]`), no-JS `<noscript>`, LCP(mount trigger)·CLS(tabular-nums 고정폭)
- `.audit-shots/`(로컬 감사 스크래치) gitignore 처리

## 검증
- `tsc --noEmit` 통과
- `next build`(output:export) 통과 — 26페이지 프리렌더, 빌드 CSS에 `--color-accent:#175fb0` 확인, 코랄 0
- i18n(ko/en/ja, **새 키 0개**)·정적 export·JSON-LD/hreflang 무손상
- 어드버서리얼 멀티 리뷰(RSC 경계 / perf·a11y·reduced-motion / 브랜드·i18n) 후 P1 결함 수정 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)
