### PR TITLE
가족 수신 알람 인앱 알림

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -747,8 +747,18 @@ internal fun MainViewModel.syncNow() {
             push to pull
         }.onSuccess { (push, pull) ->
             val failed = push.failed + pull.failed
-            if (failed > 0) {
-                message = alarmSyncFailureMessage(pushFailed = push.failed, pullFailed = pull.failed)
+            val app = getApplication<android.app.Application>()
+            when {
+                failed > 0 ->
+                    message = alarmSyncFailureMessage(pushFailed = push.failed, pullFailed = pull.failed)
+                // 앱이 열려 있을 때 새로 받은 상대 알람을 인앱으로도 알린다(시스템 알림에만 의존하지 않음).
+                // syncNow 는 알람 탭 진입 시 자동 실행되므로, 사용자가 보던 메시지를 덮지 않게 비어 있을 때만.
+                pull.imported > 0 && message.isNullOrBlank() ->
+                    message = app.resources.getQuantityString(
+                        R.plurals.msg_received_alarm_arrived,
+                        pull.imported,
+                        pull.imported,
+                    )
             }
         }.onFailure { error ->
             AlarmTalkLog.reportError("Backend sync failed", error)

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -509,6 +509,10 @@
     <string name="msg_remove_member_failed">Couldn\'t remove the member.</string>
     <string name="msg_remove_member_login_required">Please log in first to remove a member.</string>
     <string name="msg_sync_failed">A temporary error kept us from updating your alarm info. We\'ll retry automatically in a moment.</string>
+    <plurals name="msg_received_alarm_arrived">
+        <item quantity="one">A new alarm set for you by your family arrived.</item>
+        <item quantity="other">%1$d new alarms set for you by your family arrived.</item>
+    </plurals>
     <string name="msg_sync_generic_failed">Something went wrong for a moment. We\'ll retry automatically.</string>
     <string name="msg_sync_login_required">Please log in first to sync.</string>
     <string name="msg_sync_pull_partial_failed">Some received alarms haven\'t loaded yet. We\'ll retry automatically in a moment.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -518,6 +518,9 @@
     <string name="msg_remove_member_failed">メンバーを退出させられませんでした。</string>
     <string name="msg_remove_member_login_required">メンバーを退出させるには、まずログインしてください。</string>
     <string name="msg_sync_failed">一時的なエラーでアラーム情報を更新できませんでした。しばらくして自動で再試行します。</string>
+    <plurals name="msg_received_alarm_arrived">
+        <item quantity="other">相手が設定したアラーム%1$d件が届きました。</item>
+    </plurals>
     <string name="msg_sync_generic_failed">一時的なエラーが発生しました。自動で再試行します。</string>
     <string name="msg_sync_login_required">同期するには、まずログインしてください。</string>
     <string name="msg_sync_pull_partial_failed">受け取ったアラームの一部がまだ読み込めていません。しばらくして自動で再試行します。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -521,6 +521,9 @@
     <string name="msg_remove_member_failed">멤버를 내보내지 못했어요</string>
     <string name="msg_remove_member_login_required">멤버를 내보내려면 먼저 로그인해 주세요</string>
     <string name="msg_sync_failed">일시적인 오류로 알람 정보를 주고받지 못했어요. 잠시 후 자동으로 다시 시도해요.</string>
+    <plurals name="msg_received_alarm_arrived">
+        <item quantity="other">상대가 맞춰준 알람 %1$d개가 도착했어요.</item>
+    </plurals>
     <string name="msg_sync_generic_failed">일시적인 오류가 있었어요. 잠시 후 자동으로 다시 시도해요.</string>
     <string name="msg_sync_login_required">동기화하려면 먼저 로그인해 주세요</string>
     <string name="msg_sync_pull_partial_failed">받은 알람 일부를 아직 불러오지 못했어요. 잠시 후 자동으로 다시 시도해요.</string>


### PR DESCRIPTION
상대가 맞춰준 알람이 새로 도착하면(syncNow 의 pull.imported>0) 시스템 알림에만 의존하지 않고 **인앱 메시지**로도 알린다.

## 변경
- syncNow 성공 시 새 수신 알람이 있으면 인앱 안내. 자동 탭 동기화가 사용자가 보던 스낵바를 덮지 않도록 `message` 가 비어 있을 때만 표시.
- 개수는 `plurals`(getQuantityString)로 표기(ko/en/ja).

## 배경
- **배달갭은 PR #536 배포로 해소**(dev 백엔드 stale 이 원인). 앱을 열어 알람 탭에 들어가면 기존 syncNow 가 즉시 동기화(15분 주기는 백그라운드 폴백).
- 앱 전역 포그라운드 즉시 동기화(워커 트리거)·expedited 는 코드리뷰에서 syncNow 레이스·minSdk26 파손(getForegroundInfo)·배터리 이슈가 확인돼 이번엔 제외. 별도로 안전 재설계 예정.

## 검증
- 클라 클린 빌드 통과. 실기기: 배포 후 가족 알람 배달·즉시 동기화(~8s) 확인.