### PR TITLE
Codex P1: 스톡 클립 TTL 정리 제외

### DIFF
--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -215,6 +215,14 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
               JOIN messages m ON m.id = a.message_id
               WHERE m.audio_url = 'r2://' || g.audio_object_key
             )
+            -- 시스템 스톡(프리셋) 클립은 무료 버킷 회전·미리듣기용으로 의도적으로 보관한다.
+            -- 다수 variant 가 alarm.message_id 로 직접 참조되지 않으므로 TTL 정리에서 제외한다
+            -- (제외 안 하면 30일 후 audio_url 이 비워져 /tts/stock-clips 가 끊기고 재시드 전까지
+            -- 무료 음성이 무음이 된다).
+            AND NOT EXISTS (
+              SELECT 1 FROM messages mp
+              WHERE mp.id = g.message_id AND COALESCE(mp.is_preset, 0) = 1
+            )
           ORDER BY g.created_at ASC
           LIMIT ?`,
     args: [generatedCutoff, TTL_BATCH_SIZE],

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -922,7 +922,7 @@ auth.get('/me', async (c) => {
     // Phase 4-D2: apple_id 컬럼도 함께 조회·매칭한다. Apple 로그인 사용자의 JWT sub
     // 는 google_id 칼럼이 아닌 apple_id 칼럼에만 저장돼 있을 수 있다.
     const result = await db.execute({
-      sql: `SELECT id, email, name, plan, apple_id,
+      sql: `SELECT id, email, name, plan, apple_id, token_epoch, deletion_status,
                    allow_family_alarms, family_alarm_quiet_days,
                    family_alarm_quiet_start, family_alarm_quiet_end,
                    family_alarm_quiet_windows, dynamic_prompt_settings_json
@@ -939,8 +939,16 @@ auth.get('/me', async (c) => {
         name: string | null;
         plan: 'free' | 'plus' | 'family' | null;
         apple_id: string | null;
+        token_epoch: number | string | null;
+        deletion_status: string | null;
       } & Record<string, unknown>
     >(result.rows[0]!);
+    // 토큰 폐기 검사(authMiddleware 와 동일): JWT epoch 가 users.token_epoch 보다 낮으면
+    // 로그아웃(전 기기)/비밀번호 재설정으로 무효화된 구 토큰 → 401. /auth/me 가 세션
+    // 검증 역할을 하므로 보호 API 도달 전에 여기서 막아 폐기된 세션 재저장을 방지한다.
+    if ((payload.epoch ?? 0) < Number(row.token_epoch ?? 0)) {
+      return c.json(jsonError('TOKEN_REVOKED', 'Token has been revoked'), 401);
+    }
     const familyAlarmSettings = familyAlarmSettingsFromRow(row);
     const dynamicPromptSettings = dynamicPromptSettingsFromRow(row);
     return c.json({
@@ -949,6 +957,8 @@ auth.get('/me', async (c) => {
         email: row.email,
         name: row.name ?? '',
         plan: row.plan ?? 'free',
+        // 탈퇴 유예 상태 — iOS 가 복구 전용 화면 게이팅에 쓴다(누락 시 active 로 오인해 진입).
+        deletion_status: (row.deletion_status as string | null) ?? 'active',
         // Phase 4-D2: iOS 클라이언트가 credentialState 조회에 사용. 비-Apple 사용자
         // 는 null. iOS AuthUser.appleUserId 는 옵셔널이라 누락도 호환.
         apple_user_id: row.apple_id ?? null,


### PR DESCRIPTION
무료 버킷 스톡 클립(is_preset)이 30일 TTL 정리로 삭제되던 P1 수정 — audio-retention generated 정리에서 is_preset 자산 제외. #520 리뷰 후속. 백엔드 typecheck+테스트 통과.