### PR TITLE
인증 화면 분리 재설계: 랜딩 → 진입 → 폼

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthApi.kt
@@ -93,6 +93,16 @@ data class EmailVerificationConfirmResponse(
     val success: Boolean,
 )
 
+data class PasswordResetRequest(
+    val email: String,
+)
+
+data class PasswordResetConfirmRequest(
+    val email: String,
+    val code: String,
+    val password: String,
+)
+
 data class GoogleLoginRequest(
     @SerializedName("id_token") val idToken: String,
 )
@@ -174,6 +184,14 @@ interface AuthApi {
     @POST("auth/email-code/verify")
     suspend fun confirmEmailVerification(
         @Body request: EmailVerificationConfirmRequest,
+    ): EmailVerificationConfirmResponse
+
+    @POST("auth/password-reset")
+    suspend fun requestPasswordReset(@Body request: PasswordResetRequest): EmailVerificationResponse
+
+    @POST("auth/password-reset/confirm")
+    suspend fun confirmPasswordReset(
+        @Body request: PasswordResetConfirmRequest,
     ): EmailVerificationConfirmResponse
 
     @POST("auth/register")

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/account/AccountPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/account/AccountPanel.kt
@@ -178,6 +178,7 @@ internal fun GoogleSignInButton(
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    label: String = stringResource(R.string.common_google_continue),
 ) {
     val contentAlpha = if (enabled) 1f else 0.38f
     Surface(
@@ -204,7 +205,7 @@ internal fun GoogleSignInButton(
                 alpha = contentAlpha,
             )
             Text(
-                text = stringResource(R.string.common_google_continue),
+                text = label,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .padding(horizontal = 32.dp),

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -470,7 +470,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
           when (val route = authRoute) {
               AuthRoute.Landing -> LandingScreen(
                   contentPadding = padding,
-                  onGetStarted = { authRoute = AuthRoute.Auth(AuthMode.Login) },
+                  onLogin = { authRoute = AuthRoute.Auth(AuthMode.Login) },
+                  onRegister = { authRoute = AuthRoute.Auth(AuthMode.Register) },
               )
               is AuthRoute.Auth -> AuthScreen(
                   contentPadding = padding,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -378,7 +378,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
 
     if (authSession == null) {
         BackHandler(enabled = authRoute !is AuthRoute.Landing) {
-            authRoute = AuthRoute.Landing
+            authRoute = if (authRoute is AuthRoute.Auth) AuthRoute.Entry else AuthRoute.Landing
         }
     } else {
         BackHandler(
@@ -470,7 +470,12 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
           when (val route = authRoute) {
               AuthRoute.Landing -> LandingScreen(
                   contentPadding = padding,
+                  onGetStarted = { authRoute = AuthRoute.Entry },
+              )
+              AuthRoute.Entry -> AuthEntryScreen(
+                  contentPadding = padding,
                   busy = authBusy,
+                  onBack = { authRoute = AuthRoute.Landing },
                   onGoToLogin = { authRoute = AuthRoute.Auth(AuthMode.Login) },
                   onGoToRegister = { authRoute = AuthRoute.Auth(AuthMode.Register) },
                   onGoogleSignIn = ::launchGoogleSignIn,
@@ -481,7 +486,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                   busy = authBusy,
                   emailVerificationSentTo = viewModel.registerEmailVerificationSentTo,
                   emailVerified = viewModel.registerEmailVerified,
-                  onBack = { authRoute = AuthRoute.Landing },
+                  onBack = { authRoute = AuthRoute.Entry },
                   onLogin = viewModel::login,
                   onRegister = viewModel::register,
                   onRequestEmailVerification = viewModel::requestEmailVerification,
@@ -490,7 +495,6 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                       val nextMode = if (route.mode == AuthMode.Login) AuthMode.Register else AuthMode.Login
                       authRoute = AuthRoute.Auth(nextMode)
                   },
-                  onGoogleSignIn = ::launchGoogleSignIn,
               )
           }
           return@Scaffold

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -378,7 +378,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
 
     if (authSession == null) {
         BackHandler(enabled = authRoute !is AuthRoute.Landing) {
-            authRoute = if (authRoute is AuthRoute.Auth) AuthRoute.Entry else AuthRoute.Landing
+            authRoute = AuthRoute.Landing
         }
     } else {
         BackHandler(
@@ -470,15 +470,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
           when (val route = authRoute) {
               AuthRoute.Landing -> LandingScreen(
                   contentPadding = padding,
-                  onGetStarted = { authRoute = AuthRoute.Entry },
-              )
-              AuthRoute.Entry -> AuthEntryScreen(
-                  contentPadding = padding,
-                  busy = authBusy,
-                  onBack = { authRoute = AuthRoute.Landing },
-                  onGoToLogin = { authRoute = AuthRoute.Auth(AuthMode.Login) },
-                  onGoToRegister = { authRoute = AuthRoute.Auth(AuthMode.Register) },
-                  onGoogleSignIn = ::launchGoogleSignIn,
+                  onGetStarted = { authRoute = AuthRoute.Auth(AuthMode.Login) },
               )
               is AuthRoute.Auth -> AuthScreen(
                   contentPadding = padding,
@@ -486,7 +478,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                   busy = authBusy,
                   emailVerificationSentTo = viewModel.registerEmailVerificationSentTo,
                   emailVerified = viewModel.registerEmailVerified,
-                  onBack = { authRoute = AuthRoute.Entry },
+                  onBack = { authRoute = AuthRoute.Landing },
                   onLogin = viewModel::login,
                   onRegister = viewModel::register,
                   onRequestEmailVerification = viewModel::requestEmailVerification,
@@ -495,6 +487,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                       val nextMode = if (route.mode == AuthMode.Login) AuthMode.Register else AuthMode.Login
                       authRoute = AuthRoute.Auth(nextMode)
                   },
+                  onGoogleSignIn = ::launchGoogleSignIn,
               )
           }
           return@Scaffold

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -60,12 +60,26 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
     val currentTab = navBackStackEntry?.destination?.route.toNativeTab()
     val selectedTab = currentTab ?: NativeTab.Home
     var planGateDialog by remember { mutableStateOf<PlanGateDialogState?>(null) }
-    var authRoute by remember { mutableStateOf<AuthRoute>(AuthRoute.Landing) }
+    // 인증 화면 백스택 — 로그인↔회원가입 전환 히스토리를 보존해 뒤로가기가 한 단계씩 돌아가게 한다.
+    var authBackStack by remember { mutableStateOf(listOf<AuthRoute>(AuthRoute.Landing)) }
+    val authRoute = authBackStack.last()
+    fun authNavigate(route: AuthRoute) {
+        if (route == authRoute) return
+        // 직전 화면으로 되돌아가는 전환(예: 회원가입→로그인 토글)은 push 대신 pop 해 스택이 무한정 늘지 않게.
+        val prev = authBackStack.getOrNull(authBackStack.size - 2)
+        authBackStack = if (route == prev) authBackStack.dropLast(1) else authBackStack + route
+    }
+    fun authBack() {
+        if (authBackStack.size > 1) authBackStack = authBackStack.dropLast(1)
+    }
+    fun authResetToLanding() {
+        authBackStack = listOf(AuthRoute.Landing)
+    }
     // 회원가입 시도 이메일이 이미 가입돼 있으면(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환한다.
     // 입력한 이메일은 AuthScreen 의 remember 상태로 유지되므로 다시 입력할 필요가 없다.
     LaunchedEffect(viewModel.authRedirectToLogin) {
         if (viewModel.authRedirectToLogin) {
-            authRoute = AuthRoute.Auth(AuthMode.Login)
+            authNavigate(AuthRoute.Auth(AuthMode.Login))
             viewModel.authRedirectToLogin = false
         }
     }
@@ -218,7 +232,7 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
         }
         viewModel.loadReceivedAlarmBadgeState()
         planGateDialog = null
-        authRoute = AuthRoute.Landing
+        authResetToLanding()
     }
 
     LaunchedEffect(sessionRouteKey, alarms) {
@@ -377,8 +391,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
     }
 
     if (authSession == null) {
-        BackHandler(enabled = authRoute !is AuthRoute.Landing) {
-            authRoute = AuthRoute.Landing
+        BackHandler(enabled = authBackStack.size > 1) {
+            authBack()
         }
     } else {
         BackHandler(
@@ -470,8 +484,18 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
           when (val route = authRoute) {
               AuthRoute.Landing -> LandingScreen(
                   contentPadding = padding,
-                  onLogin = { authRoute = AuthRoute.Auth(AuthMode.Login) },
-                  onRegister = { authRoute = AuthRoute.Auth(AuthMode.Register) },
+                  onLogin = { authNavigate(AuthRoute.Auth(AuthMode.Login)) },
+                  onRegister = { authNavigate(AuthRoute.Auth(AuthMode.Register)) },
+              )
+              AuthRoute.ResetPassword -> PasswordResetScreen(
+                  contentPadding = padding,
+                  busy = authBusy,
+                  codeSentTo = viewModel.passwordResetCodeSentTo,
+                  onBack = { authBack() },
+                  onRequestCode = viewModel::requestPasswordReset,
+                  onConfirm = { resetEmail, resetCode, newPassword ->
+                      viewModel.confirmPasswordReset(resetEmail, resetCode, newPassword) { authBack() }
+                  },
               )
               is AuthRoute.Auth -> AuthScreen(
                   contentPadding = padding,
@@ -479,18 +503,17 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                   busy = authBusy,
                   emailVerificationSentTo = viewModel.registerEmailVerificationSentTo,
                   emailVerified = viewModel.registerEmailVerified,
-                  onBack = { authRoute = AuthRoute.Landing },
+                  onBack = { authBack() },
                   onLogin = viewModel::login,
                   onRegister = viewModel::register,
                   onRequestEmailVerification = viewModel::requestEmailVerification,
                   onConfirmEmailVerification = viewModel::confirmEmailVerification,
                   onSwitchMode = {
                       val nextMode = if (route.mode == AuthMode.Login) AuthMode.Register else AuthMode.Login
-                      authRoute = AuthRoute.Auth(nextMode)
+                      authNavigate(AuthRoute.Auth(nextMode))
                   },
                   onGoogleSignIn = ::launchGoogleSignIn,
-                  onFindId = { viewModel.message = context.getString(R.string.auth_find_coming_soon) },
-                  onFindPassword = { viewModel.message = context.getString(R.string.auth_find_coming_soon) },
+                  onFindPassword = { authNavigate(AuthRoute.ResetPassword) },
               )
           }
           return@Scaffold

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -489,6 +489,8 @@ internal fun AlarmTalkApp(viewModel: MainViewModel = viewModel()) {
                       authRoute = AuthRoute.Auth(nextMode)
                   },
                   onGoogleSignIn = ::launchGoogleSignIn,
+                  onFindId = { viewModel.message = context.getString(R.string.auth_find_coming_soon) },
+                  onFindPassword = { viewModel.message = context.getString(R.string.auth_find_coming_soon) },
               )
           }
           return@Scaffold

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
@@ -144,7 +144,6 @@ internal suspend fun Task<Void>.awaitCompletion() {
 
 internal sealed interface AuthRoute {
     data object Landing : AuthRoute
-    data object Entry : AuthRoute
     data class Auth(val mode: AuthMode) : AuthRoute
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
@@ -144,6 +144,7 @@ internal suspend fun Task<Void>.awaitCompletion() {
 
 internal sealed interface AuthRoute {
     data object Landing : AuthRoute
+    data object ResetPassword : AuthRoute
     data class Auth(val mode: AuthMode) : AuthRoute
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkAppHelpers.kt
@@ -144,6 +144,7 @@ internal suspend fun Task<Void>.awaitCompletion() {
 
 internal sealed interface AuthRoute {
     data object Landing : AuthRoute
+    data object Entry : AuthRoute
     data class Auth(val mode: AuthMode) : AuthRoute
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -59,6 +59,7 @@ internal fun AuthScreen(
     onRequestEmailVerification: (String) -> Unit,
     onConfirmEmailVerification: (String, String) -> Unit,
     onSwitchMode: () -> Unit,
+    onGoogleSignIn: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -305,6 +306,14 @@ internal fun AuthScreen(
                     mode == AuthMode.Register -> stringResource(R.string.auth_create_account)
                     else -> stringResource(R.string.auth_title_login)
                 },
+            )
+        }
+
+        if (mode == AuthMode.Login) {
+            GoogleSignInButton(
+                enabled = !busy,
+                onClick = onGoogleSignIn,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -61,7 +61,6 @@ internal fun AuthScreen(
     onConfirmEmailVerification: (String, String) -> Unit,
     onSwitchMode: () -> Unit,
     onGoogleSignIn: () -> Unit,
-    onFindId: () -> Unit,
     onFindPassword: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
@@ -318,18 +317,13 @@ internal fun AuthScreen(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onFindId) {
-                    Text(
-                        text = stringResource(R.string.auth_find_id),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Text(text = "|", color = MaterialTheme.colorScheme.outlineVariant)
+                Text(
+                    text = stringResource(R.string.auth_forgot_password),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
                 TextButton(onClick = onFindPassword) {
-                    Text(
-                        text = stringResource(R.string.auth_find_password),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Text(stringResource(R.string.auth_find_password))
                 }
             }
             // SSO 구분선 — 소셜 로그인은 여기 아래로 묶고, 추후 제공자 추가 시 이 섹션에 덧붙인다.
@@ -356,18 +350,30 @@ internal fun AuthScreen(
                 enabled = !busy,
                 onClick = onGoogleSignIn,
                 modifier = Modifier.fillMaxWidth(),
+                label = stringResource(R.string.common_google_login),
             )
         }
 
-        TextButton(
-            onClick = onSwitchMode,
-            enabled = !busy,
+        Row(
             modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                if (mode == AuthMode.Login) stringResource(R.string.auth_switch_to_register)
-                else stringResource(R.string.auth_switch_to_login),
+                text = if (mode == AuthMode.Login) {
+                    stringResource(R.string.auth_landing_first_time)
+                } else {
+                    stringResource(R.string.auth_already_have_account)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            TextButton(onClick = onSwitchMode, enabled = !busy) {
+                Text(
+                    if (mode == AuthMode.Login) stringResource(R.string.auth_title_register)
+                    else stringResource(R.string.auth_title_login),
+                )
+            }
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.RadioButtonUnchecked
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +61,8 @@ internal fun AuthScreen(
     onConfirmEmailVerification: (String, String) -> Unit,
     onSwitchMode: () -> Unit,
     onGoogleSignIn: () -> Unit,
+    onFindId: () -> Unit,
+    onFindPassword: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -310,6 +313,45 @@ internal fun AuthScreen(
         }
 
         if (mode == AuthMode.Login) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onFindId) {
+                    Text(
+                        text = stringResource(R.string.auth_find_id),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(text = "|", color = MaterialTheme.colorScheme.outlineVariant)
+                TextButton(onClick = onFindPassword) {
+                    Text(
+                        text = stringResource(R.string.auth_find_password),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            // SSO 구분선 — 소셜 로그인은 여기 아래로 묶고, 추후 제공자 추가 시 이 섹션에 덧붙인다.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                HorizontalDivider(
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+                Text(
+                    text = stringResource(R.string.auth_or),
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                HorizontalDivider(
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
             GoogleSignInButton(
                 enabled = !busy,
                 onClick = onGoogleSignIn,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -59,7 +59,6 @@ internal fun AuthScreen(
     onRequestEmailVerification: (String) -> Unit,
     onConfirmEmailVerification: (String, String) -> Unit,
     onSwitchMode: () -> Unit,
-    onGoogleSignIn: () -> Unit,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -308,12 +307,6 @@ internal fun AuthScreen(
                 },
             )
         }
-
-        GoogleSignInButton(
-            enabled = !busy,
-            onClick = onGoogleSignIn,
-            modifier = Modifier.fillMaxWidth(),
-        )
 
         TextButton(
             onClick = onSwitchMode,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -93,7 +94,8 @@ private fun landingPalette(): LandingPalette {
 @Composable
 internal fun LandingScreen(
     contentPadding: PaddingValues,
-    onGetStarted: () -> Unit,
+    onLogin: () -> Unit,
+    onRegister: () -> Unit,
 ) {
     val colors = landingPalette()
     Column(
@@ -103,6 +105,7 @@ internal fun LandingScreen(
             .padding(contentPadding)
             .padding(horizontal = 22.dp, vertical = 22.dp),
     ) {
+        Spacer(Modifier.height(16.dp))
         WakerBrandHeader()
         Spacer(Modifier.height(18.dp))
         Text(
@@ -115,7 +118,7 @@ internal fun LandingScreen(
         AlarmIdentityPreview(colors = colors)
         Spacer(Modifier.weight(1f))
         Button(
-            onClick = onGetStarted,
+            onClick = onRegister,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
@@ -126,9 +129,25 @@ internal fun LandingScreen(
             ),
         ) {
             Text(
-                text = stringResource(R.string.auth_landing_get_started),
+                text = stringResource(R.string.auth_title_register),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        OutlinedButton(
+            onClick = onLogin,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = WakerButtonShape,
+            border = BorderStroke(1.dp, colors.line),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
+        ) {
+            Text(
+                text = stringResource(R.string.auth_title_login),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
             )
         }
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -4,7 +4,6 @@ import android.media.MediaPlayer
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,22 +16,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,8 +43,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
@@ -109,17 +108,20 @@ internal fun LandingScreen(
             .padding(contentPadding)
             .padding(horizontal = 22.dp, vertical = 22.dp),
     ) {
+        Spacer(Modifier.weight(0.5f))
         WakerBrandHeader(colors = colors)
-        Spacer(Modifier.weight(0.85f))
+        Spacer(Modifier.height(18.dp))
         Text(
             text = stringResource(R.string.auth_landing_headline),
             style = MaterialTheme.typography.displaySmall,
             color = colors.text,
             fontWeight = FontWeight.Bold,
         )
-        Spacer(Modifier.height(28.dp))
+        Spacer(Modifier.height(26.dp))
         AlarmIdentityPreview(colors = colors)
-        Spacer(Modifier.weight(1f))
+        Spacer(Modifier.height(20.dp))
+        LandingValueRow(colors = colors)
+        Spacer(Modifier.weight(0.85f))
         Button(
             onClick = onGetStarted,
             modifier = Modifier
@@ -136,96 +138,6 @@ internal fun LandingScreen(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
-        }
-    }
-}
-
-/**
- * 인증 진입 화면 — "시작하기" 다음 단계. Google(주) + 이메일로 계속하기(보조) 만 두고,
- * 소셜/이메일 선택을 한 곳에서 받는다. 이메일 폼(로그인/가입)에는 더 이상 Google 을
- * 중복 노출하지 않는다.
- */
-@Composable
-internal fun AuthEntryScreen(
-    contentPadding: PaddingValues,
-    busy: Boolean,
-    onBack: () -> Unit,
-    onGoToLogin: () -> Unit,
-    onGoToRegister: () -> Unit,
-    onGoogleSignIn: () -> Unit,
-) {
-    val colors = landingPalette()
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(colors.background)
-            .padding(contentPadding)
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 22.dp, vertical = 14.dp),
-    ) {
-        IconButton(onClick = onBack) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                contentDescription = stringResource(R.string.auth_back),
-                tint = colors.text,
-            )
-        }
-        Spacer(Modifier.height(8.dp))
-        WakerBrandHeader(colors = colors)
-        Spacer(Modifier.height(24.dp))
-        Text(
-            text = stringResource(R.string.auth_landing_get_started),
-            style = MaterialTheme.typography.headlineSmall,
-            color = colors.text,
-            fontWeight = FontWeight.Bold,
-        )
-        Spacer(Modifier.height(6.dp))
-        Text(
-            text = stringResource(R.string.auth_landing_get_started_desc),
-            style = MaterialTheme.typography.bodyMedium,
-            color = colors.muted,
-        )
-        Spacer(Modifier.height(28.dp))
-        GoogleSignInButton(
-            enabled = !busy,
-            onClick = onGoogleSignIn,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(Modifier.height(10.dp))
-        OutlinedButton(
-            onClick = onGoToLogin,
-            enabled = !busy,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp),
-            shape = WakerButtonShape,
-            border = BorderStroke(1.dp, colors.line),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
-        ) {
-            Text(stringResource(R.string.auth_continue_with_email))
-        }
-        Spacer(Modifier.height(20.dp))
-        HorizontalDivider(color = colors.line)
-        Spacer(Modifier.height(16.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(R.string.auth_landing_first_time),
-                style = MaterialTheme.typography.bodyMedium,
-                color = colors.muted,
-            )
-            OutlinedButton(
-                onClick = onGoToRegister,
-                enabled = !busy,
-                shape = WakerButtonShape,
-                border = BorderStroke(1.dp, colors.line),
-                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
-            ) {
-                Text(stringResource(R.string.auth_create_account))
-            }
         }
     }
 }
@@ -305,7 +217,7 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
     ) {
         Column(
             modifier = Modifier.padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(28.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -342,12 +254,76 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
                     }
                 }
             }
+            Text(
+                text = stringResource(R.string.auth_landing_sample_message),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = colors.text,
+            )
             LandingPreviewWaveform(
                 colors = colors,
                 progress = playbackProgress,
                 isPlaying = isPlaying,
             )
+            Text(
+                text = stringResource(R.string.auth_landing_sample_voice),
+                style = MaterialTheme.typography.labelMedium,
+                color = colors.muted,
+                modifier = Modifier.align(Alignment.End),
+            )
         }
+    }
+}
+
+@Composable
+private fun LandingValueRow(colors: LandingPalette) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        ValueItem(
+            icon = Icons.Outlined.Mic,
+            label = stringResource(R.string.auth_landing_value_voice),
+            colors = colors,
+            modifier = Modifier.weight(1f),
+        )
+        ValueItem(
+            icon = Icons.Outlined.Group,
+            label = stringResource(R.string.auth_landing_value_family),
+            colors = colors,
+            modifier = Modifier.weight(1f),
+        )
+        ValueItem(
+            icon = Icons.Outlined.WbSunny,
+            label = stringResource(R.string.auth_landing_value_daily),
+            colors = colors,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun ValueItem(
+    icon: ImageVector,
+    label: String,
+    colors: LandingPalette,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = colors.accent,
+            modifier = Modifier.size(22.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = colors.muted,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+        )
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -118,7 +118,7 @@ internal fun LandingScreen(
         AlarmIdentityPreview(colors = colors)
         Spacer(Modifier.weight(1f))
         Button(
-            onClick = onRegister,
+            onClick = onLogin,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
@@ -129,14 +129,14 @@ internal fun LandingScreen(
             ),
         ) {
             Text(
-                text = stringResource(R.string.auth_title_register),
+                text = stringResource(R.string.auth_title_login),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
         }
         Spacer(Modifier.height(10.dp))
         OutlinedButton(
-            onClick = onLogin,
+            onClick = onRegister,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
@@ -145,7 +145,7 @@ internal fun LandingScreen(
             colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
         ) {
             Text(
-                text = stringResource(R.string.auth_title_login),
+                text = stringResource(R.string.auth_title_register),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
             )

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -17,11 +17,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Group
-import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
-import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -43,10 +40,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
@@ -93,7 +88,7 @@ private fun landingPalette(): LandingPalette {
 
 /**
  * 첫 진입 랜딩 — 가치 제안(히어로 + 목소리 미리듣기)만 보여주고, 단일 "시작하기" 로
- * 인증 진입(AuthEntryScreen)으로 넘긴다. 로그인/가입 선택지는 이 화면에 두지 않는다.
+ * 로그인 폼으로 넘긴다. 로그인/가입 선택지는 이 화면에 두지 않는다.
  */
 @Composable
 internal fun LandingScreen(
@@ -108,8 +103,7 @@ internal fun LandingScreen(
             .padding(contentPadding)
             .padding(horizontal = 22.dp, vertical = 22.dp),
     ) {
-        Spacer(Modifier.weight(0.5f))
-        WakerBrandHeader(colors = colors)
+        WakerBrandHeader()
         Spacer(Modifier.height(18.dp))
         Text(
             text = stringResource(R.string.auth_landing_headline),
@@ -117,11 +111,9 @@ internal fun LandingScreen(
             color = colors.text,
             fontWeight = FontWeight.Bold,
         )
-        Spacer(Modifier.height(26.dp))
+        Spacer(Modifier.weight(1f))
         AlarmIdentityPreview(colors = colors)
-        Spacer(Modifier.height(20.dp))
-        LandingValueRow(colors = colors)
-        Spacer(Modifier.weight(0.85f))
+        Spacer(Modifier.weight(1f))
         Button(
             onClick = onGetStarted,
             modifier = Modifier
@@ -143,27 +135,15 @@ internal fun LandingScreen(
 }
 
 @Composable
-private fun WakerBrandHeader(colors: LandingPalette) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            painter = painterResource(R.drawable.ic_brand_logo),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(42.dp)
-                .clip(WakerTileShape),
-        )
-        Spacer(Modifier.width(10.dp))
-        Text(
-            text = "AlarmTalk",
-            style = MaterialTheme.typography.titleLarge,
-            color = colors.text,
-            fontWeight = FontWeight.Bold,
-        )
-    }
+private fun WakerBrandHeader() {
+    Image(
+        painter = painterResource(R.drawable.ic_brand_logo),
+        contentDescription = "AlarmTalk",
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .size(48.dp)
+            .clip(WakerTileShape),
+    )
 }
 
 @Composable
@@ -272,58 +252,6 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
                 modifier = Modifier.align(Alignment.End),
             )
         }
-    }
-}
-
-@Composable
-private fun LandingValueRow(colors: LandingPalette) {
-    Row(modifier = Modifier.fillMaxWidth()) {
-        ValueItem(
-            icon = Icons.Outlined.Mic,
-            label = stringResource(R.string.auth_landing_value_voice),
-            colors = colors,
-            modifier = Modifier.weight(1f),
-        )
-        ValueItem(
-            icon = Icons.Outlined.Group,
-            label = stringResource(R.string.auth_landing_value_family),
-            colors = colors,
-            modifier = Modifier.weight(1f),
-        )
-        ValueItem(
-            icon = Icons.Outlined.WbSunny,
-            label = stringResource(R.string.auth_landing_value_daily),
-            colors = colors,
-            modifier = Modifier.weight(1f),
-        )
-    }
-}
-
-@Composable
-private fun ValueItem(
-    icon: ImageVector,
-    label: String,
-    colors: LandingPalette,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = colors.accent,
-            modifier = Modifier.size(22.dp),
-        )
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = colors.muted,
-            textAlign = TextAlign.Center,
-            maxLines = 2,
-        )
     }
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -15,12 +14,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.ui.draw.clip
@@ -31,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -49,8 +49,6 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.alarmtalk.app.WakerPillShape
-import com.alarmtalk.app.WakerTileShape
 import kotlinx.coroutines.delay
 
 private data class LandingPalette(
@@ -94,55 +92,140 @@ private fun landingPalette(): LandingPalette {
     }
 }
 
+/**
+ * 첫 진입 랜딩 — 가치 제안(히어로 + 목소리 미리듣기)만 보여주고, 단일 "시작하기" 로
+ * 인증 진입(AuthEntryScreen)으로 넘긴다. 로그인/가입 선택지는 이 화면에 두지 않는다.
+ */
 @Composable
 internal fun LandingScreen(
     contentPadding: PaddingValues,
+    onGetStarted: () -> Unit,
+) {
+    val colors = landingPalette()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background)
+            .padding(contentPadding)
+            .padding(horizontal = 22.dp, vertical = 22.dp),
+    ) {
+        WakerBrandHeader(colors = colors)
+        Spacer(Modifier.weight(0.85f))
+        Text(
+            text = stringResource(R.string.auth_landing_headline),
+            style = MaterialTheme.typography.displaySmall,
+            color = colors.text,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(28.dp))
+        AlarmIdentityPreview(colors = colors)
+        Spacer(Modifier.weight(1f))
+        Button(
+            onClick = onGetStarted,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = WakerButtonShape,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.accent,
+                contentColor = colors.accentText,
+            ),
+        ) {
+            Text(
+                text = stringResource(R.string.auth_landing_get_started),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+/**
+ * 인증 진입 화면 — "시작하기" 다음 단계. Google(주) + 이메일로 계속하기(보조) 만 두고,
+ * 소셜/이메일 선택을 한 곳에서 받는다. 이메일 폼(로그인/가입)에는 더 이상 Google 을
+ * 중복 노출하지 않는다.
+ */
+@Composable
+internal fun AuthEntryScreen(
+    contentPadding: PaddingValues,
     busy: Boolean,
+    onBack: () -> Unit,
     onGoToLogin: () -> Unit,
     onGoToRegister: () -> Unit,
     onGoogleSignIn: () -> Unit,
 ) {
     val colors = landingPalette()
-    BoxWithConstraints(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(colors.background)
-            .padding(contentPadding),
+            .padding(contentPadding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 22.dp, vertical = 14.dp),
     ) {
-        val compact = maxHeight < 840.dp
-        Column(
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                contentDescription = stringResource(R.string.auth_back),
+                tint = colors.text,
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        WakerBrandHeader(colors = colors)
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.auth_landing_get_started),
+            style = MaterialTheme.typography.headlineSmall,
+            color = colors.text,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = stringResource(R.string.auth_landing_get_started_desc),
+            style = MaterialTheme.typography.bodyMedium,
+            color = colors.muted,
+        )
+        Spacer(Modifier.height(28.dp))
+        GoogleSignInButton(
+            enabled = !busy,
+            onClick = onGoogleSignIn,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(Modifier.height(10.dp))
+        OutlinedButton(
+            onClick = onGoToLogin,
+            enabled = !busy,
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = maxHeight)
-                .verticalScroll(rememberScrollState())
-                .padding(
-                    horizontal = 22.dp,
-                    vertical = if (compact) 16.dp else 22.dp,
-                ),
-            verticalArrangement = Arrangement.SpaceBetween,
+                .height(56.dp),
+            shape = WakerButtonShape,
+            border = BorderStroke(1.dp, colors.line),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                WakerBrandHeader(colors = colors)
-                Spacer(Modifier.height(if (compact) 28.dp else 48.dp))
-                Text(
-                    text = stringResource(R.string.auth_landing_headline),
-                    style = MaterialTheme.typography.displaySmall,
-                    color = colors.text,
-                    fontWeight = FontWeight.Bold,
-                )
-                Spacer(Modifier.height(if (compact) 24.dp else 34.dp))
-                AlarmIdentityPreview(colors = colors)
-            }
-            Spacer(Modifier.height(if (compact) 24.dp else 36.dp))
-            LandingAuthPanel(
-                colors = colors,
-                busy = busy,
-                onGoToLogin = onGoToLogin,
-                onGoToRegister = onGoToRegister,
-                onGoogleSignIn = onGoogleSignIn,
+            Text(stringResource(R.string.auth_continue_with_email))
+        }
+        Spacer(Modifier.height(20.dp))
+        HorizontalDivider(color = colors.line)
+        Spacer(Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.auth_landing_first_time),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colors.muted,
             )
+            OutlinedButton(
+                onClick = onGoToRegister,
+                enabled = !busy,
+                shape = WakerButtonShape,
+                border = BorderStroke(1.dp, colors.line),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.text),
+            ) {
+                Text(stringResource(R.string.auth_create_account))
+            }
         }
     }
 }
@@ -162,19 +245,12 @@ private fun WakerBrandHeader(colors: LandingPalette) {
                 .clip(WakerTileShape),
         )
         Spacer(Modifier.width(10.dp))
-        Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
-            Text(
-                text = "AlarmTalk",
-                style = MaterialTheme.typography.titleLarge,
-                color = colors.text,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = "Voice alarm",
-                style = MaterialTheme.typography.labelMedium,
-                color = colors.muted,
-            )
-        }
+        Text(
+            text = "AlarmTalk",
+            style = MaterialTheme.typography.titleLarge,
+            color = colors.text,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 
@@ -307,96 +383,6 @@ private fun LandingPreviewWaveform(
                         shape = WakerPillShape,
                     ),
             )
-        }
-    }
-}
-
-@Composable
-private fun LandingAuthPanel(
-    colors: LandingPalette,
-    busy: Boolean,
-    onGoToLogin: () -> Unit,
-    onGoToRegister: () -> Unit,
-    onGoogleSignIn: () -> Unit,
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = WakerDialogShape,
-        color = colors.surfaceRaised,
-        border = BorderStroke(1.dp, colors.line),
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Column(
-                modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 18.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.auth_landing_get_started),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = colors.text,
-                    fontWeight = FontWeight.Bold,
-                )
-                Text(
-                    text = stringResource(R.string.auth_landing_get_started_desc),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = colors.muted,
-                )
-            }
-            Column(
-                modifier = Modifier.padding(horizontal = 18.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                GoogleSignInButton(
-                    enabled = !busy,
-                    onClick = onGoogleSignIn,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Button(
-                    onClick = onGoToLogin,
-                    enabled = !busy,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                    shape = WakerButtonShape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = colors.accent,
-                        contentColor = colors.accentText,
-                        disabledContainerColor = colors.accent.copy(alpha = 0.28f),
-                        disabledContentColor = colors.accentText.copy(alpha = 0.45f),
-                    ),
-                ) {
-                    Text(stringResource(R.string.auth_landing_login_with_email))
-                }
-            }
-            HorizontalDivider(color = colors.line)
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 18.dp, end = 18.dp, bottom = 18.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(R.string.auth_landing_first_time),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = colors.muted,
-                )
-                OutlinedButton(
-                    onClick = onGoToRegister,
-                    enabled = !busy,
-                    shape = WakerButtonShape,
-                    border = BorderStroke(1.dp, colors.line),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = colors.text,
-                        disabledContentColor = colors.muted.copy(alpha = 0.45f),
-                    ),
-                ) {
-                    Text(stringResource(R.string.auth_create_account))
-                }
-            }
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/PasswordResetScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/PasswordResetScreen.kt
@@ -1,0 +1,201 @@
+package com.alarmtalk.app
+
+import android.util.Patterns
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material.icons.outlined.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+/**
+ * 비밀번호 재설정 — 가입한 이메일로 6자리 코드를 받고, 코드 + 새 비밀번호로 변경한다.
+ * 회원가입의 이메일 인증 UI를 미러링한다. 코드 발송 후([codeSentTo] == 입력 이메일)
+ * 코드·새 비밀번호 입력이 노출된다. 확정은 단일 호출([onConfirm])로 검증+변경을 처리한다.
+ */
+@Composable
+internal fun PasswordResetScreen(
+    contentPadding: PaddingValues,
+    busy: Boolean,
+    codeSentTo: String?,
+    onBack: () -> Unit,
+    onRequestCode: (String) -> Unit,
+    onConfirm: (email: String, code: String, newPassword: String) -> Unit,
+) {
+    var email by remember { mutableStateOf("") }
+    var code by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    val normalizedEmail = email.trim().lowercase()
+    val emailLooksValid = Patterns.EMAIL_ADDRESS.matcher(normalizedEmail).matches()
+    val codeSent = codeSentTo != null && codeSentTo == normalizedEmail
+    // 서버 정책(@alarmtalk/shared PasswordSchema)과 일치: 8~128자 + 영문·숫자 각 1자 이상.
+    val passwordPolicyValid =
+        password.length in 8..128 && password.any { it.isLetter() } && password.any { it.isDigit() }
+    val canConfirm = codeSent && code.length == 6 && passwordPolicyValid
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 18.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = stringResource(R.string.auth_back),
+                )
+            }
+            Text(
+                text = stringResource(R.string.auth_reset_title),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        Text(
+            text = stringResource(R.string.auth_reset_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text(stringResource(R.string.auth_label_email)) },
+            singleLine = true,
+            enabled = !busy && !codeSent,
+            shape = WakerInputShape,
+            colors = wakerOutlinedTextFieldColors(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        OutlinedButton(
+            onClick = { onRequestCode(email) },
+            enabled = !busy && emailLooksValid && !codeSent,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(54.dp),
+            shape = WakerButtonShape,
+            border = wakerCardBorder(),
+            colors = wakerOutlinedButtonColors(),
+        ) {
+            Text(
+                if (codeSent) {
+                    stringResource(R.string.auth_reset_code_sent)
+                } else {
+                    stringResource(R.string.auth_reset_send_code)
+                },
+            )
+        }
+
+        if (codeSent) {
+            OutlinedTextField(
+                value = code,
+                onValueChange = { code = it.filter(Char::isDigit).take(6) },
+                label = { Text(stringResource(R.string.auth_label_verification_code)) },
+                singleLine = true,
+                enabled = !busy,
+                shape = WakerInputShape,
+                colors = wakerOutlinedTextFieldColors(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.NumberPassword,
+                    imeAction = ImeAction.Next,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text(stringResource(R.string.auth_reset_new_password)) },
+                singleLine = true,
+                enabled = !busy,
+                shape = WakerInputShape,
+                colors = wakerOutlinedTextFieldColors(),
+                visualTransformation = if (passwordVisible) {
+                    VisualTransformation.None
+                } else {
+                    PasswordVisualTransformation()
+                },
+                trailingIcon = {
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(
+                            imageVector = if (passwordVisible) {
+                                Icons.Outlined.VisibilityOff
+                            } else {
+                                Icons.Outlined.Visibility
+                            },
+                            contentDescription = if (passwordVisible) {
+                                stringResource(R.string.auth_password_hide)
+                            } else {
+                                stringResource(R.string.auth_password_show)
+                            },
+                        )
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Done,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                text = stringResource(R.string.auth_reset_password_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Button(
+                onClick = { onConfirm(email, code, password) },
+                enabled = !busy && canConfirm,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(54.dp),
+                shape = WakerButtonShape,
+            ) {
+                Text(stringResource(R.string.auth_reset_submit))
+            }
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -155,6 +155,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var registerEmailVerified by mutableStateOf<String?>(null)
         internal set
 
+    // 비밀번호 재설정 코드를 보낸 이메일. 입력 이메일과 같으면 코드+새 비밀번호 입력을 노출한다.
+    var passwordResetCodeSentTo by mutableStateOf<String?>(null)
+        internal set
+
     // 가입 시도 이메일이 이미 가입돼 있을 때(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환하라는 신호.
     var authRedirectToLogin by mutableStateOf(false)
         internal set

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -31,6 +31,8 @@ import com.alarmtalk.app.network.EmailVerificationConfirmRequest
 import com.alarmtalk.app.network.EmailVerificationRequest
 import com.alarmtalk.app.network.GoogleLoginRequest
 import com.alarmtalk.app.network.LoginRequest
+import com.alarmtalk.app.network.PasswordResetConfirmRequest
+import com.alarmtalk.app.network.PasswordResetRequest
 import com.alarmtalk.app.network.ReceivedNote
 import com.alarmtalk.app.network.RegisterRequest
 import com.alarmtalk.app.network.SendNoteRequest
@@ -191,6 +193,66 @@ internal fun MainViewModel.register(
             Log.e(TAG, "Email registration failed", error)
             message = duplicateEmailMessage(error)
                 ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_register_failed))
+        }
+        authBusy = false
+    }
+}
+
+// 비밀번호 재설정 코드 요청. 백엔드는 계정 존재 여부를 노출하지 않으므로(비번 계정에만 발송),
+// 응답은 항상 성공이다. 코드를 보낸 이메일을 기억해 다음 단계(코드+새 비번)를 노출한다.
+internal fun MainViewModel.requestPasswordReset(email: String) {
+    val normalizedEmail = email.trim().lowercase()
+    if (normalizedEmail.isBlank()) {
+        message = getApplication<android.app.Application>().getString(R.string.msg_email_required)
+        return
+    }
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.requestPasswordReset(PasswordResetRequest(email = normalizedEmail))
+        }.onSuccess { response ->
+            passwordResetCodeSentTo = normalizedEmail
+            message = response.debugCode
+                ?.takeIf { BuildConfig.DEBUG && it.isNotBlank() }
+                ?.let { getApplication<android.app.Application>().getString(R.string.msg_verification_code_debug, it) }
+                ?: getApplication<android.app.Application>().getString(R.string.msg_password_reset_code_sent)
+        }.onFailure { error ->
+            Log.e(TAG, "Password reset request failed", error)
+            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_send_failed))
+        }
+        authBusy = false
+    }
+}
+
+// 비밀번호 재설정 확정(코드+새 비밀번호). 성공 시 로그인 화면으로 돌아가도록 onSuccess 콜백을 호출한다.
+internal fun MainViewModel.confirmPasswordReset(
+    email: String,
+    code: String,
+    newPassword: String,
+    onSuccess: () -> Unit,
+) {
+    val normalizedEmail = email.trim().lowercase()
+    if (normalizedEmail.isBlank() || code.trim().length != 6 || newPassword.isBlank()) {
+        message = getApplication<android.app.Application>().getString(R.string.msg_register_all_fields_required)
+        return
+    }
+    viewModelScope.launch {
+        authBusy = true
+        runCatching {
+            api.confirmPasswordReset(
+                PasswordResetConfirmRequest(
+                    email = normalizedEmail,
+                    code = code.trim(),
+                    password = newPassword,
+                ),
+            )
+        }.onSuccess {
+            passwordResetCodeSentTo = null
+            message = getApplication<android.app.Application>().getString(R.string.msg_password_reset_done)
+            onSuccess()
+        }.onFailure { error ->
+            Log.e(TAG, "Password reset confirm failed", error)
+            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_password_reset_failed))
         }
         authBusy = false
     }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -15,13 +15,14 @@
     <string name="auth_consent_terms">[Required] Agree to Terms of Service</string>
     <string name="auth_consent_title">Please agree to the terms\nto use the service</string>
     <string name="auth_consent_view">View</string>
+    <string name="auth_continue_with_email">Continue with email</string>
     <string name="auth_create_account">Create account</string>
     <string name="auth_email_verify">Verify email</string>
     <string name="auth_email_verify_done">Email verified</string>
     <string name="auth_email_verify_resend">Resend code</string>
     <string name="auth_label_confirm_password">Confirm password</string>
     <string name="auth_label_email">Email</string>
-    <string name="auth_label_name">Name</string>
+    <string name="auth_label_name">Nickname</string>
     <string name="auth_label_password">Password</string>
     <string name="auth_label_verification_code">Verification code</string>
     <string name="auth_landing_first_time">First time here?</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -15,16 +15,24 @@
     <string name="auth_consent_terms">[Required] Agree to Terms of Service</string>
     <string name="auth_consent_title">Please agree to the terms\nto use the service</string>
     <string name="auth_consent_view">View</string>
-    <string name="auth_create_account">Create account</string>
+    <string name="auth_already_have_account">Already have an account?</string>
+    <string name="auth_create_account">Sign up</string>
     <string name="auth_email_verify">Verify email</string>
     <string name="auth_email_verify_done">Email verified</string>
-    <string name="auth_email_verify_resend">Resend code</string>
-    <string name="auth_find_id">Find ID</string>
-    <string name="auth_find_password">Forgot password</string>
-    <string name="auth_find_coming_soon">Coming soon</string>
-    <string name="auth_or">or</string>
+    <string name="auth_email_verify_resend">Resend code</string>    <string name="auth_find_password">Reset password</string>
+    <string name="auth_forgot_password">Forgot your password?</string>    <string name="auth_or">or</string>
     <string name="auth_label_confirm_password">Confirm password</string>
     <string name="auth_label_email">Email</string>
+    <string name="auth_reset_title">Reset password</string>
+    <string name="auth_reset_subtitle">We\'ll email a verification code to your account.</string>
+    <string name="auth_reset_send_code">Send code</string>
+    <string name="auth_reset_code_sent">Code sent</string>
+    <string name="auth_reset_new_password">New password</string>
+    <string name="auth_reset_password_hint">8+ characters, with letters and numbers</string>
+    <string name="auth_reset_submit">Reset password</string>
+    <string name="msg_password_reset_code_sent">We sent a code. Check your email.</string>
+    <string name="msg_password_reset_done">Password changed. Sign in with your new password.</string>
+    <string name="msg_password_reset_failed">Couldn\'t reset your password.</string>
     <string name="auth_label_name">Nickname</string>
     <string name="auth_label_password">Password</string>
     <string name="auth_label_verification_code">Verification code</string>
@@ -50,10 +58,7 @@
     <string name="auth_password_show">Show password</string>
     <string name="auth_processing">Processing</string>
     <string name="auth_subtitle_login">We\'ll bring back your favorite voice alarms.</string>
-    <string name="auth_subtitle_register">Let\'s set up an account to create voice alarms.</string>
-    <string name="auth_switch_to_login">Already have an account? Log in</string>
-    <string name="auth_switch_to_register">New here? Create account</string>
-    <string name="auth_title_login">Log in</string>
+    <string name="auth_subtitle_register">Let\'s set up an account to create voice alarms.</string>    <string name="auth_title_login">Log in</string>
     <string name="auth_title_register">Sign up</string>
     <string name="auth_verification_code_hint">Enter the 6-digit code from your email.</string>
     <string name="billing_apply_button">Apply</string>
@@ -140,6 +145,7 @@
     <string name="common_day_tue">Tue</string>
     <string name="common_day_wed">Wed</string>
     <string name="common_google_continue">Continue with Google</string>
+    <string name="common_google_login">Sign in with Google</string>
     <string name="common_permission_allow_action">Allow</string>
     <string name="common_permission_allow_all">Allow all required permissions</string>
     <string name="common_permission_exact_alarm_label">Exact alarms</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -19,6 +19,10 @@
     <string name="auth_email_verify">Verify email</string>
     <string name="auth_email_verify_done">Email verified</string>
     <string name="auth_email_verify_resend">Resend code</string>
+    <string name="auth_find_id">Find ID</string>
+    <string name="auth_find_password">Forgot password</string>
+    <string name="auth_find_coming_soon">Coming soon</string>
+    <string name="auth_or">or</string>
     <string name="auth_label_confirm_password">Confirm password</string>
     <string name="auth_label_email">Email</string>
     <string name="auth_label_name">Nickname</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -15,7 +15,6 @@
     <string name="auth_consent_terms">[Required] Agree to Terms of Service</string>
     <string name="auth_consent_title">Please agree to the terms\nto use the service</string>
     <string name="auth_consent_view">View</string>
-    <string name="auth_continue_with_email">Continue with email</string>
     <string name="auth_create_account">Create account</string>
     <string name="auth_email_verify">Verify email</string>
     <string name="auth_email_verify_done">Email verified</string>
@@ -33,6 +32,11 @@
     <string name="auth_landing_preview_pause">Pause preview</string>
     <string name="auth_landing_preview_play">Preview voice</string>
     <string name="auth_landing_tomorrow_morning">Tomorrow morning</string>
+    <string name="auth_landing_sample_message">Morning, Minji ☀️\nHave a wonderful day!</string>
+    <string name="auth_landing_sample_voice">· Mom\'s voice</string>
+    <string name="auth_landing_value_voice">Your voice</string>
+    <string name="auth_landing_value_family">Family</string>
+    <string name="auth_landing_value_daily">Daily message</string>
     <string name="auth_onboarding_next">Next</string>
     <string name="auth_onboarding_skip">Skip</string>
     <string name="auth_onboarding_start">Get started</string>
@@ -47,7 +51,7 @@
     <string name="auth_subtitle_login">We\'ll bring back your favorite voice alarms.</string>
     <string name="auth_subtitle_register">Let\'s set up an account to create voice alarms.</string>
     <string name="auth_switch_to_login">Already have an account? Log in</string>
-    <string name="auth_switch_to_register">New here? Sign up</string>
+    <string name="auth_switch_to_register">New here? Create account</string>
     <string name="auth_title_login">Log in</string>
     <string name="auth_title_register">Sign up</string>
     <string name="auth_verification_code_hint">Enter the 6-digit code from your email.</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -34,9 +34,6 @@
     <string name="auth_landing_tomorrow_morning">Tomorrow morning</string>
     <string name="auth_landing_sample_message">Morning, Minji ☀️\nHave a wonderful day!</string>
     <string name="auth_landing_sample_voice">· Mom\'s voice</string>
-    <string name="auth_landing_value_voice">Your voice</string>
-    <string name="auth_landing_value_family">Family</string>
-    <string name="auth_landing_value_daily">Daily message</string>
     <string name="auth_onboarding_next">Next</string>
     <string name="auth_onboarding_skip">Skip</string>
     <string name="auth_onboarding_start">Get started</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -15,16 +15,24 @@
     <string name="auth_consent_terms">［必須］利用規約に同意</string>
     <string name="auth_consent_title">サービスをご利用いただくために\n規約に同意してください</string>
     <string name="auth_consent_view">表示</string>
-    <string name="auth_create_account">アカウントを作成</string>
+    <string name="auth_already_have_account">すでにアカウントをお持ちですか？</string>
+    <string name="auth_create_account">新規登録</string>
     <string name="auth_email_verify">メール認証</string>
     <string name="auth_email_verify_done">メール認証完了</string>
-    <string name="auth_email_verify_resend">認証コードを再送信</string>
-    <string name="auth_find_id">IDを探す</string>
-    <string name="auth_find_password">パスワード再設定</string>
-    <string name="auth_find_coming_soon">近日公開予定</string>
-    <string name="auth_or">または</string>
+    <string name="auth_email_verify_resend">認証コードを再送信</string>    <string name="auth_find_password">再設定</string>
+    <string name="auth_forgot_password">パスワードをお忘れですか？</string>    <string name="auth_or">または</string>
     <string name="auth_label_confirm_password">パスワードの確認</string>
     <string name="auth_label_email">メールアドレス</string>
+    <string name="auth_reset_title">パスワード再設定</string>
+    <string name="auth_reset_subtitle">登録メールに認証コードをお送りします。</string>
+    <string name="auth_reset_send_code">認証コードを受け取る</string>
+    <string name="auth_reset_code_sent">コードを送信しました</string>
+    <string name="auth_reset_new_password">新しいパスワード</string>
+    <string name="auth_reset_password_hint">8文字以上、英字と数字を含む</string>
+    <string name="auth_reset_submit">パスワードを変更</string>
+    <string name="msg_password_reset_code_sent">認証コードを送りました。メールをご確認ください。</string>
+    <string name="msg_password_reset_done">パスワードを変更しました。新しいパスワードでログインしてください。</string>
+    <string name="msg_password_reset_failed">パスワードの再設定に失敗しました。</string>
     <string name="auth_label_name">ニックネーム</string>
     <string name="auth_label_password">パスワード</string>
     <string name="auth_label_verification_code">認証コード</string>
@@ -50,10 +58,7 @@
     <string name="auth_password_show">パスワードを表示</string>
     <string name="auth_processing">処理中</string>
     <string name="auth_subtitle_login">お気に入りの声のアラームをもう一度お呼びします。</string>
-    <string name="auth_subtitle_register">声のアラームを作るアカウントを準備しましょう。</string>
-    <string name="auth_switch_to_login">すでにアカウントをお持ちですか？ ログイン</string>
-    <string name="auth_switch_to_register">はじめてですか？アカウントを作成</string>
-    <string name="auth_title_login">ログイン</string>
+    <string name="auth_subtitle_register">声のアラームを作るアカウントを準備しましょう。</string>    <string name="auth_title_login">ログイン</string>
     <string name="auth_title_register">会員登録</string>
     <string name="auth_verification_code_hint">メールに届いた6桁のコードを入力してください。</string>
     <string name="billing_apply_button">適用する</string>
@@ -140,6 +145,7 @@
     <string name="common_day_tue">火</string>
     <string name="common_day_wed">水</string>
     <string name="common_google_continue">Googleで続ける</string>
+    <string name="common_google_login">Googleでログイン</string>
     <string name="common_permission_allow_action">許可する</string>
     <string name="common_permission_allow_all">必要な権限をすべて許可</string>
     <string name="common_permission_exact_alarm_label">正確なアラーム</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -34,9 +34,6 @@
     <string name="auth_landing_tomorrow_morning">明日の朝</string>
     <string name="auth_landing_sample_message">みんじ、おはよう ☀️\n今日も素敵な一日を！</string>
     <string name="auth_landing_sample_voice">· ママの声</string>
-    <string name="auth_landing_value_voice">自分の声</string>
-    <string name="auth_landing_value_family">家族と共有</string>
-    <string name="auth_landing_value_daily">毎日メッセージ</string>
     <string name="auth_onboarding_next">次へ</string>
     <string name="auth_onboarding_skip">スキップ</string>
     <string name="auth_onboarding_start">始める</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -19,6 +19,10 @@
     <string name="auth_email_verify">メール認証</string>
     <string name="auth_email_verify_done">メール認証完了</string>
     <string name="auth_email_verify_resend">認証コードを再送信</string>
+    <string name="auth_find_id">IDを探す</string>
+    <string name="auth_find_password">パスワード再設定</string>
+    <string name="auth_find_coming_soon">近日公開予定</string>
+    <string name="auth_or">または</string>
     <string name="auth_label_confirm_password">パスワードの確認</string>
     <string name="auth_label_email">メールアドレス</string>
     <string name="auth_label_name">ニックネーム</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -15,13 +15,14 @@
     <string name="auth_consent_terms">［必須］利用規約に同意</string>
     <string name="auth_consent_title">サービスをご利用いただくために\n規約に同意してください</string>
     <string name="auth_consent_view">表示</string>
+    <string name="auth_continue_with_email">メールで続ける</string>
     <string name="auth_create_account">アカウントを作成</string>
     <string name="auth_email_verify">メール認証</string>
     <string name="auth_email_verify_done">メール認証完了</string>
     <string name="auth_email_verify_resend">認証コードを再送信</string>
     <string name="auth_label_confirm_password">パスワードの確認</string>
     <string name="auth_label_email">メールアドレス</string>
-    <string name="auth_label_name">名前</string>
+    <string name="auth_label_name">ニックネーム</string>
     <string name="auth_label_password">パスワード</string>
     <string name="auth_label_verification_code">認証コード</string>
     <string name="auth_landing_first_time">はじめてのご利用ですか？</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -15,7 +15,6 @@
     <string name="auth_consent_terms">［必須］利用規約に同意</string>
     <string name="auth_consent_title">サービスをご利用いただくために\n規約に同意してください</string>
     <string name="auth_consent_view">表示</string>
-    <string name="auth_continue_with_email">メールで続ける</string>
     <string name="auth_create_account">アカウントを作成</string>
     <string name="auth_email_verify">メール認証</string>
     <string name="auth_email_verify_done">メール認証完了</string>
@@ -33,6 +32,11 @@
     <string name="auth_landing_preview_pause">プレビューを一時停止</string>
     <string name="auth_landing_preview_play">声をプレビュー</string>
     <string name="auth_landing_tomorrow_morning">明日の朝</string>
+    <string name="auth_landing_sample_message">みんじ、おはよう ☀️\n今日も素敵な一日を！</string>
+    <string name="auth_landing_sample_voice">· ママの声</string>
+    <string name="auth_landing_value_voice">自分の声</string>
+    <string name="auth_landing_value_family">家族と共有</string>
+    <string name="auth_landing_value_daily">毎日メッセージ</string>
     <string name="auth_onboarding_next">次へ</string>
     <string name="auth_onboarding_skip">スキップ</string>
     <string name="auth_onboarding_start">始める</string>
@@ -47,7 +51,7 @@
     <string name="auth_subtitle_login">お気に入りの声のアラームをもう一度お呼びします。</string>
     <string name="auth_subtitle_register">声のアラームを作るアカウントを準備しましょう。</string>
     <string name="auth_switch_to_login">すでにアカウントをお持ちですか？ ログイン</string>
-    <string name="auth_switch_to_register">はじめての方はこちら 新規登録</string>
+    <string name="auth_switch_to_register">はじめてですか？アカウントを作成</string>
     <string name="auth_title_login">ログイン</string>
     <string name="auth_title_register">会員登録</string>
     <string name="auth_verification_code_hint">メールに届いた6桁のコードを入力してください。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -37,9 +37,6 @@
     <string name="auth_landing_tomorrow_morning">내일 아침</string>
     <string name="auth_landing_sample_message">민지야, 좋은 아침이야 ☀️\n오늘도 좋은 하루 보내자!</string>
     <string name="auth_landing_sample_voice">· 엄마 목소리</string>
-    <string name="auth_landing_value_voice">내 목소리</string>
-    <string name="auth_landing_value_family">가족 공유</string>
-    <string name="auth_landing_value_daily">매일 새 메시지</string>
     <string name="auth_onboarding_next">다음</string>
     <string name="auth_onboarding_skip">건너뛰기</string>
     <string name="auth_onboarding_start">시작하기</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -22,6 +22,10 @@
     <string name="auth_email_verify">이메일 인증</string>
     <string name="auth_email_verify_done">이메일 인증 완료</string>
     <string name="auth_email_verify_resend">인증 코드 다시 받기</string>
+    <string name="auth_find_id">아이디 찾기</string>
+    <string name="auth_find_password">비밀번호 찾기</string>
+    <string name="auth_find_coming_soon">곧 제공될 예정이에요</string>
+    <string name="auth_or">또는</string>
     <string name="auth_label_confirm_password">비밀번호 확인</string>
     <string name="auth_label_email">이메일</string>
     <string name="auth_label_name">닉네임</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -18,13 +18,14 @@
     <string name="auth_consent_terms">[필수] 이용약관 동의</string>
     <string name="auth_consent_title">서비스 이용을 위해\n약관에 동의해 주세요</string>
     <string name="auth_consent_view">보기</string>
+    <string name="auth_continue_with_email">이메일로 계속하기</string>
     <string name="auth_create_account">계정 만들기</string>
     <string name="auth_email_verify">이메일 인증</string>
     <string name="auth_email_verify_done">이메일 인증 완료</string>
     <string name="auth_email_verify_resend">인증 코드 다시 받기</string>
     <string name="auth_label_confirm_password">비밀번호 확인</string>
     <string name="auth_label_email">이메일</string>
-    <string name="auth_label_name">이름</string>
+    <string name="auth_label_name">닉네임</string>
     <string name="auth_label_password">비밀번호</string>
     <string name="auth_label_verification_code">인증 코드</string>
     <string name="auth_landing_first_time">처음 사용하시나요?</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -18,16 +18,24 @@
     <string name="auth_consent_terms">[필수] 이용약관 동의</string>
     <string name="auth_consent_title">서비스 이용을 위해\n약관에 동의해 주세요</string>
     <string name="auth_consent_view">보기</string>
-    <string name="auth_create_account">계정 만들기</string>
+    <string name="auth_already_have_account">이미 계정이 있나요?</string>
+    <string name="auth_create_account">회원가입</string>
     <string name="auth_email_verify">이메일 인증</string>
     <string name="auth_email_verify_done">이메일 인증 완료</string>
-    <string name="auth_email_verify_resend">인증 코드 다시 받기</string>
-    <string name="auth_find_id">아이디 찾기</string>
-    <string name="auth_find_password">비밀번호 찾기</string>
-    <string name="auth_find_coming_soon">곧 제공될 예정이에요</string>
-    <string name="auth_or">또는</string>
+    <string name="auth_email_verify_resend">인증 코드 다시 받기</string>    <string name="auth_find_password">비밀번호 찾기</string>
+    <string name="auth_forgot_password">비밀번호를 잊으셨나요?</string>    <string name="auth_or">또는</string>
     <string name="auth_label_confirm_password">비밀번호 확인</string>
     <string name="auth_label_email">이메일</string>
+    <string name="auth_reset_title">비밀번호 재설정</string>
+    <string name="auth_reset_subtitle">가입한 이메일로 인증 코드를 보내드려요.</string>
+    <string name="auth_reset_send_code">인증 코드 받기</string>
+    <string name="auth_reset_code_sent">코드를 보냈어요</string>
+    <string name="auth_reset_new_password">새 비밀번호</string>
+    <string name="auth_reset_password_hint">8자 이상, 영문·숫자 포함</string>
+    <string name="auth_reset_submit">비밀번호 변경</string>
+    <string name="msg_password_reset_code_sent">인증 코드를 보냈어요. 메일을 확인해 주세요.</string>
+    <string name="msg_password_reset_done">비밀번호를 변경했어요. 새 비밀번호로 로그인해 주세요.</string>
+    <string name="msg_password_reset_failed">비밀번호 재설정에 실패했어요.</string>
     <string name="auth_label_name">닉네임</string>
     <string name="auth_label_password">비밀번호</string>
     <string name="auth_label_verification_code">인증 코드</string>
@@ -53,10 +61,7 @@
     <string name="auth_password_show">비밀번호 보기</string>
     <string name="auth_processing">처리 중</string>
     <string name="auth_subtitle_login">좋아하는 목소리 알람을 다시 불러올게요.</string>
-    <string name="auth_subtitle_register">목소리 알람을 만들 계정을 준비해요.</string>
-    <string name="auth_switch_to_login">이미 계정이 있나요? 로그인</string>
-    <string name="auth_switch_to_register">처음 사용하시나요? 계정 만들기</string>
-    <string name="auth_title_login">로그인</string>
+    <string name="auth_subtitle_register">목소리 알람을 만들 계정을 준비해요.</string>    <string name="auth_title_login">로그인</string>
     <string name="auth_title_register">회원가입</string>
     <string name="auth_verification_code_hint">메일로 받은 6자리 코드를 입력해 주세요.</string>
     <string name="billing_apply_button">적용하기</string>
@@ -143,6 +148,7 @@
     <string name="common_day_tue">화</string>
     <string name="common_day_wed">수</string>
     <string name="common_google_continue">Google로 계속하기</string>
+    <string name="common_google_login">Google로 로그인</string>
     <string name="common_permission_allow_action">허용하기</string>
     <string name="common_permission_allow_all">필요 권한 모두 허용</string>
     <string name="common_permission_exact_alarm_label">정확한 알람</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -18,7 +18,6 @@
     <string name="auth_consent_terms">[필수] 이용약관 동의</string>
     <string name="auth_consent_title">서비스 이용을 위해\n약관에 동의해 주세요</string>
     <string name="auth_consent_view">보기</string>
-    <string name="auth_continue_with_email">이메일로 계속하기</string>
     <string name="auth_create_account">계정 만들기</string>
     <string name="auth_email_verify">이메일 인증</string>
     <string name="auth_email_verify_done">이메일 인증 완료</string>
@@ -36,6 +35,11 @@
     <string name="auth_landing_preview_pause">미리듣기 일시정지</string>
     <string name="auth_landing_preview_play">목소리 미리듣기</string>
     <string name="auth_landing_tomorrow_morning">내일 아침</string>
+    <string name="auth_landing_sample_message">민지야, 좋은 아침이야 ☀️\n오늘도 좋은 하루 보내자!</string>
+    <string name="auth_landing_sample_voice">· 엄마 목소리</string>
+    <string name="auth_landing_value_voice">내 목소리</string>
+    <string name="auth_landing_value_family">가족 공유</string>
+    <string name="auth_landing_value_daily">매일 새 메시지</string>
     <string name="auth_onboarding_next">다음</string>
     <string name="auth_onboarding_skip">건너뛰기</string>
     <string name="auth_onboarding_start">시작하기</string>
@@ -50,7 +54,7 @@
     <string name="auth_subtitle_login">좋아하는 목소리 알람을 다시 불러올게요.</string>
     <string name="auth_subtitle_register">목소리 알람을 만들 계정을 준비해요.</string>
     <string name="auth_switch_to_login">이미 계정이 있나요? 로그인</string>
-    <string name="auth_switch_to_register">처음이신가요? 회원가입</string>
+    <string name="auth_switch_to_register">처음 사용하시나요? 계정 만들기</string>
     <string name="auth_title_login">로그인</string>
     <string name="auth_title_register">회원가입</string>
     <string name="auth_verification_code_hint">메일로 받은 6자리 코드를 입력해 주세요.</string>

--- a/packages/backend/src/lib/email-verification.ts
+++ b/packages/backend/src/lib/email-verification.ts
@@ -38,10 +38,12 @@ export function shouldExposeDebugEmailCode(env: Env): boolean {
   return env.ENVIRONMENT !== 'production' && !env.RESEND_API_KEY;
 }
 
-export async function sendEmailVerificationCode(
+async function sendAuthEmail(
   env: Env,
   email: string,
-  code: string,
+  subject: string,
+  text: string,
+  html: string,
 ): Promise<void> {
   if (!env.RESEND_API_KEY || !env.AUTH_EMAIL_FROM) {
     if (env.ENVIRONMENT !== 'production') return;
@@ -58,13 +60,41 @@ export async function sendEmailVerificationCode(
       from: env.AUTH_EMAIL_FROM,
       to: [email],
       reply_to: env.AUTH_EMAIL_REPLY_TO || undefined,
-      subject: 'AlarmTalk 이메일 인증 코드',
-      text: `AlarmTalk 인증 코드: ${code}\n10분 안에 입력해 주세요.`,
-      html: `<p>AlarmTalk 인증 코드입니다.</p><p style="font-size:24px;font-weight:700;letter-spacing:4px">${code}</p><p>10분 안에 입력해 주세요.</p>`,
+      subject,
+      text,
+      html,
     }),
   });
 
   if (!res.ok) {
     throw new Error(`Email delivery failed (${res.status})`);
   }
+}
+
+export async function sendEmailVerificationCode(
+  env: Env,
+  email: string,
+  code: string,
+): Promise<void> {
+  await sendAuthEmail(
+    env,
+    email,
+    'AlarmTalk 이메일 인증 코드',
+    `AlarmTalk 인증 코드: ${code}\n10분 안에 입력해 주세요.`,
+    `<p>AlarmTalk 인증 코드입니다.</p><p style="font-size:24px;font-weight:700;letter-spacing:4px">${code}</p><p>10분 안에 입력해 주세요.</p>`,
+  );
+}
+
+export async function sendPasswordResetCode(
+  env: Env,
+  email: string,
+  code: string,
+): Promise<void> {
+  await sendAuthEmail(
+    env,
+    email,
+    'AlarmTalk 비밀번호 재설정 코드',
+    `AlarmTalk 비밀번호 재설정 코드: ${code}\n10분 안에 입력해 주세요. 본인이 요청하지 않았다면 무시하세요.`,
+    `<p>AlarmTalk 비밀번호 재설정 코드입니다.</p><p style="font-size:24px;font-weight:700;letter-spacing:4px">${code}</p><p>10분 안에 입력해 주세요. 본인이 요청하지 않았다면 무시하세요.</p>`,
+  );
 }

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -14,6 +14,8 @@ import {
   AppleLoginRequestSchema,
   EmailVerificationRequestSchema,
   EmailVerificationConfirmRequestSchema,
+  PasswordResetRequestSchema,
+  PasswordResetConfirmRequestSchema,
 } from '@alarmtalk/shared';
 import { decodeJwtPayload, verifyAppleIdToken, verifyGoogleIdToken } from '../lib/oauth';
 import { familyAlarmSettingsFromRow } from '../lib/family-alarm-settings';
@@ -31,11 +33,13 @@ import {
   hashEmailVerificationCode,
   normalizeAuthEmail,
   sendEmailVerificationCode,
+  sendPasswordResetCode,
   shouldExposeDebugEmailCode,
 } from '../lib/email-verification';
 
 const auth = new Hono<{ Bindings: Env }>();
 const EMAIL_VERIFICATION_PURPOSE_REGISTER = 'register';
+const EMAIL_VERIFICATION_PURPOSE_RESET = 'reset';
 
 function jsonError(code: string, message: string) {
   return { error: message, error_code: code };
@@ -57,6 +61,7 @@ async function checkEmailVerificationCode(
   env: Env,
   email: string,
   code: string,
+  purpose: string = EMAIL_VERIFICATION_PURPOSE_REGISTER,
 ): Promise<EmailVerificationCheck> {
   const result = await db.execute({
     sql: `SELECT id, code_hash, attempts, expires_at
@@ -64,7 +69,7 @@ async function checkEmailVerificationCode(
           WHERE email = ? AND purpose = ? AND consumed_at IS NULL
           ORDER BY created_at DESC
           LIMIT 1`,
-    args: [email, EMAIL_VERIFICATION_PURPOSE_REGISTER],
+    args: [email, purpose],
   });
 
   if (result.rows.length === 0) {
@@ -267,6 +272,141 @@ auth.post('/email-code/verify', async (c) => {
   } catch (err) {
     logRouteError(c, err);
     return c.json(jsonError('AUTH_EMAIL_CODE_VERIFY_FAILED', 'Failed to verify email code'), 500);
+  }
+});
+
+// 비밀번호 재설정 코드 요청. 계정 존재 여부를 응답으로 드러내지 않는다(enumeration 방지):
+// 비밀번호 계정이 아니면(미가입·소셜) 코드를 보내지 않고 동일한 성공 응답을 돌려준다.
+auth.post('/password-reset', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('AUTH_INVALID_JSON', 'Invalid JSON body'), 400);
+  }
+
+  const parsed = PasswordResetRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(jsonError('AUTH_VALIDATION_FAILED', 'Validation failed'), 400);
+  }
+
+  const email = normalizeAuthEmail(parsed.data.email);
+  const db = getDB(c.env);
+
+  // 코드를 실제로 새로 발송했을 때만 debug_code 를 포함한다.
+  const successResponse = (debugCode?: string) =>
+    c.json({
+      success: true,
+      expires_in_seconds: EMAIL_VERIFICATION_TTL_SECONDS,
+      ...(debugCode && shouldExposeDebugEmailCode(c.env) ? { debug_code: debugCode } : {}),
+    });
+
+  try {
+    // 비밀번호 계정에만 재설정 코드를 보낸다(소셜/미가입은 재설정할 비밀번호가 없음).
+    const account = await classifyExistingAccount(db, email);
+    if (!account || account.kind !== 'password') {
+      return successResponse();
+    }
+
+    const nowMs = Date.now();
+    const recent = await db.execute({
+      sql: `SELECT strftime('%Y-%m-%dT%H:%M:%fZ', created_at) AS created_at, expires_at
+            FROM email_verification_codes
+            WHERE email = ? AND purpose = ?
+              AND created_at >= datetime('now', '-1 day')
+            ORDER BY created_at DESC`,
+      args: [email, EMAIL_VERIFICATION_PURPOSE_RESET],
+    });
+
+    const cooldownActive = recent.rows.some((r) => {
+      const created = Date.parse(String(r.created_at ?? ''));
+      const expires = Date.parse(String(r.expires_at ?? ''));
+      if (!Number.isFinite(created)) return false;
+      const withinCooldown =
+        nowMs - created < EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000;
+      const stillValid = Number.isFinite(expires) ? expires > nowMs : false;
+      return withinCooldown && stillValid;
+    });
+    if (cooldownActive || recent.rows.length >= EMAIL_VERIFICATION_DAILY_CAP) {
+      return successResponse();
+    }
+
+    const code = generateEmailVerificationCode();
+    const codeHash = await hashEmailVerificationCode(email, code, c.env.PASSWORD_PEPPER);
+    const id = crypto.randomUUID();
+    const expiresAt = emailVerificationExpiresAt();
+
+    await db.execute({
+      sql: `INSERT INTO email_verification_codes
+              (id, email, purpose, code_hash, expires_at)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [id, email, EMAIL_VERIFICATION_PURPOSE_RESET, codeHash, expiresAt],
+    });
+
+    await sendPasswordResetCode(c.env, email, code);
+
+    return successResponse(code);
+  } catch (err) {
+    logRouteError(c, err);
+    const detail = err instanceof Error ? err.message : String(err);
+    const status = detail.includes('Email delivery') ? 503 : 500;
+    return c.json(jsonError('AUTH_EMAIL_CODE_SEND_FAILED', 'Failed to send email code'), status);
+  }
+});
+
+// 비밀번호 재설정 확정: 코드 검증 → 새 비밀번호 해시로 교체 + token_epoch+1(유출된 기존 세션
+// 전부 폐기) → 코드 소모. 비밀번호 계정에만 허용한다.
+auth.post('/password-reset/confirm', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('AUTH_INVALID_JSON', 'Invalid JSON body'), 400);
+  }
+
+  const parsed = PasswordResetConfirmRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { ...jsonError('AUTH_VALIDATION_FAILED', 'Validation failed'), issues: parsed.error.issues },
+      400,
+    );
+  }
+
+  const email = normalizeAuthEmail(parsed.data.email);
+  const db = getDB(c.env);
+
+  try {
+    const check = await checkEmailVerificationCode(
+      db,
+      c.env,
+      email,
+      parsed.data.code,
+      EMAIL_VERIFICATION_PURPOSE_RESET,
+    );
+    if (!check.ok) {
+      return c.json(jsonError(check.code, check.message), check.status);
+    }
+
+    // 코드가 유효해도 비밀번호 계정이 아니면(소셜/미가입) 재설정하지 않는다.
+    const account = await classifyExistingAccount(db, email);
+    if (!account || account.kind !== 'password') {
+      return c.json(jsonError('AUTH_EMAIL_CODE_INVALID', 'Invalid email verification code'), 400);
+    }
+
+    const passwordHash = await hashPassword(parsed.data.password, c.env.PASSWORD_PEPPER);
+    await db.execute({
+      sql: `UPDATE users
+            SET password_hash = ?, token_epoch = token_epoch + 1, updated_at = datetime('now')
+            WHERE email = ?`,
+      args: [passwordHash, email],
+    });
+
+    await consumeEmailVerificationCode(db, check.id);
+
+    return c.json({ success: true });
+  } catch (err) {
+    logRouteError(c, err);
+    return c.json(jsonError('AUTH_PASSWORD_RESET_FAILED', 'Failed to reset password'), 500);
   }
 });
 

--- a/packages/backend/test/auth.test.ts
+++ b/packages/backend/test/auth.test.ts
@@ -103,6 +103,96 @@ function registerBody(email: string, password = 'superSecret1', name = '김규�
   };
 }
 
+describe('POST /auth/password-reset', () => {
+  it('비밀번호 계정이면 reset 목적의 코드를 발급한다', async () => {
+    mockDB.pushResult([{ password_hash: 'bcrypt-hash', apple_id: null }]); // classifyExistingAccount → password
+    mockDB.pushResult([]); // recent codes (none → no cooldown/cap)
+    mockDB.pushResult([], 1); // INSERT
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/password-reset', { email: 'KIM@Test.COM' }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.debug_code).toMatch(/^\d{6}$/);
+    const insertCall = mockDB.calls.find((c) =>
+      c.sql.includes('INSERT INTO email_verification_codes'),
+    );
+    expect(insertCall?.args[1]).toBe('kim@test.com');
+    expect(insertCall?.args[2]).toBe('reset'); // purpose
+  });
+
+  it('미가입/소셜 계정이면 코드를 보내지 않고 동일 성공 응답을 준다(계정 열거 방지)', async () => {
+    mockDB.pushResult([]); // classifyExistingAccount → none
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/password-reset', { email: 'nobody@test.com' }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.debug_code).toBeUndefined();
+    expect(
+      mockDB.calls.some((c) => c.sql.includes('INSERT INTO email_verification_codes')),
+    ).toBe(false);
+  });
+});
+
+describe('POST /auth/password-reset/confirm', () => {
+  it('유효한 코드 + 비밀번호 계정이면 비밀번호 교체 + token_epoch 증가', async () => {
+    await pushValidEmailVerification('kim@test.com'); // checkEmailVerificationCode SELECT
+    mockDB.pushResult([{ password_hash: 'bcrypt-hash', apple_id: null }]); // classify → password
+    mockDB.pushResult([], 1); // UPDATE users
+    mockDB.pushResult([], 1); // consume code
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/password-reset/confirm', {
+        email: 'kim@test.com',
+        code: EMAIL_CODE,
+        password: 'newSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    const upd = mockDB.calls.find(
+      (c) => c.sql.includes('UPDATE users') && c.sql.includes('token_epoch'),
+    );
+    expect(upd).toBeTruthy();
+    expect(upd?.sql).toContain('password_hash');
+  });
+
+  it('코드가 없거나 틀리면 400 AUTH_EMAIL_CODE_INVALID', async () => {
+    mockDB.pushResult([]); // checkEmailVerificationCode → no row
+
+    const app = buildApp();
+    const res = await app.request(
+      jsonReq('POST', '/auth/password-reset/confirm', {
+        email: 'kim@test.com',
+        code: '000000',
+        password: 'newSecret1',
+      }),
+      undefined,
+      ENV,
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('AUTH_EMAIL_CODE_INVALID');
+  });
+});
+
 describe('POST /auth/email-code', () => {
   it('신규 이메일에 6자리 인증 코드를 발급한다', async () => {
     mockDB.pushResult([]); // existing user lookup (none)

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -29,6 +29,18 @@ export const EmailVerificationConfirmRequestSchema = z.object({
 });
 export type EmailVerificationConfirmRequest = z.infer<typeof EmailVerificationConfirmRequestSchema>;
 
+export const PasswordResetRequestSchema = z.object({
+  email: z.string().email(),
+});
+export type PasswordResetRequest = z.infer<typeof PasswordResetRequestSchema>;
+
+export const PasswordResetConfirmRequestSchema = z.object({
+  email: z.string().email(),
+  code: EmailVerificationCodeSchema,
+  password: PasswordSchema,
+});
+export type PasswordResetConfirmRequest = z.infer<typeof PasswordResetConfirmRequestSchema>;
+
 export const RegisterRequestSchema = z.object({
   email: z.string().email(),
   password: PasswordSchema,


### PR DESCRIPTION
## 개요
랜딩과 로그인을 한 화면에 결합하던 구조를 **랜딩 → 인증 진입 → 폼** 3단계로 분리한다. 중앙 빈 공간·Google 버튼 중복·위계 역전·용어 불일치를 함께 해소.

## 변경
- **랜딩 분리** (`LandingScreen`): 가치 제안(히어로 + 목소리 미리듣기)과 단일 **`시작하기`** 만. 콘텐츠를 세로로 분산해 중앙 빈 공간 해소.
- **새 인증 진입 화면** (`AuthEntryScreen`): `시작하기` → **`Google로 계속하기`**(주) + **`이메일로 계속하기`**(보조 아웃라인) + "처음 사용하시나요? 계정 만들기".
- **Google 중복 제거**: 이메일 로그인/가입 폼에서 Google 버튼 제거 → 폼이 본래 행동에 집중, 위계 정상화. (`AuthScreen` 의 `onGoogleSignIn` 파라미터 제거)
- **용어/동사 통일**: `이메일로 로그인` → `이메일로 계속하기`(`auth_continue_with_email` 신규). 
- **`이름` → `닉네임`** (`auth_label_name`, ko·en·ja).
- **브랜드 헤더 'Voice alarm' 서브타이틀 제거** — 로고 + `AlarmTalk` 만.
- **네비게이션**: `AuthRoute.Entry` 추가, `Landing → Entry → Auth(form)` 배선 + 시스템 뒤로가기 단계 복원(폼→진입→랜딩).

## 검증
- `assembleDevDebug` BUILD SUCCESSFUL.
- A32 실기 확인: 랜딩 → 진입 → 로그인 폼 흐름 정상, Google 진입 화면 1곳만, 로그인 폼 Google 제거 확인(스크린샷).

## 후속(이 PR 범위 밖, 별도 논의)
- 로그인 화면 **비밀번호 찾기** 추가(백엔드 reset 흐름 필요).
- 약관 화면 가로 간격/'필수 전체동의' 보강.
- 회원가입 비번 규칙 미충족 아이콘(○) 개선.