### PR TITLE
목소리 만들기 UI polish 및 크롭 회귀 테스트

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
@@ -63,6 +63,40 @@ internal fun audioTimeLabel(millis: Long): String {
     return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
 }
 
+internal data class AudioCropRange(
+    val startMillis: Long,
+    val endMillis: Long,
+)
+
+internal fun constrainedAudioCropRange(
+    currentStartMillis: Long,
+    currentEndMillis: Long,
+    rawStartMillis: Long,
+    rawEndMillis: Long,
+    durationMillis: Long,
+    minDurationMillis: Long,
+    maxDurationMillis: Long,
+): AudioCropRange {
+    val safeDuration = durationMillis.coerceAtLeast(1L)
+    val safeStart = currentStartMillis.coerceIn(0L, safeDuration)
+    val safeEnd = currentEndMillis.coerceIn(safeStart, safeDuration)
+    val rawStart = rawStartMillis.coerceIn(0L, safeDuration)
+    val rawEnd = rawEndMillis.coerceIn(0L, safeDuration)
+    val safeMinDuration = minDurationMillis.coerceAtLeast(0L).coerceAtMost(safeDuration)
+    val safeMaxDuration = maxDurationMillis.coerceAtLeast(safeMinDuration).coerceAtMost(safeDuration)
+    val movingEnd = abs(rawEnd - safeEnd) >= abs(rawStart - safeStart)
+
+    return if (movingEnd) {
+        val lowerBound = (safeStart + safeMinDuration).coerceAtMost(safeDuration)
+        val upperBound = (safeStart + safeMaxDuration).coerceIn(lowerBound, safeDuration)
+        AudioCropRange(safeStart, rawEnd.coerceIn(lowerBound, upperBound))
+    } else {
+        val lowerBound = (safeEnd - safeMaxDuration).coerceAtLeast(0L)
+        val upperBound = (safeEnd - safeMinDuration).coerceAtLeast(lowerBound)
+        AudioCropRange(rawStart.coerceIn(lowerBound, upperBound), safeEnd)
+    }
+}
+
 internal fun voicePreviewContentDescription(
     context: android.content.Context,
     active: Boolean,
@@ -178,19 +212,64 @@ internal fun VoiceRecordControls(
     isRecordedPreviewPreparing: Boolean = false,
     onPreviewRecording: (() -> Unit)? = null,
 ) {
+    val statusLabel = when {
+        isRecording -> stringResource(R.string.voices_recording_status_recording)
+        recordedDurationMillis != null -> stringResource(R.string.voices_recording_status_done)
+        else -> stringResource(R.string.voices_recording_status_ready)
+    }
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = WakerCardShape,
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
-        border = wakerCardBorder(0.7f),
+        color = MaterialTheme.colorScheme.surface,
+        border = wakerCardBorder(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(14.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(46.dp)
+                        .background(
+                            if (isRecording) {
+                                MaterialTheme.colorScheme.error.copy(alpha = 0.14f)
+                            } else {
+                                MaterialTheme.colorScheme.secondaryContainer
+                            },
+                            WakerTileShape,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = if (isRecording) Icons.Outlined.Stop else Icons.Outlined.Mic,
+                        contentDescription = null,
+                        tint = if (isRecording) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        },
+                    )
+                }
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(3.dp),
+                ) {
+                    Text(
+                        text = statusLabel,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    MutedText(notice)
+                }
+            }
             Row {
                 Text(
                     text = audioTimeLabel(elapsedMillis),
@@ -294,7 +373,6 @@ internal fun VoiceRecordControls(
                     },
                 )
             }
-            MutedText(notice)
         }
     }
 }
