### PR TITLE
fix(auth/ci): 회원가입 비밀번호·중복 처리 개선 + dev 배포 마이그레이션 404 수정

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Run dev DB migrations
         if: github.ref_name == 'develop'
+        env:
+          INIT_DB_SECRET: ${{ secrets.INIT_DB_SECRET }}
         run: npm run migrate:dev
 
       - name: Deploy production to Cloudflare Workers

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/ApiErrors.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/ApiErrors.kt
@@ -4,21 +4,36 @@ import org.json.JSONObject
 import retrofit2.HttpException
 
 /**
- * 백엔드 에러 응답의 `error_code` 필드를 추출하는 공용 헬퍼.
+ * 백엔드 에러 응답에서 추출한 필드들.
  *
- * 백엔드는 4xx/5xx 에서 `{"error_code": "...", "message": "..."}` 형식 JSON 본문을 반환한다.
- * 여러 호출 지점에서 동일한 로직을 중복으로 갖고 있던 것을 한곳에 모은다.
- *
- * @return error_code 값. HTTP 예외가 아니거나 본문이 비어있거나 JSON 파싱 실패 시 null.
+ * 백엔드는 4xx/5xx 에서 `{"error_code": "...", "message": "...", "provider"?: "..."}` 형식
+ * JSON 본문을 반환한다. HttpException 의 errorBody 는 한 번만 읽을 수 있으므로 한 번 파싱해
+ * 필요한 필드를 함께 돌려준다.
  */
-fun apiErrorCode(error: Throwable): String? {
+data class ApiError(val code: String?, val provider: String?)
+
+fun apiError(error: Throwable): ApiError {
     val body = (error as? HttpException)
         ?.response()
         ?.errorBody()
         ?.string()
         ?.takeIf { it.isNotBlank() }
-        ?: return null
+        ?: return ApiError(null, null)
     return runCatching {
-        JSONObject(body).optString("error_code").takeIf { it.isNotBlank() }
-    }.getOrNull()
+        val json = JSONObject(body)
+        ApiError(
+            code = json.optString("error_code").takeIf { it.isNotBlank() },
+            provider = json.optString("provider").takeIf { it.isNotBlank() },
+        )
+    }.getOrElse { ApiError(null, null) }
 }
+
+/**
+ * error_code 값만 필요할 때의 단축 헬퍼.
+ *
+ * 주의: errorBody 는 한 번만 읽히므로, 같은 throwable 에 [apiError] 와 [apiErrorCode] 를
+ * 함께 호출하지 말 것(둘 중 하나만 사용).
+ *
+ * @return error_code 값. HTTP 예외가 아니거나 본문이 비어있거나 JSON 파싱 실패 시 null.
+ */
+fun apiErrorCode(error: Throwable): String? = apiError(error).code

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -65,6 +65,14 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
     val selectedTab = currentTab ?: NativeTab.Home
     var planGateDialog by remember { mutableStateOf<PlanGateDialogState?>(null) }
     var authRoute by remember { mutableStateOf<AuthRoute>(AuthRoute.Landing) }
