### PR TITLE
fix: 라이트 모드 인증 화면 상태바 흰 띠 제거

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -1,5 +1,9 @@
 package com.alarmtalk.app
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
 import android.util.Patterns
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -37,6 +41,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +50,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -52,6 +60,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 
 internal enum class AuthMode { Login, Register }
 
@@ -61,18 +70,57 @@ private val AuthFieldGlass = Color(0x14FFFFFF)
 internal val AuthLine = Color(0x3DFFFFFF)
 internal val AuthLineSoft = Color(0x29FFFFFF)
 internal val AuthTextMuted = Color(0x99FFFFFF)
+private val AuthSceneTop = Color(0xFF1A2A52)
+private val AuthSceneBottom = Color(0xFF070C1D)
+
+/**
+ * 고정 다크 씬(랜딩·인증 플로우)이 보이는 동안 시스템 바를 씬 색으로 덮어쓴다.
+ * 테마(AppSystemBars)는 상태바를 theme background 로 칠하므로 라이트 모드에선
+ * 네이비 씬 위에 흰 상태바 띠가 생긴다 — 씬을 벗어나면 테마 기본으로 복원한다.
+ */
+@Composable
+internal fun SceneSystemBars(top: Color, bottom: Color) {
+    val view = LocalView.current
+    val themeBackground = MaterialTheme.colorScheme.background
+    DisposableEffect(view, top, bottom, themeBackground) {
+        val window = view.context.findActivity()?.window
+        fun apply(statusColor: Color, navColor: Color, lightIcons: Boolean) {
+            window ?: return
+            window.statusBarColor = statusColor.toArgb()
+            window.navigationBarColor = navColor.toArgb()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                window.navigationBarDividerColor = navColor.toArgb()
+            }
+            WindowCompat.getInsetsController(window, view).apply {
+                isAppearanceLightStatusBars = lightIcons
+                isAppearanceLightNavigationBars = lightIcons
+            }
+        }
+        apply(top, bottom, lightIcons = false)
+        onDispose {
+            apply(themeBackground, themeBackground, lightIcons = themeBackground.luminance() > 0.5f)
+        }
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
 
 /** 인증 플로우 공통 배경 — 은은한 네이비 그라데이션 + 상단 브랜드 글로우. */
 @Composable
 internal fun AuthBackdrop(content: @Composable BoxScope.() -> Unit) {
+    SceneSystemBars(top = AuthSceneTop, bottom = AuthSceneBottom)
     Box(
         Modifier
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    0f to Color(0xFF1A2A52),
+                    0f to AuthSceneTop,
                     0.55f to Color(0xFF0E1938),
-                    1f to Color(0xFF070C1D),
+                    1f to AuthSceneBottom,
                 ),
             ),
     ) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -1,9 +1,5 @@
 package com.alarmtalk.app
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import android.os.Build
 import android.util.Patterns
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -41,7 +37,6 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,9 +45,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -60,7 +52,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.core.view.WindowCompat
 
 internal enum class AuthMode { Login, Register }
 
@@ -72,42 +63,6 @@ internal val AuthLineSoft = Color(0x29FFFFFF)
 internal val AuthTextMuted = Color(0x99FFFFFF)
 private val AuthSceneTop = Color(0xFF1A2A52)
 private val AuthSceneBottom = Color(0xFF070C1D)