@@ -355,18 +433,18 @@ internal fun VoiceFileControls(
             onClick = onPickFile,
             enabled = enabled,
             modifier = Modifier.fillMaxWidth(),
-            shape = WakerPanelShape,
-            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
-            border = wakerCardBorder(0.7f),
+            shape = WakerCardShape,
+            color = MaterialTheme.colorScheme.surface,
+            border = wakerCardBorder(),
         ) {
             Row(
-                modifier = Modifier.padding(14.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(
                     modifier = Modifier
-                        .size(44.dp)
+                        .size(52.dp)
                         .background(MaterialTheme.colorScheme.secondaryContainer, WakerTileShape),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -378,6 +456,7 @@ internal fun VoiceFileControls(
                         },
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(28.dp),
                     )
                 }
                 Column(
@@ -403,12 +482,18 @@ internal fun VoiceFileControls(
                     }
                 }
                 if (durationMillis != null) {
-                    Text(
-                        text = audioTimeLabel(durationMillis),
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Surface(
+                        shape = WakerPillShape,
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                    ) {
+                        Text(
+                            text = audioTimeLabel(durationMillis),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+                        )
+                    }
                 }
             }
         }
@@ -484,21 +569,16 @@ internal fun AudioCropRangeSelector(
             RangeSlider(
                 value = safeStart.toFloat()..safeEnd.toFloat(),
                 onValueChange = { range ->
-                    val rawStart = range.start.roundToLong().coerceIn(0L, safeDuration)
-                    val rawEnd = range.endInclusive.roundToLong().coerceIn(0L, safeDuration)
-                    // 실제로 움직인 핸들만 최소/최대 길이 안으로 클램프하고, 반대쪽 핸들은
-                    // 절대 움직이지 않는다. (기존: 한계 초과분만큼 반대쪽 핸들을 밀어서
-                    // 오른쪽 핸들만 왔다갔다해도 왼쪽 시작점이 따라 밀리는 버그가 있었음)
-                    val movingEnd = abs(rawEnd - safeEnd) >= abs(rawStart - safeStart)
-                    if (movingEnd) {
-                        val lowerBound = (safeStart + minDurationMillis).coerceAtMost(safeDuration)
-                        val upperBound = (safeStart + maxDurationMillis).coerceAtMost(safeDuration)
-                        onCropChange(safeStart, rawEnd.coerceIn(lowerBound, upperBound))
-                    } else {
-                        val lowerBound = (safeEnd - maxDurationMillis).coerceAtLeast(0L)
-                        val upperBound = (safeEnd - minDurationMillis).coerceAtLeast(0L)
-                        onCropChange(rawStart.coerceIn(lowerBound, upperBound), safeEnd)
-                    }
+                    val cropRange = constrainedAudioCropRange(
+                        currentStartMillis = safeStart,
+                        currentEndMillis = safeEnd,
+                        rawStartMillis = range.start.roundToLong(),
+                        rawEndMillis = range.endInclusive.roundToLong(),
+                        durationMillis = safeDuration,
+                        minDurationMillis = minDurationMillis,
+                        maxDurationMillis = maxDurationMillis,
+                    )
+                    onCropChange(cropRange.startMillis, cropRange.endMillis)
                 },
                 valueRange = 0f..safeDuration.toFloat(),
             )

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/VoiceInputControls.kt
@@ -57,7 +57,6 @@ internal enum class VoiceCaptureMode {
     Record,
     File,
 }
-
 internal fun audioTimeLabel(millis: Long): String {
     val totalSeconds = (millis / 1000).coerceAtLeast(0L)
     return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
@@ -96,7 +95,6 @@ internal fun constrainedAudioCropRange(
         AudioCropRange(rawStart.coerceIn(lowerBound, upperBound), safeEnd)
     }
 }
-
 internal fun voicePreviewContentDescription(
     context: android.content.Context,
     active: Boolean,
@@ -212,11 +210,6 @@ internal fun VoiceRecordControls(
     isRecordedPreviewPreparing: Boolean = false,
     onPreviewRecording: (() -> Unit)? = null,
 ) {
-    val statusLabel = when {
-        isRecording -> stringResource(R.string.voices_recording_status_recording)
-        recordedDurationMillis != null -> stringResource(R.string.voices_recording_status_done)
-        else -> stringResource(R.string.voices_recording_status_ready)
-    }
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = WakerCardShape,
@@ -230,46 +223,7 @@ internal fun VoiceRecordControls(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(46.dp)
-                        .background(
-                            if (isRecording) {
-                                MaterialTheme.colorScheme.error.copy(alpha = 0.14f)
-                            } else {
-                                MaterialTheme.colorScheme.secondaryContainer
-                            },
-                            WakerTileShape,
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = if (isRecording) Icons.Outlined.Stop else Icons.Outlined.Mic,
-                        contentDescription = null,
-                        tint = if (isRecording) {
-                            MaterialTheme.colorScheme.error
-                        } else {
-                            MaterialTheme.colorScheme.onSecondaryContainer
-                        },
-                    )
-                }
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(3.dp),
-                ) {
-                    Text(
-                        text = statusLabel,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    MutedText(notice)
-                }
-            }
+            MutedText(notice)
             Row {
                 Text(
                     text = audioTimeLabel(elapsedMillis),
@@ -291,10 +245,6 @@ internal fun VoiceRecordControls(
                 )
             }
             VoiceLevelBars(levels = levels, active = isRecording)
-            RecordingProgressBar(
-                progress = (elapsedMillis.toFloat() / maxDurationMillis.toFloat()).coerceIn(0f, 1f),
-                active = isRecording,
-            )
             Box(contentAlignment = Alignment.Center) {
                 RecordPulseRing(active = isRecording)
                 Button(
@@ -364,14 +314,6 @@ internal fun VoiceRecordControls(
                         }
                     }
                 }
-            } else {
-                MutedText(
-                    if (isRecording) {
-                        stringResource(R.string.voices_record_tap_to_stop)
-                    } else {
-                        stringResource(R.string.voices_record_tap_to_start)
-                    },
-                )
             }
         }
     }
@@ -648,28 +590,5 @@ internal fun VoiceLevelBars(
                     ),
             )
         }