+    // 회원가입 시도 이메일이 이미 가입돼 있으면(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환한다.
+    // 입력한 이메일은 AuthScreen 의 remember 상태로 유지되므로 다시 입력할 필요가 없다.
+    LaunchedEffect(viewModel.authRedirectToLogin) {
+        if (viewModel.authRedirectToLogin) {
+            authRoute = AuthRoute.Auth(AuthMode.Login)
+            viewModel.authRedirectToLogin = false
+        }
+    }
     val themeMode = viewModel.themeMode
     val snackbarHostState = remember { SnackbarHostState() }
     val sessionRouteKey = authSession?.user?.id

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -72,7 +72,12 @@ internal fun AuthScreen(
     val emailLooksValid = Patterns.EMAIL_ADDRESS.matcher(normalizedEmail).matches()
     val passwordAtLeastMin = password.length >= 8
     val passwordUnderMax = password.length <= 128
-    val passwordLengthValid = passwordAtLeastMin && passwordUnderMax
+    val passwordHasLetter = password.any { it.isLetter() }
+    val passwordHasDigit = password.any { it.isDigit() }
+    val passwordHasLetterAndDigit = passwordHasLetter && passwordHasDigit
+    // 서버 정책(@alarmtalk/shared PasswordSchema)과 일치: 8~128자 + 영문·숫자 각 1자 이상.
+    val passwordPolicyValid =
+        passwordAtLeastMin && passwordUnderMax && passwordHasLetterAndDigit
     val passwordMatches = password.isNotBlank() && password == confirmPassword
     val isEmailVerified = mode == AuthMode.Login || emailVerified == normalizedEmail
     val codeSentForEmail = emailVerificationSentTo == normalizedEmail
@@ -82,7 +87,7 @@ internal fun AuthScreen(
         name.isNotBlank() &&
             emailLooksValid &&
             isEmailVerified &&
-            passwordLengthValid &&
+            passwordPolicyValid &&
             passwordMatches
     }
 
@@ -237,7 +242,7 @@ internal fun AuthScreen(
         if (mode == AuthMode.Register) {
             PasswordRules(
                 passwordAtLeastMin = passwordAtLeastMin,
-                passwordUnderMax = passwordUnderMax,
+                passwordHasLetterAndDigit = passwordHasLetterAndDigit,
                 passwordMatches = passwordMatches,
             )
 
@@ -326,12 +331,12 @@ internal fun AuthScreen(
 @Composable
 private fun PasswordRules(
     passwordAtLeastMin: Boolean,
-    passwordUnderMax: Boolean,
+    passwordHasLetterAndDigit: Boolean,
     passwordMatches: Boolean,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         PasswordRuleRow(text = stringResource(R.string.auth_password_rule_min), satisfied = passwordAtLeastMin)
-        PasswordRuleRow(text = stringResource(R.string.auth_password_rule_max), satisfied = passwordUnderMax)
+        PasswordRuleRow(text = stringResource(R.string.auth_password_rule_alnum), satisfied = passwordHasLetterAndDigit)
         PasswordRuleRow(text = stringResource(R.string.auth_password_rule_match), satisfied = passwordMatches)
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -75,8 +75,9 @@ private fun landingPalette(): LandingPalette {
             line = Color(0xFF2D313D),
             text = Color(0xFFF7F4EE),
             muted = Color(0xFFB0A89C),
-            accent = Color(0xFFEC8C6C),
-            accentText = Color(0xFFFFFFFF),
+            // 브랜드 블루(테마 단일 출처) 사용 — 랜딩만 코랄로 어긋나지 않도록 light 분기와 동일하게 scheme 참조.
+            accent = scheme.primary,
+            accentText = scheme.onPrimary,
         )
     } else {
         LandingPalette(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -160,6 +160,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var registerEmailVerified by mutableStateOf<String?>(null)
         internal set
 
+    // 가입 시도 이메일이 이미 가입돼 있을 때(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환하라는 신호.
+    var authRedirectToLogin by mutableStateOf(false)
+        internal set
+
     var syncBusy by mutableStateOf(false)
         internal set
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -101,9 +101,29 @@ internal fun MainViewModel.requestEmailVerification(email: String) {
                 ?: getApplication<android.app.Application>().getString(R.string.msg_verification_code_sent)
         }.onFailure { error ->
             Log.e(TAG, "Email verification request failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_send_failed))
+            message = duplicateEmailMessage(error)
+                ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_send_failed))
         }
         authBusy = false
+    }
+}
+
+// 이미 가입된 이메일로 회원가입을 시도하면 백엔드가 409 로 막는다. 가입 방식에 맞는 안내
+// 메시지를 돌려주고, 비밀번호 계정(AUTH_EMAIL_TAKEN)이면 로그인 화면으로 전환을 요청한다.
+// 중복/소셜이 아니면 null 을 돌려 호출자가 기본 메시지를 쓰게 한다.
+private fun MainViewModel.duplicateEmailMessage(error: Throwable): String? {
+    val app = getApplication<android.app.Application>()
+    val parsed = com.alarmtalk.app.network.apiError(error)
+    return when (parsed.code) {
+        "AUTH_EMAIL_TAKEN" -> {
+            authRedirectToLogin = true
+            app.getString(R.string.msg_register_email_taken)
+        }
+        "AUTH_EMAIL_SOCIAL" -> when (parsed.provider) {
+            "apple" -> app.getString(R.string.msg_register_email_social_apple)
+            else -> app.getString(R.string.msg_register_email_social_google)
+        }
+        else -> null
     }
 }
 
@@ -171,7 +191,8 @@ internal fun MainViewModel.register(
             message = getApplication<android.app.Application>().getString(R.string.msg_register_success, response.user.email)
         }.onFailure { error ->
             Log.e(TAG, "Email registration failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_register_failed))
+            message = duplicateEmailMessage(error)
+                ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_register_failed))
         }
         authBusy = false
     }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -37,6 +37,7 @@
     <string name="auth_onboarding_start">Get started</string>
     <string name="auth_password_hide">Hide password</string>
     <string name="auth_password_mismatch">Passwords don\'t match.</string>
+    <string name="auth_password_rule_alnum">Letters and numbers</string>
     <string name="auth_password_rule_match">Passwords match</string>
     <string name="auth_password_rule_max">128 characters or fewer</string>
     <string name="auth_password_rule_min">8+ characters</string>
@@ -536,6 +537,9 @@
     <string name="msg_permission_notifications_required">Notification permission is needed to show the alarm screen and stop button.</string>
     <string name="msg_permission_record_audio_required">Microphone permission is needed to record your voice.</string>
     <string name="msg_register_all_fields_required">Please fill in all the sign-up details.</string>
+    <string name="msg_register_email_taken">This email is already registered. Please log in.</string>
+    <string name="msg_register_email_social_google">This email is registered with Google. Please continue with Google.</string>
+    <string name="msg_register_email_social_apple">This email is registered with Apple. Please use Sign in with Apple.</string>
     <string name="msg_register_failed">Couldn\'t complete sign-up.</string>
     <string name="msg_register_success">Your %1$s account has been created.</string>
     <string name="msg_register_verify_email_first">Please verify your email first.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -37,6 +37,7 @@
     <string name="auth_onboarding_start">始める</string>
     <string name="auth_password_hide">パスワードを隠す</string>
     <string name="auth_password_mismatch">パスワードが一致しません。</string>
+    <string name="auth_password_rule_alnum">英字と数字を含む</string>
     <string name="auth_password_rule_match">パスワードが一致</string>
     <string name="auth_password_rule_max">128文字以下</string>
     <string name="auth_password_rule_min">8文字以上</string>
@@ -536,6 +537,9 @@
     <string name="msg_permission_notifications_required">アラーム画面と停止ボタンを表示するには、通知の許可が必要です。</string>
     <string name="msg_permission_record_audio_required">音声を録音するには、マイクの許可が必要です。</string>
     <string name="msg_register_all_fields_required">会員登録の情報をすべて入力してください。</string>
+    <string name="msg_register_email_taken">既に登録済みのメールです。ログインしてください。</string>
+    <string name="msg_register_email_social_google">Googleで登録済みのメールです。「Googleで続行」でログインしてください。</string>
+    <string name="msg_register_email_social_apple">Appleで登録済みのメールです。Appleでサインインを使用してください。</string>
     <string name="msg_register_failed">会員登録に失敗しました。</string>
     <string name="msg_register_success">%1$sアカウントを作成しました。</string>
     <string name="msg_register_verify_email_first">先にメールアドレスの認証を完了してください。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="auth_onboarding_start">시작하기</string>
     <string name="auth_password_hide">비밀번호 숨기기</string>
     <string name="auth_password_mismatch">비밀번호가 일치하지 않아요.</string>
+    <string name="auth_password_rule_alnum">영문·숫자 포함</string>
     <string name="auth_password_rule_match">비밀번호 확인 일치</string>
     <string name="auth_password_rule_max">128자 이하</string>
     <string name="auth_password_rule_min">8자 이상</string>
@@ -538,6 +539,9 @@
     <string name="msg_permission_notifications_required">알람 화면과 종료 버튼을 표시하려면 알림 권한이 필요해요.</string>
     <string name="msg_permission_record_audio_required">음성을 녹음하려면 마이크 권한이 필요해요.</string>
     <string name="msg_register_all_fields_required">회원가입 정보를 모두 입력해 주세요.</string>
+    <string name="msg_register_email_taken">이미 가입된 이메일이에요. 로그인해 주세요.</string>
+    <string name="msg_register_email_social_google">구글로 가입된 이메일이에요. \'Google로 계속하기\'로 로그인해 주세요.</string>
+    <string name="msg_register_email_social_apple">애플로 가입된 이메일이에요. Apple 로그인을 사용해 주세요.</string>
     <string name="msg_register_failed">회원가입에 실패했어요</string>
     <string name="msg_register_success">%1$s 계정을 만들었어요</string>
     <string name="msg_register_verify_email_first">이메일 인증을 먼저 완료해 주세요</string>

--- a/packages/backend/scripts/run-remote-migrations.ts
+++ b/packages/backend/scripts/run-remote-migrations.ts
@@ -83,14 +83,13 @@ async function main(): Promise<void> {
     throw new Error('--from must be less than or equal to --to');
   }
 
-  const headers: Record<string, string> = {};
-  if (envName === 'production') {
-    const secret = process.env.INIT_DB_SECRET?.trim();
-    if (!secret) {
-      throw new Error('INIT_DB_SECRET is required for production migrations.');
-    }
-    headers['x-init-db-secret'] = secret;
+  // /api/init-db 는 모든 환경에서 x-init-db-secret 헤더를 요구한다(index.ts canRunInitDb).
+  // dev·production 모두 동일하게 INIT_DB_SECRET 을 보낸다 — 없으면 404 로 조용히 실패한다.
+  const secret = process.env.INIT_DB_SECRET?.trim();
+  if (!secret) {
+    throw new Error(`INIT_DB_SECRET is required for ${envName} migrations.`);
   }
+  const headers: Record<string, string> = { 'x-init-db-secret': secret };
 
   for (let id = from; id <= to; id += 1) {
     const url = `${baseUrl}/api/init-db?fromId=${id}&toId=${id}`;

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -124,6 +124,42 @@ async function consumeEmailVerificationCode(db: Client, id: string): Promise<voi
   });
 }
 
