### PR TITLE
design: 탭 배경 그라데이션을 전 탭으로 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
   - **예외(토큰화 안 함)**: `CircleShape`(원형 아바타/FAB/점), `AlarmRow` 스와이프 비대칭 shape, 타임휠 전용 컨테이너(34dp).
 - **색**: `theme/AlarmTalkTheme.kt` 의 `colorScheme` 가 유일 출처. 항상 `MaterialTheme.colorScheme.*` 로 소비, **생 `Color(0x…)` 금지**.
   - 오버레이 스크림은 `WakerScrimColor`(WakerDesign.kt) 사용.
-  - 문서화된 예외: `RingingActivity`(잠금화면 전용 고정 팔레트), 알림 팩토리(Notification accent), 랜딩/로그인 브랜드 비주얼, 알람 홈 배경 그라데이션(`AlarmListScreen`의 `HomeGradientDark/Light` — 로그인 딥네이비 감성을 홈에 재현, 라이트/다크 2종).
+  - 문서화된 예외: `RingingActivity`(잠금화면 전용 고정 팔레트), 알림 팩토리(Notification accent), 랜딩/로그인 브랜드 비주얼, 탭 배경 그라데이션(`AlarmListScreen`의 `HomeGradientDark/Light` — 로그인 딥네이비 감성을 알람/목소리/더보기 탭 전체에 재현, 라이트/다크 2종).
 
 ## 진행 중 작업 (세션 재개 시 먼저 읽을 것)
 현재 상태·폰 테스트 체크리스트·남은 follow-up: **[`docs/qa/dev-test-handoff.md`](docs/qa/dev-test-handoff.md)**.

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
@@ -54,7 +54,9 @@ private const val GUIDE_TARGET_HOME_HERO = "home_next_alarm"
 // 목소리 등록 첫 방문 안내 — 내 목소리 만들기 버튼에 스포트라이트.
 private const val GUIDE_TARGET_VOICE_CREATE = "voice_register_create"
 
-// 로그인 배경(AuthBackdrop)의 딥 네이비 감성을 알람 홈에도 가져온다 — 라이트/다크 두 버전.
+// 로그인 배경(AuthBackdrop)의 딥 네이비 감성을 탭 화면 전체에 가져온다 — 라이트/다크 두 버전.
+// 알람 홈에만 깔면 탭 전환(알람↔목소리↔더보기)마다 배경 분위기가 뚝 바뀌어 어색해서,
+// 같은 그라데이션을 모든 탭에 깔아 앱을 한 공간으로 묶는다.
 // 생 Color 리터럴은 로그인/랜딩과 같은 '브랜드 비주얼' 예외(CLAUDE.md 색 토큰 규약의 문서화된 예외).
 private val HomeGradientDark = Brush.verticalGradient(
     0f to Color(0xFF1A2A52),
@@ -192,10 +194,8 @@ internal fun AlarmListScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            // 알람 리스트 홈에만 로그인식 그라데이션 배경을 깐다(다른 탭은 평소 배경 유지).
-            .then(
-                if (selectedTab == NativeTab.Alarms) Modifier.background(homeGradient) else Modifier,
-            ),
+            // 모든 탭에 같은 그라데이션 배경 — 탭 전환 시 배경 톤이 튀지 않게 한 공간으로.
+            .background(homeGradient),
     ) {
     LazyColumn(
         state = listState,


### PR DESCRIPTION
## 배경
알람 홈에만 로그인식 네이비 그라데이션이 깔려 있어 탭 전환(알람↔목소리↔더보기) 때마다 배경 분위기가 뚝 바뀌었음. 홈 그라데이션 자체는 로그인→홈 연속성·브랜드 정체성에 기여하므로 유지하되, 나머지 탭에도 같은 그라데이션을 깔아 앱 전체를 한 공간으로 묶는다(사용자 승인한 A안).

## 변경
- `AlarmListScreen`: `selectedTab == Alarms` 조건 제거 — 탭 컨테이너 전체에 `HomeGradientDark/Light` 상시 적용
- CLAUDE.md 색 토큰 예외 문구를 '알람 홈 배경'→'탭 배경'으로 갱신

## 검증
실기기 2대(라이트 S23/다크 A32)에서 알람·목소리·더보기 탭 캡처로 확인 — 카드/텍스트 대비 문제 없음.