-    }
-}
-
-@Composable
-private fun RecordingProgressBar(
-    progress: Float,
-    active: Boolean,
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(6.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f), WakerPillShape),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth(progress)
-                .height(6.dp)
-                .background(
-                    if (active) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.secondary,
-                    WakerPillShape,
-                ),
-        )
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.icons.outlined.Badge
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
-import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -409,6 +408,7 @@ internal fun VoiceProfileManagementPanel(
     val ownVoices = remember(voiceProfiles) { voiceProfiles.filter { it.isSystem != true } }
     val isLimitReached = ownVoices.size >= MAX_VOICE_PROFILES
     val canCreateVoice = hasPaidVoiceAccess(subscriptionResponse)
+    val canOpenCreateForm = canCreateVoice && !isLimitReached
     val canShareVoice = canShareVoiceWithOthers(subscriptionResponse, familyGroup, authSession)
     val paidVoiceRequiredMessage = stringResource(R.string.voices_paid_required)
 
@@ -520,7 +520,14 @@ internal fun VoiceProfileManagementPanel(
                     applySelectedAudio(audio)
                 } else {
                     selectedAudio = null
-                    localMessage = error
+                    localMessage = if (
+                        audio.durationMillis != null &&
+                        audio.durationMillis < VoiceProfileAudioLimits.MIN_DURATION_MILLIS
+                    ) {
+                        null
+                    } else {
+                        error
+                    }
                 }
             }.onFailure { error ->
                 isRecording = false
@@ -1092,26 +1099,11 @@ internal fun VoiceProfileManagementPanel(
             )
             Button(
                 onClick = {
-                    if (canCreateVoice) {
-                        showCreateForm = true
-                    } else {
-                        localMessage = null
-                        voicePlanGateOpen = true
-                    }
+                    if (canOpenCreateForm) showCreateForm = true
                 },
-                enabled = !voiceProfileBusy && (!canCreateVoice || !isLimitReached),
+                enabled = canOpenCreateForm,
             ) {
-                if (canCreateVoice) {
-                    Text(stringResource(R.string.voices_add))
-                } else {
-                    // 무료 플랜: 텍스트 없이 자물쇠 아이콘만 — '유료 잠금'을 간결하게.
-                    // 보이는 라벨이 없으므로 contentDescription 으로 스크린리더 라벨('잠금')을 단다.
-                    Icon(
-                        imageVector = Icons.Outlined.Lock,
-                        contentDescription = stringResource(R.string.voices_locked),
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
+                Text(stringResource(R.string.voices_add))
             }
         }
 
@@ -1244,7 +1236,6 @@ internal fun VoiceProfileManagementPanel(
         val fileInputLocked = separatingBusy || hasSeparatedSpeakers
         // 1분 미만이면 "다음" 으로 넘어가지 못하게 막는다. 녹음은 selectedAudio 길이,
         // 파일은 실제 업로드되는 crop 구간 길이로 판정(백엔드 MIN_UPLOAD_DURATION_MS 와 동일 기준).
-        // 짧으면 stopRecording/prepareSelectedFile 가 안내 메시지를 이미 띄운다.
         val canSubmitRecord = inputMode == VoiceCaptureMode.Record &&
             (selectedAudio?.durationMillis ?: 0L) >= VoiceProfileAudioLimits.MIN_DURATION_MILLIS
         val canSubmitSingleFile = inputMode == VoiceCaptureMode.File &&
@@ -1329,8 +1320,6 @@ internal fun VoiceProfileManagementPanel(
                                     onSelect = {
                                         if (inputMode != it) {
                                             stopMediaPreview()
-                                            // 이전 모드의 안내(예: "1분 이상 녹음해 주세요")가
-                                            // 새 모드에 남아 헷갈리게 하지 않도록 지운다.
                                             localMessage = null
                                         }
                                         inputMode = it

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.R
-import com.alarmtalk.app.WakerPanelShape
 import com.alarmtalk.app.WakerPillShape
 import com.alarmtalk.app.network.FamilyVoiceProfile
 import com.alarmtalk.app.network.VoiceProfile
@@ -72,15 +71,27 @@ internal fun MixedVoicesSeparateRow(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = WakerPanelShape,
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.38f),
-        border = wakerCardBorder(0.7f),
+        shape = WakerCardShape,
+        color = MaterialTheme.colorScheme.surface,
+        border = wakerCardBorder(),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .background(MaterialTheme.colorScheme.secondaryContainer, WakerTileShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Mic,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(3.dp),
@@ -351,20 +362,49 @@ internal fun SpeakerDraftRow(
 ) {
     val ready = state.status == SpeakerDraftStatus.Ready && state.previewUri != null
     val context = LocalContext.current
-    OutlinedCard {
+    val durationLabel = audioTimeLabel((speaker.endMs - speaker.startMs).coerceAtLeast(0L))
+    OutlinedCard(
+        shape = WakerCardShape,
+        border = wakerCardBorder(if (ready) 1f else 0.58f),
+        colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                .padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .background(
+                        if (ready) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        },
+                        WakerTileShape,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Mic,
+                    contentDescription = null,
+                    tint = if (ready) {
+                        MaterialTheme.colorScheme.onSecondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier.size(22.dp),
+                )
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.voicesr_speaker_draft_index, index + 1),
                     fontWeight = FontWeight.SemiBold,
                 )
-                MutedText(draftStatusLabel(context, state.status, state.errorMessage))
+                MutedText("${draftStatusLabel(context, state.status, state.errorMessage)} · $durationLabel")
             }
             IconButton(
                 onClick = onTogglePlay,

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -731,6 +731,9 @@
     <string name="voices_previous">Back</string>
     <string name="voices_record_done_duration">Recorded · %1$s</string>
     <string name="voices_record_duration_notice">Please record between 1 and 2 minutes.</string>
+    <string name="voices_recording_status_done">Recording complete</string>
+    <string name="voices_recording_status_ready">Ready to record</string>
+    <string name="voices_recording_status_recording">Recording</string>
     <string name="voices_record_tap_to_start">Tap to start recording</string>
     <string name="voices_record_tap_to_stop">Tap to stop recording</string>
     <string name="voices_recording_start_failed">Couldn\'t start recording.</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -731,11 +731,6 @@
     <string name="voices_previous">Back</string>
     <string name="voices_record_done_duration">Recorded · %1$s</string>
     <string name="voices_record_duration_notice">Please record between 1 and 2 minutes.</string>
-    <string name="voices_recording_status_done">Recording complete</string>
-    <string name="voices_recording_status_ready">Ready to record</string>
-    <string name="voices_recording_status_recording">Recording</string>
-    <string name="voices_record_tap_to_start">Tap to start recording</string>
-    <string name="voices_record_tap_to_stop">Tap to stop recording</string>
     <string name="voices_recording_start_failed">Couldn\'t start recording.</string>
     <string name="voices_recording_stop_failed">Recording failed.</string>
     <string name="voices_register">Register</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -740,11 +740,6 @@
     <string name="voices_previous">戻る</string>
     <string name="voices_record_done_duration">録音完了 · %1$s</string>
     <string name="voices_record_duration_notice">1分以上2分以内で録音してください。</string>
-    <string name="voices_recording_status_done">録音完了</string>
-    <string name="voices_recording_status_ready">録音準備</string>
-    <string name="voices_recording_status_recording">録音中</string>
-    <string name="voices_record_tap_to_start">タップして録音開始</string>
-    <string name="voices_record_tap_to_stop">タップして録音終了</string>
     <string name="voices_recording_start_failed">録音を開始できませんでした。</string>
     <string name="voices_recording_stop_failed">録音に失敗しました。</string>
     <string name="voices_register">登録</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -740,6 +740,9 @@
     <string name="voices_previous">戻る</string>
     <string name="voices_record_done_duration">録音完了 · %1$s</string>
     <string name="voices_record_duration_notice">1分以上2分以内で録音してください。</string>
+    <string name="voices_recording_status_done">録音完了</string>
+    <string name="voices_recording_status_ready">録音準備</string>
+    <string name="voices_recording_status_recording">録音中</string>
     <string name="voices_record_tap_to_start">タップして録音開始</string>
     <string name="voices_record_tap_to_stop">タップして録音終了</string>
     <string name="voices_recording_start_failed">録音を開始できませんでした。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -741,11 +741,6 @@
     <string name="voices_previous">이전</string>
     <string name="voices_record_done_duration">녹음 완료 · %1$s</string>
     <string name="voices_record_duration_notice">1분 이상 2분 이하로 녹음해 주세요.</string>
-    <string name="voices_recording_status_done">녹음 완료</string>
-    <string name="voices_recording_status_ready">녹음 준비</string>
-    <string name="voices_recording_status_recording">녹음 중</string>
-    <string name="voices_record_tap_to_start">탭해서 녹음 시작</string>
-    <string name="voices_record_tap_to_stop">탭해서 녹음 종료</string>
     <string name="voices_recording_start_failed">녹음을 시작할 수 없어요.</string>
     <string name="voices_recording_stop_failed">녹음에 실패했어요.</string>
     <string name="voices_register">등록</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -741,6 +741,9 @@
     <string name="voices_previous">이전</string>
     <string name="voices_record_done_duration">녹음 완료 · %1$s</string>
     <string name="voices_record_duration_notice">1분 이상 2분 이하로 녹음해 주세요.</string>
+    <string name="voices_recording_status_done">녹음 완료</string>
+    <string name="voices_recording_status_ready">녹음 준비</string>
+    <string name="voices_recording_status_recording">녹음 중</string>
     <string name="voices_record_tap_to_start">탭해서 녹음 시작</string>
     <string name="voices_record_tap_to_stop">탭해서 녹음 종료</string>
     <string name="voices_recording_start_failed">녹음을 시작할 수 없어요.</string>

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/VoiceInputControlsTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/VoiceInputControlsTest.kt
@@ -1,0 +1,86 @@
+package com.alarmtalk.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoiceInputControlsTest {
+    @Test
+    fun rightHandleDragPastMaxDurationKeepsLeftHandleFixed() {
+        val range = constrainedAudioCropRange(
+            currentStartMillis = 30_000L,
+            currentEndMillis = 150_000L,
+            rawStartMillis = 30_000L,
+            rawEndMillis = 210_000L,
+            durationMillis = 240_000L,
+            minDurationMillis = 60_000L,
+            maxDurationMillis = 120_000L,
+        )
+
+        assertEquals(30_000L, range.startMillis)
+        assertEquals(150_000L, range.endMillis)
+    }
+
+    @Test
+    fun rightHandleDragWithinMaxDurationKeepsLeftHandleFixed() {
+        val range = constrainedAudioCropRange(
+            currentStartMillis = 30_000L,
+            currentEndMillis = 150_000L,
+            rawStartMillis = 30_000L,
+            rawEndMillis = 110_000L,
+            durationMillis = 240_000L,
+            minDurationMillis = 60_000L,
+            maxDurationMillis = 120_000L,
+        )
+
+        assertEquals(30_000L, range.startMillis)
+        assertEquals(110_000L, range.endMillis)
+    }
+
+    @Test
+    fun leftHandleDragPastMaxDurationKeepsRightHandleFixed() {
+        val range = constrainedAudioCropRange(
+            currentStartMillis = 30_000L,
+            currentEndMillis = 150_000L,
+            rawStartMillis = 0L,
+            rawEndMillis = 150_000L,
+            durationMillis = 240_000L,
+            minDurationMillis = 60_000L,
+            maxDurationMillis = 120_000L,
+        )
+
+        assertEquals(30_000L, range.startMillis)
+        assertEquals(150_000L, range.endMillis)
+    }
+
+    @Test
+    fun movingStartClampsToMinimumDurationWithoutMovingEnd() {
+        val range = constrainedAudioCropRange(
+            currentStartMillis = 30_000L,
+            currentEndMillis = 150_000L,
+            rawStartMillis = 140_000L,
+            rawEndMillis = 150_000L,
+            durationMillis = 240_000L,
+            minDurationMillis = 60_000L,
+            maxDurationMillis = 120_000L,
+        )
+
+        assertEquals(90_000L, range.startMillis)
+        assertEquals(150_000L, range.endMillis)
+    }
+
+    @Test
+    fun movingEndClampsToMinimumDurationWithoutMovingStart() {
+        val range = constrainedAudioCropRange(
+            currentStartMillis = 30_000L,
+            currentEndMillis = 150_000L,
+            rawStartMillis = 30_000L,
+            rawEndMillis = 50_000L,
+            durationMillis = 240_000L,
+            minDurationMillis = 60_000L,
+            maxDurationMillis = 120_000L,
+        )
+
+        assertEquals(30_000L, range.startMillis)
+        assertEquals(90_000L, range.endMillis)
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 녹음/파일 업로드 화면 카드 UI 정리
- 파일 업로드 화자 분리 보조 UI 정리
- 크롭 슬라이더 핸들 clamp 로직을 테스트 가능한 함수로 분리
- 오른쪽 핸들 이동 시 왼쪽 핸들이 따라 움직이지 않도록 회귀 테스트 추가

## 검증
- git diff --check
- ./gradlew :app:compileDevDebugKotlin :app:testDevDebugUnitTest
- npm run test --workspace=backend -- dynamic-prompt-settings.test.ts family-group.test.ts
- npm run typecheck --workspace=backend
- ./gradlew :app:installDevDebug