### PR TITLE
코치마크 가이드 다듬기: 시각 단계 제거 + 전환 자연스럽게

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -90,19 +90,12 @@ private enum class AudioPreviewTarget {
 
 // 처음 알람을 만드는 사용자를 위한 위치 앵커형 코치마크 가이드.
 // 각 단계가 실제 컨트롤에 스포트라이트를 비추므로 "어디서 하는지"가 함께 전달된다.
-private const val GUIDE_TARGET_TIME = "alarm_editor_time"
 private const val GUIDE_TARGET_SCHEDULE = "alarm_editor_schedule"
 private const val GUIDE_TARGET_PLAY_MODE = "alarm_editor_play_mode"
 private const val GUIDE_TARGET_SAVE = "alarm_editor_save"
 
 @Composable
 private fun alarmEditorCoachSteps(playModeItemIndex: Int) = listOf(
-    CoachMarkStep(
-        targetKey = GUIDE_TARGET_TIME,
-        title = stringResource(R.string.editor2_coach_time_title),
-        body = stringResource(R.string.editor2_coach_time_body),
-        lazyItemIndex = 0,
-    ),
     CoachMarkStep(
         targetKey = GUIDE_TARGET_SCHEDULE,
         title = stringResource(R.string.editor2_coach_schedule_title),
@@ -1084,9 +1077,7 @@ internal fun AlarmEditorScreen(
                             editor.hour = selectedHour
                             editor.minute = selectedMinute
                         },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .coachMarkTarget(coachMarkRegistry, GUIDE_TARGET_TIME, targetRadius = 34.dp),
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/guide/CoachMarkOverlay.kt
@@ -1,7 +1,10 @@
 package com.alarmtalk.app.ui.guide
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -136,16 +139,33 @@ fun CoachMarkOverlay(
     // 대상 반경 + holePadding 이어야 한다. 미등록 대상은 기존 동작(16dp)으로 폴백.
     val targetRadiusDp = registry.radii[step.targetKey] ?: 16.dp
     val holeCornerPx = with(density) { (targetRadiusDp + holePaddingDp).toPx() }
+    // 모서리 반경도 위치·크기와 같은 타임라인으로 보간해, 타깃 반경이 다른 단계로 넘어갈 때
+    // 라운드가 튀지 않고 함께 부드럽게 변하도록 한다.
+    val animatedCornerPx by animateFloatAsState(
+        targetValue = holeCornerPx,
+        animationSpec = tween(durationMillis = 320, easing = FastOutSlowInEasing),
+        label = "holeCorner",
+    )
     val highlightColor = MaterialTheme.colorScheme.primary
 
-    // 단계 전환 시 구멍이 이전 위치에서 새 위치로 미끄러지듯 이동.
-    // 첫 등록 시에는 snap 해 (0,0) 에서 자라나는 아티팩트를 막는다.
+    // 단계 전환 시 구멍이 이전 위치에서 새 위치로 부드럽게 모핑한다.
+    // 핵심: 리스트가 스크롤되는 동안에는 대상 좌표가 매 프레임 바뀌는데, 그때마다 animateTo 를
+    // 재시작하면 위치는 따라가도 크기 보간이 계속 리셋돼 "이동이 끝난 뒤에야 크기가 변하는"
+    // 현상이 생긴다. → 스크롤 중에는 구멍을 대상에 그대로 붙이고(snap), 스크롤이 멎은 뒤
+    // (혹은 스크롤이 필요 없는 단계 전환)에만 위치·크기를 한 번에 모핑한다.
+    // 첫 등록 시에도 snap 해 (0,0) 에서 자라나는 아티팩트를 막는다.
     val holeAnim = remember { Animatable(Rect.Zero, Rect.VectorConverter) }
     val inflatedTarget = targetBounds?.inflate(holePaddingPx)
-    LaunchedEffect(inflatedTarget) {
-        if (inflatedTarget != null) {
-            if (holeAnim.value == Rect.Zero) holeAnim.snapTo(inflatedTarget)
-            else holeAnim.animateTo(inflatedTarget)
+    val isScrolling = listState?.isScrollInProgress ?: false
+    LaunchedEffect(inflatedTarget, isScrolling) {
+        if (inflatedTarget == null) return@LaunchedEffect
+        if (holeAnim.value == Rect.Zero || isScrolling) {
+            holeAnim.snapTo(inflatedTarget)
+        } else {
+            holeAnim.animateTo(
+                inflatedTarget,
+                animationSpec = tween(durationMillis = 320, easing = FastOutSlowInEasing),
+            )
         }
     }
     val hole = if (inflatedTarget != null && holeAnim.value != Rect.Zero) holeAnim.value else null
@@ -168,7 +188,7 @@ fun CoachMarkOverlay(
             drawRect(WakerScrimColor)
             if (hole != null) {
                 // pill·원형·작은 타깃에서 사각이 깨지지 않도록 짧은 변의 절반으로 클램프.
-                val cornerPx = holeCornerPx.coerceAtMost(minOf(hole.size.width, hole.size.height) / 2f)
+                val cornerPx = animatedCornerPx.coerceAtMost(minOf(hole.size.width, hole.size.height) / 2f)
                 drawRoundRect(
                     color = Color.Transparent,
                     topLeft = hole.topLeft,

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -845,8 +845,6 @@
     <string name="label_sync_state_dirty">Pending save</string>
     <string name="label_sync_state_failed">Couldn\'t save to the server</string>
     <string name="label_sync_state_device_only">Saved on device only</string>
-    <string name="editor2_coach_time_title">Set the time first</string>
-    <string name="editor2_coach_time_body">Spin the wheel up or down to set when the alarm goes off.</string>
     <string name="editor2_coach_schedule_title">Set the repeat and name</string>
     <string name="editor2_coach_schedule_body">Tap a weekday to repeat it every week. When repeat is on, you can also choose to skip holidays, and you can change the alarm name here too.</string>
     <string name="editor2_coach_play_mode_title">Choose the play mode</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -845,8 +845,6 @@
     <string name="label_sync_state_dirty">保存待ち</string>
     <string name="label_sync_state_failed">サーバーに保存できませんでした</string>
     <string name="label_sync_state_device_only">端末のみに保存</string>
-    <string name="editor2_coach_time_title">まずは時刻を合わせましょう</string>
-    <string name="editor2_coach_time_body">ホイールを上下に回して、アラームが鳴る時刻を合わせましょう。</string>
     <string name="editor2_coach_schedule_title">繰り返しと名前を決めましょう</string>
     <string name="editor2_coach_schedule_body">曜日をタップすると毎週繰り返します。繰り返しをオンにすると祝日にオフにすることも選べて、アラームの名前もここで変えられます。</string>
     <string name="editor2_coach_play_mode_title">再生方式を選びましょう</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -845,8 +845,6 @@
     <string name="label_sync_state_dirty">저장 대기</string>
     <string name="label_sync_state_failed">서버에 저장하지 못했어요</string>
     <string name="label_sync_state_device_only">기기에만 저장됨</string>
-    <string name="editor2_coach_time_title">시각부터 맞춰요</string>
-    <string name="editor2_coach_time_body">휠을 위아래로 돌려 알람이 울릴 시각을 맞춰요.</string>
     <string name="editor2_coach_schedule_title">반복과 이름을 정해요</string>
     <string name="editor2_coach_schedule_body">요일을 누르면 매주 반복돼요. 반복을 켜면 공휴일에 끄기도 고를 수 있고, 알람 이름도 여기서 바꿔요.</string>
     <string name="editor2_coach_play_mode_title">재생 방식을 골라요</string>


### PR DESCRIPTION
## 개요
알람 에디터 첫-사용 코치마크 가이드를 다듬는다.

## 변경
- **시각 단계 제거**: 시간 휠은 가장 자명한 컨트롤이라 안내 가치가 낮아 4단계 → **3단계**(반복·이름 / 재생방식 / 저장). `GUIDE_TARGET_TIME` 등록·문자열(`editor2_coach_time_*`) 정리.
- **전환 자연스럽게**: 단계 넘길 때 `animateScrollToItem`으로 리스트가 스크롤되는 동안 대상 좌표가 매 프레임 바뀌어 `animateTo`가 재시작 → 위치는 따라가도 크기 보간이 리셋돼 "이동 후 축소"처럼 보이던 문제 수정. **스크롤 중 snap + 정착 후 모핑**으로 한 번에 부드럽게.

## 검증
- `assembleDevDebug` BUILD SUCCESSFUL, A32 설치.
- ⚠️ 전환 애니메이션은 로컬에 video 추출 도구가 없어 프레임 검증은 못 함 — 실기 확인 필요(원인 분석 기반 수정).