+type ExistingAccount = { kind: 'password' } | { kind: 'social'; provider: 'google' | 'apple' };
+
+// 가입 시도 이메일이 이미 존재하면 그 가입 방식을 분류한다(중복 가입 차단·로그인 유도용).
+//   - password_hash 가 있으면 이메일/비밀번호 계정 → AUTH_EMAIL_TAKEN(로그인 유도)
+//   - 없으면 소셜 계정 → AUTH_EMAIL_SOCIAL(+provider; apple_id 있으면 apple, 아니면 google)
+// 주의(의도된 트레이드오프): 이 분기는 "이 이메일이 가입돼 있는가"를 노출하므로 계정 열거
+// (account enumeration)가 가능해진다. 제품 요구(중복 이메일이면 회원가입을 막고 로그인으로
+// 안내)를 위해 의도적으로 노출하며, /api/auth/* 의 authRateLimitMiddleware 로 무차별 조회를
+// 제한한다. (로그인 라우트는 기존대로 generic 응답을 유지해 비밀번호 추측 표면은 넓히지 않는다.)
+async function classifyExistingAccount(db: Client, email: string): Promise<ExistingAccount | null> {
+  const result = await db.execute({
+    sql: 'SELECT password_hash, apple_id FROM users WHERE email = ? LIMIT 1',
+    args: [email],
+  });
+  if (result.rows.length === 0) return null;
+  const row = result.rows[0]!;
+  const passwordHash = row.password_hash;
+  if (passwordHash != null && String(passwordHash).length > 0) {
+    return { kind: 'password' };
+  }
+  return { kind: 'social', provider: row.apple_id != null ? 'apple' : 'google' };
+}
+
+function existingAccountConflict(account: ExistingAccount) {
+  if (account.kind === 'password') {
+    return { body: jsonError('AUTH_EMAIL_TAKEN', 'Email already registered'), status: 409 as const };
+  }
+  return {
+    body: {
+      ...jsonError('AUTH_EMAIL_SOCIAL', 'Email registered via social login'),
+      provider: account.provider,
+    },
+    status: 409 as const,
+  };
+}
+
 auth.post('/email-code', async (c) => {
   let body: unknown;
   try {
@@ -140,8 +176,8 @@ auth.post('/email-code', async (c) => {
   const email = normalizeAuthEmail(parsed.data.email);
   const db = getDB(c.env);
 
-  // 모든 분기에서 동일한 성공 응답을 돌려준다(계정 열거 방지). debug_code 는 코드를
-  // 실제로 새로 발송했을 때만 포함한다(쿨다운/상한/기존가입으로 미발송 시 생략).
+  // 신규(미가입) 이메일에만 코드를 발송한다. debug_code 는 코드를 실제로 새로 발송했을
+  // 때만 포함한다(쿨다운/상한으로 미발송 시 생략).
   const successResponse = (debugCode?: string) =>
     c.json({
       success: true,
@@ -150,14 +186,12 @@ auth.post('/email-code', async (c) => {
     });
 
   try {
-    const existing = await db.execute({
-      sql: 'SELECT id FROM users WHERE email = ?',
-      args: [email],
-    });
-    // 이미 가입된 이메일이라도 409(AUTH_EMAIL_TAKEN)로 회원 여부를 노출하지 않고
-    // 동일한 성공 응답을 반환한다. 코드도 보내지 않는다.
-    if (existing.rows.length > 0) {
-      return successResponse();
+    // 이미 가입된 이메일이면 가입 방식에 맞는 409 로 회원가입을 막고 로그인으로 안내한다.
+    // (AUTH_EMAIL_TAKEN=이메일/비번 계정, AUTH_EMAIL_SOCIAL+provider=소셜 계정)
+    const existingAccount = await classifyExistingAccount(db, email);
+    if (existingAccount) {
+      const conflict = existingAccountConflict(existingAccount);
+      return c.json(conflict.body, conflict.status);
     }
 
     const nowMs = Date.now();
@@ -257,9 +291,8 @@ auth.post('/register', async (c) => {
   const db = getDB(c.env);
 
   try {
-    // 계정 열거 방지: 이미 가입된 이메일이라도 409(AUTH_EMAIL_TAKEN)로 회원 여부를
-    // 노출하지 않는다. 가입된 이메일에는 /auth/email-code 가 코드를 발급하지 않으므로
-    // 아래 인증 코드 검증이 게이트 역할을 한다(미가입자만 유효 코드를 보유).
+    // 정상 흐름에선 /auth/email-code 가 미가입 이메일에만 코드를 발급하므로 인증 코드가
+    // 1차 게이트다. 여기선 방어적으로 한 번 더 검증한다.
     const verification = await checkEmailVerificationCode(
       db,
       c.env,
@@ -270,17 +303,12 @@ auth.post('/register', async (c) => {
       return c.json(jsonError(verification.code, verification.message), verification.status);
     }
 
-    // 인증 코드를 통과했더라도(이론상 경쟁 상태) 이미 존재하는 이메일이면 generic
-    // 코드 무효 응답으로 통일한다 — 회원 가입 여부를 별도 코드로 노출하지 않는다.
-    const existing = await db.execute({
-      sql: 'SELECT id FROM users WHERE email = ?',
-      args: [normalizedEmail],
-    });
-    if (existing.rows.length > 0) {
-      return c.json(
-        jsonError('AUTH_EMAIL_CODE_INVALID', 'Invalid email verification code'),
-        400,
-      );
+    // 인증 코드를 통과했더라도(이론상 경쟁 상태) 이미 존재하는 이메일이면 가입 방식에 맞는
+    // 409 로 막고 로그인으로 안내한다(email-code 와 동일한 정책).
+    const existingAccount = await classifyExistingAccount(db, normalizedEmail);
+    if (existingAccount) {
+      const conflict = existingAccountConflict(existingAccount);
+      return c.json(conflict.body, conflict.status);
     }
 
     const id = crypto.randomUUID();

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -124,8 +124,8 @@ describe('POST /auth/email-code', () => {
     expect(insertCall?.args[1]).toBe('kim@test.com');
   });
 
-  it('이미 가입된 이메일에도 동일한 성공 응답을 반환한다(회원 여부 비노출)', async () => {
-    mockDB.pushResult([{ id: 'u-1' }]);
+  it('이미 가입된 이메일(비밀번호 계정)은 409 AUTH_EMAIL_TAKEN 으로 막는다', async () => {
+    mockDB.pushResult([{ password_hash: 'bcrypt-hash', apple_id: null }]);
 
     const app = buildApp();
     const res = await app.request(
@@ -134,13 +134,29 @@ describe('POST /auth/email-code', () => {
       ENV,
     );
 
-    // 계정 열거 방지: 409/AUTH_EMAIL_TAKEN 대신 신규 이메일과 동일한 성공 응답.
-    expect(res.status).toBe(200);
+    // 중복 이메일이면 회원가입을 막고 로그인으로 안내한다.
+    expect(res.status).toBe(409);
     const body = await res.json();
-    expect(body.success).toBe(true);
-    expect(body.error_code).toBeUndefined();
-    // 코드를 발송/삽입하지 않으므로 debug_code 도 없다.
-    expect(body.debug_code).toBeUndefined();
+    expect(body.error_code).toBe('AUTH_EMAIL_TAKEN');
+    // 코드를 발송/삽입하지 않는다.
+    const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
+    expect(insertCall).toBeUndefined();
+  });
+
+  it('이미 소셜로 가입된 이메일은 409 AUTH_EMAIL_SOCIAL(+provider)로 안내한다', async () => {
+    mockDB.pushResult([{ password_hash: null, apple_id: null }]); // 비번 없음 → google 소셜
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/email-code', { email: 'social@test.com' }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error_code).toBe('AUTH_EMAIL_SOCIAL');
+    expect(body.provider).toBe('google');
     const insertCall = mockDB.calls.find((c) => c.sql.includes('INSERT INTO email_verification_codes'));
     expect(insertCall).toBeUndefined();
   });
@@ -256,9 +272,9 @@ describe('POST /auth/register', () => {
     expect(insertCall?.args[0]).toBe(body.user.id);
   });
 
-  it('중복 이메일은 회원 여부를 노출하지 않고 generic 코드 무효 응답을 반환한다', async () => {
+  it('중복 이메일(비밀번호 계정)은 409 AUTH_EMAIL_TAKEN 으로 막는다', async () => {
     await pushValidEmailVerification('kim@test.com'); // 코드 검증 통과
-    mockDB.pushResult([{ id: 'u-1' }]); // 기존 이메일 존재
+    mockDB.pushResult([{ password_hash: 'bcrypt-hash', apple_id: null }]); // 기존 비번 계정
 
     const app = buildApp();
     const res = await app.request(
@@ -266,10 +282,10 @@ describe('POST /auth/register', () => {
       undefined,
       ENV,
     );
-    // 계정 열거 방지: 409/AUTH_EMAIL_TAKEN 대신 generic AUTH_EMAIL_CODE_INVALID(400).
-    expect(res.status).toBe(400);
+    // 중복 이메일이면 회원가입을 막고 로그인으로 안내한다.
+    expect(res.status).toBe(409);
     const body = await res.json();
-    expect(body.error_code).toBe('AUTH_EMAIL_CODE_INVALID');
+    expect(body.error_code).toBe('AUTH_EMAIL_TAKEN');
     const insertCall = mockDB.calls.find((call) => call.sql.includes('INSERT INTO users'));
     expect(insertCall).toBeUndefined();
   });

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -10,7 +10,9 @@ import { z } from 'zod';
 export const PasswordSchema = z
   .string()
   .min(8, '비밀번호는 최소 8자 이상이어야 합니다')
-  .max(128, '비밀번호는 최대 128자까지 허용됩니다');
+  .max(128, '비밀번호는 최대 128자까지 허용됩니다')
+  .regex(/[A-Za-z]/, '영문자를 최소 1자 포함해야 합니다')
+  .regex(/[0-9]/, '숫자를 최소 1자 포함해야 합니다');
 
 export const EmailVerificationCodeSchema = z
   .string()

--- a/packages/shared/test/schemas.test.ts
+++ b/packages/shared/test/schemas.test.ts
@@ -63,6 +63,26 @@ describe('RegisterRequestSchema', () => {
       }),
     ).toThrow();
   });
+  it('rejects password without a digit', () => {
+    expect(() =>
+      RegisterRequestSchema.parse({
+        email: 'kim@example.com',
+        password: 'onlyletters',
+        name: 'kim',
+        email_verification_code: '123456',
+      }),
+    ).toThrow();
+  });
+  it('rejects password without a letter', () => {
+    expect(() =>
+      RegisterRequestSchema.parse({
+        email: 'kim@example.com',
+        password: '12345678',
+        name: 'kim',
+        email_verification_code: '123456',
+      }),
+    ).toThrow();
+  });
   it('rejects malformed email', () => {
     expect(() =>
       RegisterRequestSchema.parse({


### PR DESCRIPTION
## 요약
QA 중 발견된 인증/배포 이슈 묶음. (1) dev 배포 실패(#108), (2) 비밀번호 정책 모호, (3) 중복 이메일 가입 시 무응답을 수정. 랜딩 화면 코랄 색도 함께 정정.

## 1. Deploy Backend #108 (migrate:dev 404)
`/api/init-db` 가 모든 환경에서 `x-init-db-secret` 헤더를 요구하도록 강화됐는데, **dev 마이그레이션 경로만 시크릿을 보내지 않아** 404 로 실패하고 있었음.
- `run-remote-migrations.ts`: dev 도 `INIT_DB_SECRET` 요구·전송 (prod 와 대칭)
- `deploy-backend.yml`: dev 마이그레이션 스텝에 `INIT_DB_SECRET` env 주입
- ⚠️ **운영 필요**: dev 워커에 동일 값 시크릿 설정 — `wrangler secret put INIT_DB_SECRET --env dev` (GitHub Actions 시크릿과 동일 값). 미설정 시 여전히 404.

## 2. 비밀번호 정책 강화·명확화
- shared `PasswordSchema`: 8~128자 + **영문·숫자 각 1자 이상** (기존엔 길이만 검사 → `password`/`11111111` 통과)
- Android 규칙 표시: `8자 이상 / 영문·숫자 포함 / 비밀번호 일치` (혼란스럽던 "128자 이하" 체크 제거; 최대 길이는 제출 검증으로만 enforce)

## 3. 중복/소셜 이메일 가입 처리
기존엔 가입된 이메일로 인증코드를 요청해도 **동일 성공 응답 + 코드 미발송**(anti-enumeration)이라 사용자가 막힌 이유를 알 수 없었음. → 명확히 안내하도록 변경:
- `/auth/email-code`·`/auth/register`: 가입된 이메일이면 409
  - 비밀번호 계정 → `AUTH_EMAIL_TAKEN`
  - 소셜 계정 → `AUTH_EMAIL_SOCIAL` (+`provider`: google|apple)
- Android: 코드 매핑해 안내 메시지 표시. `AUTH_EMAIL_TAKEN` 이면 **로그인 화면 자동 전환**(입력 이메일 유지)
- **트레이드오프**: 가입 여부가 노출돼 account enumeration 이 가능해짐. 제품 요구(중복이면 회원가입 막고 로그인 유도)에 따른 의도된 선택. `/api/auth/*` rate-limit 으로 완화, 로그인 라우트는 기존 generic 응답 유지.

## 4. 랜딩 화면 코랄 → 브랜드 블루
`LandingScreen` 다크모드 분기만 액센트가 코랄(#EC8C6C) 하드코딩 → 테마 `scheme.primary`(브랜드 블루) 참조로 정정.

## 이메일 인증(item 3) 점검 결과
백엔드 흐름은 정상(코드 해시·10분 TTL·60초 쿨다운·일 10건 상한·5회 시도). 별도 수정 불필요.

## 검증
- 백엔드: 전체 1447 passed / 62 skipped (auth 46 포함)
- shared: 14 passed (비밀번호 규칙 테스트 추가)
- Android: `assembleDevDebug` BUILD SUCCESSFUL, 두 테스트폰 설치 완료