### PR TITLE
이용권 게이트 모달 카피·디자인 정리

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -363,6 +363,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
             !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
         ) {
             planGateDialog = PlanGateDialogState(
+                title = context.getString(R.string.r3app_messages_plan_gate_title),
                 message = context.getString(R.string.r3app_messages_plan_gate),
             )
             return
@@ -416,6 +417,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
 
     planGateDialog?.let { gate ->
         PlanGateDialog(
+            title = gate.title ?: stringResource(R.string.r3dlg_plan_gate_title),
             message = gate.message,
             confirmLabel = gate.confirmLabel ?: stringResource(R.string.r3app_plan_gate_confirm),
             onConfirm = {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
@@ -151,6 +151,8 @@ internal enum class MessageSeverity { Success, Error, Info }
 
 internal data class PlanGateDialogState(
     val message: String,
+    // null이면 PlanGateDialog의 현지화된 기본 제목을 사용한다.
+    val title: String? = null,
     // null이면 PlanGateDialog의 현지화된 기본 확인 라벨을 사용한다.
     val confirmLabel: String? = null,
 )

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/LoginPermissionGate.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/LoginPermissionGate.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.alarmtalk.app.WakerHeroShape
 import com.alarmtalk.app.network.AuthSession
+import com.alarmtalk.app.wakerCardBorder
 
 /**
  * 로그인 후 첫 진입에서 알람 앱에 필요한 권한을 한 번에 안내한다.
@@ -72,7 +73,9 @@ internal fun LoginPermissionGate(
                 .widthIn(max = 520.dp),
             shape = WakerHeroShape,
             color = MaterialTheme.colorScheme.surface,
-            tonalElevation = 6.dp,
+            tonalElevation = 0.dp,
+            shadowElevation = 18.dp,
+            border = wakerCardBorder(),
         ) {
             Column(
                 modifier = Modifier.padding(18.dp),

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/DuplicateAlarmDialog.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/DuplicateAlarmDialog.kt
@@ -1,6 +1,5 @@
 package com.alarmtalk.app
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -21,8 +20,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerButtonShape
 import com.alarmtalk.app.WakerDialogShape
+import com.alarmtalk.app.wakerCardBorder
 
 /**
  * 같은 시각에 이미 알람이 있을 때 띄우는 확인 다이얼로그.
@@ -57,8 +57,9 @@ internal fun DuplicateAlarmDialog(
                 .widthIn(max = 380.dp),
             shape = WakerDialogShape,
             color = scheme.surface,
-            tonalElevation = 6.dp,
-            border = BorderStroke(1.dp, scheme.outlineVariant),
+            tonalElevation = 0.dp,
+            shadowElevation = 18.dp,
+            border = wakerCardBorder(),
         ) {
             Column(
                 modifier = Modifier.padding(22.dp),
@@ -82,7 +83,7 @@ internal fun DuplicateAlarmDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(48.dp),
-                        shape = WakerChipShape,
+                        shape = WakerButtonShape,
                     ) {
                         Text(stringResource(R.string.r3dlg_duplicate_alarm_replace), maxLines = 1)
                     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ModalDialogTitle.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ModalDialogTitle.kt
@@ -13,9 +13,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+
+// 제목 글자 크기를 폰 가로폭에 비례시키는 기준/한계. 360dp 를 1.0 기준으로 좁은
+// 기기는 더 작게·넓은 기기는 더 크게 스케일하되, 과도해지지 않게 클램프한다.
+private const val TITLE_BASELINE_WIDTH_DP = 360f
+private const val TITLE_MIN_SCALE = 0.9f
+private const val TITLE_MAX_SCALE = 1.15f
 
 @Composable
 internal fun ModalDialogTitle(
@@ -24,6 +32,11 @@ internal fun ModalDialogTitle(
     modifier: Modifier = Modifier,
     dismissEnabled: Boolean = true,
 ) {
+    val widthScale = (LocalConfiguration.current.screenWidthDp / TITLE_BASELINE_WIDTH_DP)
+        .coerceIn(TITLE_MIN_SCALE, TITLE_MAX_SCALE)
+    val titleStyle = MaterialTheme.typography.titleLarge.let {
+        it.copy(fontWeight = FontWeight.Bold, fontSize = it.fontSize * widthScale)
+    }
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -31,16 +44,21 @@ internal fun ModalDialogTitle(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
+            style = titleStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
         IconButton(
             onClick = onDismiss,
             enabled = dismissEnabled,
-            modifier = Modifier.size(42.dp),
+            modifier = Modifier.size(48.dp),
         ) {
-            Icon(Icons.Outlined.Close, contentDescription = stringResource(R.string.r3dlg_modal_dialog_close))
+            Icon(
+                Icons.Outlined.Close,
+                contentDescription = stringResource(R.string.r3dlg_modal_dialog_close),
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ModalDialogTitle.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ModalDialogTitle.kt
@@ -13,17 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-
-// 제목 글자 크기를 폰 가로폭에 비례시키는 기준/한계. 360dp 를 1.0 기준으로 좁은
-// 기기는 더 작게·넓은 기기는 더 크게 스케일하되, 과도해지지 않게 클램프한다.
-private const val TITLE_BASELINE_WIDTH_DP = 360f
-private const val TITLE_MIN_SCALE = 0.9f
-private const val TITLE_MAX_SCALE = 1.15f
 
 @Composable
 internal fun ModalDialogTitle(
@@ -32,19 +25,18 @@ internal fun ModalDialogTitle(
     modifier: Modifier = Modifier,
     dismissEnabled: Boolean = true,
 ) {
-    val widthScale = (LocalConfiguration.current.screenWidthDp / TITLE_BASELINE_WIDTH_DP)
-        .coerceIn(TITLE_MIN_SCALE, TITLE_MAX_SCALE)
-    val titleStyle = MaterialTheme.typography.titleLarge.let {
-        it.copy(fontWeight = FontWeight.Bold, fontSize = it.fontSize * widthScale)
-    }
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // 앱 전체와 동일한 고정 타입스케일(Material titleLarge)을 사용한다. 화면 폭이 아니라
+        // 사용자 시스템 글꼴 설정에만 반응하는 표준 방식이며, 길이가 넘치면 줄바꿈 대신
+        // ellipsis 로 한 줄을 유지한다.
         Text(
             text = title,
-            style = titleStyle,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/PlanGateDialog.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/PlanGateDialog.kt
@@ -1,11 +1,11 @@
 package com.alarmtalk.app
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Button
@@ -15,11 +15,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.alarmtalk.app.WakerChipShape
+import com.alarmtalk.app.WakerButtonShape
 import com.alarmtalk.app.WakerDialogShape
+import com.alarmtalk.app.wakerCardBorder
 
 @Composable
 internal fun PlanGateDialog(
@@ -42,8 +44,9 @@ internal fun PlanGateDialog(
                 .widthIn(max = 380.dp),
             shape = WakerDialogShape,
             color = scheme.surface,
-            tonalElevation = 6.dp,
-            border = BorderStroke(1.dp, scheme.outlineVariant),
+            tonalElevation = 0.dp,
+            shadowElevation = 18.dp,
+            border = wakerCardBorder(),
         ) {
             Column(
                 modifier = Modifier.padding(22.dp),
@@ -60,19 +63,14 @@ internal fun PlanGateDialog(
                     color = scheme.onSurfaceVariant,
                 )
                 Spacer(Modifier.height(20.dp))
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                Button(
+                    onClick = onConfirm,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 48.dp),
+                    shape = WakerButtonShape,
                 ) {
-                    Button(
-                        onClick = onConfirm,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(48.dp),
-                        shape = WakerChipShape,
-                    ) {
-                        Text(confirmLabel, maxLines = 1)
-                    }
+                    Text(confirmLabel, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -1020,6 +1020,7 @@ for a smooth and secure experience.</string>
     <string name="r3app_google_signin_failed">Google sign-in failed</string>
     <string name="r3app_google_signin_no_info">We couldn\'t get your Google sign-in info. Please try again.</string>
     <string name="r3app_messages_plan_gate">Messages are available on the Couple/Family plan.</string>
+    <string name="r3app_messages_plan_gate_title">A shared feature</string>
     <string name="r3app_plan_gate_confirm">View plans</string>
     <string name="r3app_perm_required_notifications">Notification permission is needed to show the alarm screen and dismiss button.</string>
     <string name="r3app_perm_required_exact_alarms">Exact alarm permission is needed to ring at the set time.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -1020,6 +1020,7 @@
     <string name="r3app_google_signin_failed">Googleログインに失敗しました</string>
     <string name="r3app_google_signin_no_info">Googleログイン情報を取得できませんでした。もう一度お試しください。</string>
     <string name="r3app_messages_plan_gate">メッセージはカップル・ファミリープランでご利用いただけます。</string>
+    <string name="r3app_messages_plan_gate_title">一緒に使う機能です</string>
     <string name="r3app_plan_gate_confirm">プランを見る</string>
     <string name="r3app_perm_required_notifications">アラーム画面と停止ボタンを表示するには、通知の権限が必要です。</string>
     <string name="r3app_perm_required_exact_alarms">設定した時刻に鳴らすには、正確なアラームの権限が必要です。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -1020,6 +1020,7 @@
     <string name="r3app_google_signin_failed">Google 로그인에 실패했어요</string>
     <string name="r3app_google_signin_no_info">Google 로그인 정보를 받지 못했어요. 다시 시도해 주세요.</string>
     <string name="r3app_messages_plan_gate">메시지는 커플/가족 이용권에서 사용할 수 있어요.</string>
+    <string name="r3app_messages_plan_gate_title">함께 쓰는 기능이에요</string>
     <string name="r3app_plan_gate_confirm">이용권 보기</string>
     <string name="r3app_perm_required_notifications">알람 화면과 종료 버튼을 표시하려면 알림 권한이 필요해요.</string>
     <string name="r3app_perm_required_exact_alarms">정해진 시간에 울리려면 정확한 알람 권한이 필요해요.</string>


### PR DESCRIPTION
## 개요
무료 사용자가 잠긴 기능(예: 메시지 탭)을 누를 때 뜨는 이용권 게이트 모달의 카피와 디자인을 다듬고, 모달 공통 요소(제목·elevation)를 앱 표준으로 통일한다.

## 변경 내용
**카피**
- 메시지 게이트 전용 제목 `r3app_messages_plan_gate_title` 신규: **"함께 쓰는 기능이에요"** (en: A shared feature / ja: 一緒に使う機能です). `PlanGateDialogState.title` 경로로 메시지 게이트에만 전달, 다른 게이트는 공용 기본 제목 유지.

**모달 제목 (`ModalDialogTitle`, 전 모달 공통)**
- X-close 터치 타깃 **42dp → 48dp** (글리프 20dp 유지) — 접근성 최소 충족.
- 제목은 앱 전체와 동일한 **고정 타입스케일(Material `titleLarge`)** 유지 — 화면 폭 기반 폰트 스케일은 도입하지 않음(Material 권장: 고정 타입스케일 + 반응형 레이아웃, 글자 크기는 사용자 시스템 글꼴 설정에 위임). 길이 초과 시 `maxLines=1` + ellipsis 로 한 줄 유지.

**이용권 게이트 CTA (`PlanGateDialog`)**
- 버튼 모양 `WakerChipShape`(14) → **`WakerButtonShape`**(18)로 토큰 역할 일치.
- 라벨 `overflow=Ellipsis` + `heightIn(min=48dp)`로 긴 로케일·큰 폰트에서 클리핑 방지.
- 외톨이 버튼/빈 래퍼 정리 → 단일 CTA.

**다이얼로그 elevation 레시피 통일**
- `PlanGateDialog`·`DuplicateAlarmDialog`·`LoginPermissionGate`의 `tonalElevation=6 + 수동 BorderStroke` → 앱 표준 **`tonalElevation=0 + shadowElevation=18 + wakerCardBorder()`** (CTA 버튼 모양도 쌍둥이 `DuplicateAlarmDialog`까지 함께 통일).

## 검증
- `assembleDevDebug` BUILD SUCCESSFUL, S23 Ultra 실기 확인.
- 디자인 토큰/색상 규칙 준수(생 리터럴·생 Color 없음), 의존성(Compose BOM) 변경 없음.