-
-/**
- * 고정 다크 씬(랜딩·인증 플로우)이 보이는 동안 시스템 바를 씬 색으로 덮어쓴다.
- * 테마(AppSystemBars)는 상태바를 theme background 로 칠하므로 라이트 모드에선
- * 네이비 씬 위에 흰 상태바 띠가 생긴다 — 씬을 벗어나면 테마 기본으로 복원한다.
- */
-@Composable
-internal fun SceneSystemBars(top: Color, bottom: Color) {
-    val view = LocalView.current
-    val themeBackground = MaterialTheme.colorScheme.background
-    DisposableEffect(view, top, bottom, themeBackground) {
-        val window = view.context.findActivity()?.window
-        fun apply(statusColor: Color, navColor: Color, lightIcons: Boolean) {
-            window ?: return
-            window.statusBarColor = statusColor.toArgb()
-            window.navigationBarColor = navColor.toArgb()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                window.navigationBarDividerColor = navColor.toArgb()
-            }
-            WindowCompat.getInsetsController(window, view).apply {
-                isAppearanceLightStatusBars = lightIcons
-                isAppearanceLightNavigationBars = lightIcons
-            }
-        }
-        apply(top, bottom, lightIcons = false)
-        onDispose {
-            apply(themeBackground, themeBackground, lightIcons = themeBackground.luminance() > 0.5f)
-        }
-    }
-}
-
-private tailrec fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
-}
 
 /** 인증 플로우 공통 배경 — 은은한 네이비 그라데이션 + 상단 브랜드 글로우. */
 @Composable

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -131,6 +131,7 @@ internal fun LandingScreen(
     contentPadding: PaddingValues,
     onStart: () -> Unit,
 ) {
+    SceneSystemBars(top = LandingScene.skyStops.first().second, bottom = LandingScene.seaBottom)
     Box(Modifier.fillMaxSize()) {
         SunriseScene(palette = LandingScene, modifier = Modifier.fillMaxSize())
         Column(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -116,20 +118,48 @@ private val AlarmTalkShapes = Shapes(
     extraLarge = WakerDialogShape,
 )
 
+/** 시스템 바 오버라이드 값 — 고정 다크 씬(랜딩·인증)이 보이는 동안만 non-null. */
+private data class SystemBarsSpec(val status: Color, val nav: Color)
+
+private val systemBarsOverride = mutableStateOf<SystemBarsSpec?>(null)
+
+/**
+ * 고정 다크 씬(랜딩·인증 플로우)이 보이는 동안 시스템 바를 씬 색으로 덮어쓴다.
+ * 테마는 상태바를 theme background 로 칠하므로 라이트 모드에선 네이비 씬 위에
+ * 흰 상태바 띠가 생긴다 — 씬을 벗어나면 테마 기본으로 복원한다.
+ * 실제 창 조작은 항상 [AppSystemBars] 한 곳에서만 일어난다(오버라이드 상태를 읽어
+ * 재구성되므로, 테마 SideEffect 가 나중에 다시 칠해도 덮어쓰기 경쟁이 없다).
+ */
+@Composable
+internal fun SceneSystemBars(top: Color, bottom: Color) {
+    DisposableEffect(top, bottom) {
+        val spec = SystemBarsSpec(status = top, nav = bottom)
+        systemBarsOverride.value = spec
+        onDispose {
+            // 다른 씬이 이미 값을 바꿨다면(씬 간 전환) 그쪽 오버라이드를 존중한다.
+            if (systemBarsOverride.value == spec) systemBarsOverride.value = null
+        }
+    }
+}
+
 @Composable
 private fun AppSystemBars(isDark: Boolean) {
     val view = LocalView.current
     val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
+    val override = systemBarsOverride.value
     SideEffect {
         val window = view.context.findActivity()?.window ?: return@SideEffect
-        window.statusBarColor = backgroundColor
-        window.navigationBarColor = backgroundColor
+        val status = override?.status?.toArgb() ?: backgroundColor
+        val nav = override?.nav?.toArgb() ?: backgroundColor
+        window.statusBarColor = status
+        window.navigationBarColor = nav
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            window.navigationBarDividerColor = backgroundColor
+            window.navigationBarDividerColor = nav
         }
         WindowCompat.getInsetsController(window, view).apply {
-            isAppearanceLightStatusBars = !isDark
-            isAppearanceLightNavigationBars = !isDark
+            // 씬 오버라이드는 항상 어두운 배경(밝은 아이콘), 아니면 테마 명암을 따른다.
+            isAppearanceLightStatusBars = if (override != null) false else !isDark
+            isAppearanceLightNavigationBars = if (override != null) false else !isDark
         }
     }
 }


### PR DESCRIPTION
## 문제
라이트 모드에서 랜딩·로그인·회원가입 화면 위에 흰 상태바 띠가 생김. 인증 플로우는 고정 네이비 브랜드 비주얼(문서화 예외)인데, 테마(AppSystemBars)가 상태바를 항상 theme background(라이트=밝은 회색)로 칠하기 때문.

## 수정
- `SceneSystemBars(top, bottom)` 추가: 고정 다크 씬이 보이는 동안 상태바/내비바를 씬 색으로 덮어쓰고(아이콘 밝게), dispose 시 테마 기본(배경색·luminance 기반 아이콘)으로 복원.
- `AuthBackdrop`(로그인/가입/비번찾기 공통 배경)과 `LandingScreen`에서 각자 씬 색으로 호출.
- 인라인 그라데이션 색을 `AuthSceneTop/Bottom` 상수로 추출해 시스템 바와 단일 출처 공유.

## 검증
A32 실기기 라이트 모드에서 랜딩·로그인 캡처로 흰 띠 제거 확인, 다크 모드 회귀 없음(기존과 동일 색).