### PR TITLE
운세 정보 저장 버튼 아이콘 제거

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmFortuneSettings.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmFortuneSettings.kt
@@ -8,15 +8,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
@@ -161,8 +158,6 @@ internal fun FortuneInfoDialog(
                         modifier = Modifier.fillMaxWidth(),
                         shape = WakerButtonShape,
                     ) {
-                        Icon(Icons.Outlined.Save, contentDescription = null)
-                        Spacer(Modifier.width(8.dp))
                         Text(stringResource(R.string.editorp_fortune_save_button))
                     }
                 }


### PR DESCRIPTION
운세 설정 저장 버튼 앞의 Save 아이콘을 제거해 '저장' 텍스트만 남김(사용자 요청). 미사용 import 정리. 날씨 저장 버튼은 원래 아이콘이 없어 변경 없음.