### PR TITLE
문서: 입력/SQL 보안 규약 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,17 @@
 - 커밋 메시지 **한국어**. Co-Authored-By: Claude / "Generated with Claude Code" **금지**.
 - `develop`은 보호 브랜치(9개 필수 체크) → 직접 푸시 불가, **PR 필요**.
 
+### 입력/SQL 보안 규약 (백엔드)
+2026-07-01 입력·SQL 인젝션 전면 감사 결과 현행 코드는 이미 안전. 아래 패턴을 **회귀 방지 규약**으로 고정한다(신규 라우트 추가 시 코드리뷰 체크):
+- **SQL은 항상 `?`-바인딩.** `db.execute({ sql, args })` 의 `sql` 문자열에 사용자 값을 `${}`/문자열 결합으로 넣지 **말 것**. 값은 예외 없이 `args` 배열로.
+  - 동적 `${}`가 허용되는 경우는 **개발자 고정 조각뿐**: IN 절 플레이스홀더 생성기(`alarm-query.ts`의 `inPlaceholders` 등, 값 개수만큼 `?` 생성), 화이트리스트 컬럼 조각(`alarm-mutation.ts`의 `updates.push('col = ?')`), 고정 리터럴 절/테이블명. 컬럼/테이블명을 사용자 입력에서 파생하지 말 것.
+  - LIKE 검색: 절은 `LIKE ?`, 패턴 `%${q}%`는 **값으로만** 만들어 `args`에 push(`friend.ts`/`gift.ts` 방식).
+- **필터/식별자 검증 후 바인딩**: `library.ts`의 `filter=voice:/date:`처럼 `UUID_RE`/`DATE_RE`로 형식 검증 후 `?`-바인딩.
+- **페이지네이션 상한**: `limit`/`offset`은 `Math.min(...,100)`/`Math.max(...,0)`로 클램프 후 바인딩(신규 리스트 엔드포인트 필수).
+- **요청 입력 검증**: 바디는 `@alarmtalk/shared` zod 스키마로 `safeParse`, 경로/쿼리 파라미터도 검증·바운드.
+- **IDOR 방어**: 클라 제공 id/code는 조회·수정·삭제 전 소유권 확인(`WHERE ... AND user_id = ?` 게이트, cross-tenant 참조는 `*BelongsToCaller` 헬퍼). 예: `alarm-mutation.ts:402-470`.
+- **R2 object key**: 사용자 파생 세그먼트는 `encodeURIComponent`+새니타이즈 또는 JWT `sub`+`crypto.randomUUID()`로 생성(경로 조작 차단).
+
 ### 디자인 토큰 (Android Compose)
 새 화면/컴포넌트는 **생 리터럴 대신 토큰**을 가져다 쓴다. 단일 출처 두 곳:
 - **모서리 반경**: `ui/components/WakerDesign.kt` 의 `Waker*Shape` 토큰이 유일 출처.


### PR DESCRIPTION
## 요약
입력·SQL 인젝션 전면 감사 결과 확인된 현행 안전 패턴을 **회귀 방지 규약**으로 CLAUDE.md 컨벤션에 명문화(코드 변경 없음).

## 감사 결과
- 다중 에이전트 6차원 감사(SQLi·입력검증·2차인젝션·DoS·IDOR·클라이언트) → **익스플로잇 가능한 취약점 0건**.
- 확인된 방어: ?-바인딩, zod 검증, 필터 정규식(UUID/DATE) 검증, 페이지네이션 상한 클램프, IDOR 소유권 게이트, R2 key 새니타이즈.

## 규약
신규 라우트 추가 시 코드리뷰 체크 항목으로 사용.