### PR TITLE
dev 빌드 화면 캡처 허용 (FLAG_SECURE dev 제외)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/MainActivity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/MainActivity.kt
@@ -14,10 +14,13 @@ class MainActivity : ComponentActivity() {
         // 민감정보 보호(보안 감사 대응): 이 액티비티는 이메일·운세 생년월일 등 PII 와
         // 보이스 클론 녹음 UI 를 호스팅한다. FLAG_SECURE 로 스크린샷·화면 녹화·최근 앱
         // 썸네일에 내용이 노출되지 않게 한다.
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_SECURE,
-            WindowManager.LayoutParams.FLAG_SECURE,
-        )
+        // 단, dev flavor 에서는 QA·디버깅 중 화면 캡처가 필요하므로 풀어둔다(prod 는 유지).
+        if (BuildConfig.FLAVOR != "dev") {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE,
+            )
+        }
         setContent {
             val viewModel: MainViewModel = viewModel()
             AlarmTalkTheme(themeMode = viewModel.themeMode) {


### PR DESCRIPTION
## 개요
`MainActivity`의 `FLAG_SECURE`를 **dev flavor에서는 적용하지 않도록** 분기. QA·디버깅 중 스크린샷/화면 녹화/scrcpy가 가능해집니다.

## 변경
- `BuildConfig.FLAVOR != "dev"`일 때만 `FLAG_SECURE` 설정.
- prod 등 비-dev 빌드는 기존대로 이메일·생년월일 등 PII와 보이스 클론 녹음 UI 보호를 위해 캡처 차단 유지.

## 배경
앱 전체 `FLAG_SECURE`로 인해 개발 중 화면 확인(캡처)이 불가능했음. 운영 보안은 유지하면서 dev만 풀어 QA 편의를 확보.

## 검증
- `assembleDevDebug` BUILD SUCCESSFUL.
- 동작: dev = 캡처 가능 / prod = 캡처 차단(코드 분기로 보장).
