### PR TITLE
등록 미리듣기 관계·호칭 톤 적응 + 사전렌더 드레인 가속

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -400,7 +400,10 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
       releasePrerenderClaim,
     } = await import('./lib/stock-clips');
     const { missingConsentType, SENSITIVE_REQUIRED_CONSENTS } = await import('./lib/consent');
-    const MAX_CLIPS_PER_TICK = 3;
+    // 틱(5분)당 생성 클립 상한. 클립 1개 = Gemini 문구 생성 + ElevenLabs 합성 + R2 업로드라 서브리퀘스트·
+    // 비용·rate 를 제한하되, 목소리 1개 풀셋(21클립)이 너무 늦지 않게 6으로 잡는다(≈4틱, keep 후 ~20분).
+    // 발사 시각 알람 푸시는 cron 에서 제거돼(중복 알림) 이 드레인이 틱의 시간민감 작업을 막을 일은 없다.
+    const MAX_CLIPS_PER_TICK = 6;
     const claimed = await claimPendingPrerenderVoices(db, 5);
     if (claimed.length > 0) {
       const cloneVoices = await listReadyCloneVoices(db, claimed);

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1367,6 +1367,17 @@ export const migrations: Migration[] = [
        WHERE status = 'done'`,
     ],
   },
+  {
+    id: 65,
+    name: 'voice-draft-preview-text',
+    statements: [
+      // 등록 미리듣기의 관계·호칭 톤 적응 문구는 요청마다 달라질 수 있어, 첫 생성분을 draft 행에
+      // 영속해 재생(replay)을 결정적으로 만든다(같은 문구 → 같은 캐시키 → previewed_at 이후 재생이
+      // 캐시 히트로 성립). 관계/호칭 수정 시 previewed_at 과 함께 리셋해 새 문구로 재생성한다.
+      `ALTER TABLE voice_profiles ADD COLUMN preview_text TEXT`,
+      `ALTER TABLE voice_profiles ADD COLUMN preview_tag TEXT`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -935,6 +935,9 @@ tts.post('/generate', async (c) => {
             // 이미 영속된(재생될) 문구를 덮어써 재생 결정성을 깨지 못한다. 지면 승자 문구를 재사용.
             // 페르소나 predicate(관계/호칭, preview claim 과 동일 기준): 생성 왕복 중 관계·호칭이
             // 편집됐으면 옛 페르소나로 만든 문구를 저장하지 않는다(써 두면 다음 미리듣기가 재사용).
+            // previewed_at/claim 가드: 다른 요청이 이미 확정했거나(폴백 문구로 합성됐을 수 있음)
+            // 활성 claim 으로 합성 중이면 저장하지 않는다 — 늦은 영속이 '실제 합성된 문구'와 다른
+            // 문구를 남겨 재생 캐시 키를 어긋내는 것 방지(claim 과 동일한 5분 lease 기준).
             const persisted = await db.execute({
               sql: `UPDATE voice_profiles
                     SET preview_text = ?, preview_tag = ?, updated_at = datetime('now')
@@ -942,7 +945,10 @@ tts.post('/generate', async (c) => {
                       AND COALESCE(is_draft, 0) = 1
                       AND COALESCE(relationship_label, '') = ?
                       AND COALESCE(listener_title, '') = ?
-                      AND COALESCE(preview_text, '') = ''`,
+                      AND COALESCE(preview_text, '') = ''
+                      AND previewed_at IS NULL
+                      AND (preview_claimed_at IS NULL
+                        OR preview_claimed_at <= datetime('now', '-5 minutes'))`,
               args: [
                 generated.text,
                 draftPreviewTag,

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -927,13 +927,33 @@ tts.post('/generate', async (c) => {
             requestText = generated.text;
             if (generated.tag) draftPreviewTag = generated.tag;
             // 합성 전에 영속: 합성이 실패해도 재시도가 같은 문구를 쓰게(중복 생성 방지 + 캐시 정합).
-            await db.execute({
+            // 조건부(비어있을 때만) 쓰기 = first-writer-wins: 동시 첫-미리듣기 요청이 겹쳐도 늦은 쪽이
+            // 이미 영속된(재생될) 문구를 덮어써 재생 결정성을 깨지 못한다. 지면 승자 문구를 재사용.
+            const persisted = await db.execute({
               sql: `UPDATE voice_profiles
                     SET preview_text = ?, preview_tag = ?, updated_at = datetime('now')
                     WHERE id = ? AND user_id IN (?, ?) AND deleted_at IS NULL
-                      AND COALESCE(is_draft, 0) = 1`,
+                      AND COALESCE(is_draft, 0) = 1
+                      AND COALESCE(preview_text, '') = ''`,
               args: [generated.text, draftPreviewTag, body.voice_profile_id, userPk, userId],
             });
+            if ((persisted.rowsAffected ?? 0) === 0) {
+              const winner = await db.execute({
+                sql: `SELECT preview_text, preview_tag FROM voice_profiles
+                      WHERE id = ? AND user_id IN (?, ?) AND deleted_at IS NULL
+                      LIMIT 1`,
+                args: [body.voice_profile_id, userPk, userId],
+              });
+              const winnerRow = winner.rows[0];
+              const winnerText =
+                typeof winnerRow?.preview_text === 'string' ? winnerRow.preview_text.trim() : '';
+              if (winnerText) {
+                requestText = winnerText;
+                const winnerTag =
+                  typeof winnerRow?.preview_tag === 'string' ? winnerRow.preview_tag.trim() : '';
+                draftPreviewTag = winnerTag || 'cheerfully';
+              }
+            }
           }
         } catch {
           // 고정 예문 폴백 유지 (requestText 는 이미 예문+호칭으로 설정돼 있음)

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -929,13 +929,25 @@ tts.post('/generate', async (c) => {
             // 합성 전에 영속: 합성이 실패해도 재시도가 같은 문구를 쓰게(중복 생성 방지 + 캐시 정합).
             // 조건부(비어있을 때만) 쓰기 = first-writer-wins: 동시 첫-미리듣기 요청이 겹쳐도 늦은 쪽이
             // 이미 영속된(재생될) 문구를 덮어써 재생 결정성을 깨지 못한다. 지면 승자 문구를 재사용.
+            // 페르소나 predicate(관계/호칭, preview claim 과 동일 기준): 생성 왕복 중 관계·호칭이
+            // 편집됐으면 옛 페르소나로 만든 문구를 저장하지 않는다(써 두면 다음 미리듣기가 재사용).
             const persisted = await db.execute({
               sql: `UPDATE voice_profiles
                     SET preview_text = ?, preview_tag = ?, updated_at = datetime('now')
                     WHERE id = ? AND user_id IN (?, ?) AND deleted_at IS NULL
                       AND COALESCE(is_draft, 0) = 1
+                      AND COALESCE(relationship_label, '') = ?
+                      AND COALESCE(listener_title, '') = ?
                       AND COALESCE(preview_text, '') = ''`,
-              args: [generated.text, draftPreviewTag, body.voice_profile_id, userPk, userId],
+              args: [
+                generated.text,
+                draftPreviewTag,
+                body.voice_profile_id,
+                userPk,
+                userId,
+                String(vp.relationship_label ?? ''),
+                String(vp.listener_title ?? ''),
+              ],
             });
             if ((persisted.rowsAffected ?? 0) === 0) {
               const winner = await db.execute({

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -19,13 +19,18 @@ import {
   AlarmTextPreparationInvalidError,
   AlarmTextTranslationUnavailableError,
   generateDynamicAlarmTextWithVertex,
+  generatePrerenderClipText,
   deriveAlarmDisplayText,
   prepareAlarmTextWithVertex,
   type WeatherSignal,
   type WeatherCondition,
 } from '../lib/vertex-translate';
 import { loadTtsPresets, type TtsPreset } from '../lib/tts-presets';
-import { CLONE_WEATHER_CONDITIONS } from '../lib/stock-clips';
+import {
+  CLONE_CLIP_SEEDS,
+  CLONE_WEATHER_CONDITIONS,
+  STOCK_GREETING_CATEGORY,
+} from '../lib/stock-clips';
 import {
   readManualTtsUsage,
   refundManualTtsQuota,
@@ -816,6 +821,7 @@ tts.post('/generate', async (c) => {
   if (draftPreviewRequested) requestText = draftPreviewText(storedPreviewLanguage);
 
   const isSystemVoice = Boolean(Number(vp.is_system ?? 0));
+  let draftPreviewListenerTitle: string | null = null;
   if ((randomRequested && randomContext === 'preset') || draftPreviewRequested) {
     const isSharedVoiceProfileForPreset =
       typeof vp.owner_pk === 'string' && vp.owner_pk.trim() !== '' && vp.owner_pk !== userPk;
@@ -827,6 +833,9 @@ tts.post('/generate', async (c) => {
         ? await findViewerListenerTitle(db, userPk, userId, body.voice_profile_id)
         : null) ??
       normalizeRelationshipLabel(vp.listener_title);
+    if (draftPreviewRequested) draftPreviewListenerTitle = listenerTitle ?? null;
+    // 미리듣기는 아래에서 관계·호칭 톤 적응 생성을 시도한다 — 여기서 만든 '고정 예문+호칭 접두어'는
+    // 생성 실패(Vertex 미설정/모델 오류) 시의 폴백 문구가 된다.
     requestText = presetTextWithListenerTitle(requestText, listenerTitle);
   }
   if (freePlanRestricted) {
@@ -882,11 +891,36 @@ tts.post('/generate', async (c) => {
   let manualQuotaResult: { used: number; limit: number; remaining: number } | null = null;
   let previewClaimed = false;
   let activePreviewClaimToken: string | null = null;
+  let draftPreviewTag = 'cheerfully';
 
   try {
     const requestedLanguage = draftPreviewRequested
       ? storedPreviewLanguage
       : normalizeSynthesisLanguage(body.language);
+
+    if (draftPreviewRequested) {
+      // 미리듣기 문구를 keep(승격) 후 사전렌더될 greeting 과 같은 seed 로 '관계·호칭 톤 적응' 생성한다
+      // — 사용자가 확정 전에 그 목소리의 실제 말투(관계에 맞는 어투 + 호칭)를 듣고 결정하게 하기 위함.
+      // 실패(Vertex 미설정·모델 오류·검증 탈락) 시 위의 고정 예문(+호칭 접두어)으로 폴백해 미리듣기
+      // 자체는 절대 막지 않는다. Vertex(국외) 전송은 위 missingTtsConsent(overseas_transfer 포함) 통과
+      // 뒤에만 일어난다.
+      try {
+        const greetingSeed = CLONE_CLIP_SEEDS.find((s) => s.category === STOCK_GREETING_CATEGORY);
+        if (greetingSeed) {
+          const generated = await generatePrerenderClipText(c.env, {
+            seed: greetingSeed.seeds[0]!,
+            relationshipLabel: normalizeRelationshipLabel(vp.relationship_label) ?? null,
+            listenerTitle: draftPreviewListenerTitle,
+            targetLanguage: storedPreviewLanguage,
+            defaultTag: greetingSeed.defaultTag,
+          });
+          requestText = generated.text;
+          if (generated.tag) draftPreviewTag = generated.tag;
+        }
+      } catch {
+        // 고정 예문 폴백 유지 (requestText 는 이미 예문+호칭으로 설정돼 있음)
+      }
+    }
 
     // 국외 이전 동의(B4): 동적 문구 생성(wake_weather/wake_fortune 등)과 번역은
     // 텍스트를 국외(Google Vertex)로 전송하므로 overseas_transfer 동의가 필요하다.
@@ -986,10 +1020,14 @@ tts.post('/generate', async (c) => {
     // prepare는 preset/custom + 번역 경로 전용으로 남긴다.
     let prepared: { text: string; translated: boolean; tags: string[] };
     if (draftPreviewRequested) {
+      // 톤 적응 생성이 성공했으면 그 delivery 태그를, 폴백(고정 예문)이면 기본 cheerfully 를 쓴다.
+      // 동적 경로와 동일하게 태그 포함 길이가 200을 넘으면 태그를 버려 메타와 합성 텍스트를 일치시킨다.
+      const taggedText = `[${draftPreviewTag}] ${requestText}`;
+      const tagApplied = taggedText.length <= 200;
       prepared = {
-        text: `[cheerfully] ${requestText}`,
+        text: tagApplied ? taggedText : requestText,
         translated: false,
-        tags: ['cheerfully'],
+        tags: tagApplied ? [draftPreviewTag] : [],
       };
     } else if (dynamicGenerated) {
       const dynamicTag = dynamicGenerated.tags[0] ?? '';

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -901,24 +901,43 @@ tts.post('/generate', async (c) => {
     if (draftPreviewRequested) {
       // 미리듣기 문구를 keep(승격) 후 사전렌더될 greeting 과 같은 seed 로 '관계·호칭 톤 적응' 생성한다
       // — 사용자가 확정 전에 그 목소리의 실제 말투(관계에 맞는 어투 + 호칭)를 듣고 결정하게 하기 위함.
+      // 생성 문구는 요청마다 달라질 수 있으므로 첫 생성분을 draft 행(preview_text/preview_tag)에 영속해
+      // 재생을 결정적으로 만든다 — previewed_at 이후 재생은 캐시 히트로만 성립하므로 같은 문구가 필수.
+      // 관계/호칭 수정 시 previewed_at 과 함께 리셋돼 새 문구로 재생성된다(voice-profile PATCH).
       // 실패(Vertex 미설정·모델 오류·검증 탈락) 시 위의 고정 예문(+호칭 접두어)으로 폴백해 미리듣기
       // 자체는 절대 막지 않는다. Vertex(국외) 전송은 위 missingTtsConsent(overseas_transfer 포함) 통과
       // 뒤에만 일어난다.
-      try {
-        const greetingSeed = CLONE_CLIP_SEEDS.find((s) => s.category === STOCK_GREETING_CATEGORY);
-        if (greetingSeed) {
-          const generated = await generatePrerenderClipText(c.env, {
-            seed: greetingSeed.seeds[0]!,
-            relationshipLabel: normalizeRelationshipLabel(vp.relationship_label) ?? null,
-            listenerTitle: draftPreviewListenerTitle,
-            targetLanguage: storedPreviewLanguage,
-            defaultTag: greetingSeed.defaultTag,
-          });
-          requestText = generated.text;
-          if (generated.tag) draftPreviewTag = generated.tag;
+      const storedText =
+        typeof vp.preview_text === 'string' && vp.preview_text.trim() ? vp.preview_text.trim() : null;
+      if (storedText) {
+        requestText = storedText;
+        const storedTag = typeof vp.preview_tag === 'string' ? vp.preview_tag.trim() : '';
+        if (storedTag) draftPreviewTag = storedTag;
+      } else {
+        try {
+          const greetingSeed = CLONE_CLIP_SEEDS.find((s) => s.category === STOCK_GREETING_CATEGORY);
+          if (greetingSeed) {
+            const generated = await generatePrerenderClipText(c.env, {
+              seed: greetingSeed.seeds[0]!,
+              relationshipLabel: normalizeRelationshipLabel(vp.relationship_label) ?? null,
+              listenerTitle: draftPreviewListenerTitle,
+              targetLanguage: storedPreviewLanguage,
+              defaultTag: greetingSeed.defaultTag,
+            });
+            requestText = generated.text;
+            if (generated.tag) draftPreviewTag = generated.tag;
+            // 합성 전에 영속: 합성이 실패해도 재시도가 같은 문구를 쓰게(중복 생성 방지 + 캐시 정합).
+            await db.execute({
+              sql: `UPDATE voice_profiles
+                    SET preview_text = ?, preview_tag = ?, updated_at = datetime('now')
+                    WHERE id = ? AND user_id IN (?, ?) AND deleted_at IS NULL
+                      AND COALESCE(is_draft, 0) = 1`,
+              args: [generated.text, draftPreviewTag, body.voice_profile_id, userPk, userId],
+            });
+          }
+        } catch {
+          // 고정 예문 폴백 유지 (requestText 는 이미 예문+호칭으로 설정돼 있음)
         }
-      } catch {
-        // 고정 예문 폴백 유지 (requestText 는 이미 예문+호칭으로 설정돼 있음)
       }
     }
 

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -913,6 +913,10 @@ tts.post('/generate', async (c) => {
         requestText = storedText;
         const storedTag = typeof vp.preview_tag === 'string' ? vp.preview_tag.trim() : '';
         if (storedTag) draftPreviewTag = storedTag;
+      } else if (vp.previewed_at) {
+        // 이미 확정(previewed_at)됐는데 저장 문구가 없는 draft = 이 기능 이전(또는 고정 폴백으로 확정).
+        // 그때 합성된 문구는 '고정 예문+호칭'이므로 새로 생성하면 캐시 키가 어긋나 재생이
+        // VOICE_PREVIEW_UNAVAILABLE 이 된다 → 생성하지 않고 고정 폴백을 유지해 재생 캐시 히트를 지킨다.
       } else {
         try {
           const greetingSeed = CLONE_CLIP_SEEDS.find((s) => s.category === STOCK_GREETING_CATEGORY);

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -690,6 +690,9 @@ voiceProfile.patch('/:id', async (c) => {
     updates.push('previewed_at = NULL');
     updates.push('preview_claimed_at = NULL');
     updates.push('preview_claim_token = NULL');
+    // 관계가 바뀌면 톤 적응 미리듣기 문구도 무효 — 리셋해 다음 미리듣기가 새 관계로 재생성되게 한다.
+    updates.push('preview_text = NULL');
+    updates.push('preview_tag = NULL');
   }
   if (hasListenerTitle) {
     updates.push('listener_title = ?');
@@ -698,6 +701,8 @@ voiceProfile.patch('/:id', async (c) => {
       updates.push('previewed_at = NULL');
       updates.push('preview_claimed_at = NULL');
       updates.push('preview_claim_token = NULL');
+      updates.push('preview_text = NULL');
+      updates.push('preview_tag = NULL');
     }
   }
   updates.push("updated_at = datetime('now')");

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -882,6 +882,7 @@ voiceProfile.patch('/:id/relationship', async (c) => {
       sql: `UPDATE voice_profiles
             SET relationship_label = ?, listener_title = ?, previewed_at = NULL,
                 preview_claimed_at = NULL, preview_claim_token = NULL,
+                preview_text = NULL, preview_tag = NULL,
                 updated_at = datetime('now')
             WHERE id = ? AND user_id IN (?, ?) AND deleted_at IS NULL
               AND COALESCE(is_draft, 0) = 1`,

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -235,6 +235,71 @@ describe('POST /tts/generate — TTS 생성', () => {
     expect(claimCall?.sql).toContain("COALESCE(listener_title, '') = ?");
   });
 
+  it('draft 미리듣기는 Vertex 설정 시 관계·호칭 톤 적응 문구로 합성한다', async () => {
+    const toneText = '우리 아들, 잘 잤어? 오늘도 기분 좋게 하루 시작해 보자.';
+    const mockFetch = vi.fn(async (url: unknown) => {
+      if (String(url) === TOKEN_URI) {
+        return new Response(JSON.stringify({ access_token: 'test-access-token' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      // Gemini 톤 적응 생성 응답 — {text, tag} JSON
+      return geminiText(JSON.stringify({ text: toneText, tag: 'cheerfully' }));
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      mockDB.pushResult([{ plan: 'plus' }]);
+      mockDB.pushResult([
+        {
+          id: V1,
+          user_id: 'user-1',
+          status: 'ready',
+          is_draft: 1,
+          elevenlabs_voice_id: 'el-draft',
+          relationship_label: '엄마',
+          listener_title: '우리 아들',
+        },
+      ]);
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([]);
+      pushPublicationVoice({
+        is_draft: 1,
+        elevenlabs_voice_id: 'el-draft',
+        relationship_label: '엄마',
+        listener_title: '우리 아들',
+      });
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1);
+      mockTextToSpeech.mockResolvedValue(new Uint8Array([1, 2]).buffer);
+
+      const res = await buildApp().request(
+        jsonReq('POST', '/tts/generate', {
+          voice_profile_id: V1,
+          language: 'ko',
+          draft_preview: true,
+        }),
+        undefined,
+        { ...ENV, GOOGLE_VERTEX_CREDENTIALS_JSON: VERTEX_CREDENTIALS_JSON },
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      // 고정 예문이 아니라 관계·호칭 톤 적응 생성 문구로 합성/표시된다.
+      expect(body.text).toBe(toneText);
+      expect(body.synthesis_text).toBe(`[cheerfully] ${toneText}`);
+      expect(mockTextToSpeech).toHaveBeenCalledWith(
+        'el-draft',
+        body.synthesis_text,
+        expect.any(Object),
+      );
+      expect(body.preview_playback_token).toBeTypeOf('string');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('합성 중 민감 동의를 철회하면 생성 결과를 게시하지 않는다', async () => {
     mockDB.setConsentMissing(true);
     mockDB.pushResult([{ plan: 'plus' }]);

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -261,7 +261,8 @@ describe('POST /tts/generate — TTS 생성', () => {
           listener_title: '우리 아들',
         },
       ]);
-      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1); // preview_text 영속 UPDATE
+      mockDB.pushResult([], 1); // preview claim UPDATE
       mockDB.pushResult([]);
       pushPublicationVoice({
         is_draft: 1,
@@ -295,9 +296,60 @@ describe('POST /tts/generate — TTS 생성', () => {
         expect.any(Object),
       );
       expect(body.preview_playback_token).toBeTypeOf('string');
+      // 생성 문구를 draft 행에 영속해 이후 재생이 같은 문구(=캐시 히트)로 성립하게 한다.
+      const persist = mockDB.calls.find((call) => call.sql.includes('SET preview_text'));
+      expect(persist).toBeDefined();
+      expect(persist!.args).toContain(toneText);
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it('draft 미리듣기는 저장된 preview_text 가 있으면 재생성 없이 재사용한다', async () => {
+    const storedText = '우리 아들, 잘 잤어? 오늘도 힘내 보자.';
+    mockDB.pushResult([{ plan: 'plus' }]);
+    mockDB.pushResult([
+      {
+        id: V1,
+        user_id: 'user-1',
+        status: 'ready',
+        is_draft: 1,
+        elevenlabs_voice_id: 'el-draft',
+        relationship_label: '엄마',
+        listener_title: '우리 아들',
+        preview_text: storedText,
+        preview_tag: 'cheerfully',
+      },
+    ]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([]);
+    pushPublicationVoice({
+      is_draft: 1,
+      elevenlabs_voice_id: 'el-draft',
+      relationship_label: '엄마',
+      listener_title: '우리 아들',
+    });
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockTextToSpeech.mockResolvedValue(new Uint8Array([1, 2]).buffer);
+
+    const res = await reqWithEnv(
+      buildApp(),
+      jsonReq('POST', '/tts/generate', {
+        voice_profile_id: V1,
+        language: 'ko',
+        draft_preview: true,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    // 고정 예문/새 생성이 아니라 저장된 문구 그대로 — 재생이 결정적(같은 캐시키)이다.
+    expect(body.text).toBe(storedText);
+    expect(body.synthesis_text).toBe(`[cheerfully] ${storedText}`);
+    // 재사용 경로는 재생성/재영속하지 않는다.
+    expect(mockDB.calls.some((call) => call.sql.includes('SET preview_text'))).toBe(false);
   });
 
   it('합성 중 민감 동의를 철회하면 생성 결과를 게시하지 않는다', async () => {

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -300,6 +300,9 @@ describe('POST /tts/generate — TTS 생성', () => {
       const persist = mockDB.calls.find((call) => call.sql.includes('SET preview_text'));
       expect(persist).toBeDefined();
       expect(persist!.args).toContain(toneText);
+      // 확정/활성 claim 중에는 저장 금지(늦은 영속이 실제 합성 문구와 어긋나는 것 방지).
+      expect(persist!.sql).toContain('previewed_at IS NULL');
+      expect(persist!.sql).toContain('preview_claimed_at IS NULL');
     } finally {
       vi.unstubAllGlobals();
     }

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -366,6 +366,47 @@ describe('POST /tts/generate — TTS 생성', () => {
     }
   });
 
+  it('확정됐지만 preview_text 없는 레거시 draft 재생은 새로 생성하지 않는다(고정 폴백 유지)', async () => {
+    const mockFetch = vi.fn(async () => {
+      throw new Error('legacy replay must not call Vertex');
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      mockDB.pushResult([{ plan: 'plus' }]);
+      mockDB.pushResult([
+        {
+          id: V1,
+          user_id: 'user-1',
+          status: 'ready',
+          is_draft: 1,
+          elevenlabs_voice_id: 'el-draft',
+          relationship_label: '엄마',
+          listener_title: '우리 아들',
+          previewed_at: '2026-07-15 00:00:00',
+        },
+      ]);
+      // previewed_at 이 있으므로 claim 없음. 캐시 미스(mock 빈 결과) → 409 VOICE_PREVIEW_UNAVAILABLE
+      // 가 정상 경로다(실환경에선 고정 문구가 이미 합성돼 있어 캐시 히트로 재생됨). 핵심 단언은
+      // '생성/영속을 시도하지 않는다' — 새 문구를 만들면 캐시 키가 어긋나 재생이 영구히 깨진다.
+      const res = await buildApp().request(
+        jsonReq('POST', '/tts/generate', {
+          voice_profile_id: V1,
+          language: 'ko',
+          draft_preview: true,
+        }),
+        undefined,
+        { ...ENV, GOOGLE_VERTEX_CREDENTIALS_JSON: VERTEX_CREDENTIALS_JSON },
+      );
+
+      expect(res.status).toBe(409);
+      expect((await res.json()).error_code).toBe('VOICE_PREVIEW_UNAVAILABLE');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockDB.calls.some((call) => call.sql.includes('SET preview_text'))).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('draft 미리듣기는 저장된 preview_text 가 있으면 재생성 없이 재사용한다', async () => {
     const storedText = '우리 아들, 잘 잤어? 오늘도 힘내 보자.';
     mockDB.pushResult([{ plan: 'plus' }]);

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -305,6 +305,67 @@ describe('POST /tts/generate — TTS 생성', () => {
     }
   });
 
+  it('동시 첫-미리듣기 레이스에서 진 쪽은 승자의 preview_text 를 재사용한다', async () => {
+    const loserText = '우리 아들, 오늘도 상쾌하게 일어나 볼까?';
+    const winnerText = '우리 아들, 잘 잤어? 오늘 하루도 힘내자.';
+    const mockFetch = vi.fn(async (url: unknown) => {
+      if (String(url) === TOKEN_URI) {
+        return new Response(JSON.stringify({ access_token: 'test-access-token' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return geminiText(JSON.stringify({ text: loserText, tag: 'cheerfully' }));
+    });
+    vi.stubGlobal('fetch', mockFetch);
+    try {
+      mockDB.pushResult([{ plan: 'plus' }]);
+      mockDB.pushResult([
+        {
+          id: V1,
+          user_id: 'user-1',
+          status: 'ready',
+          is_draft: 1,
+          elevenlabs_voice_id: 'el-draft',
+          relationship_label: '엄마',
+          listener_title: '우리 아들',
+        },
+      ]);
+      mockDB.pushResult([], 0); // 조건부 영속 실패(다른 요청이 먼저 씀)
+      mockDB.pushResult([{ preview_text: winnerText, preview_tag: 'cheerfully' }]); // 승자 재조회
+      mockDB.pushResult([], 1); // preview claim
+      mockDB.pushResult([]);
+      pushPublicationVoice({
+        is_draft: 1,
+        elevenlabs_voice_id: 'el-draft',
+        relationship_label: '엄마',
+        listener_title: '우리 아들',
+      });
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1);
+      mockDB.pushResult([], 1);
+      mockTextToSpeech.mockResolvedValue(new Uint8Array([1, 2]).buffer);
+
+      const res = await buildApp().request(
+        jsonReq('POST', '/tts/generate', {
+          voice_profile_id: V1,
+          language: 'ko',
+          draft_preview: true,
+        }),
+        undefined,
+        { ...ENV, GOOGLE_VERTEX_CREDENTIALS_JSON: VERTEX_CREDENTIALS_JSON },
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      // 진 쪽의 새 생성 문구(loserText)가 아니라 이미 영속된 승자 문구로 합성된다.
+      expect(body.text).toBe(winnerText);
+      expect(body.synthesis_text).toBe(`[cheerfully] ${winnerText}`);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('draft 미리듣기는 저장된 preview_text 가 있으면 재생성 없이 재사용한다', async () => {
     const storedText = '우리 아들, 잘 잤어? 오늘도 힘내 보자.';
     mockDB.pushResult([{ plan: 'plus' }]);


### PR DESCRIPTION
## 1. 미리듣기 톤 적응
keep 전 필수 미리듣기가 고정 예문+호칭 접두어였던 것을, keep 후 사전렌더될 greeting 과 같은 seed 의 관계·호칭 톤 적응 생성(generatePrerenderClipText)으로 변경. 사용자가 확정 전에 그 목소리의 실제 말투를 듣고 결정한다. 실패 시 기존 고정 예문 폴백(미리듣기 절대 안 막힘). Vertex 전송은 동의(overseas_transfer) 확인 뒤에만.

## 2. 사전렌더 드레인 가속
MAX_CLIPS_PER_TICK 3→6 — 풀셋 21클립 keep 후 ~35분 → ~20분 (cron 발사 푸시 제거로 시간민감 경합 없음).

## 검증
백엔드 vitest 1334 통과(톤 적응 성공 경로 테스트 추가), typecheck OK. 클라 변경 없음(미리듣기 문구는 서버 생성).