### PR TITLE
디자인 토큰 단일 출처화 + 공유 코드 재발급/갱신 자동화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,5 +22,15 @@
 - 커밋 메시지 **한국어**. Co-Authored-By: Claude / "Generated with Claude Code" **금지**.
 - `develop`은 보호 브랜치(9개 필수 체크) → 직접 푸시 불가, **PR 필요**.
 
+### 디자인 토큰 (Android Compose)
+새 화면/컴포넌트는 **생 리터럴 대신 토큰**을 가져다 쓴다. 단일 출처 두 곳:
+- **모서리 반경**: `ui/components/WakerDesign.kt` 의 `Waker*Shape` 토큰이 유일 출처.
+  - `WakerTileShape`(12, 작은 타일·아이콘박스·인라인배너) / `WakerChipShape`(14, 칩·세그먼트·작은카드/행) / `WakerInputShape`·`WakerButtonShape`·`WakerPanelShape`(18, 입력·버튼·표준 카드/패널) / `WakerCardShape`(22, 큰 카드·다이얼로그 컨테이너) / `WakerHeroShape`(24, 히어로 카드) / `WakerDialogShape`(28, 대형 다이얼로그) / `WakerPillShape`(999, 캡슐).
+  - `RoundedCornerShape(n.dp)` 를 새로 박지 말 것. `MaterialTheme.shapes` 도 이 토큰에서 파생됨.
+  - **예외(토큰화 안 함)**: `CircleShape`(원형 아바타/FAB/점), `AlarmRow` 스와이프 비대칭 shape, 타임휠 전용 컨테이너(34dp).
+- **색**: `theme/AlarmTalkTheme.kt` 의 `colorScheme` 가 유일 출처. 항상 `MaterialTheme.colorScheme.*` 로 소비, **생 `Color(0x…)` 금지**.
+  - 오버레이 스크림은 `WakerScrimColor`(WakerDesign.kt) 사용.
+  - 문서화된 예외: `RingingActivity`(잠금화면 전용 고정 팔레트), 알림 팩토리(Notification accent), 랜딩 브랜드 비주얼.
+
 ## 진행 중 작업 (세션 재개 시 먼저 읽을 것)
 현재 상태·폰 테스트 체크리스트·남은 follow-up: **[`docs/qa/dev-test-handoff.md`](docs/qa/dev-test-handoff.md)**.

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/BillingApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/BillingApi.kt
@@ -146,6 +146,12 @@ interface BillingApi {
         @Header("Authorization") authorization: String,
     ): EnsureFamilyShareCodeResponse
 
