### PR TITLE
목소리 탭: 기본 목소리 선택을 바텀시트로 전환

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/WakerModal.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/WakerModal.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,6 +41,10 @@ import kotlinx.coroutines.launch
 // 앱 안의 선택 UI(테마 모드, 공휴일 국가, 가족 수신자 …)는 전부 이
 // WakerSelectionSheet + WakerSheetOptionRow 조합을 쓴다. 다이얼로그·시트가
 // 화면마다 다른 헤더/버튼/모서리를 갖지 않도록 하는 단일 출처.
+//
+// 기본 동작은 "탭 = 선택 + dismiss()" 지만, 미리듣기가 딸린 선택(기본 목소리)은
+// 여러 옵션을 이어 들어볼 수 있게 탭해도 시트를 닫지 않는다 — 재생 표시는
+// trailing 슬롯에 넣고, 닫기는 드래그/스크림에 맡긴다.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -69,8 +75,10 @@ internal fun WakerSelectionSheet(
         dragHandle = { WakerSheetDragHandle() },
     ) {
         Column(
+            // 옵션 목록이 시트 최대 높이를 넘으면(서버가 주는 동적 목록) 스크롤로 닿게 한다.
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .navigationBarsPadding()
                 .padding(start = 20.dp, end = 20.dp, bottom = 20.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -114,8 +122,9 @@ private fun WakerSheetDragHandle() {
 }
 
 /**
- * 선택형 시트의 공통 옵션 행: [아이콘 배지] 제목/설명 … 선택 표시.
+ * 선택형 시트의 공통 옵션 행: [아이콘 배지] 제목/설명 … [trailing] 선택 표시.
  * 선택 표시는 체크 원(선택) / 빈 링(미선택)으로 통일한다.
+ * trailing 은 선택 표시 바로 앞의 상태 슬롯 — 기본 목소리 시트의 재생 이퀄라이저 등.
  */
 @Composable
 internal fun WakerSheetOptionRow(
@@ -126,6 +135,7 @@ internal fun WakerSheetOptionRow(
     description: String? = null,
     icon: ImageVector? = null,
     leading: (@Composable () -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
 ) {
     val scheme = MaterialTheme.colorScheme
     Surface(
@@ -178,6 +188,7 @@ internal fun WakerSheetOptionRow(
                     )
                 }
             }
+            trailing?.invoke()
             if (selected) {
                 Icon(
                     imageVector = Icons.Filled.CheckCircle,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Badge
 import androidx.compose.material.icons.outlined.Close
@@ -397,8 +398,8 @@ internal fun VoiceProfileManagementPanel(
     var filePreviewPlaying by remember { mutableStateOf(false) }
     // 방금 녹음한 클립의 미리듣기 재생 상태 (녹음 완료 배지의 ▶ 버튼).
     var recordPreviewPlaying by remember { mutableStateOf(false) }
-    // 기본 제공 목소리는 정보성이라 평소엔 접어두고 헤더만 보여준다.
-    var systemVoicesExpanded by remember { mutableStateOf(false) }
+    // 기본 목소리 선택 시트 — 시트 안 탭 = 선택 + 인사말 미리듣기(닫기는 드래그/스크림).
+    var defaultVoiceSheetOpen by remember { mutableStateOf(false) }
     // 지금 인사말 샘플을 재생 중인 기본 목소리 id (재생 아이콘 토글용).
     var playingGreetingVoiceId by remember { mutableStateOf<String?>(null) }
     var greetingPreviewRequestId by remember { mutableIntStateOf(0) }
@@ -1134,50 +1135,42 @@ internal fun VoiceProfileManagementPanel(
 
         if (systemVoices.isNotEmpty()) {
             Row(
-                // 확장/축소 토글 — 눌림 리플(indication) 없이 조용히 동작.
+                // 토스식 [제목 … 값 + 셰브론] 행 — 탭하면 기본 목소리 선택 시트를 연다.
+                // 눌림 리플(indication) 없이 조용히 동작.
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
-                    ) { systemVoicesExpanded = !systemVoicesExpanded }
+                    ) {
+                        // 이전 화면 흐름의 안내가 시트 안에 엉뚱하게 보이지 않게 비우고 연다.
+                        localMessage = null
+                        defaultVoiceSheetOpen = true
+                    }
                     .padding(vertical = 4.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                val defaultVoiceName = systemVoices.firstOrNull { it.id == defaultVoiceId }?.name
                 Text(
-                    // 기본 목소리가 정해져 있으면 그 이름을, 아니면 종 수를 보여준다.
-                    text = if (defaultVoiceName != null) {
-                        stringResource(R.string.voices_default_voice_header, defaultVoiceName)
-                    } else {
-                        stringResource(R.string.voices_system_voices_count, systemVoices.size)
-                    },
+                    text = stringResource(R.string.voices_default_voice_row_title),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
                 )
-                Icon(
-                    imageVector = if (systemVoicesExpanded) {
-                        Icons.Outlined.KeyboardArrowUp
-                    } else {
-                        Icons.Outlined.KeyboardArrowDown
-                    },
-                    contentDescription = if (systemVoicesExpanded) {
-                        stringResource(R.string.voices_collapse)
-                    } else {
-                        stringResource(R.string.voices_expand)
-                    },
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (systemVoicesExpanded) {
-                systemVoices.forEach { profile ->
-                    SystemVoiceProfileRow(
-                        profile = profile,
-                        playing = playingGreetingVoiceId == profile.id,
-                        onPlay = { playGreeting(profile) },
-                        selected = profile.id == defaultVoiceId,
-                        onSelect = { onSetDefaultVoice(profile.id) },
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        // 정해진 기본 목소리 이름이 값. 아직 없으면 '선택하기'로 행동을 유도한다.
+                        text = systemVoices.firstOrNull { it.id == defaultVoiceId }?.name
+                            ?: stringResource(R.string.voices_default_voice_choose),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -1210,6 +1203,48 @@ internal fun VoiceProfileManagementPanel(
             },
             onDismiss = { voicePlanGateOpen = false },
         )
+    }
+
+    // 시트가 열린 채 시스템 보이스 목록이 비면(세션 초기화·재로딩) 재생을 멈추고 시트를 정리한다.
+    LaunchedEffect(systemVoices.isEmpty()) {
+        if (systemVoices.isEmpty() && defaultVoiceSheetOpen) {
+            stopMediaPreview()
+            defaultVoiceSheetOpen = false
+        }
+    }
+
+    if (defaultVoiceSheetOpen && systemVoices.isNotEmpty()) {
+        // 다른 선택 시트와 달리 탭해도 닫지 않는다 — 탭 = 선택 + 인사말 미리듣기(재탭 시 정지)라
+        // 여러 목소리를 이어 들어보며 고르는 흐름. 닫기는 드래그/스크림.
+        WakerSelectionSheet(
+            title = stringResource(R.string.voices_default_voice_row_title),
+            subtitle = stringResource(R.string.voices_default_voice_sheet_subtitle),
+            onDismiss = {
+                stopMediaPreview()
+                defaultVoiceSheetOpen = false
+            },
+        ) { _ ->
+            systemVoices.forEach { profile ->
+                WakerSheetOptionRow(
+                    title = profile.name,
+                    selected = profile.id == defaultVoiceId,
+                    onClick = {
+                        onSetDefaultVoice(profile.id)
+                        playGreeting(profile)
+                    },
+                    trailing = if (playingGreetingVoiceId == profile.id) {
+                        { PlayingEqualizer() }
+                    } else {
+                        null
+                    },
+                )
+            }
+            // 미리듣기 준비중/실패 안내 — 패널 본문의 MutedText 는 시트 스크림에 가려지므로
+            // 시트가 열려 있는 동안엔 여기서 보여준다(열 때 localMessage 를 비워 회귀 방지).
+            if (localMessage != null) {
+                MutedText(localMessage.orEmpty())
+            }
+        }
     }
 
     if (showCreateForm && !isLimitReached && canCreateVoice) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -423,15 +423,47 @@ internal fun VoiceProfileManagementPanel(
         playingGreetingVoiceId = null
     }
 
+    fun greetingClipFor(profile: VoiceProfile) = stockClips.firstOrNull {
+        it.voiceProfileId == profile.id && it.category == STOCK_GREETING_CATEGORY
+    } ?: stockClips.firstOrNull { it.voiceProfileId == profile.id }
+
+    // greeting 클립을 캐시에서 찾고, 없으면 내려받아 캐시한다(탭 재생·시트 프리페치 공용).
+    suspend fun ensureGreetingCached(clip: com.alarmtalk.app.network.StockClip): CachedAlarmAudio {
+        val cacheKey = "greeting_${clip.messageId}"
+        withContext(Dispatchers.IO) { audioStore.getCachedAudio(cacheKey) }?.let { return it }
+        val response = onDownloadStockAudio(clip.messageId)
+        return withContext(Dispatchers.IO) {
+            // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
+            val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
+            audioStore.cacheGeneratedAudio(
+                bytes = bytes,
+                format = response.audioFormat,
+                rawAudioUri = response.audioUrl,
+                displayName = cacheKey,
+                cacheKey = cacheKey,
+                messageId = clip.messageId,
+            )
+        }
+    }
+
+    // 기본 목소리 시트를 여는 순간 인사말 클립을 미리 받아 둔다 — 행 탭 시 지연 없이 재생되게.
+    // 실패는 조용히 넘긴다(탭 시 재시도 경로가 그대로 있음).
+    fun prefetchGreetingPreviews() {
+        scope.launch {
+            systemVoices.forEach { profile ->
+                val clip = greetingClipFor(profile) ?: return@forEach
+                runCatching { ensureGreetingCached(clip) }
+            }
+        }
+    }
+
     // 기본 목소리 행을 누르면 그 목소리의 인사말 샘플(greeting 스톡 클립)을 들려준다.
     fun playGreeting(profile: VoiceProfile) {
         if (playingGreetingVoiceId == profile.id) {
             stopMediaPreview()
             return
         }
-        val clip = stockClips.firstOrNull {
-            it.voiceProfileId == profile.id && it.category == STOCK_GREETING_CATEGORY
-        } ?: stockClips.firstOrNull { it.voiceProfileId == profile.id }
+        val clip = greetingClipFor(profile)
         if (clip == null) {
             localMessage = context.getString(R.string.voices_greeting_preview_preparing)
             return
@@ -442,19 +474,7 @@ internal fun VoiceProfileManagementPanel(
             stopMediaPreview(invalidateGreetingPreview = false)
             playingGreetingVoiceId = profile.id
             runCatching {
-                val response = onDownloadStockAudio(clip.messageId)
-                val cached = withContext(Dispatchers.IO) {
-                    // base64 디코딩도 메인 스레드가 아닌 IO 디스패처에서 수행한다.
-                    val bytes = Base64.decode(response.audioBase64, Base64.DEFAULT)
-                    audioStore.cacheGeneratedAudio(
-                        bytes = bytes,
-                        format = response.audioFormat,
-                        rawAudioUri = response.audioUrl,
-                        displayName = "greeting_${clip.messageId}",
-                        cacheKey = "greeting_${clip.messageId}",
-                        messageId = clip.messageId,
-                    )
-                }
+                val cached = ensureGreetingCached(clip)
                 val player = MediaPlayer.create(context, Uri.parse(cached.localAudioUri))
                     ?: error("Failed to create greeting preview player.")
                 if (greetingPreviewRequestId != requestId) {
@@ -1145,6 +1165,7 @@ internal fun VoiceProfileManagementPanel(
                     ) {
                         // 이전 화면 흐름의 안내가 시트 안에 엉뚱하게 보이지 않게 비우고 연다.
                         localMessage = null
+                        prefetchGreetingPreviews()
                         defaultVoiceSheetOpen = true
                     }
                     .padding(vertical = 4.dp),
@@ -1218,7 +1239,6 @@ internal fun VoiceProfileManagementPanel(
         // 여러 목소리를 이어 들어보며 고르는 흐름. 닫기는 드래그/스크림.
         WakerSelectionSheet(
             title = stringResource(R.string.voices_default_voice_row_title),
-            subtitle = stringResource(R.string.voices_default_voice_sheet_subtitle),
             onDismiss = {
                 stopMediaPreview()
                 defaultVoiceSheetOpen = false

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileRowComponents.kt
@@ -581,61 +581,12 @@ internal fun VoiceSharedBadge() {
     }
 }
 
-/** 시스템 제공(스톡) 보이스 행 — 수정/삭제/공유 액션 없이 정보만 보여준다. */
+/**
+ * 인사말 미리듣기 재생 중임을 나타내는 작은 이퀄라이저 애니메이션.
+ * 기본 목소리 선택 시트(VoiceProfileManagementPanel)의 옵션 행 trailing 에 쓰인다.
+ */
 @Composable
-internal fun SystemVoiceProfileRow(
-    profile: VoiceProfile,
-    playing: Boolean,
-    onPlay: () -> Unit,
-    selected: Boolean = false,
-    onSelect: () -> Unit = {},
-) {
-    // 행 전체 탭 = 기본 목소리로 선택 + 인사말 자동 재생(재탭 시 정지). 별도 ▶ 버튼 없음.
-    OutlinedCard(
-        onClick = {
-            onSelect()
-            onPlay()
-        },
-        shape = WakerCardShape,
-        border = wakerCardBorder(),
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = if (selected) {
-                MaterialTheme.colorScheme.secondaryContainer
-            } else {
-                MaterialTheme.colorScheme.surface
-            },
-        ),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            // 모든 행이 같은 마이크 배지를 반복해 정보가 없었음 — 이름만 보여준다.
-            Text(
-                text = profile.name,
-                fontWeight = FontWeight.SemiBold,
-                color = if (selected) {
-                    MaterialTheme.colorScheme.onSecondaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurface
-                },
-                modifier = Modifier.weight(1f),
-            )
-            // 재생 중이면 이퀄라이저로 '재생 중'을 알린다(정지는 행 재탭).
-            if (playing) {
-                PlayingEqualizer()
-            }
-            RadioButton(selected = selected, onClick = null)
-        }
-    }
-}
-
-/** 인사말 미리듣기 재생 중임을 나타내는 작은 이퀄라이저 애니메이션. */
-@Composable
-private fun PlayingEqualizer() {
+internal fun PlayingEqualizer() {
     val transition = rememberInfiniteTransition(label = "voicePlaying")
     val barColor = MaterialTheme.colorScheme.primary
     Row(

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -764,8 +764,9 @@
     <string name="voices_step_indicator">%1$d / 3 · %2$s</string>
     <string name="voices_step_sharing">Sharing settings</string>
     <string name="voices_step_source">Prepare audio</string>
-    <string name="voices_system_voices_count">%1$d default voices</string>
-    <string name="voices_default_voice_header">Default voice · %1$s</string>
+    <string name="voices_default_voice_choose">Choose</string>
+    <string name="voices_default_voice_row_title">Default voice</string>
+    <string name="voices_default_voice_sheet_subtitle">Tap a voice to preview its greeting.</string>
     <string name="voices_unsupported_audio_format">This audio format isn\'t supported.</string>
     <string name="voices_upload_change_hint">Tap to choose a different file.</string>
     <string name="voices_upload_file_or_video">Upload a file or video</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -766,7 +766,6 @@
     <string name="voices_step_source">Prepare audio</string>
     <string name="voices_default_voice_choose">Choose</string>
     <string name="voices_default_voice_row_title">Default voice</string>
-    <string name="voices_default_voice_sheet_subtitle">Tap a voice to preview its greeting.</string>
     <string name="voices_unsupported_audio_format">This audio format isn\'t supported.</string>
     <string name="voices_upload_change_hint">Tap to choose a different file.</string>
     <string name="voices_upload_file_or_video">Upload a file or video</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -775,7 +775,6 @@
     <string name="voices_step_source">音声の準備</string>
     <string name="voices_default_voice_choose">選ぶ</string>
     <string name="voices_default_voice_row_title">基本の声</string>
-    <string name="voices_default_voice_sheet_subtitle">声をタップすると挨拶を試聴できます。</string>
     <string name="voices_unsupported_audio_format">対応していない音声形式です。</string>
     <string name="voices_upload_change_hint">タップして別のファイルを選べます。</string>
     <string name="voices_upload_file_or_video">ファイルまたは動画をアップロード</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -773,8 +773,9 @@
     <string name="voices_step_indicator">%1$d / 3 · %2$s</string>
     <string name="voices_step_sharing">共有設定</string>
     <string name="voices_step_source">音声の準備</string>
-    <string name="voices_system_voices_count">基本の声 %1$d種類</string>
-    <string name="voices_default_voice_header">基本の声・%1$s</string>
+    <string name="voices_default_voice_choose">選ぶ</string>
+    <string name="voices_default_voice_row_title">基本の声</string>
+    <string name="voices_default_voice_sheet_subtitle">声をタップすると挨拶を試聴できます。</string>
     <string name="voices_unsupported_audio_format">対応していない音声形式です。</string>
     <string name="voices_upload_change_hint">タップして別のファイルを選べます。</string>
     <string name="voices_upload_file_or_video">ファイルまたは動画をアップロード</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -774,8 +774,9 @@
     <string name="voices_step_indicator">%1$d / 3 · %2$s</string>
     <string name="voices_step_sharing">공유 설정</string>
     <string name="voices_step_source">음성 준비</string>
-    <string name="voices_system_voices_count">기본 목소리 %1$d종</string>
-    <string name="voices_default_voice_header">기본 목소리 · %1$s</string>
+    <string name="voices_default_voice_choose">선택하기</string>
+    <string name="voices_default_voice_row_title">기본 목소리</string>
+    <string name="voices_default_voice_sheet_subtitle">목소리를 누르면 인사말을 미리 들을 수 있어요.</string>
     <string name="voices_unsupported_audio_format">지원하지 않는 오디오 형식이에요.</string>
     <string name="voices_upload_change_hint">다른 파일을 선택하려면 탭하세요.</string>
     <string name="voices_upload_file_or_video">파일 또는 영상 업로드</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -776,7 +776,6 @@
     <string name="voices_step_source">음성 준비</string>
     <string name="voices_default_voice_choose">선택하기</string>
     <string name="voices_default_voice_row_title">기본 목소리</string>
-    <string name="voices_default_voice_sheet_subtitle">목소리를 누르면 인사말을 미리 들을 수 있어요.</string>
     <string name="voices_unsupported_audio_format">지원하지 않는 오디오 형식이에요.</string>
     <string name="voices_upload_change_hint">다른 파일을 선택하려면 탭하세요.</string>
     <string name="voices_upload_file_or_video">파일 또는 영상 업로드</string>

--- a/apps/ios-native/AlarmTalk/Views/Voices/VoiceProfileManagementPanel.swift
+++ b/apps/ios-native/AlarmTalk/Views/Voices/VoiceProfileManagementPanel.swift
@@ -39,8 +39,8 @@ struct VoiceProfileManagementPanel: View {
     /// Android `SharedVoiceViewerInfoDialog` (VoiceProfileManagementPanel.kt:1543) 와 동일한 의도.
     @State private var sharedViewerInfoTarget: FamilyVoiceProfile?
 
-    /// 시스템(기본) 목소리 섹션 접이식 상태.
-    @State private var systemVoicesExpanded: Bool = false
+    /// 기본 목소리 선택 시트 노출 상태 (Android defaultVoiceSheetOpen 미러).
+    @State private var defaultVoiceSheetOpen: Bool = false
 
     /// 시스템(스톡) 목소리 = 무료에서도 쓰는 기본 목소리. 내 목소리/공유 목소리와 분리해 노출.
     private var systemVoices: [VoiceProfile] {
@@ -317,31 +317,24 @@ struct VoiceProfileManagementPanel: View {
     @ViewBuilder
     private var systemVoicesSection: some View {
         VStack(alignment: .leading, spacing: 12) {
+            // 토스식 [제목 … 값 + 셰브론] 행 — 탭하면 기본 목소리 선택 시트를 연다.
             Button {
-                withAnimation(.easeInOut(duration: 0.18)) { systemVoicesExpanded.toggle() }
+                defaultVoiceSheetOpen = true
             } label: {
-                HStack {
-                    // 기본이 정해졌으면 그 이름을, 아니면 종 수를 보여준다.
-                    Text(defaultVoiceName.map { "기본 목소리 · \($0)" } ?? "기본 목소리 \(systemVoices.count)종")
+                HStack(spacing: 4) {
+                    Text("기본 목소리")
                         .font(.subheadline.weight(.semibold))
                     Spacer()
-                    Image(systemName: systemVoicesExpanded ? "chevron.up" : "chevron.down")
+                    // 정해진 기본 목소리 이름이 값. 아직 없으면 '선택하기'로 행동을 유도한다.
+                    Text(defaultVoiceName ?? "선택하기")
+                        .font(.subheadline)
+                        .foregroundStyle(AlarmTalkTheme.textSecondary)
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
                         .foregroundStyle(AlarmTalkTheme.textSecondary)
                 }
             }
             .buttonStyle(.plain)
-
-            if systemVoicesExpanded {
-                ForEach(systemVoices) { profile in
-                    SystemVoiceProfileRow(
-                        profile: profile,
-                        selected: profile.id == voice.defaultVoiceId,
-                        playing: voice.previewingGreetingVoiceId == profile.id,
-                        onSelect: { voice.setDefaultVoice(profile.id) },
-                        onPlay: { Task { await voice.previewGreeting(voiceId: profile.id, session: auth.session) } }
-                    )
-                }
-            }
 
             // 기본 목소리가 정해졌으면 호칭을 여기서 수정(펼치지 않아도 보임). 입력 즉시 저장.
             if voice.defaultVoiceId != nil {
@@ -358,6 +351,17 @@ struct VoiceProfileManagementPanel: View {
                 .padding(.top, 4)
             }
         }
+        .sheet(isPresented: $defaultVoiceSheetOpen, onDismiss: { voice.stopGreetingPreview() }) {
+            DefaultVoiceSelectionSheet(
+                voices: systemVoices,
+                selectedVoiceId: voice.defaultVoiceId,
+                playingVoiceId: voice.previewingGreetingVoiceId,
+                onTap: { profile in
+                    voice.setDefaultVoice(profile.id)
+                    Task { await voice.previewGreeting(voiceId: profile.id, session: auth.session) }
+                }
+            )
+        }
     }
 
     private var canShareVoice: Bool {
@@ -371,57 +375,67 @@ struct VoiceProfileManagementPanel: View {
     }
 }
 
-/// 시스템(스톡) 목소리 행 — 카드 탭 = 기본 목소리로 선택, ▶ = 인사말 미리듣기, 라디오 = 선택 표시.
-/// Android `SystemVoiceProfileRow` 미러.
-private struct SystemVoiceProfileRow: View {
-    let profile: VoiceProfile
-    let selected: Bool
-    let playing: Bool
-    let onSelect: () -> Void
-    let onPlay: () -> Void
+/// 기본 목소리 선택 시트 — 탭 = 선택 + 인사말 미리듣기(재탭 시 정지), 탭해도 시트를 닫지 않는다.
+/// 여러 목소리를 이어 들어보며 고르는 흐름이라 닫기는 스와이프/배경 탭에 맡긴다.
+/// Android `WakerSelectionSheet` 기본 목소리 변형 미러.
+private struct DefaultVoiceSelectionSheet: View {
+    let voices: [VoiceProfile]
+    let selectedVoiceId: String?
+    let playingVoiceId: String?
+    let onTap: (VoiceProfile) -> Void
 
     var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: 8) {
-                ZStack {
-                    Circle().fill(AlarmTalkTheme.primary.opacity(0.14))
-                    Image(systemName: "mic")
-                        .foregroundStyle(AlarmTalkTheme.primary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("기본 목소리")
+                        .font(.title3.weight(.bold))
+                    Text("목소리를 누르면 인사말을 미리 들을 수 있어요.")
+                        .font(.footnote)
+                        .foregroundStyle(AlarmTalkTheme.textSecondary)
                 }
-                .frame(width: 42, height: 42)
-
-                Text(profile.name)
-                    .font(.subheadline.weight(.semibold))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Button(action: onPlay) {
-                    Image(systemName: playing ? "stop.fill" : "play.fill")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(AlarmTalkTheme.primary)
-                        .frame(width: 40, height: 40)
-                }
-                .buttonStyle(.plain)
-
-                ZStack {
-                    Circle()
-                        .strokeBorder(selected ? Color.clear : AlarmTalkTheme.outline, lineWidth: 2)
-                        .background(Circle().fill(selected ? AlarmTalkTheme.primary : Color.clear))
-                        .frame(width: 18, height: 18)
-                    if selected {
-                        Circle().fill(Color.white).frame(width: 7, height: 7)
+                ForEach(voices) { profile in
+                    let selected = profile.id == selectedVoiceId
+                    Button {
+                        onTap(profile)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Text(profile.name)
+                                .font(.subheadline.weight(.semibold))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            // 재생 중 표시 (Android PlayingEqualizer 대응). 정지는 행 재탭.
+                            if playingVoiceId == profile.id {
+                                Image(systemName: "waveform")
+                                    .foregroundStyle(AlarmTalkTheme.primary)
+                            }
+                            if selected {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(AlarmTalkTheme.primary)
+                            } else {
+                                Circle()
+                                    .strokeBorder(AlarmTalkTheme.outline, lineWidth: 1.5)
+                                    .frame(width: 20, height: 20)
+                            }
+                        }
+                        .padding(EdgeInsets(top: 13, leading: 14, bottom: 13, trailing: 14))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(selected ? AlarmTalkTheme.primary.opacity(0.10) : AlarmTalkTheme.surfaceVariant.opacity(0.34))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .stroke(
+                                    selected ? AlarmTalkTheme.primary.opacity(0.5) : AlarmTalkTheme.outline.opacity(0.4),
+                                    lineWidth: 1
+                                )
+                        )
                     }
+                    .buttonStyle(.plain)
                 }
-                .frame(width: 22, height: 22)
             }
-            .padding(EdgeInsets(top: 8, leading: 14, bottom: 8, trailing: 6))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(selected ? AlarmTalkTheme.primary.opacity(0.10) : AlarmTalkTheme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(AlarmTalkTheme.outline.opacity(0.4), lineWidth: 1)
-            )
+            .padding(20)
         }
-        .buttonStyle(.plain)
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
     }
 }

--- a/apps/ios-native/AlarmTalk/Views/Voices/VoiceProfileManagementPanel.swift
+++ b/apps/ios-native/AlarmTalk/Views/Voices/VoiceProfileManagementPanel.swift
@@ -387,13 +387,8 @@ private struct DefaultVoiceSelectionSheet: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("기본 목소리")
-                        .font(.title3.weight(.bold))
-                    Text("목소리를 누르면 인사말을 미리 들을 수 있어요.")
-                        .font(.footnote)
-                        .foregroundStyle(AlarmTalkTheme.textSecondary)
-                }
+                Text("기본 목소리")
+                    .font(.title3.weight(.bold))
                 ForEach(voices) { profile in
                     let selected = profile.id == selectedVoiceId
                     Button {

--- a/apps/ios-native/AlarmTalk/VoiceStudioViewModel.swift
+++ b/apps/ios-native/AlarmTalk/VoiceStudioViewModel.swift
@@ -184,6 +184,14 @@ final class VoiceStudioViewModel: ObservableObject {
         }
     }
 
+    /// 인사말 미리듣기만 정지한다 — 기본 목소리 선택 시트가 닫힐 때 호출.
+    /// Android VoiceProfileManagementPanel.stopMediaPreview 의 greeting 부분 미러.
+    func stopGreetingPreview() {
+        greetingPreviewRequestId += 1
+        previewPlayer.stop()
+        previewingGreetingVoiceId = nil
+    }
+
     var selectedListenerTitle: String? {
         if let listener = selectedProfile?.listenerTitle, let trimmed = (listener).nilIfBlank {
             return trimmed


### PR DESCRIPTION
## 무엇을

목소리 탭의 기본 목소리 영역을 접이식 인라인 섹션(헤더 + 라디오 행)에서 **토스식 한 줄 행 + 바텀시트**로 전환.

- 행: `기본 목소리 … {이름} >` (이름 없으면 `선택하기`) — 탭하면 시트
- 시트: `WakerSelectionSheet` 재사용. **탭 = 선택 + 인사말 미리듣기(재탭 정지)** 라 다른 선택 시트와 달리 탭해도 닫지 않음(여러 목소리를 이어 들어보는 흐름). 닫기는 드래그/스크림, 닫힐 때 재생 정지. 이 예외는 WakerModal.kt 헤더 주석에 명문화.
- `WakerSheetOptionRow` 에 `trailing` 슬롯 추가 → 재생 중 이퀄라이저 표시
- iOS 미러 동일 UX 포팅(미운영·빌드 미검증, 릴리스 전 Mac 검증 대상)

## 코드리뷰(워크플로) 반영 사항

- **[CONFIRMED] 미리듣기 실패/준비중 안내가 시트 스크림에 가려지는 회귀** → 시트 안에서도 `localMessage` 노출 + 시트 열 때 이전 안내 비움
- **[CONFIRMED] iOS 미러(SystemVoiceProfileRow) 좌초** → 동일 UX 포팅으로 해소
- **[PLAUSIBLE] 시트 열린 채 시스템 보이스 목록이 비면 빈 시트** → 가드 + 재생 정지·시트 정리
- **[PLAUSIBLE] 시트 콘텐츠 스크롤 불가(동적 목록 클리핑)** → `WakerSelectionSheet` 에 `verticalScroll` (전 호출부 공통 수혜)
- 반영 안 함: 토스식 행 중복(SettingsRow/MenuTabRow와 3벌) — 이 행은 목소리 탭 섹션 헤더 타이포(titleSmall)와 맞춰야 해서 재사용 시 오히려 어긋남. 공용화는 별도 정리로.
- 반영 안 함: stale defaultVoiceId 시 `선택하기` 폴백 — id가 해석 안 되면 사실상 미선택이라 카피가 틀리지 않다고 판단.

## 확인

- `assembleDevDebug` 빌드 통과, S23 Ultra 설치 완료(폰에서 확인 가능)
- 문자열 ko/en/ja 3개 로케일 동기화, 제거 문자열 잔여 참조 없음