### PR TITLE
문구 태그 누출 방어 강화 (deriveAlarmDisplayText 전면 스트립)

### DIFF
--- a/packages/backend/src/lib/vertex-translate.ts
+++ b/packages/backend/src/lib/vertex-translate.ts
@@ -1502,21 +1502,21 @@ export function normalizeAlarmTextWithoutTags(text: string): string {
     .trim();
 }
 
-// 표시/저장 문구(messageText)용: 우리가 자동으로 맨 앞에 붙인 delivery 태그만 벗기고,
+// 표시/저장 문구(messageText)용: 우리가 자동으로 붙인 delivery 태그는 제거하되,
 // 사용자가 직접 입력한 대괄호는 그대로 보존한다.
 //
 // 근거: 자동 태그는 prepareAlarmTextWithVertex 에서 '사용자가 대괄호를 하나도 안 쳤을 때만'
-// (shouldTag = autoTag && !TAG_RE.test) 맨 앞에 '[tag] ' 형태로 붙는다. 그러므로
-// - originalText 에 대괄호가 있으면: 자동 태그가 아니므로 합성 텍스트를 그대로 쓴다
-//   ('[after lunch]'·'오늘도 [happy]'·'[calm]'만 입력해도 문구가 안 지워짐).
-// - 없으면: 맨 앞 대괄호 1개(=자동/모델이 붙인 delivery 태그)만 제거한다. 승인 여부와 무관하게
-//   맨 앞 것만 벗기므로 번역 경로에서 모델이 비승인 태그를 붙여도 화면엔 새지 않고,
-//   맨 앞 1개만 건드려 인접 태그로 인한 이중 공백도 생기지 않는다.
+// (shouldTag = autoTag && !TAG_RE.test) 붙는다. 그러므로
+// - originalText 에 대괄호가 있으면: 자동 태그가 아니므로 합성 텍스트를 그대로 쓴다(트림만).
+//   '[after lunch]'·'오늘도 [happy]'·'[calm]'만 입력해도 문구가 안 지워진다.
+// - 없으면: 합성 텍스트 안의 대괄호는 전부 자동/모델이 붙인 delivery 태그이므로 위치·개수와
+//   무관하게 모두 제거하고 내부 공백을 한 칸으로 정리한다. 모델이 지시를 어기고 태그를 2개
+//   붙이거나 문장 중간·이중 공백을 내도 화면에 새지 않는다(normalizeAlarmTextWithoutTags 재사용).
 export function deriveAlarmDisplayText(synthesisText: string, originalText: string): string {
   if (TAG_RE.test(originalText.trim())) {
     return synthesisText.trim();
   }
-  return synthesisText.replace(/^\s*\[[a-z][a-z -]{1,32}\]\s*/i, '').trim();
+  return normalizeAlarmTextWithoutTags(synthesisText);
 }
 
 function pickApprovedTag(tags: string[]): string | null {

--- a/packages/backend/test/vertex-translate.test.ts
+++ b/packages/backend/test/vertex-translate.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/types';
 import {
   AlarmTextPreparationInvalidError,
+  deriveAlarmDisplayText,
   generateDynamicAlarmTextWithVertex,
   prepareAlarmTextWithVertex,
 } from '../src/lib/vertex-translate';
@@ -597,5 +598,47 @@ describe('generateDynamicAlarmTextWithVertex', () => {
     expect(generated.text).not.toContain('5월 19일');
     expect(generated.text).not.toContain('생년월일');
     expect(generated.text).not.toContain('태어난 시간');
+  });
+});
+
+describe('deriveAlarmDisplayText', () => {
+  it('사용자가 대괄호를 안 치면 맨 앞 자동 delivery 태그를 제거한다', () => {
+    expect(deriveAlarmDisplayText('[cheerfully] 좋은 아침이에요', '좋은 아침이에요')).toBe(
+      '좋은 아침이에요',
+    );
+  });
+
+  it('모델이 지시를 어기고 태그를 2개 붙여도 모두 제거한다', () => {
+    expect(deriveAlarmDisplayText('[happy] [excited] Good morning', 'good morning')).toBe(
+      'Good morning',
+    );
+  });
+
+  it('문장 중간에 낀 모델 태그도 제거한다', () => {
+    expect(deriveAlarmDisplayText('Good [whispers] morning', 'good morning')).toBe('Good morning');
+  });
+
+  it('태그 제거 후 남는 이중 공백을 한 칸으로 정리한다', () => {
+    expect(deriveAlarmDisplayText('take your  pills', 'take your pills')).toBe('take your pills');
+  });
+
+  it('번역 경로에서도 앞 태그만 벗기고 번역 본문은 유지한다', () => {
+    expect(deriveAlarmDisplayText('[cheerfully] Good morning', '좋은 아침이에요')).toBe(
+      'Good morning',
+    );
+  });
+
+  it('사용자가 직접 친 대괄호는 그대로 보존한다', () => {
+    expect(
+      deriveAlarmDisplayText('오늘도 [after lunch] 화이팅', '오늘도 [after lunch] 화이팅'),
+    ).toBe('오늘도 [after lunch] 화이팅');
+  });
+
+  it('사용자 문구가 대괄호 하나뿐이어도 비우지 않는다', () => {
+    expect(deriveAlarmDisplayText('[calm]', '[calm]')).toBe('[calm]');
+  });
+
+  it('사용자가 승인 태그와 겹치는 대괄호를 쳐도 삭제하지 않는다', () => {
+    expect(deriveAlarmDisplayText('오늘도 [happy]', '오늘도 [happy]')).toBe('오늘도 [happy]');
   });
 });


### PR DESCRIPTION
## 배경
코드리뷰(4차, xhigh)가 #538 머지본의 `deriveAlarmDisplayText`에서 잠재 태그 누출을 지적.

## 문제
`deriveAlarmDisplayText`가 **맨 앞 delivery 태그 1개만** 제거해서:
- 모델이 지시(`AT MOST ONE tag`)를 어기고 태그를 2개 붙이면(`[happy] [excited] …`) 두 번째가 표시/저장 문구·울림 화면·홈에 샘
- 문장 중간에 낀 모델 태그도 남음
- 태그 제거 후 남는 내부 이중 공백이 정리 안 됨

## 수정
사용자가 대괄호를 **안 친** 경우 합성 텍스트의 모든 대괄호는 자동/모델이 붙인 delivery 태그이므로, 위치·개수와 무관하게 전부 제거 + 공백 정리(`normalizeAlarmTextWithoutTags` 재사용)로 변경. 태그 누출을 근본 차단.
- 사용자가 **직접 친** 대괄호(`[after lunch]`/`[calm]`/`오늘도 [happy]`)는 종전대로 보존(빈 문구 방지 포함).

## 테스트
`deriveAlarmDisplayText` 단위 8건 추가(단일/이중/중간 태그·이중공백·번역·사용자 대괄호 보존·`[calm]`만). 전체 백엔드 **1269 통과**.

## 참고(변경 안 함)
동일 리뷰의 `RecordedPlaybackControls` 중복 지적은 사용자가 명시 요청한 편집기 전용 녹음 UI(마이크→재생·회전 다시하기)라 통합하면 그 디자인을 되돌리게 되므로 의도된 분기로 유지.