### PR TITLE
fix: Codex 인라인·독립검토 지적 반영 — 결제 정합·삭제 스코프·시간대·greeting 정책

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/billing/PlayBillingManager.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/billing/PlayBillingManager.kt
@@ -216,12 +216,14 @@ class PlayBillingManager(
             )
         // 구매-계정 바인딩(서버와 공유하는 계약: SHA-256 hex 소문자 64자, 입력은 로그인 사용자 id).
         // 서버가 confirm/RTDN 검증 시 어느 계정의 구매인지 대조할 수 있게 한다.
-        if (!userId.isNullOrBlank()) {
-            flowParamsBuilder.setObfuscatedAccountId(sha256Hex(userId))
+        val accountHash = userId?.takeIf { it.isNotBlank() }?.let { sha256Hex(it) }
+        if (accountHash != null) {
+            flowParamsBuilder.setObfuscatedAccountId(accountHash)
         }
         // 다른 상품으로의 '전환' 구매면 기존 활성 구독을 교체 모드로 잇는다 — 교체 없이 사면
         // Play 구독이 나란히 2개 생겨 이중 결제가 된다. 같은 상품 재구매/기존 구매 없음이면 현행대로.
-        findActiveSubscriptionToReplace(productId)?.let { existing ->
+        // accountHash 가 없으면(비로그인 등) 교체 대상 계정 대조가 불가능하므로 교체 없이 신규 구매.
+        findActiveSubscriptionToReplace(productId, accountHash)?.let { existing ->
             flowParamsBuilder.setSubscriptionUpdateParams(
                 BillingFlowParams.SubscriptionUpdateParams.newBuilder()
                     .setOldPurchaseToken(existing.purchaseToken)
@@ -243,8 +245,14 @@ class PlayBillingManager(
      * [productId] 로 전환할 때 교체 대상이 되는 기존 활성(PURCHASED) 구독 구매.
      * 같은 상품이거나 활성 구독이 없으면 null(교체 아님). 여러 개면(과거 이중 구독 잔재) 최신 구매.
      * 조회 실패 시에도 null — 결제 자체를 막지 않고 현행(신규 구매) 플로우로 진행한다.
+     *
+     * [accountHash](sha256Hex(userId))가 일치하는 구매만 교체 후보로 삼는다. 같은 기기·같은
+     * Google 계정에 **다른 AlarmTalk 계정**으로 결제된 구독이 있을 수 있는데, 그것을 교체하면
+     * 남의 구독을 취소/비례정산시키게 된다. 구매에 식별자가 없거나(레거시) 불일치하면, 또는
+     * accountHash 가 null 이면(비로그인) 소유 확인이 불가능하므로 교체 없이 신규 구매로 진행한다.
      */
-    private suspend fun findActiveSubscriptionToReplace(productId: String): Purchase? {
+    private suspend fun findActiveSubscriptionToReplace(productId: String, accountHash: String?): Purchase? {
+        if (accountHash == null) return null
         if (!ensureConnected()) return null
         val result = billingClient.queryPurchasesAsync(
             QueryPurchasesParams.newBuilder()
@@ -256,7 +264,11 @@ class PlayBillingManager(
             return null
         }
         return result.purchasesList
-            .filter { it.purchaseState == Purchase.PurchaseState.PURCHASED && productId !in it.products }
+            .filter {
+                it.purchaseState == Purchase.PurchaseState.PURCHASED &&
+                    productId !in it.products &&
+                    it.accountIdentifiers?.obfuscatedAccountId == accountHash
+            }
             .maxByOrNull { it.purchaseTime }
     }
 

--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -55,9 +55,20 @@ export async function enqueueExternalDeletion(
 /**
  * 사용자의 음성 외부 자원(클론 voice + R2 오브젝트) 전부를 큐에 적재한다.
  * purgeUserAccount / deletePaidVoiceDataForUser 가 행을 지우기 전에 호출해야 한다.
+ *
+ * options.includeAlarmsTargetingUser (기본 true):
+ *  - true  = 계정 삭제(purgeUserAccount) 경로 — target_user_id 알람 행까지 함께 지우므로
+ *            그 raw 오디오도 회수한다(기존 동작 보존).
+ *  - false = 유료 음성 정리(deletePaidVoiceDataForUser) 경로 — 나를 target 으로 한
+ *            '타인(발신자) 소유' 알람은 살아남으므로 발신자의 raw 오디오를 파기하면 안 된다.
  */
-export async function enqueueUserVoiceArtifacts(tx: DbExecutor, ownerIds: string[]): Promise<void> {
+export async function enqueueUserVoiceArtifacts(
+  tx: DbExecutor,
+  ownerIds: string[],
+  options: { includeAlarmsTargetingUser?: boolean } = {},
+): Promise<void> {
   if (ownerIds.length === 0) return;
+  const includeAlarmsTargetingUser = options.includeAlarmsTargetingUser !== false;
   const ph = ownerIds.map(() => '?').join(',');
 
   const voices = await tx.execute({
@@ -90,10 +101,14 @@ export async function enqueueUserVoiceArtifacts(tx: DbExecutor, ownerIds: string
 
   // 알람에 직접 연결된 사용자 녹음 원본 (r2://<key>).
   const rawAlarms = await tx.execute({
-    sql: `SELECT raw_audio_url FROM alarms
-          WHERE raw_audio_url LIKE 'r2://%'
-            AND (user_id IN (${ph}) OR target_user_id IN (${ph}))`,
-    args: [...ownerIds, ...ownerIds],
+    sql: includeAlarmsTargetingUser
+      ? `SELECT raw_audio_url FROM alarms
+         WHERE raw_audio_url LIKE 'r2://%'
+           AND (user_id IN (${ph}) OR target_user_id IN (${ph}))`
+      : `SELECT raw_audio_url FROM alarms
+         WHERE raw_audio_url LIKE 'r2://%'
+           AND user_id IN (${ph})`,
+    args: includeAlarmsTargetingUser ? [...ownerIds, ...ownerIds] : ownerIds,
   });
   for (const row of rawAlarms.rows) {
     const url = String(row.raw_audio_url ?? '');

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -11,7 +11,7 @@ import {
   type PlayEnv,
   type SubscriptionV2Response,
 } from './play-subscriptions';
-import { planTypeToUserPlan, plannedMaxUses } from '../routes/billing-helpers';
+import { PAID_PLAN_TYPES, planTypeToUserPlan, plannedMaxUses } from '../routes/billing-helpers';
 
 export interface ActiveSubscription {
   subscriptionId: string;
@@ -225,12 +225,15 @@ async function releaseInviteUseForMember(
   }
 }
 
+/**
+ * 구독 행 한 건을 취소 상태로 바꾸고, 그 구독이 발급한 미사용 코드를 만료시킨다.
+ * 사용자 plan 정리는 여기서 하지 않는다 — 호출자가 그 사용자의 구독 취소를 모두
+ * 마친 뒤 syncUserPlanAfterCancel 로 마무리한다(구독별 중복 강등 방지).
+ */
 async function cancelOneSubscriptionRow(
   db: DbExecutor,
   subscriptionId: string,
-  userPk: string,
   now: Date,
-  options: CancelCleanupOptions = {},
 ): Promise<void> {
   await db.execute({
     sql: `UPDATE subscriptions
@@ -241,8 +244,32 @@ async function cancelOneSubscriptionRow(
           WHERE id = ? AND status = 'active'`,
     args: [now.toISOString(), now.toISOString(), subscriptionId],
   });
-  await downgradeUserToFree(db, userPk, options);
   await expireUnusedVouchersFor(db, subscriptionId);
+}
+
+/**
+ * 구독 취소 후 사용자 plan 을 "실제 남은 활성 구독" 기준으로 재정렬한다 (E2).
+ * 부분 취소(/cancel 의 스냅샷 단위 취소, RTDN 스테일/단일 토큰 만료 처리 등)에서
+ * 다른 활성 유료 구독이 남아 있으면 free 로 내리지 않고 그 구독의 plan 으로 유지하며,
+ * is_shared 해제·타인 알람 강등 같은 음성 접근 정리도 하지 않는다(여전히 유료다).
+ * 남은 활성 유료 구독이 없을 때만 free 강등 + 접근 정리를 수행한다.
+ */
+async function syncUserPlanAfterCancel(
+  db: DbExecutor,
+  userPk: string,
+  options: CancelCleanupOptions = {},
+): Promise<void> {
+  const remaining = await findActiveSubscriptionsByUserPk(db, userPk);
+  // 조회가 starts_at DESC 정렬이므로 가장 최근 유료 구독이 우선된다.
+  const paid = remaining.find((s) => PAID_PLAN_TYPES.has(s.planType));
+  if (paid) {
+    await db.execute({
+      sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+      args: [planTypeToUserPlan(paid.planType), userPk],
+    });
+    return;
+  }
+  await downgradeUserToFree(db, userPk, options);
 }
 
 // 결제 해지/만료 흐름의 기본은 "음성 보존"이다. 하드 삭제는 보관 유예(sweep)나
@@ -253,7 +280,8 @@ export async function cancelSubscriptionImmediate(
   now: Date = new Date(),
   options: CancelCleanupOptions = { deleteVoiceData: false },
 ): Promise<void> {
-  await cancelOneSubscriptionRow(db, subscription.subscriptionId, subscription.userPk, now, options);
+  await cancelOneSubscriptionRow(db, subscription.subscriptionId, now);
+  await syncUserPlanAfterCancel(db, subscription.userPk, options);
 
   if (!subscription.planGroupId) return;
 
@@ -287,13 +315,18 @@ export async function cancelSubscriptionImmediate(
       args: [memberUserId, subscription.planGroupId],
     });
     for (const subRow of memberSubRes.rows) {
-      await cancelOneSubscriptionRow(db, String(subRow.id), memberUserId, now);
+      await cancelOneSubscriptionRow(db, String(subRow.id), now);
     }
     // 멤버 강등에는 소유자의 삭제 옵션(options)을 전파하지 않는다. 취소를 개시하지
     // 않은 멤버의 알람·음성·메시지가 하드 삭제되는 것을 막기 위해 데이터는 보존한다
     // (RTDN deactivate 경로와 동일하게 deleteVoiceData:false). 하드 삭제는 취소를
-    // 실제로 개시한 소유자 본인(line 149)에게만 국한한다.
-    await downgradeUserToFree(db, memberUserId, { deleteVoiceData: false });
+    // 실제로 개시한 소유자 본인에게만 국한한다.
+    await syncUserPlanAfterCancel(db, memberUserId, { deleteVoiceData: false });
+    // 소유자 해지로 유료 접근을 잃는 멤버도 소유자와 동일 정책으로 유료 음성 30일
+    // 보관을 예약한다 — 예약이 없으면 멤버의 유료 음성이 sweep 대상에서 빠져 영구
+    // 잔존한다. 멤버가 자기 결제로 재구독하면 entitle/redeem 경로가 유예를 해제하고,
+    // sweep 도 삭제 직전에 활성 유료 구독을 재확인하므로 과삭제 위험은 없다.
+    await schedulePaidVoiceRetention(db, memberUserId, now);
   }
 
   await db.execute({
@@ -338,17 +371,11 @@ export async function leavePlanGroupMember(
   });
 
   for (const row of subscriptionRes.rows) {
-    await cancelOneSubscriptionRow(
-      db,
-      String(row.id),
-      params.userPk,
-      now,
-      { deleteVoiceData: false },
-    );
+    await cancelOneSubscriptionRow(db, String(row.id), now);
   }
-  if (subscriptionRes.rows.length === 0) {
-    await downgradeUserToFree(db, params.userPk, { deleteVoiceData: false });
-  }
+  // 그룹 구독 유무와 무관하게 남은 활성 구독 기준으로 plan 을 재정렬한다
+  // (다른 유료 구독이 남아 있으면 유지, 없으면 free 강등 + 음성 접근 정리).
+  await syncUserPlanAfterCancel(db, params.userPk, { deleteVoiceData: false });
   // 그룹 이탈로 유료 접근을 잃어도 음성은 즉시 삭제하지 않고 30일 보관 유예를 건다.
   await schedulePaidVoiceRetention(db, params.userPk, now);
 

--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -20,7 +20,9 @@ export async function deletePaidVoiceDataForUser(
 
   // ElevenLabs 클론/R2 오디오 외부 삭제 참조를 행 삭제 전에 큐에 적재 —
   // 다운그레이드로 유료 음성 데이터가 사라질 때 클로닝 본체도 함께 사라지게 한다.
-  await enqueueUserVoiceArtifacts(db, ids);
+  // includeAlarmsTargetingUser:false — 나를 target 으로 한 '타인(발신자) 소유' 알람의
+  // raw 오디오는 발신자의 데이터이므로 여기서 파기하지 않는다(아래 알람 삭제 스코프와 동일).
+  await enqueueUserVoiceArtifacts(db, ids, { includeAlarmsTargetingUser: false });
 
   await db.execute({
     sql: `DELETE FROM notes WHERE sender_id = ? OR receiver_id = ?`,
@@ -65,11 +67,13 @@ export async function deletePaidVoiceDataForUser(
     args: [...ids, ...ids, ...ids, ...ids],
   });
 
+  // 삭제 스코프는 '호출 사용자 소유 데이터'로 한정한다. 나를 target 으로 한 타인(발신자)
+  // 소유 알람 행은 발신자의 데이터이므로 삭제하지 않는다 — 그 알람이 내 목소리/메시지를
+  // 참조하는 경우는 위 sound-only 강등 UPDATE 가 이미 끊었다. (계정 삭제는 이 함수가 아니라
+  // purgeUserAccount(account-deletion.ts)가 자체 스코프로 target 알람까지 정리한다.)
   await db.execute({
-    sql: `DELETE FROM alarms
-          WHERE user_id IN (${ph})
-             OR target_user_id IN (${ph})`,
-    args: [...ids, ...ids],
+    sql: `DELETE FROM alarms WHERE user_id IN (${ph})`,
+    args: ids,
   });
 
   await db.execute({

--- a/packages/backend/src/routes/alarm-helpers.ts
+++ b/packages/backend/src/routes/alarm-helpers.ts
@@ -327,9 +327,21 @@ export function computeNextAlarmFire(
   const minute = Number(match[2]);
   const zone = isSupportedTimezone(timezone) ? timezone : DEFAULT_ALARM_TIMEZONE;
   // 오늘부터 최대 8일(반복 요일 한 바퀴 + 자정 경계 여유)을 훑어 첫 매칭 시각을 찾는다.
+  // 후보 날짜는 고정 86,400,000ms 더하기가 아니라 '효과 시간대의 달력 날짜' 단위로
+  // 전진시킨다 — DST 지역은 로컬 하루가 23/25시간이라 now+24h 반복은 전환일 직전
+  // 자정 부근에서 달력 날짜를 건너뛰거나(春) 중복 방문(秋)해 발사일이 하루 밀린다.
+  // UTC 정오 앵커로 순수 날짜 산술만 하므로 월/연 롤오버 포함 DST 와 무관하게 안전하다.
+  const today = wallClockAt(now, zone);
   for (let dayOffset = 0; dayOffset <= 8; dayOffset++) {
-    const probe = wallClockAt(new Date(now.getTime() + dayOffset * 86_400_000), zone);
-    const candidate = zonedWallTimeToUtc(probe.year, probe.month, probe.day, hour, minute, zone);
+    const probeDate = new Date(Date.UTC(today.year, today.month - 1, today.day + dayOffset, 12));
+    const candidate = zonedWallTimeToUtc(
+      probeDate.getUTCFullYear(),
+      probeDate.getUTCMonth() + 1,
+      probeDate.getUTCDate(),
+      hour,
+      minute,
+      zone,
+    );
     if (candidate.getTime() <= now.getTime()) continue;
     const fireDayOfWeek = wallClockAt(candidate, zone).dayOfWeek;
     if (repeatDays.length > 0 && !repeatDays.includes(fireDayOfWeek)) continue;
@@ -339,18 +351,19 @@ export function computeNextAlarmFire(
 }
 
 /**
- * 타인 발신 알람 검증(리드타임·quiet) 전용 효과 시간대. 우선순위:
+ * 타인 발신 알람 검증(리드타임·quiet)·저장 전용 효과 시간대. 우선순위:
  *  ① 수신자의 가장 최근 '소유' 알람에 저장된 timezone (수신자 기기가 마지막으로 보고한 시간대)
- *  ② 요청 body 의 timezone (수신자 기록이 없을 때만 폴백 — 정규화 + Intl 지원 확인 통과 시)
- *  ③ DEFAULT_ALARM_TIMEZONE('Asia/Seoul')
+ *  ② DEFAULT_ALARM_TIMEZONE('Asia/Seoul')
  *
- * body.timezone 은 '발신자' 기기 값이라 신뢰할 수 없다 — 발신자가 오프셋이 다른 시간대를
- * 보내 30분 리드타임/quiet 판정을 우회할 수 있으므로, 수신자 저장 시간대가 항상 우선한다.
- * (본인 알람 생성의 timezone 저장 동작과는 무관 — 이 함수는 검증 판정에만 쓰인다.)
+ * 요청 body 의 timezone 은 '발신자' 기기 값이라 어떤 경우에도 판정 기준으로 신뢰하지
+ * 않는다 — 수신자 기록이 없을 때 body 로 폴백하면 발신자가 오프셋이 다른 시간대를 보내
+ * 30분 리드타임/quiet 판정을 우회할 수 있으므로, 폴백은 Asia/Seoul 고정이다.
+ * 호출부는 이 함수가 돌려준 효과 시간대를 알람 행(timezone)에 그대로 저장해, cron
+ * 스케줄러가 검증과 같은 시간대로 HH:mm 을 해석하게 한다.
+ * (본인 알람(비-target) 생성의 timezone 저장 동작과는 무관.)
  */
 export async function resolveEffectiveTimezone(
   db: DbExecutor,
-  bodyTimezone: unknown,
   recipientIds: [string, string],
 ): Promise<string> {
   // 수신자 '소유' 알람(user_id 매칭)의 timezone 이 수신자 기기 시간대를 반영한다.
@@ -363,8 +376,6 @@ export async function resolveEffectiveTimezone(
   });
   const stored = res.rows.length > 0 ? String(res.rows[0]!.timezone ?? '') : '';
   if (stored && isSupportedTimezone(stored)) return stored;
-  const requested = normalizeTimezone(bodyTimezone);
-  if (requested && isSupportedTimezone(requested)) return requested;
   return DEFAULT_ALARM_TIMEZONE;
 }
 
@@ -374,7 +385,9 @@ export async function resolveEffectiveTimezone(
  *
  * 1) 멱등: 같은 발신자(senderUserId)·같은 수신자·같은 time 의 active 알람이 이미 있으면
  *    새 행을 만들지 않고 그 id 를 재사용한다(호출부가 내용을 UPDATE). 같은 요청 재전송이
- *    중복 행을 만들지 않는다.
+ *    중복 행을 만들지 않는다. 이때 기존 행이 가리키던 message_id(previousMessageId)를
+ *    함께 돌려줘, 호출부가 교체로 고아가 된 이전 message 행을 같은 트랜잭션에서 정리할
+ *    수 있게 한다(가족 알람 멱등 재전송 시 미사용 메시지 누적 방지).
  * 2) 교체: 다른 발신자 것을 포함해 `target_user_id = 수신자 AND time = ? AND is_active = 1`
  *    인 기존 발신 알람을 전부 비활성화한다(최신 생성 우선). 비활성화는 클라 pull 동기화
  *    (RemoteAlarm.is_active → resolveReceivedRemoteEnabled)로 수신자 기기에 전파된다.
@@ -388,20 +401,22 @@ export async function claimTargetedAlarmSlot(
   recipientIds: [string, string],
   time: string,
   newAlarmId: string,
-): Promise<{ alarmId: string; reused: boolean }> {
+): Promise<{ alarmId: string; reused: boolean; previousMessageId: string | null }> {
   const existing = await executor.execute({
-    sql: `SELECT id FROM alarms
+    sql: `SELECT id, message_id FROM alarms
           WHERE user_id = ? AND target_user_id IN (?, ?) AND time = ? AND is_active = 1
           ORDER BY created_at DESC LIMIT 1`,
     args: [senderUserId, recipientIds[0], recipientIds[1], time],
   });
   const reused = existing.rows.length > 0;
   const alarmId = reused ? String(existing.rows[0]!.id) : newAlarmId;
+  const previousMessageId =
+    reused && existing.rows[0]!.message_id != null ? String(existing.rows[0]!.message_id) : null;
   // 유지할 행(id 재사용 시 그 행)만 남기고 같은 슬롯의 나머지 발신 알람을 비활성화.
   await executor.execute({
     sql: `UPDATE alarms SET is_active = 0, updated_at = datetime('now')
           WHERE target_user_id IN (?, ?) AND time = ? AND is_active = 1 AND id != ?`,
     args: [recipientIds[0], recipientIds[1], time, alarmId],
   });
-  return { alarmId, reused };
+  return { alarmId, reused, previousMessageId };
 }

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -26,6 +26,7 @@ import {
 } from './alarm-helpers';
 import { isPaidVoicePlan } from './billing-helpers';
 import { withWriteTransaction, type DbExecutor } from '../lib/transactions';
+import { STOCK_GREETING_CATEGORY } from '../lib/stock-clips';
 
 const alarmMutation = new Hono<AppEnv>();
 
@@ -160,6 +161,42 @@ async function voiceProfileBelongsToCaller(
   return assertSameGroup(db, viewerPk, ownerPk);
 }
 
+/**
+ * greeting 버킷 정책: 알람이 쓰는 보이스가 non-system 클론인지 판정한다.
+ * greeting 문구는 목소리 미리듣기 전용이지만, '유료 클론의 기본(기상 인사) 알람 버킷'
+ * 으로만 예외 허용한다(validateAlarmFields 의 greeting 허용 주석 참고). 시스템 스톡
+ * 보이스 + greeting 조합은 미리듣기 클립을 무료 알람으로 돌려 쓰는 우회라 차단한다.
+ * 접근 가능 여부(소유/공유/프리셋)는 voiceProfileBelongsToCaller /
+ * messageBelongsToCaller 가 별도로 강제하므로 여기서는 클론(비-시스템) 여부만 본다.
+ */
+async function greetingBucketUsesCloneVoice(
+  db: DbExecutor,
+  fields: { voice_profile_id?: string | null; message_id?: string | null },
+): Promise<boolean> {
+  if (fields.voice_profile_id) {
+    const res = await db.execute({
+      sql: `SELECT 1 FROM voice_profiles
+            WHERE id = ? AND COALESCE(is_system, 0) = 0 AND deleted_at IS NULL
+              AND COALESCE(is_draft, 0) = 0
+            LIMIT 1`,
+      args: [fields.voice_profile_id],
+    });
+    return res.rows.length > 0;
+  }
+  if (fields.message_id) {
+    const res = await db.execute({
+      sql: `SELECT 1 FROM messages m
+            JOIN voice_profiles vp ON vp.id = m.voice_profile_id
+            WHERE m.id = ? AND COALESCE(vp.is_system, 0) = 0 AND vp.deleted_at IS NULL
+            LIMIT 1`,
+      args: [fields.message_id],
+    });
+    return res.rows.length > 0;
+  }
+  // 보이스 지정이 전혀 없는 알람(alarm-only 등)은 greeting 버킷을 가질 이유가 없다.
+  return false;
+}
+
 alarmMutation.post('/', async (c) => {
   const userId = c.get('userId');
   const resolvedUserPk = c.get('userIdPK');
@@ -202,6 +239,8 @@ alarmMutation.post('/', async (c) => {
   let targetUserIdForAlarm: string | null = null;
   // 타깃 경로에서 (수신자 PK, 수신자 로그인 id) — 슬롯 교체(claimTargetedAlarmSlot)에 쓴다.
   let targetIdsForReplace: [string, string] | null = null;
+  // 타깃 경로 검증에 쓴 효과 시간대 — 행 저장에도 그대로 쓴다(검증≠저장 불일치 방지).
+  let targetEffectiveTimezone: string | null = null;
   if (body.target_user_id) {
     const rawTargetUserId = body.target_user_id.trim();
     if (!rawTargetUserId) {
@@ -240,12 +279,10 @@ alarmMutation.post('/', async (c) => {
           403,
         );
       }
-      // 수신자 시간대 기준 서버 검증: 효과 시간대(body.timezone → 수신자 최근 알람 tz →
-      // Asia/Seoul)로 다음 발사 시각을 구해 30분 리드타임과 quiet 요일을 판정한다.
-      const effectiveTimezone = await resolveEffectiveTimezone(db, body.timezone, [
-        targetPk,
-        targetLoginId,
-      ]);
+      // 수신자 시간대 기준 서버 검증: 효과 시간대(수신자 최근 알람 tz → Asia/Seoul)로
+      // 다음 발사 시각을 구해 30분 리드타임과 quiet 요일을 판정한다. 발신자 body.timezone
+      // 은 판정·저장 어디에도 쓰지 않는다(우회 차단 — resolveEffectiveTimezone 주석 참고).
+      const effectiveTimezone = await resolveEffectiveTimezone(db, [targetPk, targetLoginId]);
       const nextFire = computeNextAlarmFire(body.time, body.repeat_days ?? [], effectiveTimezone);
       if (
         nextFire &&
@@ -302,6 +339,7 @@ alarmMutation.post('/', async (c) => {
         targetUserIdForAlarm = targetLoginId;
       }
       targetIdsForReplace = [targetPk, targetLoginId];
+      targetEffectiveTimezone = effectiveTimezone;
     }
   }
 
@@ -382,12 +420,34 @@ alarmMutation.post('/', async (c) => {
     }
   }
 
+  // greeting 버킷 정책: greeting 은 '유료 클론의 기본(기상 인사) 알람'으로만 예외 허용.
+  // 시스템 스톡 보이스 + greeting 조합(무료 우회)은 400 으로 차단한다.
+  if (body.bucket_id === STOCK_GREETING_CATEGORY) {
+    const usesClone = await greetingBucketUsesCloneVoice(db, {
+      voice_profile_id: body.voice_profile_id ?? null,
+      message_id: resolvedMessageId,
+    });
+    if (!usesClone) {
+      return c.json(
+        {
+          error: 'greeting 버킷은 클론 보이스 알람에만 쓸 수 있습니다',
+          error_code: 'INVALID_BUCKET_ID',
+        },
+        400,
+      );
+    }
+  }
+
   let alarmId = crypto.randomUUID();
   const mode: AlarmMode =
     (body.mode as AlarmMode | undefined) ?? (creatorHasPaidVoice ? 'tts' : 'sound-only');
   const vibPattern: VibrationPattern =
     (body.vibration_pattern as VibrationPattern | undefined) ?? 'default';
   const wakeMode: WakeMode = (body.wake_mode as WakeMode | undefined) ?? 'sound_then_voice';
+  // 저장 timezone: 타깃 경로는 검증에 쓴 효과 시간대를 그대로 저장해 cron 스케줄러가
+  // 검증과 같은 시간대로 HH:mm 을 해석하게 한다(발신자 body.timezone 불신).
+  // 본인 알람(비-target)은 기존대로 본인 기기 timezone(body)을 저장한다.
+  const storedTimezone = targetUserIdForAlarm ? targetEffectiveTimezone : timezone;
   const insertAlarm = (executor: DbExecutor) =>
     executor.execute({
       sql: `INSERT INTO alarms
@@ -410,7 +470,7 @@ alarmMutation.post('/', async (c) => {
         body.speaker_id ?? null,
         body.raw_audio_url ?? null,
         body.raw_audio_duration_ms ?? null,
-        timezone,
+        storedTimezone,
         body.bucket_id ?? null,
       ],
     });
@@ -442,7 +502,7 @@ alarmMutation.post('/', async (c) => {
           body.speaker_id ?? null,
           body.raw_audio_url ?? null,
           body.raw_audio_duration_ms ?? null,
-          timezone,
+          storedTimezone,
           body.bucket_id ?? null,
           claimed.alarmId,
         ],
@@ -543,7 +603,7 @@ alarmMutation.patch('/:id', async (c) => {
 
   const existing = await db.execute({
     sql: `SELECT a.id, a.message_id, a.mode, a.wake_mode, a.voice_profile_id,
-                 a.speaker_id, a.raw_audio_url, u.plan AS user_plan
+                 a.speaker_id, a.raw_audio_url, a.bucket_id, u.plan AS user_plan
           FROM alarms a
           LEFT JOIN users u ON u.google_id = a.user_id OR u.id = a.user_id
           WHERE a.id = ? AND a.user_id = ?`,
@@ -560,6 +620,7 @@ alarmMutation.patch('/:id', async (c) => {
     voice_profile_id: string | null;
     speaker_id: string | null;
     raw_audio_url: string | null;
+    bucket_id?: string | null;
     user_plan?: string | null;
   }>(existing.rows[0]!);
   const resolvedUserPk = c.get('userIdPK');
@@ -606,6 +667,32 @@ alarmMutation.patch('/:id', async (c) => {
     !(await voiceProfileBelongsToCaller(db, body.voice_profile_id, ownerIds))
   ) {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
+  }
+
+  // greeting 버킷 정책: PATCH 로 bucket/voice/message 를 바꿔 '시스템 보이스 + greeting'
+  // 조합(무료 우회)을 만들 수 없게, 수정 결과(effective) 기준으로 클론 여부를 검증한다.
+  // 관련 필드를 건드리지 않는 PATCH(예: time 만 변경)는 검사하지 않는다.
+  const effectiveBucketId =
+    body.bucket_id !== undefined ? body.bucket_id : (current.bucket_id ?? null);
+  if (
+    effectiveBucketId === STOCK_GREETING_CATEGORY &&
+    (body.bucket_id !== undefined ||
+      body.voice_profile_id !== undefined ||
+      body.message_id !== undefined)
+  ) {
+    const usesClone = await greetingBucketUsesCloneVoice(db, {
+      voice_profile_id: effectiveVoiceFields.voice_profile_id,
+      message_id: effectiveVoiceFields.message_id,
+    });
+    if (!usesClone) {
+      return c.json(
+        {
+          error: 'greeting 버킷은 클론 보이스 알람에만 쓸 수 있습니다',
+          error_code: 'INVALID_BUCKET_ID',
+        },
+        400,
+      );
+    }
   }
 
   const updates: string[] = [];

--- a/packages/backend/src/routes/billing-google.ts
+++ b/packages/backend/src/routes/billing-google.ts
@@ -167,13 +167,13 @@ billingGoogle.post('/google/confirm', async (c) => {
     return c.json({ error: 'Subscription is expired', error_code: 'SUBSCRIPTION_EXPIRED' }, 400);
   }
 
+  const db = getDB(c.env);
+
   // 구매-계정 바인딩 검증 — store_transactions 최초 바인딩 전에 수행한다.
   // 계약(Android PlayBillingManager 와 공유): 클라는 구매 시
   // setObfuscatedAccountId(sha256hex(로그인 사용자 id — JWT sub 와 동일한 세션 user id))
   // 를 설정한다. Play 응답의 식별자가 호출자(sub 또는 users.id PK)의 해시와 다르면
-  // 훔친/다른 계정의 purchaseToken 이므로 403 으로 거절한다. 식별자가 없으면
-  // (계약 이전 구버전 구매) 기존대로 허용하고, applyStoreEntitlement 의 first-claim
-  // 409(TRANSACTION_OWNED_BY_OTHER_USER)가 심층방어로 남는다.
+  // 훔친/다른 계정의 purchaseToken 이므로 403 으로 거절한다.
   const obfuscatedId =
     subscription.externalAccountIdentifiers?.obfuscatedExternalAccountId?.trim();
   if (obfuscatedId) {
@@ -195,9 +195,33 @@ billingGoogle.post('/google/confirm', async (c) => {
         403,
       );
     }
+  } else {
+    // 식별자 부재 시 "최초 바인딩"은 거절한다. 출시 전 fresh DB 전제 — 새 클라는
+    // 구매 시 항상 setObfuscatedAccountId 를 설정하므로 식별자 없는 토큰은 계약 이전
+    // 구클라 구매뿐이고, 이는 앱 업데이트를 유도한다(허용하면 유출 토큰을 아무
+    // 계정이나 선점하는 first-claim 구멍이 남는다). 이미 바인딩된 토큰의 재전송
+    // (갱신)은 기존 로직대로 통과 — applyStoreEntitlement 의 소유자 검증
+    // (409 TRANSACTION_OWNED_BY_OTHER_USER)이 심층방어로 남는다.
+    const boundRes = await db.execute({
+      sql: `SELECT user_id FROM store_transactions
+            WHERE provider = 'google' AND provider_transaction_id = ?`,
+      args: [parsed.purchase_token],
+    });
+    if (boundRes.rows.length === 0) {
+      logStructured('warn', {
+        at: 'billing.google.confirm',
+        step: 'account_binding',
+        error: 'obfuscatedExternalAccountId missing on first claim',
+      });
+      return c.json(
+        {
+          error: 'Purchase is missing the account identifier',
+          error_code: 'TRANSACTION_ACCOUNT_UNVERIFIED',
+        },
+        403,
+      );
+    }
   }
-
-  const db = getDB(c.env);
   const plan = await loadPlanByKey(db, planKey);
   if (!plan) {
     return c.json({ error: 'Plan not found', error_code: 'PLAN_NOT_FOUND' }, 400);

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -811,8 +811,16 @@ billingMutation.post('/cancel', async (c) => {
   }
 
   const voiceRetentionUntil = await withWriteTransaction(db, async (tx) => {
-    await cancelActiveSubscriptionsForUser(tx, userPk, now, { deleteVoiceData: false });
+    // 트랜잭션 안에서 '사용자 전체 활성 구독'을 다시 조회해 취소하지 않는다 — Play
+    // 호출 동안 새 결제 confirm 으로 생긴 활성 구독은 위 revoke 대상이 아니었으므로
+    // Play 에선 그대로 유지된다. DB 만 취소하면 상태가 갈라지므로, Play 성공을 확인한
+    // 스냅샷(activeSubscriptions)의 구독만 취소하고 새 구독은 건드리지 않는다.
+    // (plan 재정렬은 cancelSubscriptionImmediate 내부에서 남은 활성 구독 기준으로 처리)
+    for (const subscription of activeSubscriptions) {
+      await cancelSubscriptionImmediate(tx, subscription, now, { deleteVoiceData: false });
+    }
     // 즉시 해지여도 음성은 30일 보관 — '지금 삭제'는 /voice-data/delete-now 로 분리.
+    // (그 사이 새 유료 구독이 생겼어도 sweep 이 삭제 전 활성 유료 구독을 재확인한다.)
     return schedulePaidVoiceRetention(tx, userPk, now);
   });
   return c.json({

--- a/packages/backend/src/routes/family-alarm.ts
+++ b/packages/backend/src/routes/family-alarm.ts
@@ -11,7 +11,8 @@ import {
 import { prepareAlarmTextWithVertex } from '../lib/vertex-translate';
 import { inferSynthesisLanguage } from '../lib/voice-provider';
 import { sendFamilyAlarmPush } from '../lib/fcm';
-import { withWriteTransaction } from '../lib/transactions';
+import { withWriteTransaction, type DbExecutor } from '../lib/transactions';
+import { enqueueExternalDeletion } from '../lib/audio-retention';
 import {
   resolveEffectiveTimezone,
   computeNextAlarmFire,
@@ -30,6 +31,57 @@ function normalizeRepeatDays(raw: unknown): number[] {
     .filter((n): n is number => Number.isInteger(n) && n >= 0 && n <= 6)
     .sort((a, b) => a - b);
   return Array.from(new Set(filtered));
+}
+
+/**
+ * 멱등 재전송으로 슬롯이 재사용될 때, 교체되어 더 이상 알람이 참조하지 않게 된 이전
+ * 가족 message 행을 같은 트랜잭션에서 정리한다 — 같은 (발신자,수신자,time) 재전송마다
+ * 미사용 메시지 행이 누적되는 것을 막는다. TTS·voice 두 경로 공용.
+ *
+ * 안전 가드:
+ *  - 다른 알람이 아직 참조 중이면 보존.
+ *  - dub_jobs 가 결과 대상(result_message_id)으로 참조 중이면 보존 — 진행 중 더빙이
+ *    이 메시지에 오디오를 써 넣으므로 지우면 더빙 파이프라인이 깨진다.
+ *  - 이 경로가 만든 메시지(수신자 소유 + family/family-voice 카테고리)만 삭제한다.
+ *    DELETE 가드가 0행이면 연결 에셋도 건드리지 않는다.
+ *  - 연결 generated_audio_assets 의 R2 오브젝트는 트랜잭션 안에서 직접 지울 수 없으므로
+ *    삭제 큐(pending_external_deletions)에 적재만 한다(cron 이 실제 삭제).
+ *    messages.audio_url(발신자 voice_uploads 원본 키)은 업로드 TTL 수명주기가 관리하므로
+ *    여기서 건드리지 않는다.
+ */
+async function cleanupReplacedFamilyMessage(
+  tx: DbExecutor,
+  previousMessageId: string | null,
+  newMessageId: string,
+  recipientPk: string,
+): Promise<void> {
+  if (!previousMessageId || previousMessageId === newMessageId) return;
+  const refs = await tx.execute({
+    sql: `SELECT
+            (SELECT COUNT(*) FROM alarms WHERE message_id = ?) AS alarm_refs,
+            (SELECT COUNT(*) FROM dub_jobs WHERE result_message_id = ?) AS dub_refs`,
+    args: [previousMessageId, previousMessageId],
+  });
+  const refRow = refs.rows[0];
+  if (!refRow || Number(refRow.alarm_refs ?? 0) > 0 || Number(refRow.dub_refs ?? 0) > 0) return;
+  const deleted = await tx.execute({
+    sql: `DELETE FROM messages
+          WHERE id = ? AND user_id = ? AND category IN ('family', 'family-voice')`,
+    args: [previousMessageId, recipientPk],
+  });
+  if ((deleted.rowsAffected ?? 0) === 0) return;
+  const assets = await tx.execute({
+    sql: `SELECT audio_object_key FROM generated_audio_assets
+          WHERE message_id = ? AND audio_object_key IS NOT NULL`,
+    args: [previousMessageId],
+  });
+  for (const asset of assets.rows) {
+    await enqueueExternalDeletion(tx, 'r2_object', asset.audio_object_key as string | null);
+  }
+  await tx.execute({
+    sql: `DELETE FROM generated_audio_assets WHERE message_id = ?`,
+    args: [previousMessageId],
+  });
 }
 
 // 가족 알람 생성 시 수신자에게 즉시 data-only push — 앱이 백그라운드여도 onMessageReceived 가 바로
@@ -62,7 +114,8 @@ familyAlarm.post('/alarms', async (c) => {
     message_text?: unknown;
     repeat_days?: unknown;
     voice_profile_id?: unknown;
-    /** 발신 클라 기준 수신자 시간대(IANA). 없으면 수신자 최근 알람 tz → Asia/Seoul 폴백. */
+    /** 발신 클라가 보내는 값이지만 서버는 검증·저장 어디에도 쓰지 않는다(무시) —
+     *  발신자 기기 값이라 신뢰 불가. 효과 시간대는 수신자 최근 알람 tz → Asia/Seoul. */
     timezone?: unknown;
   };
   const body: AlarmBody = await c.req.json<AlarmBody>().catch(() => ({}) as AlarmBody);
@@ -135,12 +188,10 @@ familyAlarm.post('/alarms', async (c) => {
   }
   const recipientLoginId = (recipient.google_id as string | null) ?? String(recipient.id);
   const repeatDays = normalizeRepeatDays(body.repeat_days);
-  // 수신자 시간대 기준 서버 검증: 효과 시간대(body.timezone → 수신자 최근 알람 tz →
-  // Asia/Seoul)로 다음 발사 시각을 구해 30분 리드타임과 quiet 요일을 판정한다.
-  const effectiveTimezone = await resolveEffectiveTimezone(db, body.timezone, [
-    recipientPk,
-    recipientLoginId,
-  ]);
+  // 수신자 시간대 기준 서버 검증: 효과 시간대(수신자 최근 알람 tz → Asia/Seoul)로 다음
+  // 발사 시각을 구해 30분 리드타임과 quiet 요일을 판정한다. 발신자 body.timezone 은
+  // 판정·저장 어디에도 쓰지 않는다(우회 차단 — resolveEffectiveTimezone 주석 참고).
+  const effectiveTimezone = await resolveEffectiveTimezone(db, [recipientPk, recipientLoginId]);
   const nextFire = computeNextAlarmFire(wakeAt, repeatDays, effectiveTimezone);
   if (
     nextFire &&
@@ -213,9 +264,11 @@ familyAlarm.post('/alarms', async (c) => {
   });
 
   // 메시지 insert + (수신자, time) 슬롯 점유를 한 트랜잭션으로: 같은 발신자의 재전송은
-  // 기존 알람 행을 새 메시지로 UPDATE(멱등, id 유지), 다른 발신자의 같은 시각 발신 알람은
-  // 비활성화(최신 우선). 수신자 본인 알람(target 없음)은 서버가 건드리지 않는다 —
-  // 클라 로컬 교체 확인창 담당(claimTargetedAlarmSlot 주석 참고).
+  // 기존 알람 행을 새 메시지로 UPDATE(멱등, id 유지)하고 교체된 이전 message 행을 정리,
+  // 다른 발신자의 같은 시각 발신 알람은 비활성화(최신 우선). 수신자 본인 알람(target 없음)은
+  // 서버가 건드리지 않는다 — 클라 로컬 교체 확인창 담당(claimTargetedAlarmSlot 주석 참고).
+  // timezone 은 검증에 쓴 효과 시간대를 그대로 저장한다 — cron 스케줄러가 검증과 같은
+  // 시간대로 알람 HH:mm 을 해석한다.
   const alarmId = await withWriteTransaction(db, async (tx) => {
     await tx.execute({
       sql: `INSERT INTO messages
@@ -239,15 +292,18 @@ familyAlarm.post('/alarms', async (c) => {
     );
     if (claimed.reused) {
       await tx.execute({
-        sql: `UPDATE alarms SET message_id = ?, repeat_days = ?, mode = 'tts',
+        sql: `UPDATE alarms SET message_id = ?, repeat_days = ?, mode = 'tts', timezone = ?,
                 is_active = 1, updated_at = datetime('now')
               WHERE id = ?`,
-        args: [messageId, JSON.stringify(repeatDays), claimed.alarmId],
+        args: [messageId, JSON.stringify(repeatDays), effectiveTimezone, claimed.alarmId],
       });
+      // 재전송으로 교체돼 고아가 된 이전 message 행을 같은 트랜잭션에서 정리(누적 방지).
+      await cleanupReplacedFamilyMessage(tx, claimed.previousMessageId, messageId, recipientPk);
     } else {
       await tx.execute({
-        sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, repeat_days, mode)
-              VALUES (?, ?, ?, ?, ?, ?, 'tts')`,
+        sql: `INSERT INTO alarms
+              (id, user_id, target_user_id, message_id, time, repeat_days, mode, timezone)
+              VALUES (?, ?, ?, ?, ?, ?, 'tts', ?)`,
         args: [
           claimed.alarmId,
           userId,
@@ -255,6 +311,7 @@ familyAlarm.post('/alarms', async (c) => {
           messageId,
           wakeAt,
           JSON.stringify(repeatDays),
+          effectiveTimezone,
         ],
       });
     }
@@ -302,7 +359,8 @@ familyAlarm.post('/alarms/voice', async (c) => {
     label?: unknown;
     dub_target_language?: unknown;
     repeat_days?: unknown;
-    /** 발신 클라 기준 수신자 시간대(IANA). 없으면 수신자 최근 알람 tz → Asia/Seoul 폴백. */
+    /** 발신 클라가 보내는 값이지만 서버는 검증·저장 어디에도 쓰지 않는다(무시) —
+     *  발신자 기기 값이라 신뢰 불가. 효과 시간대는 수신자 최근 알람 tz → Asia/Seoul. */
     timezone?: unknown;
   };
   const body: VoiceBody = await c.req.json<VoiceBody>().catch(() => ({}) as VoiceBody);
@@ -391,10 +449,8 @@ familyAlarm.post('/alarms/voice', async (c) => {
   const recipientLoginId = (recipient.google_id as string | null) ?? String(recipient.id);
   const repeatDays = normalizeRepeatDays(body.repeat_days);
   // 수신자 시간대 기준 서버 검증 — TTS 경로와 동일(30분 리드타임 + quiet 요일).
-  const effectiveTimezone = await resolveEffectiveTimezone(db, body.timezone, [
-    recipientPk,
-    recipientLoginId,
-  ]);
+  // 발신자 body.timezone 은 판정·저장 어디에도 쓰지 않는다(우회 차단).
+  const effectiveTimezone = await resolveEffectiveTimezone(db, [recipientPk, recipientLoginId]);
   const nextFire = computeNextAlarmFire(wakeAt, repeatDays, effectiveTimezone);
   if (
     nextFire &&
@@ -455,8 +511,12 @@ familyAlarm.post('/alarms/voice', async (c) => {
   const newAlarmId = crypto.randomUUID();
   const audioUrl = dubTarget ? null : objectKey;
 
-  // TTS 경로와 동일한 원자 교체: 같은 발신자 재전송은 기존 행 UPDATE(멱등, id 유지),
-  // 다른 발신자의 같은 시각 발신 알람은 비활성화. 수신자 본인 알람은 건드리지 않는다.
+  // TTS 경로와 동일한 원자 교체: 같은 발신자 재전송은 기존 행 UPDATE(멱등, id 유지) +
+  // 교체된 이전 message 정리, 다른 발신자의 같은 시각 발신 알람은 비활성화. 수신자 본인
+  // 알람은 건드리지 않는다. timezone 은 검증에 쓴 효과 시간대를 그대로 저장한다.
+  // dub_jobs 예약도 같은 트랜잭션에 묶는다 — 알람만 커밋되고 dub insert 가 실패해
+  // '더빙 없는 알람'이 수신자에게 노출되는 창을 제거한다.
+  let dubJob: { id: string; target_language: DubLanguage; status: 'processing' } | null = null;
   const alarmId = await withWriteTransaction(db, async (tx) => {
     await tx.execute({
       sql: `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
@@ -472,15 +532,18 @@ familyAlarm.post('/alarms/voice', async (c) => {
     );
     if (claimed.reused) {
       await tx.execute({
-        sql: `UPDATE alarms SET message_id = ?, repeat_days = ?, mode = 'sound-only',
+        sql: `UPDATE alarms SET message_id = ?, repeat_days = ?, mode = 'sound-only', timezone = ?,
                 is_active = 1, updated_at = datetime('now')
               WHERE id = ?`,
-        args: [messageId, JSON.stringify(repeatDays), claimed.alarmId],
+        args: [messageId, JSON.stringify(repeatDays), effectiveTimezone, claimed.alarmId],
       });
+      // 재전송으로 교체돼 고아가 된 이전 message 행을 같은 트랜잭션에서 정리(누적 방지).
+      await cleanupReplacedFamilyMessage(tx, claimed.previousMessageId, messageId, recipientPk);
     } else {
       await tx.execute({
-        sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, repeat_days, mode)
-              VALUES (?, ?, ?, ?, ?, ?, 'sound-only')`,
+        sql: `INSERT INTO alarms
+              (id, user_id, target_user_id, message_id, time, repeat_days, mode, timezone)
+              VALUES (?, ?, ?, ?, ?, ?, 'sound-only', ?)`,
         args: [
           claimed.alarmId,
           userId,
@@ -488,24 +551,24 @@ familyAlarm.post('/alarms/voice', async (c) => {
           messageId,
           wakeAt,
           JSON.stringify(repeatDays),
+          effectiveTimezone,
         ],
       });
+    }
+    if (dubTarget) {
+      const dubJobId = crypto.randomUUID();
+      await tx.execute({
+        sql: `INSERT INTO dub_jobs (id, user_id, source_language, target_language, status, result_message_id)
+              VALUES (?, ?, ?, ?, 'processing', ?)`,
+        args: [dubJobId, userId, 'auto', dubTarget, messageId],
+      });
+      dubJob = { id: dubJobId, target_language: dubTarget, status: 'processing' };
     }
     return claimed.alarmId;
   });
 
+  // 수신자 push 는 반드시 커밋 후에 실행한다 — 롤백될 수 있는 알람을 미리 알리지 않는다.
   notifyRecipientOfFamilyAlarm(c, db, recipient, alarmId);
-
-  let dubJob: { id: string; target_language: DubLanguage; status: 'processing' } | null = null;
-  if (dubTarget) {
-    const dubJobId = crypto.randomUUID();
-    await db.execute({
-      sql: `INSERT INTO dub_jobs (id, user_id, source_language, target_language, status, result_message_id)
-            VALUES (?, ?, ?, ?, 'processing', ?)`,
-      args: [dubJobId, userId, 'auto', dubTarget, messageId],
-    });
-    dubJob = { id: dubJobId, target_language: dubTarget, status: 'processing' };
-  }
 
   return c.json(
     {

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -1072,7 +1072,9 @@ tts.post('/generate', async (c) => {
       // 톤 적응 생성이 성공했으면 그 delivery 태그를, 폴백(고정 예문)이면 기본 cheerfully 를 쓴다.
       // 태그는 문장마다 다시 앞세워 끝까지 톤을 고정하고, 상한 초과 시 태그 없이 폴백한다
       // (그때 tags 배열도 비워 메타와 합성 텍스트를 일치시킨다).
-      const taggedText = applyDeliveryTagPerSentence(draftPreviewTag, requestText);
+      // 상한 200 = 아래 synthesisText 200자 검증과 동일 값 — 기본 300을 쓰면 태그 부착으로
+      // 200을 넘긴 텍스트가 폴백 없이 통과했다가 뒤늦게 TEXT_TOO_LONG 으로 거부된다.
+      const taggedText = applyDeliveryTagPerSentence(draftPreviewTag, requestText, 200);
       const tagApplied = taggedText !== requestText;
       prepared = {
         text: taggedText,
@@ -1081,7 +1083,8 @@ tts.post('/generate', async (c) => {
       };
     } else if (dynamicGenerated) {
       const dynamicTag = dynamicGenerated.tags[0] ?? '';
-      const taggedText = applyDeliveryTagPerSentence(dynamicTag, dynamicGenerated.text);
+      // 상한 200: 위 draft 미리듣기 경로와 동일 — 태그 부착이 200자 검증을 넘기지 않게 한다.
+      const taggedText = applyDeliveryTagPerSentence(dynamicTag, dynamicGenerated.text, 200);
       const tagApplied = dynamicTag !== '' && taggedText !== dynamicGenerated.text;
       prepared = {
         text: taggedText,

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -196,15 +196,27 @@ async function setSpeechStyleStatus(
  * 등록 녹음 전사(ElevenLabs Scribe) → Vertex 말투 분석 → speech_style 저장.
  * 결과와 무관하게 speech_style_status 를 반드시 기록한다('done' | 'failed') — 실패를 조용히
  * 삼키면 클라가 알 길이 없다. 클론 등록의 waitUntil 경로와 재시도 엔드포인트(동기)가 공유한다.
+ * 시작 시·저장 직전에 민감 동의(음성/국외이전)를 재확인한다 — 진행 중 철회되면 외부 전사/
+ * 저장을 중단한다(stock-clips generateStockClip 의 assertCloneAuthorization 패턴).
  */
 async function runSpeechStyleAnalysis(
   env: Env,
   profileId: string,
   audioData: ArrayBuffer,
-  options: { mimeType?: string | null; fileName?: string | null; language: string },
+  options: {
+    mimeType?: string | null;
+    fileName?: string | null;
+    language: string;
+    ownerPk: string;
+  },
 ): Promise<{ ok: true } | { ok: false; error: unknown }> {
   const db = getDB(env);
   try {
+    // 동의 철회 경쟁(H): 시작 시 재확인 — 철회됐으면 원본을 외부 전사(ElevenLabs)로 보내지 않는다.
+    const missingAtStart = await missingConsentType(db, options.ownerPk, SENSITIVE_REQUIRED_CONSENTS);
+    if (missingAtStart) {
+      throw new Error(`Speech style analysis aborted: consent withdrawn (${missingAtStart}).`);
+    }
     if (!env.ELEVENLABS_API_KEY) {
       throw new Error('ELEVENLABS_API_KEY is not configured for speech style analysis.');
     }
@@ -218,6 +230,11 @@ async function runSpeechStyleAnalysis(
     const style = await analyzeSpeechStyleWithVertex(env, transcript, options.language);
     if (!style) {
       throw new Error('Speech style analysis produced no result (empty transcript or Vertex failure).');
+    }
+    // 저장 직전 재확인 — 전사·분석 왕복 중 철회됐으면 파생 결과(speech_style)를 저장하지 않는다.
+    const missingBeforeSave = await missingConsentType(db, options.ownerPk, SENSITIVE_REQUIRED_CONSENTS);
+    if (missingBeforeSave) {
+      throw new Error(`Speech style analysis discarded: consent withdrawn (${missingBeforeSave}).`);
     }
     await db.execute({
       sql: `UPDATE voice_profiles
@@ -1349,33 +1366,43 @@ voiceProfile.post('/clone', async (c) => {
     // (paid-voice-cleanup)도 voice_uploads 를 사용자 단위로 지운다. draft 가 승격 전에
     // 삭제돼 행이 남아도 같은 TTL sweep 이 거둔다.
     try {
-      const uploadStorage = c.env.VOICE_BUCKET
-        ? new R2VoiceStorage(c.env.VOICE_BUCKET)
-        : getSharedInMemoryVoiceStorage();
-      // object key 는 JWT 인증 주체(userId=sub) + 타임스탬프로 생성된다(R2VoiceStorage.store)
-      // — 사용자 입력에서 파생된 세그먼트가 없어 경로 조작 불가.
-      const uploadMeta = await uploadStorage.store({
-        userId,
-        bytes: new Uint8Array(audioBuffer),
-        mimeType: audioMimeType,
-        durationMs: cloneDurationMs,
-        originalName: audioFile.name || undefined,
-      });
-      await db.execute({
-        sql: `INSERT INTO voice_uploads
-              (id, user_id, object_key, mime_type, size_bytes, duration_ms, original_name, voice_profile_id)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          crypto.randomUUID(),
+      // 동의 철회 경쟁(H): 클론 완료(ready 전환)와 이 보관 사이에 사용자가 음성/국외이전
+      // 동의를 철회했을 수 있다 — 철회됐으면 원본을 새로 보관하지 않는다(저장 스킵 + 로그).
+      const uploadConsentMissing = await missingConsentType(db, userPk, SENSITIVE_REQUIRED_CONSENTS);
+      if (uploadConsentMissing) {
+        logRouteError(
+          c,
+          new Error(`Clone source upload skipped: consent withdrawn (${uploadConsentMissing}).`),
+        );
+      } else {
+        const uploadStorage = c.env.VOICE_BUCKET
+          ? new R2VoiceStorage(c.env.VOICE_BUCKET)
+          : getSharedInMemoryVoiceStorage();
+        // object key 는 JWT 인증 주체(userId=sub) + 타임스탬프로 생성된다(R2VoiceStorage.store)
+        // — 사용자 입력에서 파생된 세그먼트가 없어 경로 조작 불가.
+        const uploadMeta = await uploadStorage.store({
           userId,
-          uploadMeta.objectKey,
-          uploadMeta.mimeType,
-          uploadMeta.sizeBytes,
-          uploadMeta.durationMs ?? null,
-          uploadMeta.originalName ?? null,
-          profileId,
-        ],
-      });
+          bytes: new Uint8Array(audioBuffer),
+          mimeType: audioMimeType,
+          durationMs: cloneDurationMs,
+          originalName: audioFile.name || undefined,
+        });
+        await db.execute({
+          sql: `INSERT INTO voice_uploads
+                (id, user_id, object_key, mime_type, size_bytes, duration_ms, original_name, voice_profile_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            crypto.randomUUID(),
+            userId,
+            uploadMeta.objectKey,
+            uploadMeta.mimeType,
+            uploadMeta.sizeBytes,
+            uploadMeta.durationMs ?? null,
+            uploadMeta.originalName ?? null,
+            profileId,
+          ],
+        });
+      }
     } catch (uploadErr) {
       logRouteError(c, uploadErr);
     }
@@ -1402,6 +1429,7 @@ voiceProfile.post('/clone', async (c) => {
             mimeType: analysisMime,
             fileName: analysisFileName,
             language: previewLanguage,
+            ownerPk: userPk,
           }).then((analysis) => {
             if (!analysis.ok) logRouteError(c, analysis.error);
           }),
@@ -1603,6 +1631,7 @@ voiceProfile.get('/:id/stats', async (c) => {
 // 자체가 실패했으면 409 — 이때는 목소리를 다시 등록해야 말투를 분석할 수 있다.
 voiceProfile.post('/:id/speech-style/retry', async (c) => {
   const ids = ownerIds(c);
+  const userPk = (c.get('userIdPK') as string | undefined) || (c.get('userId') as string);
   const db = getDB(c.env);
   const id = c.req.param('id');
 
@@ -1622,6 +1651,23 @@ voiceProfile.post('/:id/speech-style/retry', async (c) => {
   });
   if (profileRes.rows.length === 0) {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
+  }
+
+  // 동의 철회 경쟁(H): 재시도 시작 시 민감 동의(음성/국외이전)를 재확인한다 —
+  // 등록 후 철회한 사용자의 원본을 다시 외부 전사(ElevenLabs)로 보내지 않는다.
+  const missingRetryConsent = await missingConsentType(db, userPk, SENSITIVE_REQUIRED_CONSENTS);
+  if (missingRetryConsent) {
+    return c.json(
+      {
+        error:
+          missingRetryConsent === 'voice_biometric'
+            ? 'Voice biometric consent is required to analyze the voice.'
+            : 'Overseas transfer consent is required for speech style analysis.',
+        error_code: 'CONSENT_REQUIRED',
+        consent: missingRetryConsent,
+      },
+      403,
+    );
   }
   // 등록 때와 동일한 언어 화이트리스트(ko/en/ja)로 분석 언어 확정.
   const requestedLanguage = String(profileRes.rows[0]!.preview_language ?? 'ko').toLowerCase();
@@ -1652,7 +1698,24 @@ voiceProfile.post('/:id/speech-style/retry', async (c) => {
     );
   }
 
-  await setSpeechStyleStatus(db, id, 'pending');
+  // 원자적 상태 점유(H): failed 일 때만 pending 으로 클레임한다 — 동시 재시도가 겹치면
+  // 한 요청만 실행되고 나머지는 409 로 떨어져 중복 전사/분석(외부 호출 비용)을 차단한다.
+  // 이미 pending(진행 중)이거나 done/NULL(재시도 대상 아님)이어도 같은 409.
+  const claimed = await db.execute({
+    sql: `UPDATE voice_profiles
+          SET speech_style_status = 'pending', updated_at = datetime('now')
+          WHERE id = ? AND speech_style_status = 'failed' AND deleted_at IS NULL`,
+    args: [id],
+  });
+  if ((claimed.rowsAffected ?? 0) === 0) {
+    return c.json(
+      {
+        error: 'Speech style analysis is already running or not in a retryable state.',
+        error_code: 'SPEECH_STYLE_RETRY_CONFLICT',
+      },
+      409,
+    );
+  }
   // Uint8Array 뷰 → 정확한 구간만 ArrayBuffer 로 복사(오프셋 있는 버퍼 안전).
   const audioBuffer = stored.bytes.buffer.slice(
     stored.bytes.byteOffset,
@@ -1662,6 +1725,7 @@ voiceProfile.post('/:id/speech-style/retry', async (c) => {
     mimeType: (upload!.mime_type as string | null) ?? stored.meta.mimeType,
     fileName: (upload!.original_name as string | null) ?? stored.meta.originalName ?? null,
     language,
+    ownerPk: userPk,
   });
   if (!result.ok) {
     logRouteError(c, result.error);

--- a/packages/backend/test/alarm-guard.test.ts
+++ b/packages/backend/test/alarm-guard.test.ts
@@ -53,7 +53,8 @@ function postAlarm(
 
 async function alarmRow(id: string) {
   const res = await db.execute({
-    sql: `SELECT id, user_id, target_user_id, time, is_active, snooze_minutes FROM alarms WHERE id = ?`,
+    sql: `SELECT id, user_id, target_user_id, time, is_active, snooze_minutes, timezone
+          FROM alarms WHERE id = ?`,
     args: [id],
   });
   return res.rows[0] ?? null;
@@ -152,6 +153,8 @@ describe('타인 발신 알람 — (수신자, HH:mm) 슬롯 원자 교체', () 
     const row = await alarmRow(id1);
     expect(Number(row!.is_active)).toBe(1);
     expect(Number(row!.snooze_minutes)).toBe(12); // 재전송 내용으로 UPDATE 됨
+    // 재사용 UPDATE 도 검증에 쓴 효과 시간대를 저장한다(수신자 기록 없음 → Asia/Seoul).
+    expect(String(row!.timezone)).toBe('Asia/Seoul');
   });
 
   it('수신자 본인이 만든 같은 시각 알람(target 없음)은 서버가 건드리지 않는다', async () => {
@@ -236,19 +239,39 @@ describe('타인 발신 알람 — 수신자 시간대 기준 30분 리드타임
     );
   });
 
-  it('수신자 저장 tz 기록이 없으면 body timezone 으로 폴백해 판정', async () => {
+  it('수신자 저장 tz 기록이 없으면 발신자 body timezone 을 무시하고 Asia/Seoul 로 판정·저장', async () => {
     // 수신자 소유 알람이 하나도 없음(beforeEach 에서 전체 삭제됨).
-    // body = America/New_York → now = NY 7/14 20:00, '20:15' 는 15분 뒤 → 400.
-    // (기본값 Asia/Seoul 로 해석했다면 11시간 이상 남아 201 이 났을 것.)
+    // 발신자가 body 에 America/New_York 을 보내도 폴백으로 신뢰하지 않는다 —
+    // NY 로 해석하면 '20:15' 는 15분 뒤라 400 이 났겠지만, 효과 시간대는 기본값
+    // Asia/Seoul(11시간 이상 리드타임)이므로 201 이어야 한다. 저장 timezone 도
+    // 발신자 값이 아니라 효과 시간대여야 한다.
     const res = await postAlarm(SENDER_A, {
       time: '20:15',
       target_user_id: RECIPIENT.login,
       timezone: 'America/New_York',
     });
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as { error_code: string }).error_code).toBe(
-      'FAMILY_ALARM_LEAD_TIME',
-    );
+    expect(res.status).toBe(201);
+    const id = ((await res.json()) as { alarm: { id: string } }).alarm.id;
+    expect(String((await alarmRow(id))!.timezone)).toBe('Asia/Seoul');
+  });
+
+  it('수신자 저장 tz 가 있으면 그 tz 가 행에 저장된다(발신자 body tz 아님)', async () => {
+    // 수신자 기기가 마지막으로 보고한 시간대 = America/New_York.
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, time, timezone, is_active)
+            VALUES ('guard-tz', ?, '12:00', 'America/New_York', 1)`,
+      args: [RECIPIENT.login],
+    });
+    // now = NY 7/14 20:00 → '21:00' 은 NY 기준 1시간 뒤(리드타임 통과).
+    const res = await postAlarm(SENDER_A, {
+      time: '21:00',
+      target_user_id: RECIPIENT.login,
+      timezone: 'Asia/Seoul', // 발신자 값 — 판정·저장 어디에도 쓰이면 안 된다
+    });
+    expect(res.status).toBe(201);
+    const id = ((await res.json()) as { alarm: { id: string } }).alarm.id;
+    // cron 스케줄러가 검증(NY 기준 리드타임)과 같은 시간대로 해석하도록 효과 tz 저장.
+    expect(String((await alarmRow(id))!.timezone)).toBe('America/New_York');
   });
 });
 

--- a/packages/backend/test/alarm-helpers.test.ts
+++ b/packages/backend/test/alarm-helpers.test.ts
@@ -423,7 +423,7 @@ describe('normalizeTimezone / isSupportedTimezone', () => {
   });
 });
 
-describe('resolveEffectiveTimezone — 수신자 저장 tz 우선(발신자 body tz 우회 차단)', () => {
+describe('resolveEffectiveTimezone — 수신자 저장 tz 우선(발신자 body tz 는 어떤 경우에도 불신)', () => {
   /** 수신자 저장 timezone 조회를 흉내내는 DbExecutor. storedTz=null 이면 기록 없음. */
   function fakeDb(storedTz: string | null): DbExecutor & { args: unknown[] } {
     const captured: unknown[] = [];
@@ -438,34 +438,25 @@ describe('resolveEffectiveTimezone — 수신자 저장 tz 우선(발신자 body
 
   const RECIPIENT_IDS: [string, string] = ['r-pk', 'r-login'];
 
-  it('수신자 저장 tz 가 있으면 body tz 를 무시하고 저장 tz 를 반환한다', async () => {
+  it('수신자 저장 tz 가 있으면 그것을 반환한다', async () => {
     const db = fakeDb('America/New_York');
-    await expect(resolveEffectiveTimezone(db, 'Asia/Seoul', RECIPIENT_IDS)).resolves.toBe(
-      'America/New_York',
-    );
+    await expect(resolveEffectiveTimezone(db, RECIPIENT_IDS)).resolves.toBe('America/New_York');
     // 조회는 수신자 두 식별자(user_id IN)로 바인딩된다.
     expect(db.args).toEqual(['r-pk', 'r-login']);
   });
 
-  it('수신자 기록이 없으면 body tz 로 폴백한다', async () => {
-    await expect(
-      resolveEffectiveTimezone(fakeDb(null), 'America/New_York', RECIPIENT_IDS),
-    ).resolves.toBe('America/New_York');
-  });
-
-  it('저장 tz 가 Intl 미지원 값이면 body tz 로 폴백한다', async () => {
-    await expect(
-      resolveEffectiveTimezone(fakeDb('Not/AZone'), 'Asia/Tokyo', RECIPIENT_IDS),
-    ).resolves.toBe('Asia/Tokyo');
-  });
-
-  it('저장 tz 도 없고 body tz 도 무효면 Asia/Seoul 기본값', async () => {
-    await expect(resolveEffectiveTimezone(fakeDb(null), undefined, RECIPIENT_IDS)).resolves.toBe(
+  it('수신자 기록이 없으면 Asia/Seoul 로 직행한다(발신자 body tz 폴백 없음)', async () => {
+    // 발신자가 준 timezone 은 시그니처에서 아예 제거됐다 — 수신자 기록이 없어도
+    // 발신자 값으로 판정하지 않고 기본값(Asia/Seoul)으로 판정·저장한다.
+    await expect(resolveEffectiveTimezone(fakeDb(null), RECIPIENT_IDS)).resolves.toBe(
       'Asia/Seoul',
     );
-    await expect(
-      resolveEffectiveTimezone(fakeDb(null), 'bad zone!', RECIPIENT_IDS),
-    ).resolves.toBe('Asia/Seoul');
+  });
+
+  it('저장 tz 가 Intl 미지원 값이어도 Asia/Seoul 기본값', async () => {
+    await expect(resolveEffectiveTimezone(fakeDb('Not/AZone'), RECIPIENT_IDS)).resolves.toBe(
+      'Asia/Seoul',
+    );
   });
 });
 
@@ -508,5 +499,45 @@ describe('computeNextAlarmFire — 수신자 시간대 기준 다음 발사 시�
   it('시간 형식이 틀리면 null', () => {
     expect(computeNextAlarmFire('9:00', [], 'Asia/Seoul', NOW)).toBeNull();
     expect(computeNextAlarmFire('25:00', [], 'Asia/Seoul', NOW)).toBeNull();
+  });
+});
+
+describe('computeNextAlarmFire — DST 경계(달력 날짜 단위 전진)', () => {
+  // 미국 2026년 DST: 3/8(春, 23시간 하루) 시작, 11/1(秋, 25시간 하루) 종료.
+
+  it('봄 전환 직전 자정 부근: 다음 발사일이 전환일(3/8)을 건너뛰지 않는다', () => {
+    // now = 2026-03-08T04:30Z = NY 3/7(토) 23:30 EST. '23:00' 은 오늘 지남 → 다음날 3/8(일).
+    // 구버전(고정 86,400,000ms 전진)은 now+24h 가 3/9 00:30 EDT 라 달력 3/8 을 건너뛰어
+    // 하루 늦게 발사했다.
+    const now = new Date('2026-03-08T04:30:00Z');
+    const fire = computeNextAlarmFire('23:00', [], 'America/New_York', now)!;
+    // 3/8 23:00 EDT(-04) = UTC 3/9 03:00.
+    expect(fire.fireAt.toISOString()).toBe('2026-03-09T03:00:00.000Z');
+    expect(fire.fireDayOfWeek).toBe(0); // 전환일 당일(일요일)
+  });
+
+  it('봄 전환일 요일 반복: 매칭 요일(일)이 한 주 뒤로 밀리지 않는다', () => {
+    const now = new Date('2026-03-08T04:30:00Z');
+    const fire = computeNextAlarmFire('23:00', [0], 'America/New_York', now)!;
+    // 구버전은 3/8 을 건너뛰어 다음 일요일(3/15)로 한 주 밀렸다.
+    expect(fire.fireAt.toISOString()).toBe('2026-03-09T03:00:00.000Z');
+    expect(fire.fireDayOfWeek).toBe(0);
+  });
+
+  it('가을 전환(25시간 하루)도 정확한 벽시계 시각·요일로 발사', () => {
+    // now = 2026-11-01T03:30Z = NY 10/31(토) 23:30 EDT → '23:00' 다음 발사는 11/1(일) 23:00 EST.
+    const now = new Date('2026-11-01T03:30:00Z');
+    const fire = computeNextAlarmFire('23:00', [], 'America/New_York', now)!;
+    expect(fire.fireAt.toISOString()).toBe('2026-11-02T04:00:00.000Z'); // EST(-05) 23:00
+    expect(fire.fireDayOfWeek).toBe(0);
+  });
+
+  it('전환일 아침 알람: 전환 이후 오프셋(EDT)으로 벽시계 시각이 유지된다', () => {
+    // now = 2026-03-08T09:00Z = NY 3/8(일) 04:00 EST... 아님 — 3/8 02:00 에 EDT 전환됐으므로
+    // 09:00Z = 05:00 EDT. '07:00' 발사는 같은 날 07:00 EDT = 11:00Z 여야 한다(12:00Z 아님).
+    const now = new Date('2026-03-08T09:00:00Z');
+    const fire = computeNextAlarmFire('07:00', [], 'America/New_York', now)!;
+    expect(fire.fireAt.toISOString()).toBe('2026-03-08T11:00:00.000Z');
+    expect(fire.fireDayOfWeek).toBe(0);
   });
 });

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -544,6 +544,146 @@ describe('POST /alarms', () => {
 });
 
 // ---------------------------------------------------------------------------
+// greeting 버킷 정책 — 유료 클론(비-시스템) 보이스 전용, 시스템 보이스 우회 차단
+// ---------------------------------------------------------------------------
+describe('greeting 버킷 정책 (POST/PATCH)', () => {
+  const vpId = '50000000-0000-4000-8000-000000000010';
+
+  it('POST: 시스템 보이스 + greeting → 400 INVALID_BUCKET_ID (무료 우회 차단)', async () => {
+    mockDB.pushResult([{ plan: 'personal' }]); // user plan
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller(시스템 보이스도 접근은 허용)
+    mockDB.pushResult([]); // greeting 게이트: non-system 클론 아님(시스템 보이스)
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', voice_profile_id: vpId, bucket_id: 'greeting' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+  });
+
+  it('POST: 클론(비-시스템) 보이스 + greeting → 201', async () => {
+    mockDB.pushResult([{ plan: 'personal' }]); // user plan
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller(사전 검증)
+    mockDB.pushResult([{ '1': 1 }]); // greeting 게이트: non-system 클론 확인
+    mockDB.pushResult([{ '1': 1 }]); // 트랜잭션 내 voice_profile 재검증
+    mockDB.pushResult([], 1); // INSERT alarms
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', voice_profile_id: vpId, bucket_id: 'greeting' }),
+    );
+    expect(res.status).toBe(201);
+    const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(insert).toBeDefined();
+    expect(insert!.args).toContain('greeting');
+  });
+
+  it('POST: 시스템 스톡 클립 message + greeting → 400 (message 의 voice_profile 로 판정)', async () => {
+    mockDB.pushResult([{ plan: 'personal' }]); // user plan
+    mockDB.pushResult([{ '1': 1 }]); // messageBelongsToCaller(프리셋 접근은 허용)
+    mockDB.pushResult([]); // greeting 게이트: 시스템 보이스 메시지 → 클론 아님
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', message_id: ID.message, bucket_id: 'greeting' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+  });
+
+  it('POST: 보이스 지정이 전혀 없는 greeting 버킷 → 400', async () => {
+    mockDB.pushResult([{ plan: 'personal' }]); // user plan (게이트는 추가 조회 없이 거부)
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', bucket_id: 'greeting' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+  });
+
+  function pushExistingAlarmRow(overrides: Record<string, unknown> = {}) {
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        message_id: null,
+        mode: 'tts',
+        wake_mode: 'sound_then_voice',
+        voice_profile_id: null,
+        speaker_id: null,
+        raw_audio_url: null,
+        bucket_id: null,
+        user_plan: 'personal',
+        ...overrides,
+      },
+    ]);
+  }
+
+  it('PATCH: bucket_id=greeting + 시스템 voice_profile → 400 INVALID_BUCKET_ID', async () => {
+    pushExistingAlarmRow();
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller
+    mockDB.pushResult([]); // greeting 게이트: 시스템 보이스
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, { bucket_id: 'greeting', voice_profile_id: vpId }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(false);
+  });
+
+  it('PATCH: bucket_id=greeting + 클론 voice_profile → 200', async () => {
+    pushExistingAlarmRow();
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller
+    mockDB.pushResult([{ '1': 1 }]); // greeting 게이트: 클론 확인
+    mockDB.pushResult([{ '1': 1 }]); // 트랜잭션 내 voice_profile 재검증
+    mockDB.pushResult([], 1); // UPDATE alarms
+    mockDB.pushResult([
+      {
+        id: ID.alarm,
+        user_id: 'user-1',
+        target_user_id: null,
+        message_id: null,
+        time: '07:30',
+        repeat_days: '[]',
+        is_active: 1,
+        snooze_minutes: 5,
+        mode: 'tts',
+        vibration_pattern: 'default',
+        wake_mode: 'sound_then_voice',
+        voice_profile_id: vpId,
+        speaker_id: null,
+        bucket_id: 'greeting',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-02',
+      },
+    ]);
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, { bucket_id: 'greeting', voice_profile_id: vpId }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(true);
+  });
+
+  it('PATCH: 기존 greeting 알람의 voice_profile 을 시스템 보이스로 교체 시도 → 400', async () => {
+    // bucket_id 를 안 건드려도 결과 조합(effective)이 시스템+greeting 이면 거부한다.
+    pushExistingAlarmRow({ bucket_id: 'greeting', voice_profile_id: vpId });
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller(새 시스템 보이스 접근 허용)
+    mockDB.pushResult([]); // greeting 게이트: 시스템 보이스 → 클론 아님
+
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, {
+        voice_profile_id: '50000000-0000-4000-8000-0000000000bb',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PATCH /alarms/:id — 알람 수정
 // ---------------------------------------------------------------------------
 describe('PATCH /alarms/:id', () => {

--- a/packages/backend/test/billing-cancel-play.test.ts
+++ b/packages/backend/test/billing-cancel-play.test.ts
@@ -26,6 +26,7 @@ vi.mock('../src/lib/google-oauth', () => ({
 import billingMutation from '../src/routes/billing-mutation';
 import billingGoogle from '../src/routes/billing-google';
 import {
+  cancelSubscriptionImmediate,
   processSubscriptionExpiry,
   sweepPaidVoiceRetention,
 } from '../src/lib/billing-cancel';
@@ -141,9 +142,8 @@ describe('POST /billing/cancel (google 결제)', () => {
   it('immediate: Play :revoke 성공 → 구독 cancelled·음성 보존·30일 보관 예약', async () => {
     const fetchMock = stubPlayFetch(200, {});
     mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
-    mockDB.pushResult([SUB_ROW]); // 활성 구독 (라우트)
+    mockDB.pushResult([SUB_ROW]); // 활성 구독 스냅샷 (라우트, 트랜잭션 안에서 재조회 없음)
     mockDB.pushResult([GOOGLE_TXN_ROW]); // store_transactions
-    mockDB.pushResult([SUB_ROW]); // cancelActiveSubscriptionsForUser 내부 재조회
 
     const res = await buildApp().request(
       jsonReq('POST', '/billing/cancel', { mode: 'immediate' }),
@@ -304,9 +304,8 @@ describe('POST /billing/cancel — 다중 구독 토큰', () => {
   it('immediate 도 모든 토큰에 :revoke 를 호출한다', async () => {
     const fetchMock = stubPlayFetch(200, {});
     mockDB.pushResult([{ id: 'user-pk-1' }]);
-    mockDB.pushResult([SUB_ROW, SUB_ROW_2]);
+    mockDB.pushResult([SUB_ROW, SUB_ROW_2]); // 활성 구독 스냅샷 (트랜잭션 안에서 재조회 없음)
     mockDB.pushResult([GOOGLE_TXN_ROW, GOOGLE_TXN_ROW_2]);
-    mockDB.pushResult([SUB_ROW, SUB_ROW_2]); // cancelActiveSubscriptionsForUser 내부 재조회
 
     const res = await buildApp().request(
       jsonReq('POST', '/billing/cancel', { mode: 'immediate' }),
@@ -401,9 +400,8 @@ describe('POST /billing/cancel — 이미 취소/철회된 토큰 수렴 (C5)', 
       );
     vi.stubGlobal('fetch', fetchMock);
     mockDB.pushResult([{ id: 'user-pk-1' }]);
-    mockDB.pushResult([SUB_ROW]);
+    mockDB.pushResult([SUB_ROW]); // 활성 구독 스냅샷 (트랜잭션 안에서 재조회 없음)
     mockDB.pushResult([GOOGLE_TXN_ROW]);
-    mockDB.pushResult([SUB_ROW]); // cancelActiveSubscriptionsForUser 내부 재조회
 
     const res = await buildApp().request(
       jsonReq('POST', '/billing/cancel', { mode: 'immediate' }),
@@ -445,9 +443,8 @@ describe('POST /billing/cancel (apple·스텁)', () => {
   it('스토어 트랜잭션 없는 구독(dev 스텁/프로모) immediate: Play 호출 없이 해지 + 보관 예약', async () => {
     const fetchMock = stubPlayFetch(200, {});
     mockDB.pushResult([{ id: 'user-pk-1' }]);
-    mockDB.pushResult([SUB_ROW]);
+    mockDB.pushResult([SUB_ROW]); // 활성 구독 스냅샷 (트랜잭션 안에서 재조회 없음)
     mockDB.pushResult([]); // store_transactions 없음
-    mockDB.pushResult([SUB_ROW]); // cancelActiveSubscriptionsForUser 내부 재조회
 
     const res = await buildApp().request(
       jsonReq('POST', '/billing/cancel', { mode: 'immediate' }),
@@ -462,6 +459,126 @@ describe('POST /billing/cancel (apple·스텁)', () => {
     expect(findCall("status = 'cancelled'")).toBeDefined();
     expect(findCall('INSERT INTO paid_voice_retention')).toBeDefined();
     expect(findCall('DELETE FROM voice_profiles')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /billing/cancel — 스냅샷-트랜잭션 정합 (E1)
+// ---------------------------------------------------------------------------
+describe('POST /billing/cancel — 스냅샷 단위 취소 (E1)', () => {
+  it('Play 호출 중 새 구독이 confirm 되면 스냅샷만 취소하고 새 구독·plan 은 보존한다', async () => {
+    stubPlayFetch(200, {});
+    const NEW_SUB_ROW = { ...SUB_ROW, sub_id: 'sub-new' };
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([SUB_ROW]); // 활성 구독 스냅샷 (Play revoke 대상)
+    mockDB.pushResult([GOOGLE_TXN_ROW]); // store_transactions
+    mockDB.pushResult([], 1); // UPDATE subscriptions — sub-1 취소
+    mockDB.pushResult([], 1); // 미사용 코드 만료
+    mockDB.pushResult([NEW_SUB_ROW]); // plan 재정렬 조회 — 그 사이 confirm 된 새 활성 구독
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/billing/cancel', { mode: 'immediate' }),
+      undefined,
+      PLAY_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    // 취소는 스냅샷의 sub-1 한 건만 — 새 구독(sub-new)은 건드리지 않는다.
+    const cancelCalls = mockDB.calls.filter((c) => c.sql.includes("status = 'cancelled'"));
+    expect(cancelCalls).toHaveLength(1);
+    expect(cancelCalls[0]!.args).toContain('sub-1');
+    expect(cancelCalls[0]!.args).not.toContain('sub-new');
+    // 남은 활성 구독이 유료(personal)이므로 free 강등·음성 접근 정리를 하지 않는다.
+    expect(findCall("plan = 'free'")).toBeUndefined();
+    expect(findCall('UPDATE users SET plan = ?')?.args).toEqual(['plus', 'user-pk-1']);
+    expect(findCall('UPDATE voice_profiles')).toBeUndefined();
+    expect(findCall('UPDATE alarms')).toBeUndefined();
+    // 보관 예약은 유지 — sweep 이 삭제 전 활성 유료 구독을 재확인한다.
+    expect(findCall('INSERT INTO paid_voice_retention')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelSubscriptionImmediate — 남은 활성 구독 기준 plan 재정렬 (E2)
+// ---------------------------------------------------------------------------
+describe('cancelSubscriptionImmediate — plan 재정렬 (E2)', () => {
+  const SUB_1 = {
+    subscriptionId: 'sub-1',
+    userPk: 'user-pk-1',
+    planId: 'plan-1',
+    planType: 'personal',
+    planGroupId: null,
+  };
+
+  it('활성 2구독 중 1개만 취소하면 남은 구독의 plan 을 유지한다 (free 강등 없음)', async () => {
+    mockDB.pushResult([], 1); // UPDATE subscriptions — sub-1 취소
+    mockDB.pushResult([], 1); // 미사용 코드 만료
+    mockDB.pushResult([
+      { sub_id: 'sub-2', user_id: 'user-pk-1', plan_id: 'plan-1', plan_group_id: null, plan_type: 'personal' },
+    ]); // 남은 활성 구독 조회
+    mockDB.pushResult([], 1); // UPDATE users SET plan = ? (유지)
+
+    await cancelSubscriptionImmediate(mockDB.client as never, SUB_1, new Date());
+
+    expect(findCall("plan = 'free'")).toBeUndefined();
+    expect(findCall('UPDATE users SET plan = ?')?.args).toEqual(['plus', 'user-pk-1']);
+    // 여전히 유료이므로 is_shared 해제·타인 알람 강등을 하지 않는다.
+    expect(findCall('UPDATE voice_profiles')).toBeUndefined();
+    expect(findCall('UPDATE alarms')).toBeUndefined();
+  });
+
+  it('마지막 활성 구독을 취소하면 free 강등 + 음성 접근 정리를 수행한다', async () => {
+    mockDB.pushResult([], 1); // UPDATE subscriptions — sub-1 취소
+    mockDB.pushResult([], 1); // 미사용 코드 만료
+    mockDB.pushResult([]); // 남은 활성 구독 없음
+
+    await cancelSubscriptionImmediate(mockDB.client as never, SUB_1, new Date());
+
+    expect(findCall("plan = 'free'")).toBeDefined();
+    expect(findCall('UPDATE voice_profiles')).toBeDefined();
+    expect(findCall('UPDATE alarms')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelSubscriptionImmediate — 가족 소유자 즉시 해지 시 멤버 보관 예약 (B)
+// ---------------------------------------------------------------------------
+describe('cancelSubscriptionImmediate — 가족 소유자 해지 (B)', () => {
+  it('멤버 구독 취소 + 멤버에게도 유료 음성 30일 보관을 예약한다', async () => {
+    const OWNER_SUB = {
+      subscriptionId: 'sub-owner',
+      userPk: 'owner-pk',
+      planId: 'plan-f',
+      planType: 'family',
+      planGroupId: 'group-1',
+    };
+    mockDB.pushResult([], 1); // UPDATE subscriptions — 소유자 구독 취소
+    mockDB.pushResult([], 1); // 소유자 구독 미사용 코드 만료
+    mockDB.pushResult([]); // 소유자 남은 활성 구독 없음 → free 강등
+    mockDB.pushResult([], 1); // UPDATE users free (소유자)
+    mockDB.pushResult([]); // resolveUserLoginId (소유자)
+    mockDB.pushResult([], 1); // UPDATE voice_profiles (소유자)
+    mockDB.pushResult([], 1); // UPDATE alarms (소유자)
+    mockDB.pushResult([{ owner_user_id: 'owner-pk' }]); // plan_groups — 소유자 본인
+    mockDB.pushResult([
+      { user_id: 'owner-pk', role: 'owner' },
+      { user_id: 'member-pk', role: 'member' },
+    ]); // plan_group_members
+    mockDB.pushResult([{ id: 'sub-member' }]); // 멤버의 그룹 구독
+    // 이후(멤버 취소·강등·보관 예약·그룹 삭제)는 기본 빈 결과로 진행.
+
+    await cancelSubscriptionImmediate(mockDB.client as never, OWNER_SUB, new Date());
+
+    // 멤버 구독도 취소된다.
+    const cancelCalls = mockDB.calls.filter((c) => c.sql.includes("status = 'cancelled'"));
+    expect(cancelCalls.some((c) => c.args.includes('sub-member'))).toBe(true);
+    // 멤버에게도 30일 보관 예약이 생성된다 (소유자와 동일 정책).
+    const retentionInserts = mockDB.calls.filter((c) =>
+      c.sql.includes('INSERT INTO paid_voice_retention'),
+    );
+    expect(retentionInserts.map((c) => c.args[0])).toContain('member-pk');
+    // 그룹 멤버십 정리는 유지된다.
+    expect(findCall('DELETE FROM plan_group_members')).toBeDefined();
   });
 });
 
@@ -840,9 +957,32 @@ describe('POST /billing/google/confirm — 계정 바인딩 (C4)', () => {
     expect((await res.json()).success).toBe(true);
   });
 
-  it('식별자가 없으면(계약 이전 구버전 구매) 기존대로 허용한다', async () => {
+  // F: 출시 전 fresh DB 전제 — 새 클라는 항상 obfuscatedAccountId 를 설정하므로
+  // 식별자 없는 토큰의 "최초 바인딩"은 403 으로 거절한다(구클라는 업데이트 유도).
+  it('식별자 부재 + 미바인딩 토큰(첫 청구)은 403 TRANSACTION_ACCOUNT_UNVERIFIED + DB 무변경', async () => {
     stubPlayFetch(200, CONFIRM_SUB);
-    pushConfirmHappyPathResults();
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([]); // store_transactions 바인딩 조회 — 없음(첫 청구)
+
+    const res = await buildGoogleApp().request(
+      jsonReq('POST', '/billing/google/confirm', CONFIRM_BODY),
+      undefined,
+      PLAY_ENV,
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('TRANSACTION_ACCOUNT_UNVERIFIED');
+    expect(mockDB.calls.some((c) => /INSERT|UPDATE|DELETE/i.test(c.sql))).toBe(false);
+    expect(mockDB.transactions.commits).toBe(0);
+  });
+
+  it('식별자 부재라도 이미 바인딩된 토큰 재전송(갱신)은 기존 로직대로 통과한다', async () => {
+    stubPlayFetch(200, CONFIRM_SUB);
+    mockDB.pushResult([{ id: 'user-pk-1' }]); // resolveUserPk
+    mockDB.pushResult([{ user_id: 'user-pk-1' }]); // store_transactions 바인딩 조회 — 기존 바인딩
+    mockDB.pushResult([PLAN_ROW]); // loadPlanByKey
+    mockDB.pushResult([{ user_id: 'user-pk-1', subscription_id: 'sub-1' }]); // applyStoreEntitlement — 기존 트랜잭션
+    mockDB.pushResult([{ plan_id: 'plan-1' }]); // currentSubscriptionPlanId — 동일 plan → 갱신 분기
 
     const res = await buildGoogleApp().request(
       jsonReq('POST', '/billing/google/confirm', CONFIRM_BODY),
@@ -852,6 +992,7 @@ describe('POST /billing/google/confirm — 계정 바인딩 (C4)', () => {
 
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
-    expect(findCall('INSERT OR REPLACE INTO store_transactions')).toBeDefined();
+    // 갱신 분기 — 기존 구독 만료를 스토어 값으로 연장한다.
+    expect(findCall('SET expires_at = ?')).toBeDefined();
   });
 });

--- a/packages/backend/test/billing-google-rtdn.test.ts
+++ b/packages/backend/test/billing-google-rtdn.test.ts
@@ -255,8 +255,8 @@ describe('billing google RTDN', () => {
       expect(cancelCalls).toHaveLength(1);
       expect(cancelCalls[0]!.sql).toContain("WHERE id = ? AND status = 'active'");
       expect(cancelCalls[0]!.args).toContain('sub-old');
-      // 사용자 전체 활성 구독 나열(cancelActiveSubscriptionsForUser 경로)이 없어야 한다.
-      expect(findCall('ORDER BY s.starts_at DESC')).toBeUndefined();
+      // plan 재정렬(E2)을 위한 남은 활성 구독 '조회'는 허용된다 — 사용자 전체 '취소'가
+      // 없다는 보장은 위의 cancelCalls(1건·WHERE id = ? 스코프) 단언이 담당한다.
       // 30일 보관 예약은 유지된다 (sweep 이 삭제 전 활성 유료 구독을 재확인).
       expect(findCall('INSERT INTO paid_voice_retention')).toBeDefined();
       expect(mockDB.transactions.commits).toBe(1);

--- a/packages/backend/test/family-alarm-guard.test.ts
+++ b/packages/backend/test/family-alarm-guard.test.ts
@@ -1,0 +1,322 @@
+// 가족 알람 실동작 검증 — mock 결과 주입이 아니라 실제 libsql DB 에 전체 마이그레이션을
+// 올리고 실제 라우트(POST /family-alarm/alarms, /alarms/voice)를 호출해 확인한다:
+//  - 멱등 재전송 시 message 행이 누적되지 않고 교체된 이전 행이 정리되는지(항목 D)
+//  - 알람 행 timezone 이 '검증에 쓴 효과 시간대'로 저장되는지(항목 I)
+//  - dub_jobs 예약이 알람과 같은 트랜잭션으로 함께 커밋되는지(항목 J)
+//
+// libsql `:memory:` 는 연결마다 별도 DB 라 autocommit execute 와 transaction 이 스키마를
+// 공유하지 못한다(alarm-guard.test.ts 와 동일 이슈) → 임시 파일 DB 사용.
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { createClient, type Client } from '@libsql/client';
+import { Hono } from 'hono';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppEnv } from '../src/types';
+import { runMigrations } from '../src/lib/migrations';
+
+const DB_PATH = join(tmpdir(), 'alarmtalk-family-alarm-guard.db');
+const db: Client = createClient({ url: `file:${DB_PATH}` });
+
+vi.mock('../src/lib/db', () => ({ getDB: () => db }));
+
+const { default: familyAlarmRoutes } = await import('../src/routes/family-alarm');
+
+const SENDER = { pk: 'famg-s-pk', login: 'famg-gs' };
+const RECIPIENT = { pk: 'famg-r-pk', login: 'famg-gr' };
+const GROUP_ID = 'famg-group-001';
+const FAMILY_PLAN_ID = '70000000-0000-4000-8000-000000000003'; // 마이그레이션 시드 '가족' 플랜
+const VP_ID = 'famg-vp-001'; // 수신자 클론 보이스
+const UPLOAD_ID = 'famg-upload-001'; // 발신자 음성 업로드
+
+function app() {
+  const a = new Hono<AppEnv>();
+  a.use('*', async (c, next) => {
+    c.set('userId', SENDER.login);
+    await next();
+  });
+  a.route('/family-alarm', familyAlarmRoutes);
+  return a;
+}
+
+function postJson(path: string, body: Record<string, unknown>): Promise<Response> {
+  return app().request(
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function ttsBody(overrides: Record<string, unknown> = {}) {
+  return {
+    recipient_user_id: RECIPIENT.pk,
+    wake_at: '23:00',
+    message_text: '좋은 아침!',
+    ...overrides,
+  };
+}
+
+function voiceBody(overrides: Record<string, unknown> = {}) {
+  return {
+    recipient_user_id: RECIPIENT.pk,
+    wake_at: '23:00',
+    voice_upload_id: UPLOAD_ID,
+    ...overrides,
+  };
+}
+
+async function countRows(sql: string, args: (string | number)[]): Promise<number> {
+  const res = await db.execute({ sql, args });
+  return Number(res.rows[0]!.cnt);
+}
+
+beforeAll(async () => {
+  await runMigrations(db);
+  // 이전 실행 잔재 정리(파일 DB 재사용). 시스템 시드 행은 건드리지 않는다.
+  await db.execute('DELETE FROM alarms');
+  await db.execute('DELETE FROM dub_jobs');
+  await db.execute({ sql: 'DELETE FROM messages WHERE user_id = ?', args: [RECIPIENT.pk] });
+  await db.execute("DELETE FROM plan_group_members WHERE id LIKE 'famg-%'");
+  await db.execute("DELETE FROM plan_groups WHERE id LIKE 'famg-%'");
+  await db.execute({ sql: 'DELETE FROM voice_profiles WHERE id = ?', args: [VP_ID] });
+  await db.execute({ sql: 'DELETE FROM voice_uploads WHERE id = ?', args: [UPLOAD_ID] });
+  await db.execute("DELETE FROM users WHERE id LIKE 'famg-%'");
+
+  const insertUser = (u: { pk: string; login: string }, allow: number) =>
+    db.execute({
+      sql: `INSERT INTO users (id, google_id, email, allow_family_alarms, family_alarm_quiet_windows)
+            VALUES (?, ?, ?, ?, '[]')`,
+      args: [u.pk, u.login, `${u.pk}@famg.test`, allow],
+    });
+  await insertUser(SENDER, 0);
+  await insertUser(RECIPIENT, 1);
+
+  // 발신자·수신자를 같은 가족 그룹에 넣는다(assertSameGroup 통과).
+  await db.execute({
+    sql: `INSERT INTO plan_groups (id, owner_user_id, plan_id) VALUES (?, ?, ?)`,
+    args: [GROUP_ID, SENDER.pk, FAMILY_PLAN_ID],
+  });
+  await db.execute({
+    sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role) VALUES ('famg-m1', ?, ?, 'owner')`,
+    args: [GROUP_ID, SENDER.pk],
+  });
+  await db.execute({
+    sql: `INSERT INTO plan_group_members (id, plan_group_id, user_id, role) VALUES ('famg-m2', ?, ?, 'member')`,
+    args: [GROUP_ID, RECIPIENT.pk],
+  });
+
+  // 수신자 클론 보이스(ready, 비-draft) + 발신자 음성 업로드.
+  await db.execute({
+    sql: `INSERT INTO voice_profiles (id, user_id, name, status) VALUES (?, ?, '엄마', 'ready')`,
+    args: [VP_ID, RECIPIENT.pk],
+  });
+  await db.execute({
+    sql: `INSERT INTO voice_uploads (id, user_id, object_key, mime_type, size_bytes)
+          VALUES (?, ?, 'family-voice/famg.wav', 'audio/wav', 1024)`,
+    args: [UPLOAD_ID, SENDER.pk],
+  });
+});
+
+beforeEach(async () => {
+  await db.execute('DELETE FROM alarms');
+  await db.execute('DELETE FROM dub_jobs');
+  await db.execute('DELETE FROM pending_external_deletions');
+  await db.execute('DELETE FROM generated_audio_assets');
+  await db.execute({ sql: 'DELETE FROM messages WHERE user_id = ?', args: [RECIPIENT.pk] });
+  // 리드타임 판정이 실제 시계에 좌우되지 않도록 고정: 2026-07-15T00:00Z = KST 수요일 09:00.
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('가족 알람 멱등 재전송 — message 행 누적 방지(항목 D)', () => {
+  it('TTS 재전송 2회: 알람 1행 유지 + 교체된 이전 message 행 삭제(messages 1행)', async () => {
+    const res1 = await postJson('/family-alarm/alarms', ttsBody({ message_text: '첫번째' }));
+    expect(res1.status).toBe(201);
+    const body1 = (await res1.json()) as { alarm: { id: string }; message: { id: string } };
+
+    const res2 = await postJson('/family-alarm/alarms', ttsBody({ message_text: '두번째' }));
+    expect(res2.status).toBe(201);
+    const body2 = (await res2.json()) as { alarm: { id: string }; message: { id: string } };
+
+    expect(body2.alarm.id).toBe(body1.alarm.id); // 알람 행 재사용(멱등)
+    expect(body2.message.id).not.toBe(body1.message.id); // 메시지는 새 내용으로 교체
+
+    // 알람 1행 + 최신 메시지 연결.
+    expect(
+      await countRows(
+        'SELECT COUNT(*) AS cnt FROM alarms WHERE user_id = ? AND target_user_id = ? AND time = ?',
+        [SENDER.login, RECIPIENT.login, '23:00'],
+      ),
+    ).toBe(1);
+    const alarm = await db.execute({
+      sql: 'SELECT message_id FROM alarms WHERE id = ?',
+      args: [body1.alarm.id],
+    });
+    expect(String(alarm.rows[0]!.message_id)).toBe(body2.message.id);
+
+    // 교체된 이전 메시지는 같은 트랜잭션에서 정리되어 누적되지 않는다.
+    expect(
+      await countRows(
+        "SELECT COUNT(*) AS cnt FROM messages WHERE user_id = ? AND category = 'family'",
+        [RECIPIENT.pk],
+      ),
+    ).toBe(1);
+    expect(
+      await countRows('SELECT COUNT(*) AS cnt FROM messages WHERE id = ?', [body1.message.id]),
+    ).toBe(0);
+  });
+
+  it('TTS 재전송: 이전 메시지의 generated_audio_assets 정리 + R2 키 삭제 큐 적재', async () => {
+    const res1 = await postJson('/family-alarm/alarms', ttsBody({ message_text: '첫번째' }));
+    const body1 = (await res1.json()) as { message: { id: string } };
+
+    // 수신자가 프리페치해 이전 메시지의 TTS 캐시가 생긴 상황을 재현.
+    const objectKey = 'generated-tts/famg-old.mp3';
+    await db.execute({
+      sql: `INSERT INTO generated_audio_assets
+            (id, user_id, voice_profile_id, message_id, provider, provider_voice_id,
+             model_id, language, request_hash, text, audio_object_key)
+            VALUES ('famg-asset-1', ?, ?, ?, 'elevenlabs', 'ev-1', 'm1', 'ko', ?, '첫번째', ?)`,
+      args: [RECIPIENT.pk, VP_ID, body1.message.id, crypto.randomUUID(), objectKey],
+    });
+
+    const res2 = await postJson('/family-alarm/alarms', ttsBody({ message_text: '두번째' }));
+    expect(res2.status).toBe(201);
+
+    expect(
+      await countRows('SELECT COUNT(*) AS cnt FROM generated_audio_assets WHERE message_id = ?', [
+        body1.message.id,
+      ]),
+    ).toBe(0);
+    // R2 오브젝트는 트랜잭션 안에서 직접 못 지우므로 삭제 큐에 적재된다.
+    expect(
+      await countRows(
+        "SELECT COUNT(*) AS cnt FROM pending_external_deletions WHERE kind = 'r2_object' AND ref = ?",
+        [objectKey],
+      ),
+    ).toBe(1);
+  });
+
+  it('voice 재전송 2회: family-voice 메시지도 1행 유지', async () => {
+    const res1 = await postJson('/family-alarm/alarms/voice', voiceBody({ label: '첫번째 응원' }));
+    expect(res1.status).toBe(201);
+    const body1 = (await res1.json()) as { alarm: { id: string }; message: { id: string } };
+
+    const res2 = await postJson('/family-alarm/alarms/voice', voiceBody({ label: '두번째 응원' }));
+    expect(res2.status).toBe(201);
+    const body2 = (await res2.json()) as { alarm: { id: string }; message: { id: string } };
+
+    expect(body2.alarm.id).toBe(body1.alarm.id);
+    expect(
+      await countRows(
+        "SELECT COUNT(*) AS cnt FROM messages WHERE user_id = ? AND category = 'family-voice'",
+        [RECIPIENT.pk],
+      ),
+    ).toBe(1);
+    expect(
+      await countRows('SELECT COUNT(*) AS cnt FROM messages WHERE id = ?', [body1.message.id]),
+    ).toBe(0);
+  });
+
+  it('진행 중 dub 가 참조하는 이전 메시지는 보존한다(더빙 파이프라인 보호)', async () => {
+    const res1 = await postJson(
+      '/family-alarm/alarms/voice',
+      voiceBody({ dub_target_language: 'en' }),
+    );
+    expect(res1.status).toBe(201);
+    const body1 = (await res1.json()) as { message: { id: string } };
+
+    const res2 = await postJson(
+      '/family-alarm/alarms/voice',
+      voiceBody({ dub_target_language: 'en' }),
+    );
+    expect(res2.status).toBe(201);
+
+    // 첫 메시지는 dub_jobs.result_message_id 가 참조 중 → 삭제하지 않는다.
+    expect(
+      await countRows('SELECT COUNT(*) AS cnt FROM messages WHERE id = ?', [body1.message.id]),
+    ).toBe(1);
+    expect(
+      await countRows(
+        "SELECT COUNT(*) AS cnt FROM messages WHERE user_id = ? AND category = 'family-voice'",
+        [RECIPIENT.pk],
+      ),
+    ).toBe(2);
+  });
+});
+
+describe('가족 알람 timezone 저장 — 검증에 쓴 효과 시간대와 일치(항목 I)', () => {
+  it('수신자 기록 없음: 발신자 body tz 를 무시하고 Asia/Seoul 로 판정·저장', async () => {
+    // 발신자가 America/New_York 을 보내도 신뢰하지 않는다. NY 로 판정했다면 '23:00' 은
+    // NY 7/15 23:00(리드타임 통과)이지만, 저장 tz 까지 NY 가 되면 cron 이 발신자 주장
+    // 시간대로 울린다 — 효과 시간대(Asia/Seoul)가 판정·저장 모두에 쓰여야 한다.
+    const res = await postJson(
+      '/family-alarm/alarms',
+      ttsBody({ timezone: 'America/New_York' }),
+    );
+    expect(res.status).toBe(201);
+    const { alarm } = (await res.json()) as { alarm: { id: string } };
+    const row = await db.execute({
+      sql: 'SELECT timezone FROM alarms WHERE id = ?',
+      args: [alarm.id],
+    });
+    expect(String(row.rows[0]!.timezone)).toBe('Asia/Seoul');
+  });
+
+  it('수신자 저장 tz 있음: 그 tz 로 판정하고 같은 값을 행에 저장(voice 경로 포함)', async () => {
+    // 수신자 기기가 마지막으로 보고한 시간대 = America/New_York.
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, time, timezone, is_active)
+            VALUES ('famg-own-tz', ?, '12:00', 'America/New_York', 1)`,
+      args: [RECIPIENT.login],
+    });
+    // now = NY 7/14 20:00 → wake 10:00 은 NY 다음날 10:00(리드타임 통과).
+    const res = await postJson(
+      '/family-alarm/alarms/voice',
+      voiceBody({ wake_at: '10:00', timezone: 'Asia/Seoul' }),
+    );
+    expect(res.status).toBe(201);
+    const { alarm } = (await res.json()) as { alarm: { id: string } };
+    const row = await db.execute({
+      sql: 'SELECT timezone FROM alarms WHERE id = ?',
+      args: [alarm.id],
+    });
+    // cron 스케줄러가 검증(NY 리드타임)과 같은 시간대로 HH:mm 을 해석하게 저장한다.
+    expect(String(row.rows[0]!.timezone)).toBe('America/New_York');
+  });
+});
+
+describe('가족 음성알람 dub 원자성(항목 J)', () => {
+  it('dub 예약이 알람·메시지와 함께 커밋된다(result_message_id 연결)', async () => {
+    const res = await postJson(
+      '/family-alarm/alarms/voice',
+      voiceBody({ dub_target_language: 'ja' }),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      alarm: { id: string };
+      message: { id: string };
+      dub_job: { id: string; target_language: string; status: string };
+    };
+    expect(body.dub_job).not.toBeNull();
+
+    const dub = await db.execute({
+      sql: 'SELECT user_id, target_language, status, result_message_id FROM dub_jobs WHERE id = ?',
+      args: [body.dub_job.id],
+    });
+    expect(dub.rows.length).toBe(1);
+    expect(String(dub.rows[0]!.user_id)).toBe(SENDER.login);
+    expect(String(dub.rows[0]!.target_language)).toBe('ja');
+    expect(String(dub.rows[0]!.status)).toBe('processing');
+    expect(String(dub.rows[0]!.result_message_id)).toBe(body.message.id);
+    // 알람도 같은 커밋으로 존재한다.
+    expect(
+      await countRows('SELECT COUNT(*) AS cnt FROM alarms WHERE id = ?', [body.alarm.id]),
+    ).toBe(1);
+  });
+});

--- a/packages/backend/test/family-alarm.test.ts
+++ b/packages/backend/test/family-alarm.test.ts
@@ -55,8 +55,8 @@ function pushRecipient(
 }
 
 function pushRecipientTimezone() {
-  // 효과 시간대 결정: 수신자 최근 알람 timezone 조회. 수신자 저장 tz 가 body timezone 보다
-  // 우선하므로 body 유무와 무관하게 항상 실행된다(없음 → body tz → Asia/Seoul 폴백).
+  // 효과 시간대 결정: 수신자 최근 알람 timezone 조회. 발신자 body timezone 은 어떤
+  // 경우에도 판정에 쓰지 않으므로 항상 실행된다(기록 없음 → Asia/Seoul 직행).
   mockDB.pushResult([]);
 }
 
@@ -560,6 +560,45 @@ describe('POST /family-alarm/alarms/voice — 음성 업로드 가족 알람', (
     expect(dubInsert).toBeDefined();
   });
 
+  it('dub_jobs INSERT 는 알람/메시지와 같은 트랜잭션 안(커밋 전)에서 실행된다', async () => {
+    // 커밋 후 별도 실행이면 dub insert 실패/워커 종료 시 '더빙 없는 알람'만 커밋된 채
+    // 수신자에게 노출되는 창이 생긴다 — 커밋 시점에 이미 실행됐는지 검증한다.
+    pushResolveUserPk(SENDER_PK);
+    pushAssertSameGroup([GROUP_ID], [GROUP_ID]);
+    pushRecipient();
+    pushRecipientTimezone();
+    mockDB.pushResult([{ id: UPLOAD_ID, user_id: SENDER_PK, object_key: 'audio/voice.wav' }]);
+    pushLatestVoiceProfile(true);
+    pushInserts();
+    mockDB.pushResult([], 1); // INSERT dub_jobs (트랜잭션 내부)
+
+    const client = mockDB.client as unknown as {
+      transaction: () => Promise<{ commit: () => Promise<void> }>;
+    };
+    const origTransaction = client.transaction.bind(mockDB.client);
+    let dubInsertedBeforeCommit = false;
+    client.transaction = async () => {
+      const tx = await origTransaction();
+      const origCommit = tx.commit.bind(tx);
+      tx.commit = async () => {
+        dubInsertedBeforeCommit = mockDB.calls.some((c) => c.sql.includes('INSERT INTO dub_jobs'));
+        await origCommit();
+      };
+      return tx;
+    };
+    try {
+      const app = buildApp();
+      const res = await app.request(
+        jsonReq('POST', '/family-alarm/alarms/voice', validVoiceBody({ dub_target_language: 'en' })),
+      );
+      expect(res.status).toBe(201);
+      expect((await res.json()).dub_job).not.toBeNull();
+    } finally {
+      client.transaction = origTransaction;
+    }
+    expect(dubInsertedBeforeCommit).toBe(true);
+  });
+
   it('repeat_days 정규화 (voice 엔드포인트)', async () => {
     pushVoiceHappyPath();
 
@@ -624,7 +663,7 @@ describe('POST /family-alarm/alarms — 수신자 시간대 가드', () => {
     pushResolveUserPk(SENDER_PK);
     pushAssertSameGroup([GROUP_ID], [GROUP_ID]);
     pushRecipient({ quietWindows: '[]' });
-    pushRecipientTimezone(); // 수신자 저장 tz 없음 → body 의 Asia/Seoul. KST 09:20 은 20분 뒤 → 거부.
+    pushRecipientTimezone(); // 수신자 저장 tz 없음 → Asia/Seoul 기본값. KST 09:20 은 20분 뒤 → 거부.
 
     const app = buildApp();
     const res = await app.request(

--- a/packages/backend/test/paid-voice-cleanup.test.ts
+++ b/packages/backend/test/paid-voice-cleanup.test.ts
@@ -6,6 +6,7 @@ import {
   deleteSensitiveVoiceDataForUser,
 } from '../src/lib/paid-voice-cleanup';
 import { downgradeUserToFree } from '../src/lib/billing-cancel';
+import { purgeUserAccount } from '../src/lib/account-deletion';
 
 // 실제 libSQL(인메모리) + 실제 마이그레이션으로 검증한다. 공유 목소리 제공자가 취소/강등될 때
 // 그 목소리를 참조하는 '타인 소유' 알람이 하드 삭제되면 수신자의 기상 알람이 통째로 사라지는
@@ -162,4 +163,79 @@ describe('paid voice cleanup — 공유 목소리 소멸 시 타인 알람 보�
   // deletePaidVoiceDataForUser 와 동일하게 [userPk, loginId] 두 id 를 모두 매칭해 덮는다(PR #536 P1).
   // 이 인메모리 테스트는 FK(user_id REFERENCES users(id))를 강제해 login-id 저장 자체를 못 만드므로
   // 별도 재현 대신 코드 정합(두 id 매칭)으로 보장한다.
+
+  // ---- G(P1): 삭제 스코프는 '호출 사용자 소유 데이터'로 한정 ----
+  // 나를 target 으로 한 타인(발신자) 소유 알람 행과 그 raw 오디오는 발신자의 데이터다.
+  // 수신자의 delete-now/보관만료/강등이 발신자 데이터를 파기하면 안 된다.
+
+  async function enqueuedRefs(db: Client): Promise<string[]> {
+    const res = await db.execute(`SELECT ref FROM pending_external_deletions`);
+    return res.rows.map((r) => String(r.ref));
+  }
+
+  it('deletePaidVoiceDataForUser(B): 발신자(A)가 B에게 보낸 알람 행·raw 오디오는 보존, B 본인 알람은 삭제', async () => {
+    // A → B 가족 알람(행 소유 A, target 만 B) — A 자신의 목소리/메시지/녹음 사용.
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, voice_profile_id, time, mode, raw_audio_url)
+            VALUES ('al-sent', 'A', 'B', 'msg-A', 'vp-A', '07:00', 'tts', 'r2://sender-raw')`,
+      args: [],
+    });
+    // B 본인 소유 알람(B의 정리 대상).
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, message_id, voice_profile_id, time, mode, raw_audio_url)
+            VALUES ('al-B-own', 'B', 'msg-B', 'vp-A', '08:00', 'tts', 'r2://b-own-raw')`,
+      args: [],
+    });
+
+    await deletePaidVoiceDataForUser(db, 'B');
+
+    // B 본인 알람은 삭제 + raw 오디오 외부 삭제 큐 적재.
+    expect(await getAlarm(db, 'al-B-own')).toBeNull();
+    const refs = await enqueuedRefs(db);
+    expect(refs).toContain('b-own-raw');
+
+    // 발신자 소유 알람 행은 무손상 생존(강등도 없음 — A의 목소리/메시지만 참조).
+    const sent = await getAlarm(db, 'al-sent');
+    expect(sent).not.toBeNull();
+    expect(sent!.mode).toBe('tts');
+    expect(sent!.voice_profile_id).toBe('vp-A');
+    expect(sent!.message_id).toBe('msg-A');
+    expect(sent!.raw_audio_url).toBe('r2://sender-raw');
+    // 발신자 raw 오디오는 외부 삭제 큐에 올라가면 안 된다.
+    expect(refs).not.toContain('sender-raw');
+  });
+
+  it('deletePaidVoiceDataForUser(B): 나를 target 으로 한 타인 알람이 B의 목소리를 참조하면 삭제 대신 강등', async () => {
+    await insertSharedVoiceProfile(db, 'vp-B', 'B');
+    await insertMessage(db, 'msg-AB', 'A', 'vp-B'); // A의 메시지가 B의 공유 목소리로 합성됨
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, voice_profile_id, time, mode)
+            VALUES ('al-sent2', 'A', 'B', 'msg-AB', 'vp-B', '07:30', 'tts')`,
+      args: [],
+    });
+
+    await deletePaidVoiceDataForUser(db, 'B');
+
+    // 행은 발신자 소유라 생존하되, B의 목소리 참조는 sound-only 강등으로 끊는다.
+    const sent2 = await getAlarm(db, 'al-sent2');
+    expect(sent2).not.toBeNull();
+    expect(sent2!.mode).toBe('sound-only');
+    expect(sent2!.voice_profile_id).toBeNull();
+    expect(sent2!.message_id).toBeNull();
+  });
+
+  it('purgeUserAccount(B, 계정 삭제): target 알람 삭제 + 발신자 raw 오디오 회수(기존 동작 보존)', async () => {
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, target_user_id, message_id, voice_profile_id, time, mode, raw_audio_url)
+            VALUES ('al-sent', 'A', 'B', 'msg-A', 'vp-A', '07:00', 'tts', 'r2://sender-raw')`,
+      args: [],
+    });
+
+    await purgeUserAccount(db, 'B', 'google-B');
+
+    // 계정 삭제는 수신자 없는 알람을 남기지 않는다 — target 알람 행 삭제 + raw 오디오 회수.
+    expect(await getAlarm(db, 'al-sent')).toBeNull();
+    expect(await enqueuedRefs(db)).toContain('sender-raw');
+    expect((await db.execute(`SELECT id FROM users WHERE id = 'B'`)).rows).toEqual([]);
+  });
 });

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -457,6 +457,84 @@ describe('POST /tts/generate — TTS 생성', () => {
     expect(mockDB.calls.some((call) => call.sql.includes('SET preview_text'))).toBe(false);
   });
 
+  // 태그 부착 상한 = /tts/generate 의 200자 상한(경계 정합). 기본 상한(300)을 쓰면
+  // 원문은 200자 이내인데 문장별 태그 부착으로 200을 넘긴 텍스트가 폴백 없이 통과했다가
+  // 뒤늦게 TEXT_TOO_LONG(400)으로 거부된다 — 폴백(선두 1회 태그/무태그)으로 성공해야 한다.
+  function pushStoredPreviewFlow(storedText: string) {
+    mockDB.pushResult([{ plan: 'plus' }]);
+    mockDB.pushResult([
+      {
+        id: V1,
+        user_id: 'user-1',
+        status: 'ready',
+        is_draft: 1,
+        elevenlabs_voice_id: 'el-draft',
+        relationship_label: '엄마',
+        listener_title: '우리 아들',
+        preview_text: storedText,
+        preview_tag: 'cheerfully',
+      },
+    ]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([]);
+    pushPublicationVoice({
+      is_draft: 1,
+      elevenlabs_voice_id: 'el-draft',
+      relationship_label: '엄마',
+      listener_title: '우리 아들',
+    });
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+  }
+
+  it('문장별 태그가 200자를 넘기면 선두 1회 태그로 폴백해 성공한다(경계 정합)', async () => {
+    // 183자 2문장: 문장별 태그(209자) > 200, 선두 1회 태그(196자) ≤ 200.
+    const s1 = `${'a'.repeat(90)}.`;
+    const s2 = `${'b'.repeat(90)}.`;
+    const storedText = `${s1} ${s2}`;
+    expect(storedText.length).toBe(183);
+    pushStoredPreviewFlow(storedText);
+    mockTextToSpeech.mockResolvedValue(new Uint8Array([1, 2]).buffer);
+
+    const res = await reqWithEnv(
+      buildApp(),
+      jsonReq('POST', '/tts/generate', {
+        voice_profile_id: V1,
+        language: 'ko',
+        draft_preview: true,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.synthesis_text).toBe(`[cheerfully] ${storedText}`);
+    expect(body.synthesis_text.length).toBeLessThanOrEqual(200);
+    expect(body.text).toBe(storedText);
+  });
+
+  it('선두 1회 태그도 200자를 넘기면 무태그로 폴백해 성공한다(TEXT_TOO_LONG 아님)', async () => {
+    // 195자 1문장: 태그 부착 시 208자 > 200 → 원문 그대로 합성.
+    const storedText = `${'c'.repeat(194)}.`;
+    expect(storedText.length).toBe(195);
+    pushStoredPreviewFlow(storedText);
+    mockTextToSpeech.mockResolvedValue(new Uint8Array([1, 2]).buffer);
+
+    const res = await reqWithEnv(
+      buildApp(),
+      jsonReq('POST', '/tts/generate', {
+        voice_profile_id: V1,
+        language: 'ko',
+        draft_preview: true,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.synthesis_text).toBe(storedText);
+    expect(body.text).toBe(storedText);
+  });
+
   it('합성 중 민감 동의를 철회하면 생성 결과를 게시하지 않는다', async () => {
     mockDB.setConsentMissing(true);
     mockDB.pushResult([{ plan: 'plus' }]);

--- a/packages/backend/test/voice-profile-speech-style.test.ts
+++ b/packages/backend/test/voice-profile-speech-style.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import type { AppEnv, Env } from '../src/types';
 import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+import { CURRENT_POLICY_VERSION } from '../src/lib/consent';
 import {
   getSharedInMemoryVoiceStorage,
   resetSharedInMemoryVoiceStorage,
@@ -114,6 +115,24 @@ function statusCalls(status: string) {
     (call) =>
       call.sql.includes('speech_style_status = ?') && call.args.includes(status),
   );
+}
+
+/** 재시도 원자적 클레임(failed → pending) UPDATE 콜 조회. */
+function retryClaimCalls() {
+  return mockDB.calls.filter(
+    (call) =>
+      call.sql.includes("speech_style_status = 'pending'") &&
+      call.sql.includes("speech_style_status = 'failed'"),
+  );
+}
+
+/** 민감 동의(음성/국외이전) 동의 완료 행 — setConsentMissing(true) 큐 제어용. */
+function sensitiveConsentRows() {
+  return ['voice_biometric', 'overseas_transfer'].map((t) => ({
+    consent_type: t,
+    policy_version: CURRENT_POLICY_VERSION,
+    agreed: 1,
+  }));
 }
 
 beforeEach(() => {
@@ -228,6 +247,67 @@ describe('POST /clone — 말투 분석 상태 기록 (speech_style_status)', ()
     const stored = await getSharedInMemoryVoiceStorage().get(objectKey);
     expect(stored).not.toBeNull();
   });
+
+  it('클론 완료 직후 동의 철회 시 원본 보관을 스킵하고 외부 전사도 시작하지 않는다 (H)', async () => {
+    mockDB.setConsentMissing(true);
+    mockDB.pushResult(sensitiveConsentRows()); // 1) 라우트 진입 동의 확인 — 동의됨
+    mockDB.pushResult([{ draft_count: 0, official_count: 0 }]); // 2) 프로필 수
+    mockDB.pushResult([{ draft_count: 0, official_count: 0 }]); // 3) 슬롯 수(tx)
+    mockDB.pushResult([], 1); // 4) 월간 attempt 예약
+    mockDB.pushResult([], 1); // 5) voice_profiles INSERT
+    mockDB.pushResult(sensitiveConsentRows()); // 6) 완료 tx 동의 재확인 — 아직 동의됨
+    mockDB.pushResult([], 1); // 7) status='ready' 전환
+    mockDB.pushResult([]); // 8) 원본 보관 직전 재확인 — 철회됨(빈 결과)
+    // 이후(상태 pending 기록, 분석 시작 동의 재확인)는 큐 소진 → 기본 빈 결과(=철회 유지).
+    mockCreateInstantClone.mockResolvedValue({ voice_id: 'elv-ok' });
+
+    const { ctx, drain } = fakeExecutionCtx();
+    const app = buildApp();
+    const res = await app.request(cloneForm(), undefined, ENV, ctx);
+    expect(res.status).toBe(201); // 등록 자체는 이미 완료 — 보관/분석만 중단한다
+    await drain();
+
+    // 철회 후에는 원본을 R2/voice_uploads 에 새로 남기지 않는다.
+    expect(mockDB.calls.some((call) => call.sql.includes('INSERT INTO voice_uploads'))).toBe(false);
+    // 분석 시작 재확인에도 걸려 외부 전사(ElevenLabs)로 원본을 보내지 않는다.
+    expect(mockSpeechToText).not.toHaveBeenCalled();
+    expect(statusCalls('pending')).toHaveLength(1);
+    expect(statusCalls('failed')).toHaveLength(1);
+  });
+
+  it('분석 왕복 중 동의 철회 시 말투 결과를 저장하지 않는다 (H — 저장 직전 재확인)', async () => {
+    mockDB.setConsentMissing(true);
+    mockDB.pushResult(sensitiveConsentRows()); // 1) 라우트 진입
+    mockDB.pushResult([{ draft_count: 0, official_count: 0 }]); // 2) 프로필 수
+    mockDB.pushResult([{ draft_count: 0, official_count: 0 }]); // 3) 슬롯 수
+    mockDB.pushResult([], 1); // 4) attempt 예약
+    mockDB.pushResult([], 1); // 5) voice_profiles INSERT
+    mockDB.pushResult(sensitiveConsentRows()); // 6) 완료 tx 재확인
+    mockDB.pushResult([], 1); // 7) ready 전환
+    mockDB.pushResult(sensitiveConsentRows()); // 8) 원본 보관 직전 재확인 — 동의됨(보관 진행)
+    mockDB.pushResult([], 1); // 9) voice_uploads INSERT
+    mockDB.pushResult([], 1); // 10) status='pending'
+    mockDB.pushResult(sensitiveConsentRows()); // 11) 분석 시작 재확인 — 동의됨
+    mockDB.pushResult([]); // 12) 저장 직전 재확인 — 철회됨
+    mockCreateInstantClone.mockResolvedValue({ voice_id: 'elv-ok' });
+    mockSpeechToText.mockResolvedValue('마 오늘 아침은 우째 이래 좋노, 퍼뜩 일어나라 마');
+    mockAnalyzeSpeechStyle.mockResolvedValue(SAMPLE_STYLE);
+
+    const { ctx, drain } = fakeExecutionCtx();
+    const app = buildApp();
+    const res = await app.request(cloneForm(), undefined, ENV, ctx);
+    expect(res.status).toBe(201);
+    await drain();
+
+    // 철회 전에 시작된 전사는 있었지만, 파생 결과(speech_style)는 저장하지 않는다.
+    expect(mockSpeechToText).toHaveBeenCalled();
+    expect(mockDB.calls.some((call) => call.sql.includes("speech_style_status = 'done'"))).toBe(
+      false,
+    );
+    expect(statusCalls('failed')).toHaveLength(1);
+    // 보관은 철회 전에 이뤄졌으므로 존재한다(원본 보관 스킵과 구분).
+    expect(mockDB.calls.some((call) => call.sql.includes('INSERT INTO voice_uploads'))).toBe(true);
+  });
 });
 
 /* ------------------------------------------------------------------ */
@@ -275,8 +355,9 @@ describe('POST /:id/speech-style/retry — 말투 분석 재시도', () => {
     expect(res.status).toBe(409);
     expect((await res.json()).error_code).toBe('SOURCE_AUDIO_MISSING');
     expect(mockSpeechToText).not.toHaveBeenCalled();
-    // 소스가 없으면 상태를 pending 으로 바꾸지 않는다(기존 failed 유지).
+    // 소스가 없으면 상태를 pending 으로 바꾸지 않는다(기존 failed 유지 — 클레임도 없음).
     expect(statusCalls('pending')).toHaveLength(0);
+    expect(retryClaimCalls()).toHaveLength(0);
     expectProfileScopedSourceQuery();
   });
 
@@ -309,6 +390,7 @@ describe('POST /:id/speech-style/retry — 말투 분석 재시도', () => {
     mockDB.pushResult([
       { object_key: meta.objectKey, mime_type: 'audio/wav', original_name: 'sample.wav' },
     ]);
+    mockDB.pushResult([], 1); // 원자적 클레임(failed → pending) 성공
     mockSpeechToText.mockResolvedValue('오늘도 존댓말로 또박또박 말하는 전사 텍스트입니다');
     mockAnalyzeSpeechStyle.mockResolvedValue(SAMPLE_STYLE);
 
@@ -323,7 +405,10 @@ describe('POST /:id/speech-style/retry — 말투 분석 재시도', () => {
       mimeType: 'audio/wav',
       fileName: 'sample.wav',
     });
-    expect(statusCalls('pending')).toHaveLength(1);
+    // pending 전환은 무조건 UPDATE 가 아니라 failed 일 때만 성립하는 원자적 클레임이다.
+    const claims = retryClaimCalls();
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.args).toContain(V1);
     const doneCall = mockDB.calls.find((call) =>
       call.sql.includes("speech_style_status = 'done'"),
     );
@@ -332,12 +417,45 @@ describe('POST /:id/speech-style/retry — 말투 분석 재시도', () => {
     expect(doneCall!.args).toContain(V1);
   });
 
+  it('동시 재시도 경쟁: 클레임(failed→pending) 0행이면 409 + 분석 미실행', async () => {
+    const meta = await storeSourceUpload();
+    mockDB.pushResult([{ id: V1, preview_language: 'ko' }]);
+    mockDB.pushResult([
+      { object_key: meta.objectKey, mime_type: 'audio/wav', original_name: 'sample.wav' },
+    ]);
+    mockDB.pushResult([], 0); // 다른 요청이 이미 pending 점유(또는 failed 아님)
+
+    const res = await req(buildApp(), jsonReq('POST', `/vp/${V1}/speech-style/retry`));
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error_code).toBe('SPEECH_STYLE_RETRY_CONFLICT');
+    // 진 쪽은 전사/분석(외부 호출)을 시작하지 않는다.
+    expect(mockSpeechToText).not.toHaveBeenCalled();
+    expect(mockAnalyzeSpeechStyle).not.toHaveBeenCalled();
+  });
+
+  it('동의 철회 후 재시도는 403 CONSENT_REQUIRED — 전사/클레임 없이 차단', async () => {
+    mockDB.setConsentMissing(true);
+    mockDB.pushResult([{ id: V1, preview_language: 'ko' }]); // 소유권 조회
+    mockDB.pushResult([]); // user_consents — 철회 상태(빈 결과)
+
+    const res = await req(buildApp(), jsonReq('POST', `/vp/${V1}/speech-style/retry`));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error_code).toBe('CONSENT_REQUIRED');
+    expect(body.consent).toBe('voice_biometric');
+    expect(mockSpeechToText).not.toHaveBeenCalled();
+    expect(retryClaimCalls()).toHaveLength(0);
+  });
+
   it('preview_language=ja 는 분석 언어로 전달된다', async () => {
     const meta = await storeSourceUpload();
     mockDB.pushResult([{ id: V1, preview_language: 'ja' }]);
     mockDB.pushResult([
       { object_key: meta.objectKey, mime_type: 'audio/wav', original_name: 'sample.wav' },
     ]);
+    mockDB.pushResult([], 1); // 원자적 클레임 성공
     mockSpeechToText.mockResolvedValue('関西弁でほんまに元気よく話す文字起こしテキストやで');
     mockAnalyzeSpeechStyle.mockResolvedValue(SAMPLE_STYLE);
 
@@ -352,6 +470,7 @@ describe('POST /:id/speech-style/retry — 말투 분석 재시도', () => {
     mockDB.pushResult([
       { object_key: meta.objectKey, mime_type: 'audio/wav', original_name: 'sample.wav' },
     ]);
+    mockDB.pushResult([], 1); // 원자적 클레임 성공
     mockSpeechToText.mockRejectedValue(new Error('scribe down'));
 
     const res = await req(buildApp(), jsonReq('POST', `/vp/${V1}/speech-style/retry`));


### PR DESCRIPTION
## 배경
#561 머지 시 Codex 인라인 지적(P1 2·P2 2)이 폴링 필터 버그로 누락 확인 → 해당 4건 + #559 잔여 1건(tts 200자 캡) + 독립 검토의 배포 차단 지적 전부 반영. **prod 승격 없음 — dev까지만.**

## 수정 내역
### Codex 인라인 (#561·#559)
- **[P1] 구독 교체 계정 스코프**: 교체 후보를 `obfuscatedAccountId == sha256(현 사용자)` 일치 구매로 한정 — 타 AlarmTalk 계정 구독 취소 사고 차단 (PlayBillingManager)
- **[P1] 가족 멤버 30일 보관 예약**: 소유자 즉시해지 시 멤버에도 `paid_voice_retention` 예약
- **[P2] DST 발사일**: 고정 +24h → 수신자 시간대 달력 날짜 산술 (DST 4케이스 테스트)
- **[P2] 멱등 재전송 메시지 누적**: 교체된 message 행+에셋을 같은 트랜잭션에서 정리
- **[P2] tts 태그 200자 캡 정합** (#559 잔여)

### 독립 검토 차단 지적
- **/cancel 스냅샷 정합**: Play 확인된 구독만 DB 취소, 그 사이 들어온 새 confirm 구독 보존
- **plan 오강등 차단**: 다른 활성 구독이 남아 있으면 users.plan 유지(RTDN 단일 토큰 만료 포함)
- **레거시 토큰 first-claim**: 계정 식별자 부재 첫 바인딩 403 `TRANSACTION_ACCOUNT_UNVERIFIED` (출시 전 fresh DB 전제)
- **삭제 스코프**: delete-now/강등이 타인 발신(target) 알람·발신자 원본을 건드리지 않음(계정 삭제 경로는 자체 SQL로 기존 동작)
- **동의 철회 경쟁**: 클론 원본 저장·분석 전 동의 재확인, 말투 재시도 원자적 failed→pending 점유(중복 409)
- **수신자 시간대**: 검증 폴백에서 발신자 tz 완전 배제(저장 tz→Seoul), 검증 tz를 알람 행에 저장해 스케줄러 해석 일치
- **가족 음성알람 원자성**: dub_jobs 삽입을 트랜잭션 안으로, push는 커밋 후
- **greeting 정책 서버 강제**: bucket 'greeting'은 유료 클론 조합만(시스템 보이스 400) — 미리듣기 전용 확정

### 무대응(사유 기록)
- #560 iOS 레거시 디코딩 2건: iOS 미운영 + 출시 전 초기화 방침으로 레거시 설치 부재

## 검증
- 백엔드: typecheck ✅ · eslint ✅ · vitest **76파일 1480 passed / 0 failed**
- Android: 단위테스트·lintDevDebug·assembleDevDebug **BUILD SUCCESSFUL**