### PR TITLE
가족 알람 즉시 배달(FCM + 포그라운드 pull) + 날씨 미해결 안내 클립

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ node_modules/
 .env.production
 .dev.vars*
 !packages/backend/.dev.vars.example
+# Firebase 서비스계정(진짜 시크릿)은 .dev.vars* 로 커버됨. google-services_* 루스 원본은 커밋하지 않는다
+# (실사용본은 app/src/{dev,prod}/google-services.json — 저감도 클라 키라 커밋해 CI devDebug 빌드를 통과시킨다).
+apps/android-native/app/google-services_*.json
+firebase-adminsdk-*.json
 
 # Build outputs
 dist/

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -256,6 +256,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    // 앱 프로세스 포그라운드 복귀 감지(ProcessLifecycleOwner) — 복귀 시 원격 알람 즉시 pull.
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     implementation("androidx.navigation:navigation-compose:2.8.5")
     implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.room:room-runtime:2.6.1")

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
+    // FCM: google-services.json(app/src/{dev,prod}/) 을 읽어 Firebase 초기화 리소스를 생성.
+    id("com.google.gms.google-services")
 }
 
 abstract class GenerateAlarmToneTask : DefaultTask() {
@@ -258,6 +260,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     // 앱 프로세스 포그라운드 복귀 감지(ProcessLifecycleOwner) — 복귀 시 원격 알람 즉시 pull.
     implementation("androidx.lifecycle:lifecycle-process:2.8.7")
+    // FCM(가족 알람 즉시 배달) — 앱이 백그라운드/종료여도 data push 로 즉시 pull. BoM 으로 버전 통일.
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation("com.google.firebase:firebase-messaging")
     implementation("androidx.navigation:navigation-compose:2.8.5")
     implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.room:room-runtime:2.6.1")

--- a/apps/android-native/app/src/dev/google-services.json
+++ b/apps/android-native/app/src/dev/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "927504470160",
+    "project_id": "alarm-9b3e3",
+    "storage_bucket": "alarm-9b3e3.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:927504470160:android:6e8e33d481553269340815",
+        "android_client_info": {
+          "package_name": "com.alarmtalk.app.dev"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBQcHXXaFN9QvRkoNrlw8G7P20B378DFJk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/apps/android-native/app/src/main/AndroidManifest.xml
+++ b/apps/android-native/app/src/main/AndroidManifest.xml
@@ -64,6 +64,15 @@
             android:exported="false"
             android:foregroundServiceType="mediaPlayback" />
 
+        <!-- FCM 수신(가족 알람 즉시 배달) — data push 로 백그라운드에서도 즉시 pull. -->
+        <service
+            android:name=".fcm.AlarmTalkMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".alarm.AlarmReceiver"
             android:exported="false" />

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.alarmtalk.app.alarm.NotificationChannels
+import com.alarmtalk.app.fcm.AlarmTalkMessagingService
 import com.alarmtalk.app.core.AlarmTalkLog
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
 import com.alarmtalk.app.data.AlarmAppContainer
@@ -50,6 +51,9 @@ class AlarmTalkApplication : Application() {
                 },
             )
         }.onFailure { AlarmTalkLog.reportError("ProcessLifecycle observer registration failed", it) }
