### PR TITLE
백엔드: bcrypt 72바이트 절단 방지 — 비밀번호 SHA-256 pre-hash

### DIFF
--- a/packages/backend/src/lib/password.ts
+++ b/packages/backend/src/lib/password.ts
@@ -14,8 +14,24 @@ export function applyPepper(password: string, pepper: string): string {
   return `${password}::${pepper ?? ''}`;
 }
 
+// bcrypt(bcryptjs)는 입력의 첫 72바이트만 사용하고 그 이상은 무시한다. password 뒤에
+// pepper 를 붙이는 구조라, 비밀번호가 길면(특히 한글·이모지는 1자당 3~4바이트) 72바이트
+// 경계를 넘는 뒷부분과 pepper 가 통째로 잘려 해시에 반영되지 않는다(정책상 128자를 받아도
+// 사실상 앞부분만 유효, pepper 방어도 무력화). 이를 막기 위해 password+pepper 를 먼저
+// SHA-256 으로 압축(hex 64자 → 64바이트, 72바이트 미만·null 바이트 없음)한 뒤 bcrypt 에
+// 넣는다. 이렇게 하면 임의 길이 입력의 엔트로피가 온전히 반영되고 pepper 도 항상 적용된다.
+async function prehashPassword(password: string, pepper: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(applyPepper(password, pepper)),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 export async function hashPassword(password: string, pepper: string): Promise<string> {
-  return bcrypt.hash(applyPepper(password, pepper), BCRYPT_ROUNDS);
+  return bcrypt.hash(await prehashPassword(password, pepper), BCRYPT_ROUNDS);
 }
 
 export async function verifyPassword(
@@ -24,5 +40,5 @@ export async function verifyPassword(
   pepper: string,
 ): Promise<boolean> {
   if (!hash) return false;
-  return bcrypt.compare(applyPepper(password, pepper), hash);
+  return bcrypt.compare(await prehashPassword(password, pepper), hash);
 }

--- a/packages/backend/src/lib/password.ts
+++ b/packages/backend/src/lib/password.ts
@@ -40,5 +40,13 @@ export async function verifyPassword(
   pepper: string,
 ): Promise<boolean> {
   if (!hash) return false;
-  return bcrypt.compare(await prehashPassword(password, pepper), hash);
+  // 신 스킴: bcrypt(SHA-256(password::pepper)).
+  if (await bcrypt.compare(await prehashPassword(password, pepper), hash)) {
+    return true;
+  }
+  // 레거시 폴백: pre-hash 도입 이전에 저장된 해시는 bcrypt(password::pepper) 였다.
+  // 기존 사용자가 잠기지 않도록 옛 스킴으로도 검증한다(출시 전 DB 초기화 시 자연 소멸).
+  // 틀린 비밀번호·부재 사용자(DUMMY_BCRYPT_HASH)는 두 스킴 모두 실패해 항상 2회
+  // 비교하므로, 로그인 실패 경로의 타이밍 균일성(계정 열거 방어)은 유지된다.
+  return bcrypt.compare(applyPepper(password, pepper), hash);
 }

--- a/packages/backend/test/password.test.ts
+++ b/packages/backend/test/password.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import bcrypt from 'bcryptjs';
 import {
   hashPassword,
   verifyPassword,
@@ -37,6 +38,14 @@ describe('password hashing', () => {
 
   it('applyPepper 는 페퍼를 비밀번호 뒤에 붙인다', () => {
     expect(applyPepper('pw', 'sauce')).toBe('pw::sauce');
+  });
+
+  it('pre-hash 도입 이전 방식(bcrypt(password::pepper))으로 저장된 해시도 검증된다 (레거시 폴백)', async () => {
+    const pepper = 'test-pepper';
+    // 옛 hashPassword 가 만들던 해시: SHA-256 pre-hash 없이 password::pepper 를 직접 bcrypt.
+    const legacyHash = await bcrypt.hash(applyPepper('correct-horse', pepper), 10);
+    expect(await verifyPassword('correct-horse', legacyHash, pepper)).toBe(true);
+    expect(await verifyPassword('wrong', legacyHash, pepper)).toBe(false);
   });
 
   it('DUMMY_BCRYPT_HASH 는 유효한 bcrypt 해시이며 어떤 평문과도 일치하지 않는다', async () => {


### PR DESCRIPTION
## 문제
bcryptjs는 입력의 **첫 72바이트만** 사용한다. `password + '::' + pepper`를 그대로 bcrypt에 넣어, 긴 비밀번호(특히 한글·이모지는 1자당 3~4바이트)와 뒤에 붙는 pepper가 72바이트 경계를 넘으면 잘려 해시에 반영되지 않았다.

## 변경
- `password+pepper`를 SHA-256(hex 64바이트)으로 먼저 압축한 뒤 bcrypt에 투입 → 임의 길이 엔트로피 온전 반영 + pepper 항상 적용.
- **레거시 폴백**(Codex P1 대응): pre-hash 도입 이전 해시(`bcrypt(password::pepper)`)도 `verifyPassword`가 폴백으로 검증 → 기존 사용자 로그인 유지(잠김 없음).

## 영향
- 신규/재설정 비밀번호는 새 스킴으로 저장. 기존 해시는 폴백으로 계속 검증되므로 **재로그인 가능**(back-compat 유지).
- 로그인 실패 경로는 두 스킴 모두 비교 → 타이밍 균일성(계정 열거 방어) 유지.

## 검증
- 백엔드 테스트 **58건 통과**(레거시 폴백 테스트 포함).