+    /** 기존 공유 코드를 무효화하고 새 코드를 발급한다(유출 의심 시 재발급). */
+    @POST("billing/vouchers/family-share/regenerate")
+    suspend fun regenerateFamilyShareCode(
+        @Header("Authorization") authorization: String,
+    ): EnsureFamilyShareCodeResponse
+
     @POST("billing/cancel")
     suspend fun cancelSubscription(
         @Header("Authorization") authorization: String,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ringing/RingingActivity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ringing/RingingActivity.kt
@@ -70,6 +70,9 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.ui.graphics.graphicsLayer
 import com.alarmtalk.app.AlarmTalkDarkColorScheme
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerCardShape
+import com.alarmtalk.app.WakerDialogShape
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.alarm.AlarmContract.EXTRA_ALARM_ID
 import com.alarmtalk.app.alarm.RingingService
 import com.alarmtalk.app.data.AlarmAppContainer
@@ -276,7 +279,7 @@ private fun RingingVoiceCard(uiState: RingingUiState) {
         modifier = Modifier
             .fillMaxWidth()
             .widthIn(max = 440.dp),
-        shape = RoundedCornerShape(28.dp),
+        shape = WakerDialogShape,
         color = Color(0xFF122034).copy(alpha = 0.66f),
         border = BorderStroke(1.dp, Color(0x24FFFFFF)),
     ) {
@@ -348,7 +351,7 @@ private fun RingingSnoozeButton(minutes: Int, onSnooze: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .height(62.dp),
-        shape = RoundedCornerShape(22.dp),
+        shape = WakerCardShape,
         color = Color.White.copy(alpha = 0.07f),
         border = BorderStroke(1.dp, Color(0x24FFFFFF)),
     ) {
@@ -531,7 +534,7 @@ private fun RingingVoiceWaveform() {
                             15, 16, 17 -> MaterialTheme.colorScheme.secondary
                             else -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.52f)
                         },
-                        shape = RoundedCornerShape(999.dp),
+                        shape = WakerPillShape,
                     ),
             )
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListComponents.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Alarm
@@ -29,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 
 @Composable
 internal fun AlarmsHeader(
@@ -51,7 +52,7 @@ internal fun AlarmsHeader(
         ) {
             Button(
                 onClick = onCreateAlarm,
-                shape = RoundedCornerShape(999.dp),
+                shape = WakerPillShape,
                 contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
             ) {
                 Icon(
@@ -70,7 +71,7 @@ internal fun AlarmsHeader(
 @Composable
 internal fun EmptyAlarmCard(onCreateAlarm: () -> Unit) {
     Card(
-        shape = RoundedCornerShape(16.dp),
+        shape = WakerPanelShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
     ) {
@@ -92,7 +93,7 @@ internal fun EmptyAlarmCard(onCreateAlarm: () -> Unit) {
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
-            Button(onClick = onCreateAlarm, shape = RoundedCornerShape(999.dp)) {
+            Button(onClick = onCreateAlarm, shape = WakerPillShape) {
                 Text(stringResource(R.string.r3misc_alarms_create_new_button))
             }
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
@@ -197,7 +197,7 @@ internal fun AlarmListScreen(
             NativeTab.Home -> {
                 item { HomeHeader() }
                 item {
-                    Box(modifier = Modifier.coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_HOME_HERO)) {
+                    Box(modifier = Modifier.coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_HOME_HERO, targetRadius = 24.dp)) {
                         NextAlarmHeroCard(
                             nextAlarm = nextAlarm,
                             onClick = {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -753,6 +753,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                       onBack = ::goBackInApp,
                       onRemoveFamilyMember = viewModel::removeFamilyMember,
                       onEnsureFamilyShareCode = viewModel::ensureFamilyShareCode,
+                      onRegenerateFamilyShareCode = viewModel::regenerateFamilyShareCode,
                       onChangeFamilyAlarmSettings = viewModel::updateFamilyAlarmSettings,
                   )
               }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.ErrorOutline
@@ -185,8 +184,8 @@ internal fun PrettySnackbar(message: String) {
     Snackbar(
         modifier = Modifier
             .padding(horizontal = 16.dp, vertical = 8.dp)
-            .shadow(elevation = 12.dp, shape = RoundedCornerShape(20.dp), clip = false),
-        shape = RoundedCornerShape(20.dp),
+            .shadow(elevation = 12.dp, shape = WakerCardShape, clip = false),
+        shape = WakerCardShape,
         containerColor = containerColor,
         contentColor = contentColor,
     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkBottomBar.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkBottomBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
@@ -39,6 +38,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.alarmtalk.app.WakerChipShape
 
 @Composable
 internal fun AlarmTalkBottomBar(
@@ -142,7 +142,7 @@ internal fun AlarmTalkTabItem(
                 } else {
                     Color.Transparent
                 },
-                shape = RoundedCornerShape(14.dp),
+                shape = WakerChipShape,
             )
             .padding(vertical = 6.dp),
     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/LoginPermissionGate.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/LoginPermissionGate.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -20,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.alarmtalk.app.WakerHeroShape
 import com.alarmtalk.app.network.AuthSession
 
 /**
@@ -70,7 +70,7 @@ internal fun LoginPermissionGate(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .widthIn(max = 520.dp),
-            shape = RoundedCornerShape(24.dp),
+            shape = WakerHeroShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 6.dp,
         ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Pause
@@ -50,6 +49,8 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.alarmtalk.app.WakerPillShape
+import com.alarmtalk.app.WakerTileShape
 import kotlinx.coroutines.delay
 
 private data class LandingPalette(
@@ -158,7 +159,7 @@ private fun WakerBrandHeader(colors: LandingPalette) {
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(42.dp)
-                .clip(RoundedCornerShape(12.dp)),
+                .clip(WakerTileShape),
         )
         Spacer(Modifier.width(10.dp))
         Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
@@ -222,7 +223,7 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(26.dp),
+        shape = WakerHeroShape,
         color = colors.surface,
         border = BorderStroke(1.dp, colors.line),
     ) {
@@ -251,7 +252,7 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
                 Surface(
                     onClick = ::togglePreview,
                     modifier = Modifier.size(54.dp),
-                    shape = RoundedCornerShape(999.dp),
+                    shape = WakerPillShape,
                     color = colors.accent.copy(alpha = 0.14f),
                     contentColor = colors.accent,
                     border = BorderStroke(1.dp, colors.accent.copy(alpha = 0.28f)),
@@ -303,7 +304,7 @@ private fun LandingPreviewWaveform(
                     .height((9 + level * 34).dp)
                     .background(
                         color = color.copy(alpha = if (played) 1f else 0.78f),
-                        shape = RoundedCornerShape(999.dp),
+                        shape = WakerPillShape,
                     ),
             )
         }
@@ -320,7 +321,7 @@ private fun LandingAuthPanel(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(30.dp),
+        shape = WakerDialogShape,
         color = colors.surfaceRaised,
         border = BorderStroke(1.dp, colors.line),
     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingCharacterPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingCharacterPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.Icon
@@ -33,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.data.AlarmEntity
 import com.alarmtalk.app.data.CharacterEventEntity
 import com.alarmtalk.app.data.CharacterEventStates
@@ -287,7 +287,7 @@ internal fun CharacterStatTile(
 ) {
     Surface(
         modifier = modifier,
-        shape = RoundedCornerShape(18.dp),
+        shape = WakerPanelShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
         contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
@@ -316,7 +316,7 @@ internal fun CharacterSyncStatus(
 ) {
     val needsCheck = failedCount > 0
     Surface(
-        shape = RoundedCornerShape(16.dp),
+        shape = WakerPanelShape,
         color = if (needsCheck) {
             MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.68f)
         } else {
@@ -447,7 +447,7 @@ internal fun CharacterXpBar(
     progress: Float,
     modifier: Modifier = Modifier,
 ) {
-    val shape = RoundedCornerShape(999.dp)
+    val shape = WakerPillShape
     Box(
         modifier = modifier
             .height(8.dp)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material3.Button
@@ -46,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.billing.PlayBillingProducts
 import com.alarmtalk.app.network.BillingPlan
 import com.alarmtalk.app.network.BillingPlanSummary
@@ -463,7 +463,7 @@ private fun BillingActionDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -637,7 +637,7 @@ private fun CurrentPassSummaryCard(
 @Composable
 private fun PassSummaryChip(label: String) {
     Surface(
-        shape = RoundedCornerShape(999.dp),
+        shape = WakerPillShape,
         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
         contentColor = MaterialTheme.colorScheme.onSurface,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
@@ -731,7 +731,7 @@ internal fun SubscriptionPlanCard(
                 }
                 if (isCurrent) {
                     Surface(
-                        shape = RoundedCornerShape(999.dp),
+                        shape = WakerPillShape,
                         color = MaterialTheme.colorScheme.primary,
                         contentColor = MaterialTheme.colorScheme.onPrimary,
                     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
@@ -473,8 +474,12 @@ private fun BillingActionDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(22.dp),
             ) {
+                // 설명은 마침표(". ") 단위로 줄바꿈해 한 문장씩 읽기 쉽게 보여준다.
+                val formattedDescription = remember(description) {
+                    description.replace(". ", ".\n")
+                }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -482,14 +487,19 @@ private fun BillingActionDialog(
                 ) {
                     Column(
                         modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         Text(
                             text = title,
                             style = MaterialTheme.typography.titleLarge,
                             fontWeight = FontWeight.Bold,
                         )
-                        MutedText(description)
+                        Text(
+                            text = formattedDescription,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            lineHeight = 20.sp,
+                        )
                     }
                     IconButton(
                         onClick = onDismiss,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerTileShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -163,7 +164,7 @@ internal fun PermissionRow(
         ) {
             Surface(
                 modifier = Modifier.size(38.dp),
-                shape = RoundedCornerShape(12.dp),
+                shape = WakerTileShape,
                 color = if (granted) {
                     MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
                 } else {
@@ -334,7 +335,7 @@ internal fun AlarmRow(
                 if (warningText != null) {
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp),
+                        shape = WakerTileShape,
                         color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.72f),
                         contentColor = MaterialTheme.colorScheme.onErrorContainer,
                     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/DuplicateAlarmDialog.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/DuplicateAlarmDialog.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -21,6 +20,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerDialogShape
 
 /**
  * 같은 시각에 이미 알람이 있을 때 띄우는 확인 다이얼로그.
@@ -53,7 +54,7 @@ internal fun DuplicateAlarmDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 24.dp)
                 .widthIn(max = 380.dp),
-            shape = RoundedCornerShape(28.dp),
+            shape = WakerDialogShape,
             color = scheme.surface,
             tonalElevation = 6.dp,
             border = BorderStroke(1.dp, scheme.outlineVariant),
@@ -79,7 +80,7 @@ internal fun DuplicateAlarmDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(48.dp),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Text(stringResource(R.string.r3dlg_duplicate_alarm_replace), maxLines = 1)
                     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/PlanGateDialog.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/PlanGateDialog.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -20,6 +19,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerDialogShape
 
 @Composable
 internal fun PlanGateDialog(
@@ -40,7 +41,7 @@ internal fun PlanGateDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 24.dp)
                 .widthIn(max = 380.dp),
-            shape = RoundedCornerShape(28.dp),
+            shape = WakerDialogShape,
             color = scheme.surface,
             tonalElevation = 6.dp,
             border = BorderStroke(1.dp, scheme.outlineVariant),
@@ -76,7 +77,7 @@ internal fun PlanGateDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(48.dp),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Text(confirmLabel, maxLines = 1)
                     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Pause
@@ -35,6 +34,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.math.roundToLong
@@ -125,7 +126,7 @@ internal fun VoiceInputModeButton(
             onClick = onClick,
             enabled = enabled,
             modifier = modifier,
-            shape = RoundedCornerShape(999.dp),
+            shape = WakerPillShape,
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.secondary,
                 contentColor = MaterialTheme.colorScheme.onSecondary,
@@ -138,7 +139,7 @@ internal fun VoiceInputModeButton(
             onClick = onClick,
             enabled = enabled,
             modifier = modifier,
-            shape = RoundedCornerShape(999.dp),
+            shape = WakerPillShape,
         ) {
             Text(label)
         }
@@ -229,7 +230,7 @@ internal fun VoiceFileControls(
             onClick = onPickFile,
             enabled = enabled,
             modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(16.dp),
+            shape = WakerPanelShape,
         ) {
             Icon(Icons.Outlined.UploadFile, contentDescription = null)
             Spacer(Modifier.width(8.dp))
@@ -361,7 +362,7 @@ internal fun VoiceLevelBars(
                         } else {
                             MaterialTheme.colorScheme.outlineVariant
                         },
-                        RoundedCornerShape(999.dp),
+                        WakerPillShape,
                     ),
             )
         }
@@ -377,7 +378,7 @@ private fun RecordingProgressBar(
         modifier = Modifier
             .fillMaxWidth()
             .height(6.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(999.dp)),
+            .background(MaterialTheme.colorScheme.outlineVariant, WakerPillShape),
     ) {
         Box(
             modifier = Modifier
@@ -385,7 +386,7 @@ private fun RecordingProgressBar(
                 .height(6.dp)
                 .background(
                     if (active) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.secondary,
-                    RoundedCornerShape(999.dp),
+                    WakerPillShape,
                 ),
         )
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/WakerDesign.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/WakerDesign.kt
@@ -7,11 +7,31 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
-internal val WakerCardShape = RoundedCornerShape(22.dp)
-internal val WakerInputShape = RoundedCornerShape(18.dp)
-internal val WakerButtonShape = RoundedCornerShape(18.dp)
+// ─────────────────────────────────────────────────────────────────────────────
+// 디자인 토큰 — 모서리 반경(코너 radius)의 단일 출처(single source of truth).
+//
+// 새 화면/컴포넌트는 생 RoundedCornerShape(n.dp) 대신 아래 토큰을 가져다 쓴다.
+// MaterialTheme.shapes(AlarmTalkTheme.kt)도 이 값들에서 파생되므로, shape 를
+// 지정하지 않은 M3 컴포넌트(Card/Dialog/Chip/TextField 기본형)까지 같은 스케일을 따른다.
+//
+// 예외(토큰화하지 않음): CircleShape(완전 원형 아바타/FAB/점), AlarmRow 스와이프
+// 비대칭 shape, 타임휠 전용 컨테이너 — 의도적 형태이므로 토큰 스케일에 흡수하지 않는다.
+// ─────────────────────────────────────────────────────────────────────────────
+internal val WakerTileShape = RoundedCornerShape(12.dp)    // 작은 타일·아이콘 박스·인라인 배너
+internal val WakerChipShape = RoundedCornerShape(14.dp)    // 칩·세그먼트·작은 카드/리스트 행
+internal val WakerInputShape = RoundedCornerShape(18.dp)   // 입력 필드(OutlinedTextField)
+internal val WakerButtonShape = RoundedCornerShape(18.dp)  // 버튼
+internal val WakerPanelShape = RoundedCornerShape(18.dp)   // 표준 콘텐츠 카드/패널(구 16dp 흡수)
+internal val WakerCardShape = RoundedCornerShape(22.dp)    // 큰 콘텐츠 카드
+internal val WakerHeroShape = RoundedCornerShape(24.dp)    // 히어로/프로미넌트 카드(홈 NextAlarm), 타임피커 전용 다이얼로그
+internal val WakerDialogShape = RoundedCornerShape(28.dp)  // 모든 모달 다이얼로그 컨테이너 표준(M3 extra-large=28dp, AlertDialog 기본과 일치)
+internal val WakerPillShape = RoundedCornerShape(999.dp)   // 완전 캡슐(pill) — 진행바·세그먼트·상태 배지
+
+/** 오버레이/코치마크 스크림 — 테마 무관 고정 농도 rgba(5,8,14,.74). */
+internal val WakerScrimColor = Color(0xBD05080E)
 
 @Composable
 internal fun wakerCardBorder(alpha: Float = 1f): BorderStroke =

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorControls.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorControls.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -27,6 +26,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.data.AlarmAudioLimits
 import com.alarmtalk.app.data.AlarmPlayModes
 import com.alarmtalk.app.data.AlarmTimeCalculator
@@ -288,7 +289,7 @@ internal fun QuickChip(
 ) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(999.dp),
+        shape = WakerPillShape,
         color = MaterialTheme.colorScheme.surfaceVariant,
     ) {
         Text(
@@ -372,7 +373,7 @@ internal fun PlayModeChip(
     Surface(
         onClick = onClick,
         modifier = modifier.alpha(if (locked && !selected) 0.58f else 1f),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = if (selected) {
             MaterialTheme.colorScheme.primaryContainer
         } else if (locked) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -1086,7 +1086,7 @@ internal fun AlarmEditorScreen(
                         },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_TIME),
+                            .coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_TIME, targetRadius = 34.dp),
                     )
                 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreenComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreenComponents.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
@@ -46,6 +45,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
+import com.alarmtalk.app.WakerTileShape
 import com.alarmtalk.app.data.AlarmTimeCalculator
 import com.alarmtalk.app.data.DynamicPromptPreferences
 import com.alarmtalk.app.network.DynamicPromptSettings
@@ -84,7 +87,7 @@ internal fun SharedVoiceInfoRequiredDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .widthIn(max = 460.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -103,7 +106,7 @@ internal fun SharedVoiceInfoRequiredDialog(
                 )
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
                     border = wakerCardBorder(),
                 ) {
@@ -312,7 +315,7 @@ internal fun FamilyAlarmTargetCard(
     }
 
     Card(
-        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+        shape = WakerPanelShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
     ) {
@@ -399,7 +402,7 @@ internal fun RecipientSummaryRow(
         Surface(
             onClick = onClick,
             modifier = Modifier.fillMaxWidth(),
-            shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+            shape = WakerChipShape,
             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.52f),
         ) {
             content()
@@ -407,7 +410,7 @@ internal fun RecipientSummaryRow(
     } else {
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = androidx.compose.foundation.shape.RoundedCornerShape(14.dp),
+            shape = WakerChipShape,
             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.52f),
         ) {
             content()
@@ -425,7 +428,7 @@ internal fun RecipientPickerRow(
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+        shape = WakerTileShape,
         color = if (selected) {
             MaterialTheme.colorScheme.secondaryContainer
         } else {
@@ -469,7 +472,7 @@ internal fun FamilyAlarmTargetStatus(
         else -> stringResource(R.string.editor_status_available)
     }
     Surface(
-        shape = androidx.compose.foundation.shape.RoundedCornerShape(999.dp),
+        shape = WakerPillShape,
         color = if (blocked) {
             MaterialTheme.colorScheme.errorContainer
         } else {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmFortuneSettings.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmFortuneSettings.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Save
@@ -43,6 +42,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerHeroShape
+import com.alarmtalk.app.WakerPanelShape
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import java.text.SimpleDateFormat
@@ -80,7 +82,7 @@ internal fun FortuneInfoDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .widthIn(max = 460.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -100,7 +102,7 @@ internal fun FortuneInfoDialog(
                 )
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.45f),
                     border = wakerCardBorder(),
                 ) {
@@ -238,7 +240,7 @@ internal fun FortuneInfoDialog(
         )
         Dialog(onDismissRequest = { timePickerOpen = false }) {
             Surface(
-                shape = RoundedCornerShape(24.dp),
+                shape = WakerHeroShape,
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 6.dp,
                 shadowElevation = 18.dp,
@@ -390,7 +392,7 @@ internal fun FortuneInputSection(
     }
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(18.dp),
+        shape = WakerPanelShape,
         color = MaterialTheme.colorScheme.surface,
         border = BorderStroke(1.dp, borderColor),
     ) {
@@ -464,7 +466,7 @@ internal fun FortuneTimeChoice(
 ) {
     Surface(
         onClick = { onClick(value) },
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = if (selected) {
             MaterialTheme.colorScheme.primaryContainer
         } else {
@@ -548,7 +550,7 @@ internal fun GenderChoice(
 ) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = if (selected) {
             MaterialTheme.colorScheme.primaryContainer
         } else {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmRandomPromptSettings.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmRandomPromptSettings.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MyLocation
@@ -50,6 +49,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
@@ -173,7 +174,7 @@ internal fun RandomPromptSettingsPane(
             ) {
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f),
                 ) {
                     Text(
@@ -297,7 +298,7 @@ internal fun RandomPromptDetailRow(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
     ) {
         Column(
@@ -376,7 +377,7 @@ internal fun WeatherLocationDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .widthIn(max = 460.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -393,7 +394,7 @@ internal fun WeatherLocationDialog(
                     onDismiss = onDismissWithoutSave,
                 )
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.34f),
                     border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                 ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSettingsCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSettingsCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Alarm
@@ -35,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
 import com.alarmtalk.app.data.VibrationPatterns
 
 @Composable
@@ -306,7 +306,7 @@ internal fun AlarmSoundSettingsPane(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.surface,
                 ) {
                     Row(
@@ -428,7 +428,7 @@ internal fun VibrationSettingsPane(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.surface,
                 ) {
                     Row(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSnoozeSettings.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSnoozeSettings.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.Icons
@@ -48,6 +47,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
 import com.alarmtalk.app.data.SnoozeRepeatLimits
 import com.alarmtalk.app.data.VibrationPatternLibrary
 import com.alarmtalk.app.data.VibrationPatterns
@@ -236,7 +237,7 @@ internal fun SnoozeSettingsPane(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.surface,
                 ) {
                     Row(
@@ -358,7 +359,7 @@ internal fun SnoozeOptionSection(
             modifier = Modifier.padding(start = 4.dp),
         )
         Surface(
-            shape = RoundedCornerShape(14.dp),
+            shape = WakerChipShape,
             color = MaterialTheme.colorScheme.surface,
         ) {
             Column(modifier = Modifier.fillMaxWidth()) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Check
@@ -52,6 +51,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerTileShape
 import com.alarmtalk.app.data.AlarmAudioLimits
 import com.alarmtalk.app.data.AlarmPlayModes
 import com.alarmtalk.app.data.VibrationPatterns
@@ -208,7 +210,7 @@ internal fun VoiceAudioCard(
                 if (selectedProfileUnavailable) {
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                         color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.58f),
                     ) {
                         Column(
@@ -431,7 +433,7 @@ private fun NoUsableVoiceProfileCallout(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = WakerPanelShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
     ) {
         Row(
@@ -467,7 +469,7 @@ private fun VoiceProfileSelector(
     val selectedOption = options.firstOrNull { it.id == selectedId } ?: options.firstOrNull()
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
     ) {
         Column {
@@ -536,7 +538,7 @@ private fun VoiceProfileOptionRow(
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = if (selected) {
             MaterialTheme.colorScheme.secondaryContainer
         } else {
@@ -592,7 +594,7 @@ private fun StockClipDropdown(
     var expanded by remember { mutableStateOf(false) }
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
     ) {
         Column {
@@ -687,7 +689,7 @@ private fun StockClipRow(
     Surface(
         onClick = onSelect,
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = if (selected) {
             MaterialTheme.colorScheme.secondaryContainer
         } else {
@@ -824,7 +826,7 @@ private fun ManualTranslationRow(
             if (enabled) onOpenSettings()
         },
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
     ) {
         Row(
@@ -871,7 +873,7 @@ private fun RandomPromptSummaryRow(
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f),
     ) {
         Row(
@@ -931,7 +933,7 @@ private fun VoiceRepeatChoice(
     Surface(
         onClick = onClick,
         modifier = modifier,
-        shape = RoundedCornerShape(12.dp),
+        shape = WakerTileShape,
         color = if (selected) {
             MaterialTheme.colorScheme.secondaryContainer
         } else {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -49,9 +48,12 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerScrimColor
 import kotlin.math.roundToInt
 
 /**
@@ -72,11 +74,23 @@ data class CoachMarkStep(
  */
 class CoachMarkRegistry {
     internal val bounds = mutableStateMapOf<String, Rect>()
+    /** 대상별 모서리 반경 — 스포트라이트 구멍이 대상과 동심(concentric)으로 떨어지도록 쓴다. */
+    internal val radii = mutableStateMapOf<String, Dp>()
 }
 
-/** 이 컴포저블을 [key] 코치마크의 스포트라이트 대상으로 등록한다. */
-fun Modifier.coachMarkTarget(registry: CoachMarkRegistry, key: String): Modifier =
-    onGloballyPositioned { coordinates -> registry.bounds[key] = coordinates.boundsInRoot() }
+/**
+ * 이 컴포저블을 [key] 코치마크의 스포트라이트 대상으로 등록한다.
+ * [targetRadius] 는 대상의 모서리 반경 — 구멍 라운드를 대상과 평행하게 맞추는 데 쓴다.
+ * 카드면 그 카드 shape 의 dp(예: 22), pill/원형이면 매우 큰 값(예: 999), 모르면 기본 16dp.
+ */
+fun Modifier.coachMarkTarget(
+    registry: CoachMarkRegistry,
+    key: String,
+    targetRadius: Dp = 16.dp,
+): Modifier = onGloballyPositioned { coordinates ->
+    registry.bounds[key] = coordinates.boundsInRoot()
+    registry.radii[key] = targetRadius
+}
 
 /**
  * 위치 앵커형 첫 사용 가이드 오버레이.
@@ -114,8 +128,12 @@ fun CoachMarkOverlay(
     val targetBounds = rawTarget?.translate(-overlayOrigin.x, -overlayOrigin.y)
 
     val density = LocalDensity.current
-    val holePaddingPx = with(density) { 6.dp.toPx() }
-    val holeCornerPx = with(density) { 16.dp.toPx() }
+    val holePaddingDp = 6.dp
+    val holePaddingPx = with(density) { holePaddingDp.toPx() }
+    // 구멍은 대상보다 holePadding 만큼 부풀려 그리므로, 동심으로 보이려면 구멍 반경 =
+    // 대상 반경 + holePadding 이어야 한다. 미등록 대상은 기존 동작(16dp)으로 폴백.
+    val targetRadiusDp = registry.radii[step.targetKey] ?: 16.dp
+    val holeCornerPx = with(density) { (targetRadiusDp + holePaddingDp).toPx() }
     val highlightColor = MaterialTheme.colorScheme.primary
 
     // 단계 전환 시 구멍이 이전 위치에서 새 위치로 미끄러지듯 이동.
@@ -145,20 +163,22 @@ fun CoachMarkOverlay(
                 .fillMaxSize()
                 .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen),
         ) {
-            drawRect(SCRIM_COLOR)
+            drawRect(WakerScrimColor)
             if (hole != null) {
+                // pill·원형·작은 타깃에서 사각이 깨지지 않도록 짧은 변의 절반으로 클램프.
+                val cornerPx = holeCornerPx.coerceAtMost(minOf(hole.size.width, hole.size.height) / 2f)
                 drawRoundRect(
                     color = Color.Transparent,
                     topLeft = hole.topLeft,
                     size = hole.size,
-                    cornerRadius = CornerRadius(holeCornerPx),
+                    cornerRadius = CornerRadius(cornerPx),
                     blendMode = BlendMode.Clear,
                 )
                 drawRoundRect(
                     color = highlightColor,
                     topLeft = hole.topLeft,
                     size = hole.size,
-                    cornerRadius = CornerRadius(holeCornerPx),
+                    cornerRadius = CornerRadius(cornerPx),
                     style = Stroke(width = 2.dp.toPx()),
                 )
             }
@@ -223,7 +243,7 @@ private fun CoachMarkCard(
                 .onSizeChanged { cardHeightPx = it.height }
                 // 첫 프레임에 높이를 모른 채 그려지는 깜빡임을 숨긴다.
                 .graphicsLayer { alpha = if (cardHeightPx == 0) 0f else 1f },
-            shape = RoundedCornerShape(18.dp),
+            shape = WakerPanelShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 3.dp,
         ) {
@@ -266,6 +286,3 @@ private fun CoachMarkCard(
         }
     }
 }
-
-/** UsageGuideOverlay 의 코치마크 스크림과 같은 농도. */
-private val SCRIM_COLOR = Color(0xBD05080E)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/UsageGuideOverlay.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/UsageGuideOverlay.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -36,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerHeroShape
+import com.alarmtalk.app.WakerScrimColor
 
 /** 사용 가이드 한 단계의 내용. */
 data class UsageGuideStep(
@@ -65,7 +65,7 @@ fun UsageGuideOverlay(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(SCRIM_COLOR)
+            .background(WakerScrimColor)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
@@ -77,7 +77,7 @@ fun UsageGuideOverlay(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 28.dp),
-            shape = RoundedCornerShape(24.dp),
+            shape = WakerHeroShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 3.dp,
         ) {
@@ -177,6 +177,3 @@ fun UsageGuideDialog(
         UsageGuideOverlay(steps = steps, onFinish = onFinish)
     }
 }
-
-/** handoff 프로토타입 코치마크 스크림 rgba(5,8,14,.74) 과 같은 농도. */
-private val SCRIM_COLOR = Color(0xBD05080E)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/home/HomeCards.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/home/HomeCards.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowForward
 import androidx.compose.material.icons.outlined.Alarm
@@ -41,6 +40,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerHeroShape
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.data.AlarmEntity
 import com.alarmtalk.app.network.CharacterResponse
 import kotlin.math.PI
@@ -54,7 +56,7 @@ internal fun NextAlarmHeroCard(
     val hasAlarm = nextAlarm != null
     Card(
         onClick = onClick,
-        shape = RoundedCornerShape(24.dp),
+        shape = WakerHeroShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
@@ -180,7 +182,7 @@ private fun HomeVoiceWaveform(
                     .height((8 + animatedLevel * 34).dp)
                     .background(
                         color = MaterialTheme.colorScheme.primary.copy(alpha = alpha),
-                        shape = RoundedCornerShape(999.dp),
+                        shape = WakerPillShape,
                     ),
             )
         }
@@ -256,7 +258,7 @@ internal fun HomeActionCard(
     Card(
         onClick = onClick,
         modifier = modifier,
-        shape = RoundedCornerShape(18.dp),
+        shape = WakerPanelShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
@@ -335,7 +337,7 @@ internal fun CharacterMiniCard(
 
     Card(
         onClick = onClick,
-        shape = RoundedCornerShape(20.dp),
+        shape = WakerPanelShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
@@ -385,13 +387,13 @@ internal fun CharacterMiniCard(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(5.dp)
-                        .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(999.dp)),
+                        .background(MaterialTheme.colorScheme.surfaceVariant, WakerPillShape),
                 ) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth(progress)
                             .height(5.dp)
-                            .background(MaterialTheme.colorScheme.tertiary, RoundedCornerShape(999.dp)),
+                            .background(MaterialTheme.colorScheme.tertiary, WakerPillShape),
                     )
                 }
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/home/HomeComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/home/HomeComponents.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.DarkMode
@@ -43,6 +42,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerCardShape
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.widthIn
@@ -110,7 +112,7 @@ internal fun ProfileMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
             modifier = Modifier.width(232.dp),
-            shape = RoundedCornerShape(22.dp),
+            shape = WakerCardShape,
             containerColor = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 14.dp,
@@ -248,7 +250,7 @@ internal fun ThemeModePickerDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
                 .widthIn(max = 420.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -295,7 +297,7 @@ private fun ThemeModeOptionRow(
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(18.dp),
+        shape = WakerPanelShape,
         color = if (selected) {
             scheme.primaryContainer.copy(alpha = 0.62f)
         } else {
@@ -346,7 +348,7 @@ private fun ThemeModeOptionRow(
             }
             if (selected) {
                 Surface(
-                    shape = RoundedCornerShape(999.dp),
+                    shape = WakerPillShape,
                     color = scheme.primary,
                     contentColor = scheme.onPrimary,
                 ) {
@@ -382,7 +384,7 @@ internal fun NicknameEditDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
                 .widthIn(max = 430.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -400,7 +402,7 @@ internal fun NicknameEditDialog(
                     dismissEnabled = !busy,
                 )
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.34f),
                     border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                 ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -572,6 +572,35 @@ internal fun MainViewModel.ensureFamilyShareCode() {
     }
 }
 
+internal fun MainViewModel.regenerateFamilyShareCode() {
+    val authorization = bearerOrMessage(getApplication<android.app.Application>().getString(R.string.msg_gb_login_required_create_share_code)) ?: return
+    val planLabel = when (subscriptionResponse?.plan?.key) {
+        "couple" -> getApplication<android.app.Application>().getString(R.string.msg_gb_plan_label_couple)
+        "family" -> getApplication<android.app.Application>().getString(R.string.msg_gb_plan_label_family)
+        else -> getApplication<android.app.Application>().getString(R.string.msg_gb_plan_label_shared)
+    }
+    viewModelScope.launch {
+        billingBusy = true
+        runCatching {
+            api.regenerateFamilyShareCode(authorization).voucher
+        }.onSuccess { voucher ->
+            // 새 코드를 즉시 노출. 만료된 옛 코드는 아래 새로고침에서 서버 기준으로 정리된다.
+            vouchers = listOf(voucher) + vouchers.filterNot { it.id == voucher.id }
+            message = getApplication<android.app.Application>().getString(R.string.msg_gb_share_code_regenerated, planLabel)
+            refreshCharacterBillingAfterMutation(authorization, "regenerate family share code")
+            refreshSocial()
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to regenerate family share code", error)
+            message = billingFailureMessage(
+                getApplication<android.app.Application>(),
+                apiErrorCode(error),
+                userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_gb_share_code_load_failed, planLabel)),
+            )
+        }
+        billingBusy = false
+    }
+}
+
 private fun com.alarmtalk.app.network.BillingPlan.isSharedPassPlan(): Boolean =
     key in setOf("couple", "family") || planType in setOf("couple", "family")
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.PersonRemove
@@ -43,6 +42,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
 import com.alarmtalk.app.network.AuthSession
 import com.alarmtalk.app.network.BillingSubscriptionResponse
 import com.alarmtalk.app.network.FamilyAlarmQuietWindow
@@ -190,7 +191,7 @@ internal fun MemberManagementScreen(
                         onClick = onEnsureFamilyShareCode,
                         enabled = !billingBusy && !isCapacityFull,
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Text(if (isCapacityFull) stringResource(R.string.social_share_unavailable) else stringResource(R.string.social_create_share_code))
                     }
@@ -200,7 +201,7 @@ internal fun MemberManagementScreen(
                     val isFull = isCapacityFull || shareVoucher.useCount >= shareVoucher.maxUses
                     Surface(
                         color = MaterialTheme.colorScheme.surfaceVariant,
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Column(
                             modifier = Modifier.padding(14.dp),
@@ -232,7 +233,7 @@ internal fun MemberManagementScreen(
                                 onClick = { shareCode(shareVoucher.code) },
                                 enabled = !billingBusy && !isFull,
                                 modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(14.dp),
+                                shape = WakerChipShape,
                             ) {
                                 Text(if (isFull) stringResource(R.string.social_share_unavailable) else stringResource(R.string.social_share_button))
                             }
@@ -318,7 +319,7 @@ private fun FamilyAlarmPermissionCard(
 ) {
     val context = LocalContext.current
     Card(
-        shape = RoundedCornerShape(16.dp),
+        shape = WakerPanelShape,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
@@ -390,7 +391,7 @@ private fun MemberRow(
     onRemove: () -> Unit,
 ) {
     Card(
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         colors = CardDefaults.cardColors(
             containerColor = if (isMe) {
                 MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/members/MemberManagementScreen.kt
@@ -64,6 +64,7 @@ internal fun MemberManagementScreen(
     onBack: () -> Unit,
     onRemoveFamilyMember: (String, String) -> Unit,
     onEnsureFamilyShareCode: () -> Unit,
+    onRegenerateFamilyShareCode: () -> Unit,
     onChangeFamilyAlarmSettings: (Boolean, List<FamilyAlarmQuietWindow>) -> Unit,
 ) {
     val group = familyGroup?.group
@@ -99,6 +100,7 @@ internal fun MemberManagementScreen(
 
     var pendingRemoveMember by remember { mutableStateOf<FamilyGroupMember?>(null) }
     var showFamilyAlarmDialog by remember { mutableStateOf(false) }
+    var showRegenerateConfirm by remember { mutableStateOf(false) }
 
     LazyColumn(
         modifier = Modifier
@@ -237,6 +239,19 @@ internal fun MemberManagementScreen(
                             ) {
                                 Text(if (isFull) stringResource(R.string.social_share_unavailable) else stringResource(R.string.social_share_button))
                             }
+                            OutlinedButton(
+                                onClick = { showRegenerateConfirm = true },
+                                enabled = !billingBusy,
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = WakerChipShape,
+                            ) {
+                                Text(stringResource(R.string.social_regenerate_share_code))
+                            }
+                            Text(
+                                text = stringResource(R.string.social_regenerate_share_code_hint),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
                         }
                     }
                 }
@@ -293,6 +308,44 @@ internal fun MemberManagementScreen(
                         text = stringResource(R.string.social_remove_button),
                         color = MaterialTheme.colorScheme.error,
                     )
+                }
+            },
+        )
+    }
+
+    if (showRegenerateConfirm) {
+        AlertDialog(
+            onDismissRequest = { showRegenerateConfirm = false },
+            title = {
+                ModalDialogTitle(
+                    title = stringResource(R.string.social_regenerate_share_code_dialog_title),
+                    onDismiss = { showRegenerateConfirm = false },
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.social_regenerate_share_code_dialog_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = !billingBusy,
+                    onClick = {
+                        showRegenerateConfirm = false
+                        onRegenerateFamilyShareCode()
+                    },
+                ) {
+                    Text(
+                        text = stringResource(R.string.social_regenerate_share_code),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRegenerateConfirm = false }) {
+                    Text(stringResource(R.string.social_cancel_button))
                 }
             },
         )

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/settings/SettingsScreenComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/settings/SettingsScreenComponents.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -161,7 +160,7 @@ internal fun WeatherLocationPreferenceDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
                 .widthIn(max = 430.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -173,7 +172,7 @@ internal fun WeatherLocationPreferenceDialog(
             ) {
                 ModalDialogTitle(stringResource(R.string.hs_weather_dialog_title), onDismiss = onDismiss)
                 Surface(
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.34f),
                     border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                 ) {
@@ -272,7 +271,7 @@ internal fun FamilyAlarmQuietTimeDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp),
-            shape = RoundedCornerShape(28.dp),
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 6.dp,
             shadowElevation = 18.dp,
@@ -369,7 +368,7 @@ internal fun FamilyAlarmQuietTimeDialog(
         )
         Dialog(onDismissRequest = { timePickerTarget = null }) {
             Surface(
-                shape = RoundedCornerShape(24.dp),
+                shape = WakerHeroShape,
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 6.dp,
                 shadowElevation = 18.dp,
@@ -500,7 +499,7 @@ internal fun QuietTimeChip(
 ) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)),
         modifier = modifier,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/social/SocialPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/social/SocialPanels.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.PlayArrow
@@ -63,6 +62,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerTileShape
 import com.alarmtalk.app.network.AuthSession
 import com.alarmtalk.app.network.apiErrorCode
 import com.alarmtalk.app.network.BillingSubscriptionResponse
@@ -146,7 +148,7 @@ internal fun FamilyConnectionPanel(
                         onClick = { showLeaveDialog = true },
                         enabled = !socialBusy,
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Text(
                             text = stringResource(R.string.social_leave_and_register_new_code),
@@ -158,7 +160,7 @@ internal fun FamilyConnectionPanel(
                         onClick = { showCodeInputs = true },
                         enabled = !socialBusy,
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = WakerChipShape,
                     ) {
                         Text(stringResource(R.string.social_register_other_code))
                     }
@@ -468,7 +470,7 @@ internal fun VoiceMessagePanel(
                     Button(
                         onClick = { showComposer = true },
                         enabled = recipients.isNotEmpty() && !noteBusy,
-                        shape = RoundedCornerShape(12.dp),
+                        shape = WakerTileShape,
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Add,
@@ -530,7 +532,7 @@ internal fun VoiceMessagePanel(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .widthIn(max = 520.dp),
-                shape = WakerCardShape,
+                shape = WakerDialogShape,
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 0.dp,
                 shadowElevation = 18.dp,
@@ -651,7 +653,7 @@ private fun ComposerSection(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(18.dp),
+        shape = WakerPanelShape,
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
@@ -682,7 +684,7 @@ internal fun NoteRow(
     val unread = note.readAt == null
     Card(
         onClick = onMarkRead,
-        shape = RoundedCornerShape(14.dp),
+        shape = WakerChipShape,
         colors = CardDefaults.cardColors(
             containerColor = if (unread) {
                 MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.62f)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.os.Build
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -15,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 
 /**
@@ -106,12 +104,14 @@ internal fun AlarmTalkTheme(
     }
 }
 
+// 모서리 스케일의 단일 출처는 WakerDesign.kt 의 Waker*Shape 토큰이다.
+// 여기서는 그 토큰을 M3 Shapes 슬롯에 매핑만 한다(값 중복 정의 금지).
 private val AlarmTalkShapes = Shapes(
-    extraSmall = RoundedCornerShape(12.dp),
-    small = RoundedCornerShape(14.dp),
-    medium = RoundedCornerShape(18.dp),
-    large = RoundedCornerShape(24.dp),
-    extraLarge = RoundedCornerShape(28.dp),
+    extraSmall = WakerTileShape,
+    small = WakerChipShape,
+    medium = WakerInputShape,
+    large = WakerCardShape,
+    extraLarge = WakerDialogShape,
 )
 
 @Composable

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementComponents.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Mic
@@ -39,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 
 // VoiceProfileManagementPanel 에서 분리한 하위 컴포넌트/다이얼로그.
 // 동작/디자인 변경 없음 — top-level private→internal 가시성만 조정.
@@ -46,7 +47,7 @@ import com.alarmtalk.app.R
 @Composable
 internal fun VoiceProgressMessage(text: String) {
     Surface(
-        shape = RoundedCornerShape(999.dp),
+        shape = WakerPillShape,
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.58f),
     ) {
         Row(
@@ -159,7 +160,7 @@ internal fun SharedVoiceViewerInfoDialog(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .widthIn(max = 460.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -202,7 +203,7 @@ internal fun SharedVoiceViewerInfoDialog(
                 }
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(18.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.45f),
                     border = wakerCardBorder(),
                 ) {
@@ -299,7 +300,7 @@ internal fun VoiceFormDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,
@@ -371,7 +372,7 @@ internal fun VoiceProfileDeleteDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
-            shape = WakerCardShape,
+            shape = WakerDialogShape,
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 0.dp,
             shadowElevation = 18.dp,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
@@ -49,6 +48,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
+import com.alarmtalk.app.WakerPanelShape
+import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.network.FamilyVoiceProfile
 import com.alarmtalk.app.network.VoiceProfile
 import com.alarmtalk.app.network.VoiceSpeakerSegment
@@ -98,7 +99,7 @@ internal fun FileSpeakerModeButton(
             onClick = onClick,
             enabled = enabled,
             modifier = modifier,
-            shape = RoundedCornerShape(999.dp),
+            shape = WakerPillShape,
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.secondary,
                 contentColor = MaterialTheme.colorScheme.onSecondary,
@@ -111,7 +112,7 @@ internal fun FileSpeakerModeButton(
             onClick = onClick,
             enabled = enabled,
             modifier = modifier,
-            shape = RoundedCornerShape(999.dp),
+            shape = WakerPillShape,
         ) {
             Text(label)
         }
@@ -139,7 +140,7 @@ internal fun RecordingLevelBars(
                         } else {
                             MaterialTheme.colorScheme.outlineVariant
                         },
-                        RoundedCornerShape(999.dp),
+                        WakerPillShape,
                     ),
             )
         }
@@ -418,7 +419,7 @@ internal fun SpeakerDraftRow(
             Button(
                 onClick = onSelect,
                 enabled = ready && !promotingBusy,
-                shape = RoundedCornerShape(999.dp),
+                shape = WakerPillShape,
             ) {
                 Text(stringResource(R.string.voicesr_select))
             }
@@ -534,7 +535,7 @@ internal fun VoiceProfileRow(
             if (!isProcessing && !isDeleting) {
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
+                    shape = WakerPanelShape,
                     color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
                     border = wakerCardBorder(if (canShareVoice) 0.72f else 0.36f),
                 ) {
@@ -568,7 +569,7 @@ internal fun VoiceProfileRow(
 @Composable
 internal fun VoiceSharedBadge() {
     Surface(
-        shape = RoundedCornerShape(999.dp),
+        shape = WakerPillShape,
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f),
     ) {
         Text(

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -510,6 +510,7 @@
     <string name="msg_gb_share_code_info_load_failed">Couldn\'t load the share code info</string>
     <string name="msg_gb_share_code_load_failed">Couldn\'t load the %1$s share code.</string>
     <string name="msg_gb_share_code_ready">Your %1$s share code is ready.</string>
+    <string name="msg_gb_share_code_regenerated">Issued a new %1$s share code. The old code no longer works.</string>
     <string name="msg_gb_subscription_cancel_at_period_end">We\'ve scheduled it to cancel automatically after your next billing date.</string>
     <string name="msg_gb_subscription_cancel_failed">Couldn\'t cancel your plan.</string>
     <string name="msg_gb_subscription_canceled">Your plan has been canceled.</string>
@@ -622,6 +623,7 @@
     <string name="social_composer_message">Message</string>
     <string name="social_composer_recipient">Recipient</string>
     <string name="social_composer_send_method">Send method</string>
+    <string name="social_cancel_button">Cancel</string>
     <string name="social_composer_voice">Voice to send</string>
     <string name="social_connect_button">Connect</string>
     <string name="social_create_share_code">Create share code</string>
@@ -652,6 +654,10 @@
     <string name="social_quiet_time_label">Do-not-disturb hours</string>
     <string name="social_received_messages_title">Received messages</string>
     <string name="social_refresh_cd">Refresh</string>
+    <string name="social_regenerate_share_code">Regenerate code</string>
+    <string name="social_regenerate_share_code_dialog_message">Regenerating disables the current code. You\'ll need to resend the new code to anyone you already shared it with.</string>
+    <string name="social_regenerate_share_code_dialog_title">Regenerate share code</string>
+    <string name="social_regenerate_share_code_hint">If the code was exposed, regenerate it to disable the old one.</string>
     <string name="social_register_button">Register</string>
     <string name="social_register_dialog_message">Register this code?</string>
     <string name="social_register_dialog_message_active">If this code is valid, your current %1$s plan will end and switch to the new plan. Register?</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -510,6 +510,7 @@
     <string name="msg_gb_share_code_info_load_failed">共有コード情報を読み込めませんでした</string>
     <string name="msg_gb_share_code_load_failed">%1$s共有コードを読み込めませんでした。</string>
     <string name="msg_gb_share_code_ready">%1$s共有コードを準備しました。</string>
+    <string name="msg_gb_share_code_regenerated">%1$s共有コードを新しく発行しました。以前のコードは使えません。</string>
     <string name="msg_gb_subscription_cancel_at_period_end">次回のお支払い日まで利用後、自動で解約されるよう予約しました。</string>
     <string name="msg_gb_subscription_cancel_failed">解約に失敗しました。</string>
     <string name="msg_gb_subscription_canceled">プランを解約しました。</string>
@@ -622,6 +623,7 @@
     <string name="social_composer_message">メッセージ</string>
     <string name="social_composer_recipient">宛先</string>
     <string name="social_composer_send_method">送信方法</string>
+    <string name="social_cancel_button">キャンセル</string>
     <string name="social_composer_voice">送る声</string>
     <string name="social_connect_button">連携する</string>
     <string name="social_create_share_code">共有コードを作成</string>
@@ -652,6 +654,10 @@
     <string name="social_quiet_time_label">アラームを受け取らない時間</string>
     <string name="social_received_messages_title">受信メッセージ</string>
     <string name="social_refresh_cd">更新</string>
+    <string name="social_regenerate_share_code">コードを再発行</string>
+    <string name="social_regenerate_share_code_dialog_message">再発行すると現在のコードは使えなくなります。すでに共有した相手には新しいコードを送り直してください。</string>
+    <string name="social_regenerate_share_code_dialog_title">共有コードの再発行</string>
+    <string name="social_regenerate_share_code_hint">コードが外部に漏れた場合は再発行して既存のコードを無効にできます。</string>
     <string name="social_register_button">登録</string>
     <string name="social_register_dialog_message">このコードを登録しますか？</string>
     <string name="social_register_dialog_message_active">登録可能なコードの場合、現在の%1$sプランは終了し、新しいプランに切り替わります。登録しますか？</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -512,6 +512,7 @@
     <string name="msg_gb_share_code_info_load_failed">공유 코드 정보를 불러오지 못했어요</string>
     <string name="msg_gb_share_code_load_failed">%1$s 공유 코드를 불러오지 못했어요</string>
     <string name="msg_gb_share_code_ready">%1$s 공유 코드를 준비했어요</string>
+    <string name="msg_gb_share_code_regenerated">%1$s 공유 코드를 새로 발급했어요. 기존 코드는 더 이상 쓸 수 없어요</string>
     <string name="msg_gb_subscription_cancel_at_period_end">다음 결제일까지 사용 후 자동 해지되도록 예약했어요</string>
     <string name="msg_gb_subscription_cancel_failed">해지에 실패했어요</string>
     <string name="msg_gb_subscription_canceled">이용권을 해지했어요</string>
@@ -622,6 +623,7 @@
     <string name="social_composer_message">메시지</string>
     <string name="social_composer_recipient">받는 사람</string>
     <string name="social_composer_send_method">보내기 방식</string>
+    <string name="social_cancel_button">취소</string>
     <string name="social_composer_voice">보낼 목소리</string>
     <string name="social_connect_button">연결하기</string>
     <string name="social_create_share_code">공유 코드 만들기</string>
@@ -652,6 +654,10 @@
     <string name="social_quiet_time_label">알람 받지 않을 시간</string>
     <string name="social_received_messages_title">받은 메시지</string>
     <string name="social_refresh_cd">새로고침</string>
+    <string name="social_regenerate_share_code">코드 재발급</string>
+    <string name="social_regenerate_share_code_dialog_message">재발급하면 지금 코드는 더 이상 쓸 수 없어요. 이미 코드를 보낸 사람에게는 새 코드를 다시 보내야 해요.</string>
+    <string name="social_regenerate_share_code_dialog_title">공유 코드 재발급</string>
+    <string name="social_regenerate_share_code_hint">코드가 외부에 노출됐다면 재발급해서 기존 코드를 막을 수 있어요.</string>
     <string name="social_register_button">등록</string>
     <string name="social_register_dialog_message">이 코드를 등록할까요?</string>
     <string name="social_register_dialog_message_active">등록 가능한 코드라면 현재 %1$s 이용권은 종료되고 새 이용권으로 바뀌어요. 등록할까요?</string>

--- a/packages/backend/src/lib/store-billing.ts
+++ b/packages/backend/src/lib/store-billing.ts
@@ -104,6 +104,15 @@ export async function applyStoreEntitlement(
               WHERE id = ?`,
         args: [expiresAtIso, subscriptionId],
       });
+      // 갱신(다음 달 결제 등)으로 구독 만료가 연장되면, 같은 구독에 묶인 활성
+      // 공유 코드의 만료도 함께 밀어 코드가 끊기지 않게 한다. 코드 문자열은 그대로
+      // 유지되므로 이미 공유한 코드도 다음 기간 동안 계속 유효하다.
+      await tx.execute({
+        sql: `UPDATE voucher_codes
+              SET expires_at = ?
+              WHERE issuer_subscription_id = ? AND status = 'issued'`,
+        args: [expiresAtIso, subscriptionId],
+      });
       await tx.execute({
         sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
         args: [planTypeToUserPlan(input.plan.plan_type), input.userPk],

--- a/packages/backend/src/lib/store-billing.ts
+++ b/packages/backend/src/lib/store-billing.ts
@@ -104,13 +104,17 @@ export async function applyStoreEntitlement(
               WHERE id = ?`,
         args: [expiresAtIso, subscriptionId],
       });
-      // 갱신(다음 달 결제 등)으로 구독 만료가 연장되면, 같은 구독에 묶인 활성
-      // 공유 코드의 만료도 함께 밀어 코드가 끊기지 않게 한다. 코드 문자열은 그대로
-      // 유지되므로 이미 공유한 코드도 다음 기간 동안 계속 유효하다.
+      // 갱신(다음 달 결제 등)으로 구독 만료가 연장되면, 같은 구독에 묶인 공유 코드의
+      // 만료도 함께 밀어 코드가 끊기지 않게 한다. 코드 문자열은 그대로 유지되므로
+      // 이미 공유한 코드도 다음 기간 동안 계속 유효하다.
+      // issued 뿐 아니라 used 도 연장한다: 정원이 찬 상태로 갱신된 뒤 멤버가 이탈하면
+      // releaseInviteUseForMember 가 used→issued 로 되돌리는데, 이때 expires_at 은
+      // 건드리지 않으므로 옛 만료가 남아 즉시 만료 처리되는 것을 막는다.
+      // (expired 코드는 의도적으로 무효화된 것이므로 되살리지 않는다.)
       await tx.execute({
         sql: `UPDATE voucher_codes
               SET expires_at = ?
-              WHERE issuer_subscription_id = ? AND status = 'issued'`,
+              WHERE issuer_subscription_id = ? AND status IN ('issued', 'used')`,
         args: [expiresAtIso, subscriptionId],
       });
       await tx.execute({

--- a/packages/backend/src/routes/billing-google-rtdn.ts
+++ b/packages/backend/src/routes/billing-google-rtdn.ts
@@ -210,6 +210,7 @@ billingGoogleRtdn.post('/rtdn', async (c) => {
     // 알림을 놓쳤거나 순서가 뒤바뀌어 DB 만료가 과거값으로 남아 있으면,
     // processSubscriptionExpiry 가 기간이 남았는데도 즉시 해지해버리기 때문이다.
     // (decideSubscriptionAction 이 cancel_at_period_end 를 반환하는 조건상 expiryMs 는 유한값이다.)
+    const periodEndIso = new Date(expiryMs).toISOString();
     await db.execute({
       sql: `UPDATE subscriptions
             SET cancel_at_period_end = 1,
@@ -217,7 +218,20 @@ billingGoogleRtdn.post('/rtdn', async (c) => {
                 canceled_at = COALESCE(canceled_at, datetime('now')),
                 updated_at = datetime('now')
             WHERE user_id = ? AND status = 'active'`,
-      args: [new Date(expiryMs).toISOString(), userPk],
+      args: [periodEndIso, userPk],
+    });
+    // 구독 만료를 권위값으로 밀 때 같은 구독에 묶인 공유 코드 만료도 함께 동기화한다.
+    // (store-billing 갱신 경로와 동일 규칙) issued·used 모두 연장, expired 는 제외.
+    // 누락하면 만료가 미뤄진 구독에 옛 만료의 코드가 남아 redemption 이 만료로 거부된다.
+    await db.execute({
+      sql: `UPDATE voucher_codes
+            SET expires_at = ?
+            WHERE issuer_user_id = ?
+              AND status IN ('issued', 'used')
+              AND issuer_subscription_id IN (
+                SELECT id FROM subscriptions WHERE user_id = ? AND status = 'active'
+              )`,
+      args: [periodEndIso, userPk, userPk],
     });
     logStructured('info', { at: 'billing.google.rtdn', action: 'cancel_at_period_end', userPk });
     return c.json({ success: true, action: 'cancel_at_period_end' });

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -451,6 +451,124 @@ billingMutation.post('/redeem', async (c) => {
   }
 });
 
+interface FamilyOwnerContext {
+  subscriptionId: string;
+  planId: string;
+  planKey: string;
+  planName: string;
+  planType: string;
+  maxMembers: number;
+  maxUses: number;
+  expiresAt: string;
+}
+
+type FamilyOwnerLookup =
+  | { ctx: FamilyOwnerContext }
+  | {
+      error: {
+        status: 404 | 409;
+        body: { error: string; error_code: string };
+      };
+    };
+
+/** 활성 가족 플랜 소유자 구독 + 그룹 정원 가드. 공유 코드 발급/재발급 공통. */
+async function loadActiveFamilyOwnerContext(
+  tx: DbExecutor,
+  userPk: string,
+): Promise<FamilyOwnerLookup> {
+  const subscriptionRes = await tx.execute({
+    sql: `SELECT s.id AS subscription_id, s.plan_id, s.expires_at,
+                 pg.id AS plan_group_id, pg.max_members AS group_max_members,
+                 (SELECT COUNT(*) FROM plan_group_members WHERE plan_group_id = pg.id) AS member_count,
+                 p.key AS plan_key, p.name AS plan_name, p.plan_type,
+                 p.period_days, p.max_members, p.price_krw
+          FROM subscriptions s
+          JOIN plans p ON p.id = s.plan_id
+          JOIN plan_groups pg ON pg.id = s.plan_group_id
+          WHERE s.user_id = ?
+            AND pg.owner_user_id = ?
+            AND s.status = 'active'
+            AND s.expires_at > datetime('now')
+            AND p.plan_type = 'family'
+          ORDER BY s.starts_at DESC
+          LIMIT 1`,
+    args: [userPk, userPk],
+  });
+
+  if (subscriptionRes.rows.length === 0) {
+    return {
+      error: {
+        status: 404,
+        body: {
+          error: 'Active family plan ownership is required',
+          error_code: 'NO_ACTIVE_FAMILY_OWNER_SUBSCRIPTION',
+        },
+      },
+    };
+  }
+
+  const subscription = subscriptionRes.rows[0]!;
+  const planType = String(subscription.plan_type);
+  const maxMembers = Number(subscription.group_max_members ?? subscription.max_members) || 6;
+  const memberCount = Number(subscription.member_count ?? 0);
+  if (memberCount >= maxMembers) {
+    return {
+      error: {
+        status: 409,
+        body: {
+          error: `Group is full: max ${maxMembers}`,
+          error_code: 'GROUP_FULL',
+        },
+      },
+    };
+  }
+
+  return {
+    ctx: {
+      subscriptionId: String(subscription.subscription_id),
+      planId: String(subscription.plan_id),
+      planKey: String(subscription.plan_key),
+      planName: String(subscription.plan_name),
+      planType,
+      maxMembers,
+      maxUses: plannedMaxUses(planType, maxMembers),
+      expiresAt: String(subscription.expires_at),
+    },
+  };
+}
+
+/** 새 invite 코드를 발급해 공유용 응답 모양으로 만든다. */
+async function issueShareableVoucher(
+  tx: DbExecutor,
+  userPk: string,
+  ctx: FamilyOwnerContext,
+): Promise<ShareableVoucherCode> {
+  const issuedAt = new Date().toISOString();
+  const issued = await issueVoucherCode(tx, {
+    kind: 'invite',
+    planId: ctx.planId,
+    issuerUserId: userPk,
+    issuerSubscriptionId: ctx.subscriptionId,
+    issuedAt,
+    expiresAt: ctx.expiresAt,
+    maxUses: ctx.maxUses,
+  });
+  return {
+    id: issued.id,
+    code: issued.code,
+    plan_id: ctx.planId,
+    plan_key: ctx.planKey,
+    plan_name: ctx.planName,
+    plan_type: ctx.planType,
+    subscription_id: ctx.subscriptionId,
+    status: 'issued',
+    issued_at: issuedAt,
+    expires_at: issued.expires_at,
+    max_uses: issued.max_uses,
+    use_count: issued.use_count,
+  };
+}
+
 billingMutation.post('/vouchers/family-share', async (c) => {
   const userPk = await resolveUserPk(c);
   if (!userPk) {
@@ -459,57 +577,9 @@ billingMutation.post('/vouchers/family-share', async (c) => {
 
   const db = getDB(c.env);
   const result: FamilyShareCodeResult = await withWriteTransaction(db, async (tx) => {
-    const subscriptionRes = await tx.execute({
-      sql: `SELECT s.id AS subscription_id, s.plan_id, s.expires_at,
-                   pg.id AS plan_group_id, pg.max_members AS group_max_members,
-                   (SELECT COUNT(*) FROM plan_group_members WHERE plan_group_id = pg.id) AS member_count,
-                   p.key AS plan_key, p.name AS plan_name, p.plan_type,
-                   p.period_days, p.max_members, p.price_krw
-            FROM subscriptions s
-            JOIN plans p ON p.id = s.plan_id
-            JOIN plan_groups pg ON pg.id = s.plan_group_id
-            WHERE s.user_id = ?
-              AND pg.owner_user_id = ?
-              AND s.status = 'active'
-              AND s.expires_at > datetime('now')
-              AND p.plan_type = 'family'
-            ORDER BY s.starts_at DESC
-            LIMIT 1`,
-      args: [userPk, userPk],
-    });
-
-    if (subscriptionRes.rows.length === 0) {
-      return {
-        error: {
-          status: 404,
-          body: {
-            error: 'Active family plan ownership is required',
-            error_code: 'NO_ACTIVE_FAMILY_OWNER_SUBSCRIPTION',
-          },
-        },
-      };
-    }
-
-    const subscription = subscriptionRes.rows[0]!;
-    const subscriptionId = String(subscription.subscription_id);
-    const planId = String(subscription.plan_id);
-    const planKey = String(subscription.plan_key);
-    const planName = String(subscription.plan_name);
-    const planType = String(subscription.plan_type);
-    const maxMembers = Number(subscription.group_max_members ?? subscription.max_members) || 6;
-    const memberCount = Number(subscription.member_count ?? 0);
-    if (memberCount >= maxMembers) {
-      return {
-        error: {
-          status: 409,
-          body: {
-            error: `Group is full: max ${maxMembers}`,
-            error_code: 'GROUP_FULL',
-          },
-        },
-      };
-    }
-    const maxUses = plannedMaxUses(planType, maxMembers);
+    const lookup = await loadActiveFamilyOwnerContext(tx, userPk);
+    if ('error' in lookup) return lookup;
+    const ctx = lookup.ctx;
 
     const existingRes = await tx.execute({
       sql: `SELECT v.id, v.code, v.status, v.issued_at, v.expires_at, v.max_uses,
@@ -520,7 +590,7 @@ billingMutation.post('/vouchers/family-share', async (c) => {
               AND v.status = 'issued'
               AND v.expires_at > datetime('now')
             ORDER BY v.issued_at DESC`,
-      args: [userPk, subscriptionId],
+      args: [userPk, ctx.subscriptionId],
     });
 
     const existing = existingRes.rows.find((row) => {
@@ -533,46 +603,56 @@ billingMutation.post('/vouchers/family-share', async (c) => {
       const voucher: ShareableVoucherCode = {
         id: String(existing.id),
         code: String(existing.code),
-        plan_id: planId,
-        plan_key: planKey,
-        plan_name: planName,
-        plan_type: planType,
-        subscription_id: subscriptionId,
+        plan_id: ctx.planId,
+        plan_key: ctx.planKey,
+        plan_name: ctx.planName,
+        plan_type: ctx.planType,
+        subscription_id: ctx.subscriptionId,
         status: 'issued',
         issued_at: String(existing.issued_at),
         expires_at: String(existing.expires_at),
-        max_uses: Number(existing.max_uses ?? maxUses),
+        max_uses: Number(existing.max_uses ?? ctx.maxUses),
         use_count: Number(existing.use_count ?? 0),
       };
       return { voucher };
     }
 
-    const issuedAt = new Date().toISOString();
-    const issued = await issueVoucherCode(tx, {
-      kind: 'invite',
-      planId,
-      issuerUserId: userPk,
-      issuerSubscriptionId: subscriptionId,
-      issuedAt,
-      expiresAt: String(subscription.expires_at),
-      maxUses,
+    return { voucher: await issueShareableVoucher(tx, userPk, ctx) };
+  });
+
+  if ('error' in result) {
+    return c.json(result.error.body, result.error.status);
+  }
+
+  return c.json({ success: true, voucher: result.voucher });
+});
+
+// 공유 코드 재발급: 기존 활성 코드를 무효화(expired)하고 새 코드를 발급한다.
+// 유출이 의심될 때 사용자가 직접 코드를 끊고 새로 만들 수 있게 한다.
+billingMutation.post('/vouchers/family-share/regenerate', async (c) => {
+  const userPk = await resolveUserPk(c);
+  if (!userPk) {
+    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
+  }
+
+  const db = getDB(c.env);
+  const result: FamilyShareCodeResult = await withWriteTransaction(db, async (tx) => {
+    const lookup = await loadActiveFamilyOwnerContext(tx, userPk);
+    if ('error' in lookup) return lookup;
+    const ctx = lookup.ctx;
+
+    // 같은 구독에 묶인 현재 발급 상태의 코드를 모두 만료 처리(이미 합류한 멤버는
+    // 별도 구독으로 유지되므로 영향 없음 — 남은 미사용 슬롯의 코드만 무효화된다).
+    await tx.execute({
+      sql: `UPDATE voucher_codes
+            SET status = 'expired'
+            WHERE issuer_user_id = ?
+              AND issuer_subscription_id = ?
+              AND status = 'issued'`,
+      args: [userPk, ctx.subscriptionId],
     });
 
-    const voucher: ShareableVoucherCode = {
-      id: issued.id,
-      code: issued.code,
-      plan_id: planId,
-      plan_key: planKey,
-      plan_name: planName,
-      plan_type: planType,
-      subscription_id: subscriptionId,
-      status: 'issued',
-      issued_at: issuedAt,
-      expires_at: issued.expires_at,
-      max_uses: issued.max_uses,
-      use_count: issued.use_count,
-    };
-    return { voucher };
+    return { voucher: await issueShareableVoucher(tx, userPk, ctx) };
   });
 
   if ('error' in result) {

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -463,15 +463,20 @@ interface FamilyOwnerContext {
 }
 
 type FamilyOwnerLookup =
-  | { ctx: FamilyOwnerContext }
+  | { ctx: FamilyOwnerContext; memberCount: number }
   | {
       error: {
-        status: 404 | 409;
+        status: 404;
         body: { error: string; error_code: string };
       };
     };
 
-/** 활성 가족 플랜 소유자 구독 + 그룹 정원 가드. 공유 코드 발급/재발급 공통. */
+/**
+ * 활성 가족 플랜 소유자 구독을 찾는다(정원 가드는 호출 측 책임).
+ *  - 발급(family-share)은 정원이 차면 새 코드가 무의미하므로 GROUP_FULL 로 막는다.
+ *  - 재발급(regenerate)은 *정원이 찼을 때도* 유출된 코드를 끊을 수 있어야 하므로
+ *    정원 가드를 적용하지 않는다. 그래서 가드를 여기서 빼고 memberCount 만 넘긴다.
+ */
 async function loadActiveFamilyOwnerContext(
   tx: DbExecutor,
   userPk: string,
@@ -511,17 +516,6 @@ async function loadActiveFamilyOwnerContext(
   const planType = String(subscription.plan_type);
   const maxMembers = Number(subscription.group_max_members ?? subscription.max_members) || 6;
   const memberCount = Number(subscription.member_count ?? 0);
-  if (memberCount >= maxMembers) {
-    return {
-      error: {
-        status: 409,
-        body: {
-          error: `Group is full: max ${maxMembers}`,
-          error_code: 'GROUP_FULL',
-        },
-      },
-    };
-  }
 
   return {
     ctx: {
@@ -534,6 +528,7 @@ async function loadActiveFamilyOwnerContext(
       maxUses: plannedMaxUses(planType, maxMembers),
       expiresAt: String(subscription.expires_at),
     },
+    memberCount,
   };
 }
 
@@ -581,6 +576,19 @@ billingMutation.post('/vouchers/family-share', async (c) => {
     if ('error' in lookup) return lookup;
     const ctx = lookup.ctx;
 
+    // 정원이 차면 더 초대할 수 없으므로 새 코드 발급/재사용을 막는다.
+    if (lookup.memberCount >= ctx.maxMembers) {
+      return {
+        error: {
+          status: 409,
+          body: {
+            error: `Group is full: max ${ctx.maxMembers}`,
+            error_code: 'GROUP_FULL',
+          },
+        },
+      };
+    }
+
     const existingRes = await tx.execute({
       sql: `SELECT v.id, v.code, v.status, v.issued_at, v.expires_at, v.max_uses,
                    (SELECT COUNT(*) FROM voucher_redemptions WHERE voucher_id = v.id) AS use_count
@@ -627,8 +635,9 @@ billingMutation.post('/vouchers/family-share', async (c) => {
   return c.json({ success: true, voucher: result.voucher });
 });
 
-// 공유 코드 재발급: 기존 활성 코드를 무효화(expired)하고 새 코드를 발급한다.
+// 공유 코드 재발급: 기존 코드를 무효화(expired)하고 새 코드를 발급한다.
 // 유출이 의심될 때 사용자가 직접 코드를 끊고 새로 만들 수 있게 한다.
+// 정원이 꽉 차도(유출 의심 시점이 보통 이때다) 허용해야 하므로 GROUP_FULL 가드를 두지 않는다.
 billingMutation.post('/vouchers/family-share/regenerate', async (c) => {
   const userPk = await resolveUserPk(c);
   if (!userPk) {
@@ -641,14 +650,16 @@ billingMutation.post('/vouchers/family-share/regenerate', async (c) => {
     if ('error' in lookup) return lookup;
     const ctx = lookup.ctx;
 
-    // 같은 구독에 묶인 현재 발급 상태의 코드를 모두 만료 처리(이미 합류한 멤버는
-    // 별도 구독으로 유지되므로 영향 없음 — 남은 미사용 슬롯의 코드만 무효화된다).
+    // 같은 구독에 묶인 기존 코드를 issued·used 모두 만료 처리한다.
+    // used 만 빼면, 멤버 이탈 시 releaseInviteUseForMember 가 used→issued 로 되돌려
+    // 유출된 코드가 다시 사용 가능해질 수 있다(expired 는 되돌리지 않음).
+    // 이미 합류한 멤버의 구독 자체는 별도 행이라 영향 없다.
     await tx.execute({
       sql: `UPDATE voucher_codes
             SET status = 'expired'
             WHERE issuer_user_id = ?
               AND issuer_subscription_id = ?
-              AND status = 'issued'`,
+              AND status IN ('issued', 'used')`,
       args: [userPk, ctx.subscriptionId],
     });
 


### PR DESCRIPTION
## 개요
디자인 토큰 정리에 더해, 이용권 모달 가독성 개선과 공유 코드(가족 초대) 재발급/갱신 자동화를 함께 담았습니다.

## 1. 디자인 토큰 (기존 커밋)
- 코너 반경·색 단일 출처화(`WakerDesign.kt` / `AlarmTalkTheme.kt`), 화면 전반의 생 리터럴 → 토큰 전환, 코치마크 스크림 토큰화.

## 2. 이용권 모달 가독성 (`BillingActionDialog`)
- 공통 컴포넌트 한 곳 수정으로 결제/이용권 모달 전체에 일괄 적용.
- 제목↔설명 6→12dp, 헤더↔버튼 16→22dp, 설명 `lineHeight` 20sp.
- 설명을 마침표(`. `) 단위로 줄바꿈해 한 문장씩 읽기 쉽게. (날짜 포맷 `M/d`는 공백 없는 마침표라 영향 없음)

## 3. 공유 코드 재발급 + 갱신 자동 최신화
**백엔드**
- `POST /billing/vouchers/family-share/regenerate` 신설: 기존 활성 코드를 `expired` 처리하고 새 코드 발급. 이미 합류한 멤버는 별도 구독이라 영향 없고 남은 미사용 슬롯만 무효화. (status CHECK 제약 그대로 사용 → 마이그레이션 불필요)
- 구독 갱신(`applyStoreEntitlement` 동일 트랜잭션 재전송 경로)에서 구독 `expires_at` 연장 시 **같은 구독의 활성 공유 코드 `expires_at`도 동기 연장** → 다음 달 결제 후 코드가 만료돼 끊기던 문제 해결. 코드 문자열은 유지되어 이미 공유한 코드도 계속 유효.
- `family-share`/`regenerate` 공통 로직(`loadActiveFamilyOwnerContext`, `issueShareableVoucher`) 추출.

**안드로이드**
- 구성원 관리 화면에 **'코드 재발급' 버튼 + 안내문 + 확인 다이얼로그**(되돌릴 수 없으므로 컨펌).
- `BillingApi.regenerateFamilyShareCode`, `MainViewModel.regenerateFamilyShareCode()`, 문자열 한·영·일 추가.

## 검증
- 백엔드 `tsc --noEmit` 클린, 관련 테스트 8파일 96 passed / 0 failed.
- Android `assembleDevDebug` BUILD SUCCESSFUL, 테스트폰(S23 Ultra) 설치 확인.

## 배포 메모
머지 시 dev 자동 배포 + 마이그레이션. 재발급 엔드포인트는 dev 배포 후 앱에서 동작.
