### PR TITLE
프론트: 로그인 첫 화면 정리 및 비밀번호 재설정 규칙 체크리스트 일치

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -392,7 +392,7 @@ private fun PasswordRules(
 }
 
 @Composable
-private fun PasswordRuleRow(text: String, satisfied: Boolean) {
+internal fun PasswordRuleRow(text: String, satisfied: Boolean) {
     val color = if (satisfied) {
         MaterialTheme.colorScheme.primary
     } else {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -264,12 +264,6 @@ private fun AlarmIdentityPreview(colors: LandingPalette) {
                 progress = playbackProgress,
                 isPlaying = isPlaying,
             )
-            Text(
-                text = stringResource(R.string.auth_landing_sample_voice),
-                style = MaterialTheme.typography.labelMedium,
-                color = colors.muted,
-                modifier = Modifier.align(Alignment.End),
-            )
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/PasswordResetScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/PasswordResetScreen.kt
@@ -61,8 +61,10 @@ internal fun PasswordResetScreen(
     val emailLooksValid = Patterns.EMAIL_ADDRESS.matcher(normalizedEmail).matches()
     val codeSent = codeSentTo != null && codeSentTo == normalizedEmail
     // 서버 정책(@alarmtalk/shared PasswordSchema)과 일치: 8~128자 + 영문·숫자 각 1자 이상.
-    val passwordPolicyValid =
-        password.length in 8..128 && password.any { it.isLetter() } && password.any { it.isDigit() }
+    val passwordAtLeastMin = password.length >= 8
+    val passwordUnderMax = password.length <= 128
+    val passwordHasLetterAndDigit = password.any { it.isLetter() } && password.any { it.isDigit() }
+    val passwordPolicyValid = passwordAtLeastMin && passwordUnderMax && passwordHasLetterAndDigit
     val canConfirm = codeSent && code.length == 6 && passwordPolicyValid
 
     Column(
@@ -180,11 +182,16 @@ internal fun PasswordResetScreen(
                 ),
                 modifier = Modifier.fillMaxWidth(),
             )
-            Text(
-                text = stringResource(R.string.auth_reset_password_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                PasswordRuleRow(
+                    text = stringResource(R.string.auth_password_rule_min),
+                    satisfied = passwordAtLeastMin,
+                )
+                PasswordRuleRow(
+                    text = stringResource(R.string.auth_password_rule_alnum),
+                    satisfied = passwordHasLetterAndDigit,
+                )
+            }
 
             Button(
                 onClick = { onConfirm(email, code, password) },

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -32,7 +32,6 @@
     <string name="auth_reset_send_code">Send code</string>
     <string name="auth_reset_code_sent">Code sent</string>
     <string name="auth_reset_new_password">New password</string>
-    <string name="auth_reset_password_hint">8+ characters, with letters and numbers</string>
     <string name="auth_reset_submit">Reset password</string>
     <string name="msg_password_reset_code_sent">We sent a code. Check your email.</string>
     <string name="msg_password_reset_done">Password changed. Sign in with your new password.</string>
@@ -48,8 +47,7 @@
     <string name="auth_landing_preview_pause">Pause preview</string>
     <string name="auth_landing_preview_play">Preview voice</string>
     <string name="auth_landing_tomorrow_morning">Tomorrow morning</string>
-    <string name="auth_landing_sample_message">Morning, Minji ☀️\nHave a wonderful day!</string>
-    <string name="auth_landing_sample_voice">· Mom\'s voice</string>
+    <string name="auth_landing_sample_message">Morning, Minji\nHave a wonderful day!</string>
     <string name="auth_onboarding_next">Next</string>
     <string name="auth_onboarding_skip">Skip</string>
     <string name="auth_onboarding_start">Get started</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -32,7 +32,6 @@
     <string name="auth_reset_send_code">認証コードを受け取る</string>
     <string name="auth_reset_code_sent">コードを送信しました</string>
     <string name="auth_reset_new_password">新しいパスワード</string>
-    <string name="auth_reset_password_hint">8文字以上、英字と数字を含む</string>
     <string name="auth_reset_submit">パスワードを変更</string>
     <string name="msg_password_reset_code_sent">認証コードを送りました。メールをご確認ください。</string>
     <string name="msg_password_reset_done">パスワードを変更しました。新しいパスワードでログインしてください。</string>
@@ -48,8 +47,7 @@
     <string name="auth_landing_preview_pause">プレビューを一時停止</string>
     <string name="auth_landing_preview_play">声をプレビュー</string>
     <string name="auth_landing_tomorrow_morning">明日の朝</string>
-    <string name="auth_landing_sample_message">みんじ、おはよう ☀️\n今日も素敵な一日を！</string>
-    <string name="auth_landing_sample_voice">· ママの声</string>
+    <string name="auth_landing_sample_message">みんじ、おはよう\n今日も素敵な一日を！</string>
     <string name="auth_onboarding_next">次へ</string>
     <string name="auth_onboarding_skip">スキップ</string>
     <string name="auth_onboarding_start">始める</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -35,7 +35,6 @@
     <string name="auth_reset_send_code">인증 코드 받기</string>
     <string name="auth_reset_code_sent">코드를 보냈어요</string>
     <string name="auth_reset_new_password">새 비밀번호</string>
-    <string name="auth_reset_password_hint">8자 이상, 영문·숫자 포함</string>
     <string name="auth_reset_submit">비밀번호 변경</string>
     <string name="msg_password_reset_code_sent">인증 코드를 보냈어요. 메일을 확인해 주세요.</string>
     <string name="msg_password_reset_done">비밀번호를 변경했어요. 새 비밀번호로 로그인해 주세요.</string>
@@ -51,8 +50,7 @@
     <string name="auth_landing_preview_pause">미리듣기 일시정지</string>
     <string name="auth_landing_preview_play">목소리 미리듣기</string>
     <string name="auth_landing_tomorrow_morning">내일 아침</string>
-    <string name="auth_landing_sample_message">민지야, 좋은 아침이야 ☀️\n오늘도 좋은 하루 보내자!</string>
-    <string name="auth_landing_sample_voice">· 엄마 목소리</string>
+    <string name="auth_landing_sample_message">민지야, 좋은 아침이야\n오늘도 좋은 하루 보내자!</string>
     <string name="auth_onboarding_next">다음</string>
     <string name="auth_onboarding_skip">건너뛰기</string>
     <string name="auth_onboarding_start">시작하기</string>


### PR DESCRIPTION
## 요약
- 로그인 첫 화면(LandingScreen) 미리듣기 카드에서 '엄마 목소리' 라벨과 해(☀️) 이모지 제거
- 비밀번호 재설정 화면에 가입 화면과 동일한 **라이브 규칙 체크리스트**(8자 이상·영문/숫자) 적용

## 변경
- `LandingScreen`: sample_voice 라벨 제거, sample_message 이모지 제거
- `AuthScreen`: PasswordRuleRow를 internal로 전환(재설정 화면과 재사용)
- `PasswordResetScreen`: 정적 안내문 → 라이브 체크리스트
- strings(ko/ja/en): `auth_landing_sample_voice`·`auth_reset_password_hint` 제거, sample_message 이모지 제거

## 검증
- devDebug 빌드·설치 확인(S23 Ultra)