+        // 로그인 세션이 있으면 현재 FCM 토큰을 서버에 등록(가족 알람 push 대상). 세션 없으면 내부에서 no-op.
+        runCatching { AlarmTalkMessagingService.registerCurrentToken(this) }
+            .onFailure { AlarmTalkLog.reportError("FCM token registration failed", it) }
         // 30일 이상 미참조 음성 캐시를 백그라운드에서 정리. 실패해도 앱 진입에 영향 없음.
         applicationScope.launch {
             runCatching { AlarmAppContainer.repository(this@AlarmTalkApplication).sweepStaleAudioCache() }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
@@ -2,6 +2,9 @@ package com.alarmtalk.app
 
 import android.app.Application
 import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.alarmtalk.app.alarm.NotificationChannels
 import com.alarmtalk.app.core.AlarmTalkLog
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
@@ -30,11 +33,23 @@ class AlarmTalkApplication : Application() {
             .onFailure { AlarmTalkLog.reportError("NotificationChannels init failed", it) }
         runCatching { RemoteAlarmSyncScheduler.ensurePeriodic(this) }
             .onFailure { AlarmTalkLog.reportError("RemoteAlarmSyncScheduler.ensurePeriodic failed", it) }
+        // 앱이 포그라운드로 올라올 때마다(cold start 포함, 어느 화면/탭이든) 즉시 원격 알람을 pull 한다.
+        // 로그인 세션이 있을 때만, 60초 throttle 로 연속 복귀 중복을 막는다. 이전엔 cold start + '알람 탭
+        // 진입' 에서만 즉시 pull 이었던 것을 포그라운드 복귀 전체로 확장 — FCM 없이도 "앱을 열면 바로"
+        // 가족 알람 수신+로컬 알림이 촘촘해진다(백그라운드 초단위 즉시는 별도 push 필요).
         runCatching {
-            if (AuthSessionStore(this).read() != null) {
-                RemoteAlarmSyncScheduler.runOnce(this)
-            }
-        }.onFailure { AlarmTalkLog.reportError("RemoteAlarmSyncScheduler.runOnce failed", it) }
+            ProcessLifecycleOwner.get().lifecycle.addObserver(
+                object : DefaultLifecycleObserver {
+                    override fun onStart(owner: LifecycleOwner) {
+                        runCatching {
+                            if (AuthSessionStore(this@AlarmTalkApplication).read() != null) {
+                                RemoteAlarmSyncScheduler.runOnceThrottled(this@AlarmTalkApplication)
+                            }
+                        }.onFailure { AlarmTalkLog.reportError("Foreground alarm sync failed", it) }
+                    }
+                },
+            )
+        }.onFailure { AlarmTalkLog.reportError("ProcessLifecycle observer registration failed", it) }
         // 30일 이상 미참조 음성 캐시를 백그라운드에서 정리. 실패해도 앱 진입에 영향 없음.
         applicationScope.launch {
             runCatching { AlarmAppContainer.repository(this@AlarmTalkApplication).sweepStaleAudioCache() }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
@@ -166,6 +166,13 @@ fun appVoiceLanguageOf(language: String?): String = when (language) {
 }
 
 /**
+ * 날씨 클론 버킷의 '완전한' 클립 수 = 조건 8(CLONE_WEATHER_CONDITIONS) + '미해결 안내' 1(마지막).
+ * hasCompleteCloneBucket(완전 판정)과 발사 시 미해결 폴백(마지막=안내 클립)이 공유하는 단일 상수.
+ * 백엔드 CLONE_CLIP_SEEDS weather 개수와 일치해야 한다(개수 계약 테스트가 동기화 강제).
+ */
+const val WEATHER_CLONE_CLIP_COUNT = 9
+
+/**
  * 이 버킷 알람이 발사 시 재생/표시할 variant 인덱스(0..N-1). 오디오(resolveBucketClipLocalUri)와
  * 잠금화면 문구(RingingActivity)가 같은 이 인덱스를 써야 음성=문구가 일치한다.
  * 운세=사주+발사일자 결정적 계산, 날씨=준비창 스냅샷 조건 인덱스, 그 외=순차 회전.
@@ -186,8 +193,17 @@ fun AlarmEntity.bucketVariantIndex(): Int? {
         )
         // 날씨 미해결(준비창에서 인터넷이 안 돼 조건을 못 받아옴)이면 마지막 클립(=서버가 마지막 seed 로
         // 넣은 '인터넷이 안 돼서 날씨를 못 알아봤어요' 안내)으로 폴백한다. 무음/오재생(맑음=0) 대신 정직한
-        // 안내. 서버 조건 인덱스는 0..size-2 만 오므로 size-1 은 안내 전용이다.
-        "weather" -> contextVariantIndex ?: (size - 1)
+        // 안내. 단 안내 클립이 실제로 있는 새 버킷(size == WEATHER_CLONE_CLIP_COUNT)에서만 — 이 변경 전
+        // 저장된 옛 버킷은 조건 클립만 있어(size < 9) size-1 이 마지막 '조건'(cold)을 가리키므로, 폴백하지
+        // 않고 null(대표)로 둔다. 재바인딩(재저장/매니페스트 갱신)되면 안내 클립이 채워져 정상 폴백된다.
+        "weather" -> {
+            val resolved = contextVariantIndex
+            when {
+                resolved != null -> resolved
+                size >= WEATHER_CLONE_CLIP_COUNT -> size - 1
+                else -> return null
+            }
+        }
         else -> bucketRotationIndex
     }
     return ((raw % size) + size) % size

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
@@ -184,7 +184,10 @@ fun AlarmEntity.bucketVariantIndex(): Int? {
                 .toString(),
             count = size,
         )
-        "weather" -> contextVariantIndex ?: return null
+        // 날씨 미해결(준비창에서 인터넷이 안 돼 조건을 못 받아옴)이면 마지막 클립(=서버가 마지막 seed 로
+        // 넣은 '인터넷이 안 돼서 날씨를 못 알아봤어요' 안내)으로 폴백한다. 무음/오재생(맑음=0) 대신 정직한
+        // 안내. 서버 조건 인덱스는 0..size-2 만 오므로 size-1 은 안내 전용이다.
+        "weather" -> contextVariantIndex ?: (size - 1)
         else -> bucketRotationIndex
     }
     return ((raw % size) + size) % size

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
@@ -5,7 +5,9 @@ import com.alarmtalk.app.core.AlarmTalkLog
 import com.alarmtalk.app.network.AlarmTalkApiClient
 import com.alarmtalk.app.network.AuthSessionStore
 import com.alarmtalk.app.network.PushTokenRegisterRequest
+import com.alarmtalk.app.network.PushTokenUnregisterRequest
 import com.alarmtalk.app.sync.RemoteAlarmSyncScheduler
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
@@ -13,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * FCM 수신 서비스. 가족 알람 push(data-only)를 받으면 즉시 원격 알람을 pull 해 로컬 스케줄+알림을
@@ -54,6 +57,26 @@ class AlarmTalkMessagingService : FirebaseMessagingService() {
                     )
                 }.onFailure { AlarmTalkLog.reportError("Push token register failed", it) }
             }
+        }
+
+        /**
+         * 로그아웃 시 이 기기의 FCM 토큰을 서버에서 제거해, 로그아웃한(또는 공유) 기기가 이 계정의 알람
+         * push 를 더 받지 않게 한다. 반드시 /auth/logout(=token_epoch 무효화) '전에' 유효한 세션 토큰으로
+         * 호출해야 한다. 현재 토큰을 받아 서버 unregister 까지 끝나면 반환(suspend). 실패해도 로그아웃은 계속.
+         */
+        suspend fun unregisterCurrentToken(authorizationToken: String) {
+            runCatching {
+                val token = withContext(Dispatchers.IO) {
+                    Tasks.await(FirebaseMessaging.getInstance().token)
+                }
+                if (token.isNullOrBlank()) return
+                withContext(Dispatchers.IO) {
+                    AlarmTalkApiClient.create().unregisterPushToken(
+                        AlarmTalkApiClient.bearer(authorizationToken),
+                        PushTokenUnregisterRequest(token = token),
+                    )
+                }
+            }.onFailure { AlarmTalkLog.reportError("Push token unregister failed", it) }
         }
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
@@ -1,0 +1,59 @@
+package com.alarmtalk.app.fcm
+
+import android.content.Context
+import com.alarmtalk.app.core.AlarmTalkLog
+import com.alarmtalk.app.network.AlarmTalkApiClient
+import com.alarmtalk.app.network.AuthSessionStore
+import com.alarmtalk.app.network.PushTokenRegisterRequest
+import com.alarmtalk.app.sync.RemoteAlarmSyncScheduler
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * FCM 수신 서비스. 가족 알람 push(data-only)를 받으면 즉시 원격 알람을 pull 해 로컬 스케줄+알림을
+ * 그린다(앱이 백그라운드/종료여도). 토큰 회전 시 서버에 재등록한다. push 를 놓쳐도 15분 주기 pull 폴백.
+ */
+class AlarmTalkMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        registerToken(applicationContext, token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        // data-only 가족 알람 신호 → 즉시 pull(RemoteAlarmPullSyncService 가 upsert + notifyReceivedAlarm).
+        if (message.data["type"] == "family_alarm") {
+            runCatching { RemoteAlarmSyncScheduler.runOnce(applicationContext) }
+                .onFailure { AlarmTalkLog.reportError("FCM-triggered alarm pull failed", it) }
+        }
+    }
+
+    companion object {
+        private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+        /** 로그인·앱 시작 시 현재 FCM 토큰을 받아 서버에 등록(onNewToken 은 토큰 회전 때만 발화). */
+        fun registerCurrentToken(context: Context) {
+            val appContext = context.applicationContext
+            if (AuthSessionStore(appContext).read() == null) return
+            FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token -> registerToken(appContext, token) }
+                .addOnFailureListener { AlarmTalkLog.reportError("FCM getToken failed", it) }
+        }
+
+        private fun registerToken(context: Context, token: String) {
+            val session = AuthSessionStore(context).read() ?: return
+            if (token.isBlank()) return
+            ioScope.launch {
+                runCatching {
+                    AlarmTalkApiClient.create().registerPushToken(
+                        AlarmTalkApiClient.bearer(session.token),
+                        PushTokenRegisterRequest(token = token),
+                    )
+                }.onFailure { AlarmTalkLog.reportError("Push token register failed", it) }
+            }
+        }
+    }
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
@@ -50,6 +50,11 @@ class AlarmTalkMessagingService : FirebaseMessagingService() {
             val session = AuthSessionStore(context).read() ?: return
             if (token.isBlank()) return
             ioScope.launch {
+                // 등록 API 를 쏘기 직전에 세션이 아직 이 세션 그대로인지 재확인한다. 로그인/앱 시작 시 시작된
+                // 등록(fire-and-forget)이 로그아웃/계정전환 뒤에 늦게 완료돼 옛 세션으로 토큰을 되살리는
+                // 레이스를 막는다(서버 로그아웃은 JWT 만 무효화하고 push_tokens 를 지우지 않으므로).
+                val current = AuthSessionStore(context).read()
+                if (current == null || current.token != session.token) return@launch
                 runCatching {
                     AlarmTalkApiClient.create().registerPushToken(
                         AlarmTalkApiClient.bearer(session.token),

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AlarmTalkApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AlarmTalkApi.kt
@@ -8,4 +8,5 @@ interface AlarmTalkApi :
     FamilyApi,
     CodeApi,
     BillingApi,
-    HolidayApi
+    HolidayApi,
+    PushApi

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/PushApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/PushApi.kt
@@ -1,0 +1,24 @@
+package com.alarmtalk.app.network
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+data class PushTokenRegisterRequest(
+    @SerializedName("token") val token: String,
+    @SerializedName("platform") val platform: String = "android",
+)
+
+data class PushTokenRegisterResponse(
+    @SerializedName("success") val success: Boolean = false,
+)
+
+interface PushApi {
+    // FCM 등록 토큰을 서버에 저장(가족 알람 push 대상). 로그인·앱 시작·토큰 회전 시 호출.
+    @POST("push/register")
+    suspend fun registerPushToken(
+        @Header("Authorization") authorization: String,
+        @Body body: PushTokenRegisterRequest,
+    ): PushTokenRegisterResponse
+}

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/PushApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/PushApi.kt
@@ -14,6 +14,14 @@ data class PushTokenRegisterResponse(
     @SerializedName("success") val success: Boolean = false,
 )
 
+data class PushTokenUnregisterRequest(
+    @SerializedName("token") val token: String,
+)
+
+data class PushTokenUnregisterResponse(
+    @SerializedName("success") val success: Boolean = false,
+)
+
 interface PushApi {
     // FCM 등록 토큰을 서버에 저장(가족 알람 push 대상). 로그인·앱 시작·토큰 회전 시 호출.
     @POST("push/register")
@@ -21,4 +29,11 @@ interface PushApi {
         @Header("Authorization") authorization: String,
         @Body body: PushTokenRegisterRequest,
     ): PushTokenRegisterResponse
+
+    // 로그아웃/기기 해제 시 이 기기 토큰을 서버에서 제거(로그아웃한 기기에 push 안 오게).
+    @POST("push/unregister")
+    suspend fun unregisterPushToken(
+        @Header("Authorization") authorization: String,
+        @Body body: PushTokenUnregisterRequest,
+    ): PushTokenUnregisterResponse
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/RemoteAlarmSyncScheduler.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/RemoteAlarmSyncScheduler.kt
@@ -1,6 +1,7 @@
 package com.alarmtalk.app.sync
 
 import android.content.Context
+import android.os.SystemClock
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
@@ -43,5 +44,19 @@ object RemoteAlarmSyncScheduler {
             ExistingWorkPolicy.REPLACE,
             request,
         )
+    }
+
+    // 앱이 포그라운드로 복귀할 때마다 호출되는 즉시 pull. 짧은 시간 연속 복귀(탭 전환 등)로 인한 중복
+    // 실행을 minIntervalMs throttle 로 막는다. 첫 호출은 항상 실행(=null). elapsedRealtime 은 부팅 후
+    // 경과라 초기 0 비교 이슈를 피하려 nullable 로 둔다.
+    @Volatile
+    private var lastForegroundRunAtMs: Long? = null
+
+    fun runOnceThrottled(context: Context, minIntervalMs: Long = 60_000L) {
+        val now = SystemClock.elapsedRealtime()
+        val last = lastForegroundRunAtMs
+        if (last != null && now - last < minIntervalMs) return
+        lastForegroundRunAtMs = now
+        runOnce(context)
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -94,8 +94,9 @@ import kotlinx.coroutines.withContext
 
 internal fun expectedCloneBucketVariantCount(category: String): Int? =
     when (category) {
-        // 날씨 = 조건 8 + '인터넷 안 돼서 못 알아봤어요' 미해결 안내 1 = 9(마지막 클립이 안내).
-        "weather" -> 9
+        // 날씨 = 조건 8 + '인터넷 안 돼서 못 알아봤어요' 미해결 안내 1(마지막 클립이 안내). data 계층
+        // 상수를 참조해 발사 폴백(bucketVariantIndex)과 단일 출처로 유지.
+        "weather" -> com.alarmtalk.app.data.WEATHER_CLONE_CLIP_COUNT
         "fortune" -> 5
         "love" -> 3
         "medication" -> 3

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -94,7 +94,8 @@ import kotlinx.coroutines.withContext
 
 internal fun expectedCloneBucketVariantCount(category: String): Int? =
     when (category) {
-        "weather" -> 8
+        // 날씨 = 조건 8 + '인터넷 안 돼서 못 알아봤어요' 미해결 안내 1 = 9(마지막 클립이 안내).
+        "weather" -> 9
         "fortune" -> 5
         "love" -> 3
         "medication" -> 3

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -384,6 +384,10 @@ internal fun MainViewModel.cancelAccountDeletion() {
             api.cancelAccountDeletion(authorization)
         }.onSuccess {
             pendingDeletion = false
+            // 철회로 계정이 'active' 로 복구됐으니, 삭제 신청 때 제거됐던 이 기기 FCM 토큰을 다시 등록한다.
+            // (pending 중엔 로그인해도 게이트가 /push/register 를 막아 등록이 안 됐다.) 그래야 가족 알람
+            // push 가 이 기기에 다시 온다 — active 복구 후라 등록 게이트를 통과한다.
+            com.alarmtalk.app.fcm.AlarmTalkMessagingService.registerCurrentToken(getApplication())
             message = getApplication<android.app.Application>().getString(R.string.msg_account_deletion_cancelled)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Failed to cancel account deletion", error)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -290,6 +290,11 @@ internal fun MainViewModel.logout(signOutGoogle: suspend () -> Unit = {}) {
         // 서버에 로그아웃을 알려 token_epoch 를 올린다(남아있던 토큰 전부 401 TOKEN_REVOKED).
         // 네트워크 실패가 로컬 로그아웃을 막지 않도록 best-effort 로 처리한다.
         if (session != null) {
+            // token_epoch 를 올리기 전에(=세션 토큰 유효할 때) 이 기기 FCM 토큰을 서버에서 먼저 제거한다.
+            // 로그아웃한(또는 공유) 기기에 이 계정의 알람 push 가 계속 오는 것을 막는다.
+            runCatching {
+                com.alarmtalk.app.fcm.AlarmTalkMessagingService.unregisterCurrentToken(session.token)
+            }.onFailure { error -> Log.w(TAG, "FCM unregister on logout failed (continuing)", error) }
             runCatching {
                 api.logout(com.alarmtalk.app.network.AlarmTalkApiClient.bearer(session.token))
             }.onFailure { error ->

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -187,6 +187,7 @@ internal fun MainViewModel.register(
             registerEmailVerified = null
             RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
             RemoteAlarmSyncScheduler.runOnce(getApplication())
+            com.alarmtalk.app.fcm.AlarmTalkMessagingService.registerCurrentToken(getApplication())
             message = getApplication<android.app.Application>().getString(R.string.msg_register_success, response.user.email)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email registration failed", error)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -72,6 +72,7 @@ internal fun MainViewModel.login(email: String, password: String) {
             restoreAccessSnapshotForCurrentUser()
             RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
             RemoteAlarmSyncScheduler.runOnce(getApplication())
+            com.alarmtalk.app.fcm.AlarmTalkMessagingService.registerCurrentToken(getApplication())
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email login failed", error)
             message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_login_failed))
@@ -270,6 +271,7 @@ internal fun MainViewModel.finishGoogleLogin(idToken: String) {
             restoreAccessSnapshotForCurrentUser()
             RemoteAlarmSyncScheduler.ensurePeriodic(getApplication())
             RemoteAlarmSyncScheduler.runOnce(getApplication())
+            com.alarmtalk.app.fcm.AlarmTalkMessagingService.registerCurrentToken(getApplication())
             message = null
         }.onFailure { error ->
             AlarmTalkLog.reportError("Google token exchange failed", error)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -328,6 +328,11 @@ internal fun MainViewModel.requestAccountDeletion(signOutGoogle: suspend () -> U
     viewModelScope.launch {
         authBusy = true
         try {
+            // 삭제 신청 전에(세션 토큰 유효할 때) 이 기기 FCM 토큰을 서버에서 제거한다. 유예 기간 동안
+            // 삭제 신청한 계정의 알람 push 가 이 기기로 계속 오는 것을 막는다(로그아웃과 동일 처리).
+            runCatching {
+                com.alarmtalk.app.fcm.AlarmTalkMessagingService.unregisterCurrentToken(session.token)
+            }.onFailure { error -> Log.w(TAG, "FCM unregister on deletion failed (continuing)", error) }
             api.requestAccountDeletion(authorization)
             if (shouldSignOutGoogle) {
                 runCatching { signOutGoogle() }.onFailure { Log.w(TAG, "Google sign-out failed", it) }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -328,12 +328,13 @@ internal fun MainViewModel.requestAccountDeletion(signOutGoogle: suspend () -> U
     viewModelScope.launch {
         authBusy = true
         try {
-            // 삭제 신청 전에(세션 토큰 유효할 때) 이 기기 FCM 토큰을 서버에서 제거한다. 유예 기간 동안
-            // 삭제 신청한 계정의 알람 push 가 이 기기로 계속 오는 것을 막는다(로그아웃과 동일 처리).
+            api.requestAccountDeletion(authorization)
+            // 삭제 신청이 '성공한 뒤에만' 이 기기 FCM 토큰을 제거한다(유예 기간 동안 push 방지). 신청이
+            // 실패하면 사용자는 로그인 유지 상태이므로 토큰을 지우지 않아 즉시 push 를 계속 받게 한다.
+            // /me/deletion 은 token_epoch 를 올리지 않아(user.ts) 신청 후에도 세션 토큰이 유효하다.
             runCatching {
                 com.alarmtalk.app.fcm.AlarmTalkMessagingService.unregisterCurrentToken(session.token)
             }.onFailure { error -> Log.w(TAG, "FCM unregister on deletion failed (continuing)", error) }
-            api.requestAccountDeletion(authorization)
             if (shouldSignOutGoogle) {
                 runCatching { signOutGoogle() }.onFailure { Log.w(TAG, "Google sign-out failed", it) }
             }

--- a/apps/android-native/app/src/prod/google-services.json
+++ b/apps/android-native/app/src/prod/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "927504470160",
+    "project_id": "alarm-9b3e3",
+    "storage_bucket": "alarm-9b3e3.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:927504470160:android:2636920829e01f67340815",
+        "android_client_info": {
+          "package_name": "com.alarmtalk.app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBQcHXXaFN9QvRkoNrlw8G7P20B378DFJk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:927504470160:android:6e8e33d481553269340815",
+        "android_client_info": {
+          "package_name": "com.alarmtalk.app.dev"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBQcHXXaFN9QvRkoNrlw8G7P20B378DFJk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/AlarmEditorStateTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/AlarmEditorStateTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class AlarmEditorStateTest {
     @Test
     fun cloneBucketsRequireEveryBackendVariant() {
-        assertEquals(8, expectedCloneBucketVariantCount("weather"))
+        assertEquals(9, expectedCloneBucketVariantCount("weather")) // 조건 8 + 미해결 안내 1
         assertEquals(5, expectedCloneBucketVariantCount("fortune"))
         assertEquals(3, expectedCloneBucketVariantCount("love"))
         assertEquals(3, expectedCloneBucketVariantCount("medication"))

--- a/apps/android-native/build.gradle.kts
+++ b/apps/android-native/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+    // FCM(가족 알람 즉시 배달)용 google-services 플러그인. app 모듈에서 apply.
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -27,6 +27,7 @@ import billingRoutes from './routes/billing';
 import billingGoogleRtdn from './routes/billing-google-rtdn';
 import familyRoutes from './routes/family';
 import codeRoutes from './routes/code';
+import pushRoutes from './routes/push';
 import holidayRoutes from './routes/holiday';
 import adminRoutes from './routes/admin';
 
@@ -240,6 +241,7 @@ api.route('/stats', statsRoutes);
 api.route('/billing', billingRoutes);
 api.route('/family', familyRoutes);
 api.route('/code', codeRoutes);
+api.route('/push', pushRoutes);
 
 // 관리자 콘솔(/admin) — 사용자 JWT 가 아니라 ADMIN_SECRET(HTTP Basic)로 보호한다
 // (admin.ts 내부 미들웨어). 프로모 쿠폰 발급/관리 등 SQL 수기 없이 웹 폼에서.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,7 +12,6 @@ import { sentryMiddleware } from './middleware/sentry';
 import { Toucan } from 'toucan-js';
 import { getDB, initDB } from './lib/db';
 import { selectFiringAlarms, type ScheduledAlarm } from './lib/scheduler';
-import { sendAlarmPush } from './lib/fcm';
 import { logRouteError, logStructured } from './lib/logger';
 import voiceRoutes from './routes/voice';
 import ttsRoutes from './routes/tts';
@@ -382,18 +381,10 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
     firing_ids: firing.map((a) => a.id),
   });
 
-  // 알람 푸시를 순차(await in loop)로 보내면 동시에 울릴 알람이 많을 때 지연이
-  // 선형으로 쌓인다(마지막 사용자는 늦게 울림). Workers 의 subrequest 상한을
-  // 고려해 청크 단위로 병렬 전송하고, 한 건 실패가 나머지를 막지 않도록 allSettled.
-  const PUSH_CONCURRENCY = 10;
-  for (let i = 0; i < firing.length; i += PUSH_CONCURRENCY) {
-    const chunk = firing.slice(i, i + PUSH_CONCURRENCY);
-    await Promise.allSettled(
-      chunk.map((alarm) =>
-        sendAlarmPush(db, env, alarm.target_user_id ?? alarm.user_id, alarm.id, alarm.time),
-      ),
-    );
-  }
+  // 발사 시각 서버 push 는 보내지 않는다: 알람은 각 기기가 로컬 AlarmManager 로 직접 울리고(수신 가족
+  // 알람도 pull→로컬 스케줄), 서버가 발사 때 type=alarm notification 을 또 보내면 로컬 링과 중복 알림이
+  // 된다(push_tokens 는 즉시 배달용 토큰이라 이 경로가 소비하면 안 됨). '새 가족 알람 도착' 즉시성은 생성
+  // 시점의 sendFamilyAlarmPush(data-only)로 처리하고, 발사 자체는 로컬에 맡긴다.
 
   // 유료 클론 목소리 preset 사전렌더 드레인. 시간민감 알람 푸시 '뒤'에서, 틱당 소량만 생성해
   // Workers 서브리퀘스트 상한·ElevenLabs 비용/rate·푸시 지연을 막는다. 큐가 지목한 클론만

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -34,6 +34,32 @@ export interface FcmSendResult {
 
 const FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging';
 
+/**
+ * FCM v1 메시지 본문 구성. title/body 가 모두 비면 data-only 로 보낸다(가족 알람 신호처럼 클라가
+ * 직접 pull 후 알림을 그릴 때). data-only 는 notification 블록을 빼(시스템 트레이 중복 알림 방지),
+ * onMessageReceived 가 백그라운드에서도 호출돼 즉시 pull→로컬 스케줄이 되게 한다. iOS 는
+ * content-available 로 백그라운드 깨움만 요청. title/body 가 있으면 기존 notification 방식 그대로.
+ */
+function buildFcmMessage(msg: FcmMessage): Record<string, unknown> {
+  const hasNotification = Boolean(msg.title || msg.body);
+  const message: Record<string, unknown> = {
+    token: msg.token,
+    data: msg.data ?? {},
+    android: {
+      priority: 'HIGH',
+      ...(hasNotification ? { notification: { channel_id: msg.data?.channelId ?? 'alarms' } } : {}),
+    },
+    apns: {
+      headers: { 'apns-priority': hasNotification ? '10' : '5' },
+      payload: hasNotification ? { aps: { sound: 'default' } } : { aps: { 'content-available': 1 } },
+    },
+  };
+  if (hasNotification) {
+    message.notification = { title: msg.title, body: msg.body };
+  }
+  return message;
+}
+
 /** 영구적으로 무효한 토큰을 뜻하는 FCM v1 에러 코드 — push_tokens 에서 제거 대상. */
 const STALE_TOKEN_ERRORS = new Set(['UNREGISTERED', 'INVALID_ARGUMENT', 'NOT_FOUND']);
 
@@ -100,21 +126,7 @@ export async function sendPushNotifications(
           Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          message: {
-            token: msg.token,
-            notification: { title: msg.title, body: msg.body },
-            data: msg.data ?? {},
-            android: {
-              priority: 'HIGH',
-              notification: { channel_id: msg.data?.channelId ?? 'alarms' },
-            },
-            apns: {
-              headers: { 'apns-priority': '10' },
-              payload: { aps: { sound: 'default' } },
-            },
-          },
-        }),
+        body: JSON.stringify({ message: buildFcmMessage(msg) }),
       });
 
       if (res.ok) {
@@ -157,6 +169,33 @@ export async function pruneStaleTokens(db: Client, results: FcmSendResult[]): Pr
       logStructured('error', { at: 'fcm.pruneStaleTokens', error: String(err) });
     }
   }
+}
+
+/**
+ * 가족 알람 생성 시 수신자에게 보내는 data-only 신호. 클라(onMessageReceived)가 받으면 즉시 원격
+ * 알람을 pull 해 로컬 스케줄+알림(notifyReceivedAlarm)을 그린다 — 여기서 notification 을 넣지 않아
+ * 중복 알림을 막는다. 앱이 완전 종료돼 신호를 놓쳐도 15분 주기 pull 이 폴백. 토큰 없으면 no-op.
+ * userId 는 수신자의 users.id(PK) — push_tokens.user_id(=FK users(id))와 정합.
+ */
+export async function sendFamilyAlarmPush(
+  db: Client,
+  env: Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>,
+  recipientUserId: string,
+  alarmId: string,
+): Promise<FcmSendResult[]> {
+  const tokens = await getTokensForUser(db, recipientUserId);
+  if (tokens.length === 0) return [];
+
+  const messages: FcmMessage[] = tokens.map((token) => ({
+    token,
+    title: '',
+    body: '',
+    data: { type: 'family_alarm', alarmId },
+  }));
+
+  const results = await sendPushNotifications(messages, env);
+  await pruneStaleTokens(db, results);
+  return results;
 }
 
 export async function sendAlarmPush(

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -64,9 +64,15 @@ function buildFcmMessage(msg: FcmMessage): Record<string, unknown> {
 const STALE_TOKEN_ERRORS = new Set(['UNREGISTERED', 'INVALID_ARGUMENT', 'NOT_FOUND']);
 
 export async function getTokensForUser(db: Client, userId: string): Promise<string[]> {
+  // push_tokens.user_id 는 users.id(PK, FK REFERENCES users(id))로 저장한다. 하지만 호출부는 users.id
+  // (가족 push=recipient.id) 또는 로그인 ID/google_id(예약 알람 push=alarm.target_user_id/user_id)를
+  // 넘긴다 — Google 등 users.id != google_id 인 계정에서 후자가 안 맞으면 토큰을 못 찾는다. users 로
+  // 조인해 두 식별자 모두 매칭한다(id/google_id 는 각각 유니크라 최대 1명 매칭).
   const result = await db.execute({
-    sql: 'SELECT token FROM push_tokens WHERE user_id = ?',
-    args: [userId],
+    sql: `SELECT pt.token FROM push_tokens pt
+          JOIN users u ON u.id = pt.user_id
+          WHERE u.id = ? OR u.google_id = ?`,
+    args: [userId, userId],
   });
   return result.rows.map((r) => String(r.token));
 }

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -65,14 +65,14 @@ const STALE_TOKEN_ERRORS = new Set(['UNREGISTERED', 'INVALID_ARGUMENT', 'NOT_FOU
 
 export async function getTokensForUser(db: Client, userId: string): Promise<string[]> {
   // push_tokens.user_id 는 users.id(PK, FK REFERENCES users(id))로 저장한다. 하지만 호출부는 users.id
-  // (가족 push=recipient.id) 또는 로그인 ID/google_id(예약 알람 push=alarm.target_user_id/user_id)를
-  // 넘긴다 — Google 등 users.id != google_id 인 계정에서 후자가 안 맞으면 토큰을 못 찾는다. users 로
-  // 조인해 두 식별자 모두 매칭한다(id/google_id 는 각각 유니크라 최대 1명 매칭).
+  // (가족 push=recipient.id) 또는 로그인 ID(예약 알람 push=alarm.target_user_id/user_id)를 넘긴다.
+  // 로그인 ID 는 계정 종류별로 google_id/apple_id/email-계정=users.id 로 다르므로(auth.ts loginSub),
+  // users 로 조인해 세 식별자(id/google_id/apple_id) 모두 매칭한다(각각 유니크라 최대 1명 매칭).
   const result = await db.execute({
     sql: `SELECT pt.token FROM push_tokens pt
           JOIN users u ON u.id = pt.user_id
-          WHERE u.id = ? OR u.google_id = ?`,
-    args: [userId, userId],
+          WHERE u.id = ? OR u.google_id = ? OR u.apple_id = ?`,
+    args: [userId, userId, userId],
   });
   return result.rows.map((r) => String(r.token));
 }

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1341,6 +1341,17 @@ export const migrations: Migration[] = [
       `ALTER TABLE voice_profiles ADD COLUMN preview_language TEXT NOT NULL DEFAULT 'ko'`,
     ],
   },
+  {
+    id: 63,
+    name: 'push-tokens-token-index',
+    statements: [
+      // /push/register 의 재배정 삭제(WHERE token = ? AND user_id != ?)와 /push/unregister(WHERE token = ?)
+      // 는 token 으로 조회·삭제한다. 기존 인덱스(idx_push_tokens_user=user_id, idx_push_tokens_unique=
+      // (user_id, token))는 모두 user_id 선행이라 token 단독 predicate 에 안 걸려, 앱 시작/로그인마다
+      // 호출되는 등록이 push_tokens full scan 으로 저하될 수 있다 → token 선행 인덱스로 방지.
+      'CREATE INDEX IF NOT EXISTS idx_push_tokens_token ON push_tokens(token)',
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1352,6 +1352,21 @@ export const migrations: Migration[] = [
       'CREATE INDEX IF NOT EXISTS idx_push_tokens_token ON push_tokens(token)',
     ],
   },
+  {
+    id: 64,
+    name: 'requeue-clone-prerender-for-weather-unknown-clip',
+    statements: [
+      // 날씨 버킷에 '미해결 안내' 클립(variant 8)이 추가돼, 이 배포 전 이미 렌더된(status='done') 클론
+      // 목소리는 weather 클립이 8개라 클라 hasCompleteCloneBucket(=9)에 미달해 오프라인 버킷이 안 붙는다.
+      // 스케줄 cron 은 voice_prerender_queue 의 'pending' 만 처리하므로(완료 목소리는 재스캔 안 함), 완료
+      // 클론 목소리를 requeue 해 다음 cron 이 findMissingStockTargets 로 '빠진 variant 8 만' 채우게 한다
+      // (기존 8개는 messages 에 있어 'seen' 이라 스킵). 신규 launch DB 는 done 행이 없어 무해(no-op).
+      `UPDATE voice_prerender_queue
+         SET status = 'pending', claimed_at = NULL, claim_token = NULL, attempts = 0,
+             updated_at = datetime('now')
+       WHERE status = 'done'`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/stock-clips.ts
+++ b/packages/backend/src/lib/stock-clips.ts
@@ -115,7 +115,8 @@ export const CLONE_FORTUNE_THEMES = [
 /**
  * 유료 클론 사전렌더의 '의미 seed'. 각 문자열은 최종 문구가 아니라 생성 지시(outcome)이며,
  * generatePrerenderClipText 가 그 목소리의 관계/호칭/말투에 맞춰 실제 문구로 만든다. 소량 유지.
- * greeting=기상 인사(미리듣기 겸용). weather=CLONE_WEATHER_CONDITIONS 순서, fortune=CLONE_FORTUNE_THEMES 순서.
+ * greeting=기상 인사(미리듣기 겸용). weather=CLONE_WEATHER_CONDITIONS 순서(0..7) + 미해결 안내 1(마지막),
+ * fortune=CLONE_FORTUNE_THEMES 순서(기기 결정적이라 미해결 없음).
  */
 export const CLONE_CLIP_SEEDS: {
   category: string;
@@ -132,6 +133,10 @@ export const CLONE_CLIP_SEEDS: {
   {
     category: 'weather',
     defaultTag: 'cheerfully',
+    // seeds[0..7] = CLONE_WEATHER_CONDITIONS 순서(nice/rain/snow/dust/cloud/fog/heat/cold).
+    // seeds[8] = '날씨 미해결' 안내(반드시 마지막). 준비창에서 인터넷이 안 돼 날씨를 못 받아온 경우,
+    // 클라가 무음/오재생(맑음) 대신 이 클립으로 폴백해 정직하게 안내한다(클라 bucketVariantIndex 의
+    // size-1 규약 = 마지막 클립). resolvePrerenderWeatherIndex 는 0..7 만 반환하므로 8 은 오직 폴백용.
     seeds: [
       '오늘 날씨가 맑고 좋다고 알리며, 잠깐 바깥바람을 쐬거나 산책하기에도 좋겠다고 가볍게 권한다.',
       '오늘 비가 온다고 알리고, 나갈 때 우산을 꼭 챙기고 길이 미끄러우니 조심하라고 다정하게 당부한다.',
@@ -141,6 +146,7 @@ export const CLONE_CLIP_SEEDS: {
       '오늘 안개가 짙다고 알리고, 길을 나설 때 시야가 안 좋으니 천천히 조심해서 다니라고 챙긴다.',
       '오늘 날이 많이 덥다고 알리고, 물을 자주 마시고 더위 먹지 않게 조심하라고 다정하게 챙긴다.',
       '오늘 날이 많이 춥다고 알리고, 따뜻하게 든든히 입고 감기 걸리지 않게 조심하라고 다정하게 챙긴다.',
+      '인터넷이 연결되지 않아 오늘 날씨를 미리 확인하지 못했다고 미안한 듯 알리고, 그래도 오늘 하루 좋은 일만 가득하길 바란다고 다정하게 응원한다.',
     ],
   },
   {

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -128,7 +128,10 @@ export async function authMiddleware(c: Context<AppEnv>, next: Next) {
         const method = c.req.method;
         const isCancelDeletion = method === 'DELETE' && path.endsWith('/user/me/deletion');
         const isReadMe = method === 'GET' && path.endsWith('/user/me');
-        if (!isCancelDeletion && !isReadMe) {
+        // FCM 토큰 해제는 허용한다 — 클라가 삭제 신청 '성공 후'(=pending 전환 후) 이 기기 토큰을 제거해
+        // 유예 기간 push 를 막는데, 이걸 차단하면 토큰이 영구파기까지 남아 push 가 계속 온다.
+        const isPushUnregister = method === 'POST' && path.endsWith('/push/unregister');
+        if (!isCancelDeletion && !isReadMe && !isPushUnregister) {
           return c.json(
             {
               error: 'Account is scheduled for deletion',

--- a/packages/backend/src/middleware/consent.ts
+++ b/packages/backend/src/middleware/consent.ts
@@ -40,6 +40,8 @@ function isExempt(path: string, method: string): boolean {
   // 탈퇴/철회: DELETE /user/me, POST·DELETE /user/me/deletion
   if (p === '/user/me/deletion') return true;
   if (method === 'DELETE' && p === '/user/me') return true;
+  // 푸시 토큰 등록(운영성) — 알림 수신 설정은 데이터 수집이 아니라 동의 미완 사용자도 통과해야 한다.
+  if (p === '/push' || p.startsWith('/push/')) return true;
 
   return false;
 }

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -6,6 +6,7 @@ import { UUID_RE } from '../lib/validate';
 import { logRouteError } from '../lib/logger';
 import { R2VoiceStorage } from '../lib/r2-storage';
 import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
+import { sendFamilyAlarmPush } from '../lib/fcm';
 import {
   familyAlarmSettingsFromRow,
   isBlockedByFamilyAlarmQuietTime,
@@ -414,6 +415,21 @@ alarmMutation.post('/', async (c) => {
   }
   if (inserted.status === 'message_not_found') {
     return c.json({ error: 'Message not found', error_code: 'MESSAGE_NOT_FOUND' }, 404);
+  }
+
+  // 가족 알람(target_user_id 지정)이면 수신자에게 즉시 push — /family/alarms 뿐 아니라 이 일반 생성
+  // 경로(stock/TTS/녹음 가족 알람, 클라 createAlarm)도 즉시 배달한다. getTokensForUser 가
+  // google_id/apple_id/id 를 정규화하므로 targetLoginId 그대로 전달. 논블로킹(waitUntil), executionCtx
+  // 없는 컨텍스트(테스트)에선 c.executionCtx 접근이 던지므로 try 로 감싸 생략(그 경우 쿼리도 안 돌아 mock
+  // FIFO 도 안 밀림), 15분 주기 pull 폴백.
+  if (targetUserIdForAlarm) {
+    try {
+      c.executionCtx.waitUntil(
+        sendFamilyAlarmPush(db, c.env, targetUserIdForAlarm, alarmId).catch(() => {}),
+      );
+    } catch {
+      // executionCtx 없음(비-fetch/테스트) → push 생략, pull 폴백.
+    }
   }
 
   return c.json(

--- a/packages/backend/src/routes/family-alarm.ts
+++ b/packages/backend/src/routes/family-alarm.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
+import type { Client } from '@libsql/client/web';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { resolveUserPk, assertSameGroup } from '../lib/family-helpers';
@@ -8,6 +10,7 @@ import {
 } from '../lib/family-alarm-settings';
 import { prepareAlarmTextWithVertex } from '../lib/vertex-translate';
 import { inferSynthesisLanguage } from '../lib/voice-provider';
+import { sendFamilyAlarmPush } from '../lib/fcm';
 
 const familyAlarm = new Hono<AppEnv>();
 
@@ -20,6 +23,26 @@ function normalizeRepeatDays(raw: unknown): number[] {
     .filter((n): n is number => Number.isInteger(n) && n >= 0 && n <= 6)
     .sort((a, b) => a - b);
   return Array.from(new Set(filtered));
+}
+
+// 가족 알람 생성 시 수신자에게 즉시 data-only push — 앱이 백그라운드여도 onMessageReceived 가 바로
+// pull 해 로컬 스케줄+알림(notifyReceivedAlarm)을 그린다. 논블로킹(waitUntil), 실패해도 15분 주기 pull
+// 폴백. recipient.id=users.id(PK) 로 타깃(push_tokens.user_id FK 정합). executionCtx 가 없는
+// 컨텍스트(테스트 등)에선 c.executionCtx 접근이 던지므로 try 로 감싸 push 를 생략한다(그 경우
+// sendFamilyAlarmPush 자체가 호출되지 않아 mock DB FIFO 순서도 밀리지 않는다).
+function notifyRecipientOfFamilyAlarm(
+  c: Context<AppEnv>,
+  db: Client,
+  recipient: Record<string, unknown>,
+  alarmId: string,
+): void {
+  try {
+    c.executionCtx.waitUntil(
+      sendFamilyAlarmPush(db, c.env, String(recipient.id), alarmId).catch(() => {}),
+    );
+  } catch {
+    // executionCtx 없음(비-fetch/테스트) → push 생략, 15분 주기 pull 폴백.
+  }
 }
 
 familyAlarm.post('/alarms', async (c) => {
@@ -179,6 +202,8 @@ familyAlarm.post('/alarms', async (c) => {
       JSON.stringify(repeatDays),
     ],
   });
+
+  notifyRecipientOfFamilyAlarm(c, db, recipient, alarmId);
 
   return c.json(
     {
@@ -362,6 +387,8 @@ familyAlarm.post('/alarms/voice', async (c) => {
       JSON.stringify(repeatDays),
     ],
   });
+
+  notifyRecipientOfFamilyAlarm(c, db, recipient, alarmId);
 
   let dubJob: { id: string; target_language: DubLanguage; status: 'processing' } | null = null;
   if (dubTarget) {

--- a/packages/backend/src/routes/push.ts
+++ b/packages/backend/src/routes/push.ts
@@ -37,6 +37,13 @@ push.post('/register', async (c) => {
     );
   }
 
+  // 이 기기 토큰을 현재 사용자 전용으로 재배정한다. 같은 기기에서 A 로그아웃→B 로그인 시 Firebase 등록
+  // 토큰은 그대로라, 옛 소유자(A) 행이 남으면 A 의 알람 push 가 이 기기로 잘못 배달된다(P1). 그러니 이
+  // 토큰의 다른 소유자 행을 먼저 제거해 (user, token) 이 전역에서 현재 사용자 하나만 남게 한다.
+  await db.execute({
+    sql: 'DELETE FROM push_tokens WHERE token = ? AND user_id != ?',
+    args: [token, userPk],
+  });
   // 같은 (user, token) 이면 platform/updated_at 만 갱신(멱등). 고유 인덱스 idx_push_tokens_unique(user_id, token).
   await db.execute({
     sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)

--- a/packages/backend/src/routes/push.ts
+++ b/packages/backend/src/routes/push.ts
@@ -57,4 +57,30 @@ push.post('/register', async (c) => {
   return c.json({ success: true });
 });
 
+// 로그아웃/기기 해제 시 이 기기의 FCM 토큰을 제거해 더 이상 alarm push 가 오지 않게 한다. 기기 토큰은
+// delete-on-register 로 전역 단일 소유자라, 토큰 자체로 삭제하면 로그아웃한(또는 공유) 기기가 이전
+// 계정의 알람 알림을 계속 받는 것을 막는다. 로그아웃 시 클라가 token_epoch 무효화(/auth/logout) 전에 호출.
+push.post('/unregister', async (c) => {
+  const db = getDB(c.env);
+
+  let body: { token?: unknown };
+  try {
+    body = (await c.req.json()) as { token?: unknown };
+  } catch {
+    return c.json({ error: 'Invalid JSON body', error_code: 'INVALID_JSON' }, 400);
+  }
+
+  const token = typeof body.token === 'string' ? body.token.trim() : '';
+  if (!token || token.length > TOKEN_MAX) {
+    return c.json({ error: 'token is required', error_code: 'INVALID_PUSH_TOKEN' }, 400);
+  }
+
+  await db.execute({
+    sql: 'DELETE FROM push_tokens WHERE token = ?',
+    args: [token],
+  });
+
+  return c.json({ success: true });
+});
+
 export default push;

--- a/packages/backend/src/routes/push.ts
+++ b/packages/backend/src/routes/push.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono';
+import type { AppEnv } from '../types';
+import { getDB } from '../lib/db';
+
+const push = new Hono<AppEnv>();
+
+const PUSH_PLATFORMS = ['ios', 'android', 'web'] as const;
+type PushPlatform = (typeof PUSH_PLATFORMS)[number];
+const TOKEN_MAX = 4096;
+
+// 클라가 FCM 등록 토큰을 서버에 저장한다(가족 알람 등 push 대상). 로그인·토큰 갱신(onNewToken) 시 호출.
+// push_tokens 에 INSERT 하는 유일한 경로 — 이게 없어서 테이블이 항상 비어 모든 push 가 no-op 이던 갭을 채운다.
+// user_id 는 users.id(PK) — push_tokens.user_id FK(REFERENCES users(id)) 와 정합하도록 userIdPK 를 쓴다.
+push.post('/register', async (c) => {
+  const userPk = c.get('userIdPK') || c.get('userId');
+  const db = getDB(c.env);
+
+  let body: { token?: unknown; platform?: unknown };
+  try {
+    body = (await c.req.json()) as { token?: unknown; platform?: unknown };
+  } catch {
+    return c.json({ error: 'Invalid JSON body', error_code: 'INVALID_JSON' }, 400);
+  }
+
+  const token = typeof body.token === 'string' ? body.token.trim() : '';
+  if (!token || token.length > TOKEN_MAX) {
+    return c.json({ error: 'token is required', error_code: 'INVALID_PUSH_TOKEN' }, 400);
+  }
+  const platform = typeof body.platform === 'string' ? body.platform : '';
+  if (!PUSH_PLATFORMS.includes(platform as PushPlatform)) {
+    return c.json(
+      {
+        error: `platform must be one of: ${PUSH_PLATFORMS.join(', ')}`,
+        error_code: 'INVALID_PLATFORM',
+      },
+      400,
+    );
+  }
+
+  // 같은 (user, token) 이면 platform/updated_at 만 갱신(멱등). 고유 인덱스 idx_push_tokens_unique(user_id, token).
+  await db.execute({
+    sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+          VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+          ON CONFLICT(user_id, token) DO UPDATE SET
+            platform = excluded.platform,
+            updated_at = datetime('now')`,
+    args: [crypto.randomUUID(), userPk, token, platform],
+  });
+
+  return c.json({ success: true });
+});
+
+export default push;

--- a/packages/backend/test/prerender-variant.test.ts
+++ b/packages/backend/test/prerender-variant.test.ts
@@ -1,13 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import { resolvePrerenderWeatherIndex, type WeatherSignalInput } from '../src/routes/tts';
-import { CLONE_WEATHER_CONDITIONS, CLONE_FORTUNE_THEMES } from '../src/lib/stock-clips';
+import {
+  CLONE_WEATHER_CONDITIONS,
+  CLONE_FORTUNE_THEMES,
+  CLONE_CLIP_SEEDS,
+} from '../src/lib/stock-clips';
 
-// 클라 hasCompleteCloneBucket 가 날씨=8·운세=5 를 하드코딩하므로(오프라인 버킷 '완전' 판정),
-// 백엔드 개수가 바뀌면 이 단언이 깨져 클라 상수 동기화를 강제한다.
+// 클라 hasCompleteCloneBucket 가 날씨=9(조건 8 + 미해결 안내 1)·운세=5 를 하드코딩하므로(오프라인 버킷
+// '완전' 판정), 백엔드 개수가 바뀌면 이 단언이 깨져 클라 상수 동기화를 강제한다.
 describe('클론 매칭 버킷 개수 계약', () => {
-  it('날씨 조건=8, 운세 테마=5 (클라 하드코딩과 일치해야 함)', () => {
+  it('날씨 조건=8, 운세 테마=5', () => {
     expect(CLONE_WEATHER_CONDITIONS.length).toBe(8);
     expect(CLONE_FORTUNE_THEMES.length).toBe(5);
+  });
+
+  it('날씨 클립=조건+미해결안내(9), 운세 클립=테마(5) — 클라 하드코딩과 일치', () => {
+    const weatherSeeds = CLONE_CLIP_SEEDS.find((s) => s.category === 'weather')?.seeds.length ?? 0;
+    const fortuneSeeds = CLONE_CLIP_SEEDS.find((s) => s.category === 'fortune')?.seeds.length ?? 0;
+    // 날씨는 준비창에서 인터넷이 안 되면 미해결이라 안내 클립 1개를 마지막에 더한다(클라 size-1 폴백).
+    expect(weatherSeeds).toBe(CLONE_WEATHER_CONDITIONS.length + 1);
+    expect(weatherSeeds).toBe(9);
+    // 운세는 기기 결정적 계산이라 미해결이 없어 테마 개수 = 클립 개수.
+    expect(fortuneSeeds).toBe(CLONE_FORTUNE_THEMES.length);
+    expect(fortuneSeeds).toBe(5);
   });
 });
 

--- a/packages/backend/test/push.test.ts
+++ b/packages/backend/test/push.test.ts
@@ -78,3 +78,26 @@ describe('POST /push/register — FCM 토큰 등록', () => {
     expect((await res.json()).error_code).toBe('INVALID_JSON');
   });
 });
+
+describe('POST /push/unregister — 토큰 해제(로그아웃)', () => {
+  beforeEach(() => mockDB.reset());
+
+  it('토큰 전역 제거 → success', async () => {
+    mockDB.pushResult([], 1); // DELETE FROM push_tokens WHERE token = ?
+    const res = await buildApp('user-1').request(
+      jsonReq('POST', '/push/unregister', { token: 'fcm-token-abc' }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    const del = mockDB.calls.find((c) => c.sql.startsWith('DELETE FROM push_tokens'));
+    expect(del).toBeDefined();
+    expect(del!.sql).toContain('WHERE token = ?');
+    expect(del!.args).toEqual(['fcm-token-abc']);
+  });
+
+  it('token 누락 → 400', async () => {
+    const res = await buildApp().request(jsonReq('POST', '/push/unregister', {}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_PUSH_TOKEN');
+  });
+});

--- a/packages/backend/test/push.test.ts
+++ b/packages/backend/test/push.test.ts
@@ -21,13 +21,20 @@ function buildApp(userId = 'user-1') {
 describe('POST /push/register — FCM 토큰 등록', () => {
   beforeEach(() => mockDB.reset());
 
-  it('유효 토큰+플랫폼 → success, push_tokens upsert', async () => {
+  it('유효 토큰+플랫폼 → success, 재배정 DELETE 후 upsert', async () => {
+    mockDB.pushResult([], 0); // DELETE 다른 소유자 행
     mockDB.pushResult([], 1); // INSERT ... ON CONFLICT push_tokens
     const res = await buildApp('user-1').request(
       jsonReq('POST', '/push/register', { token: 'fcm-token-abc', platform: 'android' }),
     );
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
+    // 이 토큰의 다른 소유자 행을 먼저 제거(전역 단일 소유자) — A→B 로그인 시 오배달 방지.
+    const del = mockDB.calls.find((c) => c.sql.startsWith('DELETE FROM push_tokens'));
+    expect(del).toBeDefined();
+    expect(del!.sql).toContain('token = ?');
+    expect(del!.sql).toContain('user_id != ?');
+    expect(del!.args).toEqual(['fcm-token-abc', 'user-1']);
     const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO push_tokens'));
     expect(insert).toBeDefined();
     expect(insert!.sql).toContain('ON CONFLICT(user_id, token)');

--- a/packages/backend/test/push.test.ts
+++ b/packages/backend/test/push.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+import pushRoutes from '../src/routes/push';
+
+function buildApp(userId = 'user-1') {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware(userId));
+  app.route('/push', pushRoutes);
+  return app;
+}
+
+describe('POST /push/register — FCM 토큰 등록', () => {
+  beforeEach(() => mockDB.reset());
+
+  it('유효 토큰+플랫폼 → success, push_tokens upsert', async () => {
+    mockDB.pushResult([], 1); // INSERT ... ON CONFLICT push_tokens
+    const res = await buildApp('user-1').request(
+      jsonReq('POST', '/push/register', { token: 'fcm-token-abc', platform: 'android' }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO push_tokens'));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain('ON CONFLICT(user_id, token)');
+    // args = [uuid, userPk, token, platform] — 소유자 스코프(userPk)로 저장.
+    expect(insert!.args).toContain('user-1');
+    expect(insert!.args).toContain('fcm-token-abc');
+    expect(insert!.args).toContain('android');
+  });
+
+  it('token 누락 → 400 INVALID_PUSH_TOKEN', async () => {
+    const res = await buildApp().request(jsonReq('POST', '/push/register', { platform: 'android' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_PUSH_TOKEN');
+  });
+
+  it('공백 token → 400', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/push/register', { token: '   ', platform: 'ios' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_PUSH_TOKEN');
+  });
+
+  it('허용되지 않은 platform → 400 INVALID_PLATFORM', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/push/register', { token: 'tok', platform: 'windows' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_PLATFORM');
+  });
+
+  it('잘못된 JSON → 400 INVALID_JSON', async () => {
+    const res = await buildApp().request(
+      new Request('http://localhost/push/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{not json',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_JSON');
+  });
+});


### PR DESCRIPTION
dev-test-handoff 의 남은 작업 중 코드로 완결 가능한 것들을 구현.

## 1. 가족 알람 즉시 배달
- **포그라운드 즉시 pull**: `ProcessLifecycleOwner` onStart(앱 복귀)마다 원격 알람 즉시 pull(+로컬 알림). 지금까지 '알람 탭 진입'에서만 되던 걸 어느 화면 복귀에도 확장. 60초 throttle. (Firebase 무관)
- **FCM 백그라운드 즉시**: 앱을 안 켠 백그라운드/종료 상태에서도 수신자에게 data-only push → 즉시 pull → 로컬 스케줄+알림.
  - 백엔드: `POST /api/push/register`(토큰 저장 — 없던 INSERT 경로), 가족 알람 생성 시 `sendFamilyAlarmPush`(waitUntil 논블로킹), `sendPushNotifications` data-only 지원.
  - Android: `AlarmTalkMessagingService`(onMessageReceived→pull, onNewToken→등록), 앱 시작·로그인 시 토큰 등록. firebase-messaging + google-services 플러그인.

## 2. 날씨 미해결 안내 클립
준비창에서 인터넷이 안 돼 날씨를 못 받아온 경우, 대표(맑음) 오재생 대신 "인터넷이 안 돼서 오늘 날씨를 못 알아봤어요…" 안내 클립을 그 목소리로 재생. weather 클립 = 조건 8 + 안내 1 = 9(마지막이 안내), 클라는 `size-1` 폴백.

## 검증
- 백엔드 vitest **1331 통과**, 타입체크·lint OK (push 등록 테스트 5건, 개수 계약 테스트 포함).
- Android **assembleDevDebug BUILD SUCCESSFUL**(APK) + testDevDebugUnitTest 통과.

## 시크릿/파일
- 서비스계정 JSON = `.dev.vars.dev`(gitignore)에만. `google-services.json`(저감도 클라 키)은 flavor(dev/prod)에 커밋 → CI devDebug 빌드 통과. 실제 개인키/service-account email 커밋 트리에 없음.

## 머지 후 필요
1. `npm run secrets:sync:dev` — `FIREBASE_PROJECT_ID`/`FIREBASE_SERVICE_ACCOUNT_JSON` 을 dev 워커에 반영(안 하면 fcm MOCK 로그만).
2. 날씨 9번째 클립은 cron `findMissingStockTargets` 가 자동 생성(재시드 불필요).
3. 폰 실기기: 로그인(토큰 등록)→가족 알람 push 수신, 오프라인 날씨 알람 안내 클립.