### PR TITLE
design: 알람 편집기 디테일 정리 — 어포던스 통일·실값 표기·다크 토글 가독성

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
@@ -55,6 +55,7 @@ import com.alarmtalk.app.R
 import com.alarmtalk.app.WakerTileShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -73,13 +74,20 @@ internal fun AlarmTalkSwitch(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
+    // 다크 팔레트는 onPrimary 가 진네이비라 켜짐 썸이 트랙보다 어두워져 꺼짐으로 오독될 수
+    // 있다 — 다크에선 밝은 썸(onPrimaryContainer)으로 켜짐을 명확히 하고, 라이트는 흰 썸 유지.
+    val checkedThumbColor = if (MaterialTheme.colorScheme.background.luminance() < 0.5f) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onPrimary
+    }
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
         enabled = enabled,
         modifier = modifier,
         colors = SwitchDefaults.colors(
-            checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+            checkedThumbColor = checkedThumbColor,
             checkedTrackColor = MaterialTheme.colorScheme.primary,
             checkedBorderColor = Color.Transparent,
             uncheckedThumbColor = MaterialTheme.colorScheme.surface,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -1193,7 +1193,9 @@ internal fun AlarmEditorScreen(
                 shadowElevation = 0.dp,
             ) {
                 Column {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+                    // 바 배경이 페이지 배경과 같아 경계가 없으면 스크롤 콘텐츠가 '잘린' 것처럼
+                    // 보인다 — 다른 카드 구분선과 같은 풀 톤 헤어라인으로 바의 시작을 분명히 한다.
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                     if (editorSaveBlockedReason != null) {
                         Text(
                             text = editorSaveBlockedReason,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreenComponents.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreenComponents.kt
@@ -42,16 +42,17 @@ internal fun DynamicPromptSettings.toPromptPreferences(): DynamicPromptPreferenc
         fortuneBirthTime = fortune.birthTime?.trim().orEmpty(),
     )
 
-// 편집기 섹션 헤더 단일 출처. '재생 방식'·'세부 설정'이 이미 쓰던 titleMedium/Bold/onBackground
-// 규격으로 맞춰, 각 파일에 흩어진 인라인 Text 대신 이 컴포저블로 통일한다.
+// 편집기 섹션 헤더 단일 출처. 예전 titleMedium/Bold 는 카드 안 행 제목(titleMedium/SemiBold)과
+// 크기가 같아 섹션 경계가 안 읽혔다 — 그룹 리스트 헤더 관례대로 한 단계 조용하게
+// (titleSmall + onSurfaceVariant) 낮춰 행 제목과 위계를 분리한다.
 @Composable
 internal fun EditorSectionTitle(title: String, modifier: Modifier = Modifier) {
     Text(
         text = title,
         modifier = modifier,
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.Bold,
-        color = MaterialTheme.colorScheme.onBackground,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSettingsCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSettingsCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,6 +56,24 @@ private val VibrationOptions = listOf(
     VibrationPatterns.SIREN,
 )
 
+// '기본 알람음'이라는 정보량 없는 표기 대신 시스템 기본 알람음의 실제 이름을 보여준다.
+// 타이틀 조회는 바인더 호출이라 컴포지션당 한 번만 하고, 실패 시에만 기존 문구로 폴백.
+@Composable
+internal fun rememberDefaultAlarmSoundTitle(): String {
+    val context = LocalContext.current
+    val fallback = stringResource(R.string.editor2_default_alarm_sound)
+    return remember(context, fallback) {
+        runCatching {
+            android.media.RingtoneManager.getActualDefaultRingtoneUri(
+                context,
+                android.media.RingtoneManager.TYPE_ALARM,
+            )?.let { uri ->
+                android.media.RingtoneManager.getRingtone(context, uri)?.getTitle(context)
+            }
+        }.getOrNull()?.takeIf { it.isNotBlank() } ?: fallback
+    }
+}
+
 @Composable
 internal fun AlarmSettingsCard(
     snoozeEnabled: Boolean,
@@ -80,6 +99,8 @@ internal fun AlarmSettingsCard(
     onOpenVoiceOutputSettings: () -> Unit,
 ) {
     val context = LocalContext.current
+    // 라벨이 없으면(시스템 기본) 실제 기본 알람음 이름으로 보여준다.
+    val resolvedAlarmSoundLabel = alarmSoundLabel ?: rememberDefaultAlarmSoundTitle()
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -126,7 +147,7 @@ internal fun AlarmSettingsCard(
                         subtitle = alarmSoundSummary(
                             context = context,
                             alarmVolumePercent = alarmVolumePercent,
-                            alarmSoundLabel = alarmSoundLabel,
+                            alarmSoundLabel = resolvedAlarmSoundLabel,
                         ),
                         onClick = onOpenAlarmSoundSettings,
                         trailing = {
@@ -306,7 +327,7 @@ internal fun AlarmSoundSettingsPane(
                     SnoozeOptionSection(title = stringResource(R.string.editor_alarm_sound_title)) {
                         AlarmSoundActionRow(
                             title = stringResource(R.string.editor_alarm_sound_title),
-                            subtitle = alarmSoundLabel ?: stringResource(R.string.editor_default_alarm_sound),
+                            subtitle = alarmSoundLabel ?: rememberDefaultAlarmSoundTitle(),
                             onClick = onPickAlarmSound,
                         )
                     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSnoozeSettings.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmSnoozeSettings.kt
@@ -122,10 +122,11 @@ internal fun AlarmSettingRow(
 }
 
 @Composable
-internal fun AlarmSettingDivider() {
-    // 행에 아이콘 배지가 없어 제목 텍스트가 카드 안쪽 left에서 시작 → 구분선도 들여쓰기 없이 텍스트 시작선에 맞춘다.
+internal fun AlarmSettingDivider(modifier: Modifier = Modifier) {
+    // 구분선은 행 텍스트 시작선에 맞춘다 — 세부 설정 카드는 카드 자체 패딩이 있어 그대로,
+    // 목소리 카드처럼 행이 자체 패딩을 갖는 곳은 호출부에서 같은 값으로 인셋을 준다.
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(1.dp)
             .background(MaterialTheme.colorScheme.outlineVariant),

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
@@ -221,14 +222,14 @@ internal fun VoiceAudioCard(
                                     selectedId = editor.voiceProfileId ?: "",
                                     onSelect = { option -> editor.selectVoiceProfile(option.id) },
                                 )
-                                AlarmSettingDivider()
+                                AlarmSettingDivider(modifier = Modifier.padding(horizontal = 14.dp))
                                 MessageModeSummaryRow(
                                     isManual = !editor.voiceRandomPrompt,
                                     randomContext = editor.voiceRandomContext,
                                     manualText = editor.voiceText,
                                     onClick = onOpenRandomPromptSettings,
                                 )
-                                AlarmSettingDivider()
+                                AlarmSettingDivider(modifier = Modifier.padding(horizontal = 14.dp))
                                 VoiceVolumeSummaryRow(
                                     volumePercent = editor.voiceVolumePercent,
                                     onClick = onOpenVoiceOutputSettings,
@@ -617,11 +618,11 @@ private fun FreeVoiceSummaryRow(
                 maxLines = 1,
             )
             Spacer(Modifier.width(12.dp))
-            Text(
-                text = stringResource(R.string.editor_change),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.SemiBold,
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
             )
         }
     }
@@ -665,11 +666,11 @@ internal fun MessageModeSummaryRow(
                 MutedText(valueLabel)
             }
             Spacer(Modifier.width(12.dp))
-            Text(
-                text = stringResource(R.string.editor_change),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.SemiBold,
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
             )
         }
     }
@@ -760,11 +761,11 @@ private fun VoiceVolumeSummaryRow(volumePercent: Int, onClick: () -> Unit) {
                 MutedText("$volumePercent%")
             }
             Spacer(Modifier.width(12.dp))
-            Text(
-                text = stringResource(R.string.editor_change),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.SemiBold,
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
             )
         }
     }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -183,10 +183,8 @@
     <string name="editor_record_again">Record again</string>
     <string name="editor_audio_preview_stop">Stop</string>
     <string name="editor_back">Back</string>
-    <string name="editor_change">Change</string>
     <string name="editor_collapse">Collapse</string>
     <string name="editor_create_voice">Create a voice</string>
-    <string name="editor_default_alarm_sound">Default alarm sound</string>
     <string name="editor_detail_settings">Detailed settings</string>
     <string name="editor_error_audio_duration_unreadable">Files whose audio length can\'t be read can\'t be used.</string>
     <string name="editor_error_crop_save_failed">Couldn\'t save the selected section.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -183,10 +183,8 @@
     <string name="editor_record_again">録り直す</string>
     <string name="editor_audio_preview_stop">停止</string>
     <string name="editor_back">戻る</string>
-    <string name="editor_change">変更</string>
     <string name="editor_collapse">折りたたむ</string>
     <string name="editor_create_voice">声を作る</string>
-    <string name="editor_default_alarm_sound">標準アラーム音</string>
     <string name="editor_detail_settings">詳細設定</string>
     <string name="editor_error_audio_duration_unreadable">音声の長さを確認できないファイルは使用できません。</string>
     <string name="editor_error_crop_save_failed">選択した区間を保存できませんでした。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -185,10 +185,8 @@
     <string name="editor_record_again">다시 녹음</string>
     <string name="editor_audio_preview_stop">정지</string>
     <string name="editor_back">뒤로</string>
-    <string name="editor_change">변경</string>
     <string name="editor_collapse">접기</string>
     <string name="editor_create_voice">목소리 만들기</string>
-    <string name="editor_default_alarm_sound">기본 알람음</string>
     <string name="editor_detail_settings">세부 설정</string>
     <string name="editor_error_audio_duration_unreadable">오디오 길이를 확인할 수 없는 파일은 사용할 수 없어요.</string>
     <string name="editor_error_crop_save_failed">선택한 구간을 저장하지 못했어요.</string>


### PR DESCRIPTION
## 배경
알람 설정(편집) 화면 디자인 검토(AI-slop·크래프트·UX 3렌즈, 라이트/다크 실기기)에서 확인된 지적 중, 시각·문법 정리로 안전하게 해결 가능한 항목을 반영합니다. 동작 로직이 얽힌 항목(재생 방식↔알람음 이중 통제, 신규 알람 문구 UX)은 별도 PR로 분리.

## 변경
- **탭 어포던스 문법 통일**: 파란 '변경' 텍스트 링크 3곳(문구·목소리 크기·무료 플랜 목소리 요약)을 세부 설정 행과 동일한 셰브론(`onSurfaceVariant`, 20dp)으로 교체. 화면 전체가 "셰브론 = 눌러서 상세" 하나의 언어가 되고, 반복되던 파랑 액센트가 줄어듭니다.
- **'기본 알람음' → 실제 이름**: 시스템 기본 알람음의 실제 타이틀(예: `Homecoming`)을 표시하는 `rememberDefaultAlarmSoundTitle()` 추가 (카드 요약·알람음 pane 두 곳, 조회 실패 시 기존 문구 폴백).
- **다크 토글 가독성**: 다크 팔레트에서 켜짐 썸이 `onPrimary`(진네이비)라 트랙보다 어두워 꺼짐으로 오독되던 문제 → 다크에서만 밝은 썸(`onPrimaryContainer`). 라이트는 흰 썸 그대로.
- **디바이더 인셋 통일**: 목소리 카드의 풀블리드 행 구분선에 행 패딩과 같은 14dp 인셋 — 세부 설정 카드와 한 규칙.
- **섹션 헤더 위계 분리**: `EditorSectionTitle`을 titleSmall + `onSurfaceVariant`로 낮춰 카드 행 제목(titleMedium)과 구분 — 그룹 리스트 헤더 관례.
- **하단 저장 바 경계**: 헤어라인을 풀 톤 `outlineVariant`로 — 바 배경이 페이지 배경과 같아 스크롤 콘텐츠가 '잘려 보이던' 문제 완화.
- 미사용 문자열 `editor_change`·`editor_default_alarm_sound` 제거 (ko/en/ja).

## 검증
- devDebug 컴파일·빌드 통과
- S22(다크)·S23(라이트) 실기기 설치: 셰브론 통일, "Homecoming · 100%" 표기, 다크 썸 밝게, 인셋 디바이더, 조용해진 섹션 헤더, 하단 바 헤어라인 — 두 모드 모두 스크린샷 확인
