### PR TITLE
fix: 3차 감사 지적 반영 — PATCH 가드 우회(P1)·R2 소유권·DST·ack 재시도

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAudioStore.kt
@@ -176,10 +176,14 @@ class AlarmAudioStore(
                 }
             }
         }
-        val needsTrim = forceExtractAudio || resolvedStartMillis > 0 || durationMillis > maxDurationMillis
+        // 업로드 화이트리스트 밖 컨테이너(FLAC/WebM/OPUS 등 낯선 확장자)는 그대로 올리면
+        // octet-stream 으로 나가 백엔드가 거절한다 — 항상 트랜스코드 경로로 보내 m4a 로 정규화한다.
+        val unknownUploadContainer = extension.lowercase(Locale.US) !in UPLOAD_AUDIO_MIME_BY_EXTENSION
+        val needsTrim = forceExtractAudio || resolvedStartMillis > 0 || durationMillis > maxDurationMillis ||
+            unknownUploadContainer
         Log.i(
             TAG,
-            "cacheFromUri source=$sourceUri sourceMime=$sourceMimeType trackMime=$trackMimeType ext=$extension duration=$durationMillis max=$maxDurationMillis start=$resolvedStartMillis needsTrim=$needsTrim trimAsMp3=$trimAsMp3",
+            "cacheFromUri source=$sourceUri sourceMime=$sourceMimeType trackMime=$trackMimeType ext=$extension duration=$durationMillis max=$maxDurationMillis start=$resolvedStartMillis needsTrim=$needsTrim unknownContainer=$unknownUploadContainer trimAsMp3=$trimAsMp3",
         )
         val target = if (needsTrim) {
             val trimExtension = if (trimAsMp3) "mp3" else "m4a"
@@ -806,6 +810,24 @@ class AlarmAudioStore(
     companion object {
         private const val AUDIO_DIR = "alarm-audio"
         private const val META_EXTENSION = "meta"
+
+        // 백엔드 /voice/clone 은 audio/* 접두 MIME 만 받는다(아니면 INVALID_AUDIO_MIME_TYPE).
+        // 이 확장자들은 업로드 시 대응 audio/* 로 매핑되고(voiceUploadPart), 목록 밖 컨테이너는
+        // cacheFromUri 가 m4a 로 트랜스코드해 application/octet-stream 거절을 막는다.
+        val UPLOAD_AUDIO_MIME_BY_EXTENSION: Map<String, String> = mapOf(
+            "m4a" to "audio/mp4",
+            "mp4" to "audio/mp4",
+            "aac" to "audio/mp4",
+            "mp3" to "audio/mpeg",
+            "wav" to "audio/wav",
+            "ogg" to "audio/ogg",
+            "flac" to "audio/flac",
+            "webm" to "audio/webm",
+            "opus" to "audio/opus",
+            "3ga" to "audio/3gpp",
+            "3gp" to "audio/3gpp",
+            "amr" to "audio/amr",
+        )
 
         /** 이 기간 이상 손대지 않은(미참조) 캐시 파일은 앱 시작 시 백그라운드 sweep 으로 정리한다. */
         const val STALE_CACHE_MAX_AGE_MILLIS: Long = 30L * 24 * 60 * 60 * 1_000

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -269,6 +269,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // 진행 중인 프리페치 잡 — 목소리를 연달아 바꾸면 이전 잡을 취소하고 마지막 선택만 받는다.
     internal var voicePrefetchJob: kotlinx.coroutines.Job? = null
 
+    // setDefaultVoice 시점에 매니페스트(stockClips)가 아직 안 왔으면 프리페치가 빈손으로 끝난다.
+    // 대상 목소리를 여기 담아 두고 loadStockClips 성공 시 1회 재시도한다(재시도 후 클리어).
+    internal var pendingPrefetchVoiceId: String? = null
+
     private val consentPrefs = application.getSharedPreferences("voice_alarm_consent", android.content.Context.MODE_PRIVATE)
 
     // 필수 개인정보/약관 동의가 아직 안 된 경우 true → 로그인 후 동의 화면을 띄운다.
@@ -381,6 +385,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val userId = authSession?.user?.id?.takeIf { it.isNotBlank() }
         defaultVoiceStore.set(userId, voiceId)
         defaultVoiceId = voiceId
+        // 매니페스트가 아직 없으면 이번 프리페치는 빈손으로 끝난다 — 대상을 기억해 두고
+        // loadStockClips 성공 시 재시도한다(온보딩 중 목소리 선택이 매니페스트보다 빠른 경우).
+        if (stockClips.isEmpty()) pendingPrefetchVoiceId = voiceId
         prefetchFreeBucketClips(voiceId)
     }
 
@@ -461,6 +468,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         voicePrefetchJob?.cancel()
         voicePrefetchJob = null
         voicePrefetchProgress = null
+        pendingPrefetchVoiceId = null
         voiceProfiles = emptyList()
         pendingVoiceDraft = null
         voiceProfileLoadFinished = false

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
@@ -164,6 +164,7 @@ internal fun MainViewModel.createVoiceProfiles(items: List<VoiceProfileCreationD
                 "VOICE_CLONE_AUDIO_TOO_SHORT" -> app.getString(R.string.msg_voice_clone_audio_too_short)
                 "VOICE_CLONE_AUDIO_TOO_LONG" -> app.getString(R.string.msg_voice_clone_audio_too_long)
                 "INVALID_DURATION" -> app.getString(R.string.msg_voice_invalid_duration)
+                "INVALID_AUDIO_MIME_TYPE" -> app.getString(R.string.msg_voice_invalid_audio_format)
                 "VOICE_SLOT_EXHAUSTED" -> app.getString(R.string.msg_voice_slot_exhausted)
                 "VOICE_DRAFT_ATTEMPT_LIMIT_REACHED" -> app.getString(R.string.msg_voice_monthly_limit_reached)
                 "VOICE_FEATURE_REQUIRES_PAID_PLAN" -> app.getString(R.string.msg_voice_paid_plan_required)
@@ -635,6 +636,12 @@ internal fun MainViewModel.loadStockClips(forceReload: Boolean = false) {
             api.getStockClips(AlarmTalkApiClient.bearer(session.token)).clips
         }.onSuccess { clips ->
             stockClips = clips
+            // 매니페스트 도착 전 setDefaultVoice 로 프리페치가 빈손이었으면 여기서 1회 재시도한다.
+            // 재시도 여부와 무관하게 pending 은 비워 무한 재시도를 막는다(비움 결과도 정상 종료).
+            pendingPrefetchVoiceId?.let { voiceId ->
+                pendingPrefetchVoiceId = null
+                prefetchFreeBucketClips(voiceId)
+            }
         }.onFailure { error ->
             AlarmTalkLog.reportError("Failed to load stock clips", error)
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
@@ -106,13 +106,13 @@ internal fun voiceUploadPart(audio: CachedAlarmAudio): MultipartBody.Part {
     require(uri.scheme == "file") { "로컬에 저장된 오디오만 업로드할 수 있어요." }
     val file = File(requireNotNull(uri.path) { "오디오 파일 경로를 찾을 수 없어요." })
     require(file.exists()) { "오디오 파일을 찾을 수 없어요." }
-    val mediaType = when (file.extension.lowercase()) {
-        "m4a", "mp4", "aac" -> "audio/mp4"
-        "mp3" -> "audio/mpeg"
-        "wav" -> "audio/wav"
-        "ogg" -> "audio/ogg"
-        else -> "application/octet-stream"
-    }.toMediaType()
+    // 확장자→MIME 매핑 단일 출처는 AlarmAudioStore.UPLOAD_AUDIO_MIME_BY_EXTENSION.
+    // 목록 밖 컨테이너는 cacheFromUri 가 미리 m4a 로 트랜스코드하므로 여기 octet-stream 폴백은
+    // 사실상 도달하지 않지만, 방어적으로 남겨 둔다.
+    val mediaType = (
+        com.alarmtalk.app.data.AlarmAudioStore.UPLOAD_AUDIO_MIME_BY_EXTENSION[file.extension.lowercase()]
+            ?: "application/octet-stream"
+        ).toMediaType()
     val uploadName = audio.displayName.ifBlank { file.name }
     return MultipartBody.Part.createFormData(
         name = "audio",

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -535,6 +535,7 @@
     <string name="msg_voice_fetch_login_required">Please log in first to load the voice.</string>
     <string name="msg_voice_info_update_failed">Couldn\'t update your info.</string>
     <string name="msg_voice_info_updated">Your info has been updated.</string>
+    <string name="msg_voice_invalid_audio_format">That audio format isn\'t supported. Please try another file.</string>
     <string name="msg_voice_invalid_duration">Couldn\'t check the audio length. Please select the file again.</string>
     <string name="msg_voice_listener_title_required">Please enter what this voice will call you.</string>
     <string name="msg_voice_max_profiles_reached">You can create up to %1$d voices.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -543,6 +543,7 @@
     <string name="msg_voice_fetch_login_required">音声を読み込むには、まずログインしてください。</string>
     <string name="msg_voice_info_update_failed">情報の更新に失敗しました。</string>
     <string name="msg_voice_info_updated">情報を更新しました。</string>
+    <string name="msg_voice_invalid_audio_format">対応していない音声形式です。別のファイルでもう一度お試しください。</string>
     <string name="msg_voice_invalid_duration">音声の長さを確認できませんでした。ファイルをもう一度選んでください。</string>
     <string name="msg_voice_listener_title_required">この声があなたを呼ぶ名前を入力してください。</string>
     <string name="msg_voice_max_profiles_reached">声は最大%1$d個まで作成できます。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -546,6 +546,7 @@
     <string name="msg_voice_fetch_login_required">음성을 불러오려면 먼저 로그인해 주세요</string>
     <string name="msg_voice_info_update_failed">정보 수정에 실패했어요</string>
     <string name="msg_voice_info_updated">정보를 수정했어요</string>
+    <string name="msg_voice_invalid_audio_format">지원하지 않는 오디오 형식이에요. 다른 파일로 다시 시도해 주세요.</string>
     <string name="msg_voice_invalid_duration">음성 길이를 확인하지 못했어요. 파일을 다시 선택해 주세요.</string>
     <string name="msg_voice_listener_title_required">이 목소리가 나를 부를 이름을 입력해 주세요</string>
     <string name="msg_voice_max_profiles_reached">목소리는 최대 %1$d개까지 만들 수 있어요</string>

--- a/packages/backend/src/lib/audio-loader.ts
+++ b/packages/backend/src/lib/audio-loader.ts
@@ -14,10 +14,13 @@ const MAX_AUDIO_URL_LENGTH = 2048;
 
 /**
  * R2 객체 키 네임스페이스. 보이스/녹음 원본은 voices/{userId}/...,
- * 생성 TTS 캐시는 generated-tts/{userId}/... 형태로 저장된다
- * (r2-storage.ts, audio-cache.ts 참고). 키의 둘째 path segment 가 소유자 id.
+ * 생성 TTS 캐시는 generated-tts/{userId}/..., 알람 직접재생 클립은
+ * raw-alarms/{userId}/... 형태로 저장된다(r2-storage.ts, audio-cache.ts,
+ * alarm-source.ts 참고). 키의 둘째 path segment 가 소유자 id.
+ * raw-alarms/ 는 alarm.raw_audio_url 소유권 게이트(alarm-mutation.ts)가
+ * isR2KeyAuthorized({kind:'owner'}) 로 이 네임스페이스를 검증하는 데 쓴다.
  */
-const R2_USER_PREFIXES = ['voices/', 'generated-tts/'] as const;
+const R2_USER_PREFIXES = ['voices/', 'generated-tts/', 'raw-alarms/'] as const;
 
 export type AudioAccess =
   /**

--- a/packages/backend/src/lib/audio-loader.ts
+++ b/packages/backend/src/lib/audio-loader.ts
@@ -55,7 +55,14 @@ function r2KeyOwner(objectKey: string): string | null {
       const rest = objectKey.slice(prefix.length);
       const slash = rest.indexOf('/');
       if (slash <= 0) return null;
-      return decodeURIComponent(rest.slice(0, slash));
+      // 클라 제공 raw_audio_url 은 형식만 통과하면 여기 도달할 수 있다. 잘못된 퍼센트
+      // 인코딩(예: '%')이면 decodeURIComponent 가 throw 하는데, 이를 500 이 아니라
+      // '소유자 판별 불가(null)'로 처리해 호출자 소유권 게이트가 403/400 을 내게 한다.
+      try {
+        return decodeURIComponent(rest.slice(0, slash));
+      } catch {
+        return null;
+      }
     }
   }
   return null;

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -272,6 +272,34 @@ async function syncUserPlanAfterCancel(
   await downgradeUserToFree(db, userPk, options);
 }
 
+/**
+ * suspend(ON_HOLD/PAUSED) 전용 plan 재정렬 (E). 매핑(정지된) 구독을 제외한 다른 활성 유료
+ * 구독이 남아 있으면 그 plan 을 유지하고, 없을 때만 free 로 내린다 — deactivate 경로
+ * (syncUserPlanAfterCancel)의 E2(잔여 유료 구독 유지)와 대칭.
+ *
+ * deactivate 와 달리 ON_HOLD/PAUSED 는 결제 복구로 되살아날 수 있는 회복형 상태라,
+ * is_shared 해제·타인 알람 강등 같은 음성 접근 정리는 하지 않는다(그룹·공유 구조 보존).
+ * 소유자 users.plan 만 보수적으로 회수하며, 결제가 복구되면 entitle 가 users.plan 을 원복한다.
+ * (매핑 구독은 suspend 에서 취소하지 않아 여전히 active 이므로 subscriptionId 로 명시 제외한다.)
+ * 반환값: 유지된 plan_type(없으면 null — free 로 내림).
+ */
+export async function resolvePlanAfterSuspend(
+  db: DbExecutor,
+  userPk: string,
+  excludeSubscriptionId: string,
+): Promise<string | null> {
+  const remaining = await findActiveSubscriptionsByUserPk(db, userPk);
+  // 조회가 starts_at DESC 정렬이므로 가장 최근 유료 구독이 우선된다. 매핑(정지된) 구독은 제외.
+  const paid = remaining.find(
+    (s) => s.subscriptionId !== excludeSubscriptionId && PAID_PLAN_TYPES.has(s.planType),
+  );
+  await db.execute({
+    sql: `UPDATE users SET plan = ?, updated_at = datetime('now') WHERE id = ?`,
+    args: [paid ? planTypeToUserPlan(paid.planType) : 'free', userPk],
+  });
+  return paid ? paid.planType : null;
+}
+
 // 결제 해지/만료 흐름의 기본은 "음성 보존"이다. 하드 삭제는 보관 유예(sweep)나
 // 계정 삭제(account-deletion) 같은 명시적 경로에서만 deleteVoiceData:true 로 요청한다.
 export async function cancelSubscriptionImmediate(

--- a/packages/backend/src/lib/elevenlabs.ts
+++ b/packages/backend/src/lib/elevenlabs.ts
@@ -1,6 +1,10 @@
 const ELEVENLABS_BASE_URL = 'https://api.elevenlabs.io';
 const DEFAULT_TTS_MODEL_ID = 'eleven_v3';
 const DEFAULT_AUDIO_MIME_TYPE = 'audio/wav';
+// TTS 출력 포맷을 명시 고정한다(미지정 시 제공자 기본값에 의존). mp3 44.1kHz 128kbps →
+// mimeType audio/mpeg, 파일 확장자 'mp3' 와 일치한다(voice-provider.ts 의 outputFormat 라벨/
+// 캐시키가 'mp3' 인 것과 어긋나지 않는다).
+export const ELEVENLABS_TTS_OUTPUT_FORMAT = 'mp3_44100_128';
 
 type AudioUploadOptions = {
   mimeType?: string | null;
@@ -124,14 +128,17 @@ export class ElevenLabsClient {
     };
     body.voice_settings = voiceSettings;
 
-    const res = await this.request(`/v1/text-to-speech/${voiceId}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'audio/mpeg',
+    const res = await this.request(
+      `/v1/text-to-speech/${voiceId}?output_format=${ELEVENLABS_TTS_OUTPUT_FORMAT}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'audio/mpeg',
+        },
+        body: JSON.stringify(body),
       },
-      body: JSON.stringify(body),
-    });
+    );
 
     return res.arrayBuffer();
   }

--- a/packages/backend/src/lib/r2-storage.ts
+++ b/packages/backend/src/lib/r2-storage.ts
@@ -2,6 +2,12 @@ import type { VoiceStorage, StoreInput, StoredObject } from '@alarmtalk/voice';
 
 type StoreAtKeyInput = Omit<StoreInput, 'bytes'> & { bytes: Uint8Array<ArrayBufferLike> };
 
+/**
+ * 음성 업로드/클론 원본 최대 크기(25 MiB ≈ 2분 음성). voice-upload(/upload)·
+ * voice-profile(/clone) 공용 — arrayBuffer→R2→ElevenLabs 전에 크기 가드로 쓴다.
+ */
+export const MAX_VOICE_UPLOAD_BYTES = 25 * 1024 * 1024;
+
 export class R2VoiceStorage implements VoiceStorage {
   readonly name = 'r2';
   private bucket: R2Bucket;

--- a/packages/backend/src/lib/voice-provider.ts
+++ b/packages/backend/src/lib/voice-provider.ts
@@ -99,6 +99,8 @@ export function createSynthesisAttempts(params: {
       provider: 'elevenlabs',
       providerVoiceId: params.profile.elevenlabs_voice_id,
       modelId: ELEVENLABS_V3_MODEL_ID,
+      // 파일 확장자/캐시키용 coarse 라벨. 실제 제공자 출력은 elevenlabs.ts 의
+      // ELEVENLABS_TTS_OUTPUT_FORMAT(mp3_44100_128) 로 고정되며 그 형식은 mp3(audio/mpeg)라 일치한다.
       outputFormat: 'mp3',
       voiceSettings: params.voiceSettings,
       synthesize: async () => {

--- a/packages/backend/src/routes/alarm-helpers.ts
+++ b/packages/backend/src/routes/alarm-helpers.ts
@@ -2,6 +2,10 @@ import { UUID_RE } from '../lib/validate';
 import { isStoredAudioUrl } from '../lib/audio-loader';
 import { FREE_BUCKET_CATEGORIES, CLONE_PRERENDER_CATEGORIES } from '../lib/stock-clips';
 import { DEFAULT_ALARM_TIMEZONE } from '../lib/scheduler';
+import {
+  isBlockedByFamilyAlarmQuietTime,
+  type FamilyAlarmSettings,
+} from '../lib/family-alarm-settings';
 import type { DbExecutor } from '../lib/transactions';
 
 export const ALARM_MODES = ['sound-only', 'tts'] as const;
@@ -284,7 +288,16 @@ function wallClockAt(at: Date, timezone: string): WallClock {
   return clock;
 }
 
-/** 시간대의 (y,m,d HH:mm) 벽시계 시각을 UTC Date 로 변환한다(2회 보정으로 DST 경계 흡수). */
+/**
+ * 시간대의 (y,m,d HH:mm) 벽시계 시각을 UTC Date 로 변환한다(2회 보정으로 DST 경계 흡수).
+ *
+ * DST 경계 정책:
+ *  - gap(스프링포워드로 존재하지 않는 벽시계, 예 NY 2026-03-08 02:30): 2회 보정만으로는
+ *    gap '이전'(01:30 EST)으로 수렴한다. 보정 후 결과 벽시계의 HH:mm 이 요청과 다르면
+ *    잔여 오프셋을 한 번 더 더해 gap '이후'(03:30 EDT)로 확정한다.
+ *  - ambiguous(폴백으로 두 번 나타나는 벽시계, 예 NY 2026-11-01 01:30): 2회 보정이 자연히
+ *    '이른 쪽'(01:30 EDT)으로 수렴하며 HH:mm 이 일치하므로 추가 보정 없이 그대로 둔다.
+ */
 function zonedWallTimeToUtc(
   year: number,
   month: number,
@@ -298,6 +311,19 @@ function zonedWallTimeToUtc(
   for (let i = 0; i < 2; i++) {
     const clock = wallClockAt(new Date(ts), timezone);
     const asUtc = Date.UTC(clock.year, clock.month - 1, clock.day, clock.hour, clock.minute);
+    ts += target - asUtc;
+  }
+  // gap 감지: 보정 결과의 벽시계 HH:mm 이 요청과 다르면 존재하지 않는 시각이므로 잔여
+  // 오프셋을 한 번 더 더해 gap 이후 시각으로 확정한다(위 정책 주석 참고).
+  const settled = wallClockAt(new Date(ts), timezone);
+  if (settled.hour !== hour || settled.minute !== minute) {
+    const asUtc = Date.UTC(
+      settled.year,
+      settled.month - 1,
+      settled.day,
+      settled.hour,
+      settled.minute,
+    );
     ts += target - asUtc;
   }
   return new Date(ts);
@@ -419,4 +445,66 @@ export async function claimTargetedAlarmSlot(
     args: [recipientIds[0], recipientIds[1], time, alarmId],
   });
   return { alarmId, reused, previousMessageId };
+}
+
+/** 타인 발신 알람 시각 가드 결과 — 통과(효과 시간대 반환) 또는 거부(에러 응답 필드). */
+export type FamilyAlarmTimingGuardResult =
+  | { ok: true; effectiveTimezone: string; nextFire: NextAlarmFire | null }
+  | { ok: false; error: string; error_code: string; status: 400 | 403 };
+
+/**
+ * 타인 발신(가족/친구) 알람의 시각 가드 — POST(생성)·PATCH(수정) 공용.
+ * 발신자 body.timezone 은 어떤 경우에도 신뢰하지 않고, resolveEffectiveTimezone 이 산출한
+ * 효과 시간대(수신자 최근 알람 tz → Asia/Seoul)로 다음 발사 시각을 구해 판정한다.
+ *  ① 수신자가 알람 수신을 허용하지 않으면 403 FAMILY_ALARM_DISABLED
+ *  ② 다음 발사 시각이 30분 리드타임 미만이면 400 FAMILY_ALARM_LEAD_TIME
+ *  ③ 다음 발사 요일·시각이 수신자 quiet 창에 걸리면 403 FAMILY_ALARM_QUIET_TIME
+ * 통과 시 { ok:true, effectiveTimezone } — 호출부는 이 효과 시간대를 알람 행(timezone)에
+ * 그대로 저장해 cron 스케줄러가 검증과 같은 시간대로 HH:mm 을 해석하게 한다.
+ */
+export async function evaluateFamilyAlarmTimingGuard(
+  db: DbExecutor,
+  recipientIds: [string, string],
+  settings: FamilyAlarmSettings,
+  time: string,
+  repeatDays: number[],
+  now: Date = new Date(),
+): Promise<FamilyAlarmTimingGuardResult> {
+  if (!settings.allowFamilyAlarms) {
+    return {
+      ok: false,
+      error: '상대방이 알람 설정을 허용하지 않았습니다.',
+      error_code: 'FAMILY_ALARM_DISABLED',
+      status: 403,
+    };
+  }
+  const effectiveTimezone = await resolveEffectiveTimezone(db, recipientIds);
+  const nextFire = computeNextAlarmFire(time, repeatDays, effectiveTimezone, now);
+  if (
+    nextFire &&
+    nextFire.fireAt.getTime() - now.getTime() < FAMILY_ALARM_MIN_LEAD_MINUTES * 60_000
+  ) {
+    return {
+      ok: false,
+      error: `알람은 최소 ${FAMILY_ALARM_MIN_LEAD_MINUTES}분 이후 시각으로만 보낼 수 있습니다.`,
+      error_code: 'FAMILY_ALARM_LEAD_TIME',
+      status: 400,
+    };
+  }
+  if (
+    isBlockedByFamilyAlarmQuietTime(
+      time,
+      repeatDays,
+      settings,
+      nextFire?.fireDayOfWeek ?? now.getDay(),
+    )
+  ) {
+    return {
+      ok: false,
+      error: '상대방이 설정한 불가 시간에는 알람을 만들 수 없습니다.',
+      error_code: 'FAMILY_ALARM_QUIET_TIME',
+      status: 403,
+    };
+  }
+  return { ok: true, effectiveTimezone, nextFire };
 }

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -854,6 +854,14 @@ alarmMutation.patch('/:id', async (c) => {
     }
   }
 
+  // 슬롯 재점유 경로에서는 PATCH 대상이 (수신자, time) 슬롯의 유일 승자이므로 반드시 활성으로
+  // 남긴다. time 만 바꾸는 경우 is_active 가 updates 에 없어 기존 활성값이 유지되지만, 명시적으로
+  // 1 을 보장해 아래 슬롯 비활성화 UPDATE 로 대상이 함께 꺼지는 일이 없게 한다.
+  if (familyReclaim && !updates.includes('is_active = ?')) {
+    updates.push('is_active = ?');
+    args.push(1);
+  }
+
   if (updates.length === 0) {
     return c.json({ error: 'No fields to update', error_code: 'NO_UPDATE_FIELDS' }, 400);
   }
@@ -886,24 +894,18 @@ alarmMutation.patch('/:id', async (c) => {
             return { status: 'message_not_found' as const, result: null };
           }
           if (familyReclaim) {
-            // (수신자, 새 time) 슬롯을 원자 재점유 — 이 알람(id)을 keeper 로 두고 같은 슬롯의
-            // 다른 활성 발신 알람(다른 발신자·이전 중복)을 비활성화한다. 같은 발신자가 그 시각에
-            // 다른 활성 알람을 이미 갖고 있으면(같은 시각 이중 예약) claim 이 그 행을 keeper 로
-            // 고를 수 있으므로, PATCH 대상(id)이 승자가 되도록 그 행도 비활성화한다.
-            const claimed = await claimTargetedAlarmSlot(
-              tx,
-              userId,
-              familyReclaim.ids,
-              familyReclaim.time,
-              id,
-            );
-            if (claimed.reused && claimed.alarmId !== id) {
-              await tx.execute({
-                sql: `UPDATE alarms SET is_active = 0, updated_at = datetime('now')
-                      WHERE id = ? AND target_user_id IN (?, ?)`,
-                args: [claimed.alarmId, familyReclaim.ids[0], familyReclaim.ids[1]],
-              });
-            }
+            // (수신자, 새 time) 슬롯을 PATCH 대상(id)이 유일 승자가 되도록 원자 재점유한다.
+            // 같은 슬롯의 다른 활성 발신 알람(다른 발신자 + 같은 발신자의 같은 시각 이중 예약
+            // 포함)을 전부 비활성화하되 PATCH 대상(id != ?)은 제외한다. 대상은 위에서 is_active=1
+            // 을 보장했으므로 아래 updateAlarm 으로 활성 상태로 확정된다.
+            // (POST 용 claimTargetedAlarmSlot 은 '기존 행을 keeper 로 재사용'하는 의미라 특정
+            //  행을 수정하는 PATCH 에는 부적합 — 대상이 아닌 행이 keeper 로 뽑혀 대상까지
+            //  비활성화돼 두 알람이 모두 꺼지는 버그가 있었다: Codex #563.)
+            await tx.execute({
+              sql: `UPDATE alarms SET is_active = 0, updated_at = datetime('now')
+                    WHERE target_user_id IN (?, ?) AND time = ? AND is_active = 1 AND id != ?`,
+              args: [familyReclaim.ids[0], familyReclaim.ids[1], familyReclaim.time, id],
+            });
           }
           return { status: 'ok' as const, result: await updateAlarm(tx) };
         })

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -918,9 +918,16 @@ alarmMutation.patch('/:id', async (c) => {
   // raw_audio_url 을 새 값으로 교체하면 이전 R2 녹음이 어떤 알람에서도 참조되지
   // 않을 수 있다. DELETE 핸들러와 동일하게, 더 이상 쓰이지 않는 이전 오브젝트를
   // 삭제 큐에 적재해 영구 고아를 막는다(교체 경로에는 기존에 이 정리가 없었다).
+  // 단, 쓰기 게이트(rawAudioUrlBelongsToCaller) 이전에 생성된 레거시 알람은 타인
+  // 키를 참조할 수 있으므로, 삭제 큐 적재 전에도 소유권을 확인해 타인 오브젝트가
+  // 삭제되지 않게 한다(cross-tenant 삭제 차단).
   if (body.raw_audio_url !== undefined) {
     const previousRawUrl = current.raw_audio_url;
-    if (previousRawUrl?.startsWith('r2://') && previousRawUrl !== body.raw_audio_url) {
+    if (
+      previousRawUrl?.startsWith('r2://') &&
+      previousRawUrl !== body.raw_audio_url &&
+      rawAudioUrlBelongsToCaller(previousRawUrl, ownerIds)
+    ) {
       const stillReferenced = await db.execute({
         sql: 'SELECT COUNT(*) AS cnt FROM alarms WHERE raw_audio_url = ?',
         args: [previousRawUrl],
@@ -1034,7 +1041,9 @@ alarmMutation.delete('/:id', async (c) => {
   }
 
   // 사용자 녹음 원본(r2://)이 더 이상 어떤 알람에도 쓰이지 않으면 R2 삭제 큐에 적재.
-  if (rawAudioUrl?.startsWith('r2://')) {
+  // 쓰기 게이트 이전의 레거시 알람이 타인 키를 참조할 수 있으므로, 삭제 큐 적재 전에
+  // 소유권을 확인해 타인 오브젝트가 삭제되지 않게 한다(cross-tenant 삭제 차단).
+  if (rawAudioUrl?.startsWith('r2://') && rawAudioUrlBelongsToCaller(rawAudioUrl, ownerIds)) {
     const rawRefRes = await db.execute({
       sql: 'SELECT COUNT(*) AS cnt FROM alarms WHERE raw_audio_url = ?',
       args: [rawAudioUrl],

--- a/packages/backend/src/routes/alarm-mutation.ts
+++ b/packages/backend/src/routes/alarm-mutation.ts
@@ -7,18 +7,13 @@ import { logRouteError } from '../lib/logger';
 import { R2VoiceStorage } from '../lib/r2-storage';
 import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import { sendFamilyAlarmPush } from '../lib/fcm';
-import {
-  familyAlarmSettingsFromRow,
-  isBlockedByFamilyAlarmQuietTime,
-} from '../lib/family-alarm-settings';
+import { familyAlarmSettingsFromRow } from '../lib/family-alarm-settings';
 import {
   validateAlarmFields,
   normalizeAlarmRow,
   normalizeTimezone,
-  resolveEffectiveTimezone,
-  computeNextAlarmFire,
   claimTargetedAlarmSlot,
-  FAMILY_ALARM_MIN_LEAD_MINUTES,
+  evaluateFamilyAlarmTimingGuard,
   type AlarmRow,
   type AlarmMode,
   type VibrationPattern,
@@ -27,8 +22,22 @@ import {
 import { isPaidVoicePlan } from './billing-helpers';
 import { withWriteTransaction, type DbExecutor } from '../lib/transactions';
 import { STOCK_GREETING_CATEGORY } from '../lib/stock-clips';
+import { isR2KeyAuthorized } from '../lib/audio-loader';
 
 const alarmMutation = new Hono<AppEnv>();
+
+/**
+ * raw_audio_url(사용자 녹음 원본, r2://raw-alarms/{userId}/...)의 소유권을 검증한다.
+ * validateAlarmFields 의 isStoredAudioUrl 은 r2:// 형식만 확인하므로, 그것만으로는
+ * 공격자가 타인 R2 키를 자기 알람 raw_audio_url 에 끼워 넣고 DELETE/PATCH 로 참조를
+ * 0 으로 만들어(삭제 큐 적재) 타인 객체를 지우는 벡터가 열린다. 키에 박힌 소유자
+ * segment 가 호출자(ownerIds)와 일치할 때만 허용한다(isR2KeyAuthorized owner 게이트 재사용).
+ */
+function rawAudioUrlBelongsToCaller(rawAudioUrl: string, ownerIds: string[]): boolean {
+  const trimmed = rawAudioUrl.trim();
+  const key = trimmed.startsWith('r2://') ? trimmed.slice('r2://'.length) : trimmed;
+  return isR2KeyAuthorized(key, { kind: 'owner', ownerIds });
+}
 
 function alarmUsesPaidVoice(body: {
   mode?: string | null;
@@ -169,6 +178,17 @@ async function voiceProfileBelongsToCaller(
  * 접근 가능 여부(소유/공유/프리셋)는 voiceProfileBelongsToCaller /
  * messageBelongsToCaller 가 별도로 강제하므로 여기서는 클론(비-시스템) 여부만 본다.
  */
+async function messageGreetingUsesCloneVoice(db: DbExecutor, messageId: string): Promise<boolean> {
+  const res = await db.execute({
+    sql: `SELECT 1 FROM messages m
+          JOIN voice_profiles vp ON vp.id = m.voice_profile_id
+          WHERE m.id = ? AND COALESCE(vp.is_system, 0) = 0 AND vp.deleted_at IS NULL
+          LIMIT 1`,
+    args: [messageId],
+  });
+  return res.rows.length > 0;
+}
+
 async function greetingBucketUsesCloneVoice(
   db: DbExecutor,
   fields: { voice_profile_id?: string | null; message_id?: string | null },
@@ -181,17 +201,15 @@ async function greetingBucketUsesCloneVoice(
             LIMIT 1`,
       args: [fields.voice_profile_id],
     });
-    return res.rows.length > 0;
+    if (res.rows.length === 0) return false;
+    // vp 는 클론이지만 message_id 가 함께 지정되면(클론 vp + 시스템 greeting 메시지 혼합)
+    // 그 message 의 voice_profile 도 비-시스템(클론)인지 AND 로 검증한다 — 시스템 greeting
+    // 미리듣기 클립을 클론 vp 뒤에 끼워 무료 알람으로 돌려 쓰는 우회를 방어심화한다.
+    if (fields.message_id) return messageGreetingUsesCloneVoice(db, fields.message_id);
+    return true;
   }
   if (fields.message_id) {
-    const res = await db.execute({
-      sql: `SELECT 1 FROM messages m
-            JOIN voice_profiles vp ON vp.id = m.voice_profile_id
-            WHERE m.id = ? AND COALESCE(vp.is_system, 0) = 0 AND vp.deleted_at IS NULL
-            LIMIT 1`,
-      args: [fields.message_id],
-    });
-    return res.rows.length > 0;
+    return messageGreetingUsesCloneVoice(db, fields.message_id);
   }
   // 보이스 지정이 전혀 없는 알람(alarm-only 등)은 greeting 버킷을 가질 이유가 없다.
   return false;
@@ -236,6 +254,15 @@ alarmMutation.post('/', async (c) => {
   const fieldError = validateAlarmFields(body);
   if (fieldError) return c.json(fieldError, 400);
 
+  // raw_audio_url 소유권 검증(B): 저장 전에 r2:// 키의 소유자 segment 가 호출자인지 확인한다.
+  // 타인 키를 넣어 두면 이후 DELETE/PATCH 교체 시 참조 0 판정으로 타인 R2 객체가 삭제 큐에 적재된다.
+  if (
+    body.raw_audio_url != null &&
+    !rawAudioUrlBelongsToCaller(body.raw_audio_url, ownerIds)
+  ) {
+    return c.json({ error: 'Raw audio not found', error_code: 'RAW_AUDIO_FORBIDDEN' }, 403);
+  }
+
   let targetUserIdForAlarm: string | null = null;
   // 타깃 경로에서 (수신자 PK, 수신자 로그인 id) — 슬롯 교체(claimTargetedAlarmSlot)에 쓴다.
   let targetIdsForReplace: [string, string] | null = null;
@@ -270,48 +297,20 @@ alarmMutation.post('/', async (c) => {
       const targetPk = String(target.id);
       const targetLoginId = (target.google_id as string | null) ?? targetPk;
       const targetSettings = familyAlarmSettingsFromRow(target as Record<string, unknown>);
-      if (!targetSettings.allowFamilyAlarms) {
-        return c.json(
-          {
-            error: '상대방이 알람 설정을 허용하지 않았습니다.',
-            error_code: 'FAMILY_ALARM_DISABLED',
-          },
-          403,
-        );
+      // 수신자 기준 시각 가드(허용 여부·30분 리드타임·quiet 요일). 발신자 body.timezone 은
+      // 판정·저장 어디에도 쓰지 않고, 헬퍼가 산출한 효과 시간대(수신자 최근 알람 tz →
+      // Asia/Seoul)로 판정한다. PATCH 수정 경로와 동일 헬퍼를 공유한다(중복 구현 방지).
+      const guard = await evaluateFamilyAlarmTimingGuard(
+        db,
+        [targetPk, targetLoginId],
+        targetSettings,
+        body.time,
+        body.repeat_days ?? [],
+      );
+      if (!guard.ok) {
+        return c.json({ error: guard.error, error_code: guard.error_code }, guard.status);
       }
-      // 수신자 시간대 기준 서버 검증: 효과 시간대(수신자 최근 알람 tz → Asia/Seoul)로
-      // 다음 발사 시각을 구해 30분 리드타임과 quiet 요일을 판정한다. 발신자 body.timezone
-      // 은 판정·저장 어디에도 쓰지 않는다(우회 차단 — resolveEffectiveTimezone 주석 참고).
-      const effectiveTimezone = await resolveEffectiveTimezone(db, [targetPk, targetLoginId]);
-      const nextFire = computeNextAlarmFire(body.time, body.repeat_days ?? [], effectiveTimezone);
-      if (
-        nextFire &&
-        nextFire.fireAt.getTime() - Date.now() < FAMILY_ALARM_MIN_LEAD_MINUTES * 60_000
-      ) {
-        return c.json(
-          {
-            error: `알람은 최소 ${FAMILY_ALARM_MIN_LEAD_MINUTES}분 이후 시각으로만 보낼 수 있습니다.`,
-            error_code: 'FAMILY_ALARM_LEAD_TIME',
-          },
-          400,
-        );
-      }
-      if (
-        isBlockedByFamilyAlarmQuietTime(
-          body.time,
-          body.repeat_days ?? [],
-          targetSettings,
-          nextFire?.fireDayOfWeek ?? new Date().getDay(),
-        )
-      ) {
-        return c.json(
-          {
-            error: '상대방이 설정한 불가 시간에는 알람을 만들 수 없습니다.',
-            error_code: 'FAMILY_ALARM_QUIET_TIME',
-          },
-          403,
-        );
-      }
+      const effectiveTimezone = guard.effectiveTimezone;
 
       const friendship = await db.execute({
         sql: `SELECT id FROM friendships
@@ -572,6 +571,19 @@ alarmMutation.post('/', async (c) => {
   );
 });
 
+/** 저장된 repeat_days JSON 문자열('[1,3,5]')을 number[] 로 파싱한다(0-6 정수만). */
+function parseStoredRepeatDays(raw: unknown): number[] {
+  if (typeof raw === 'string' && raw.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.filter((n): n is number => Number.isInteger(n));
+    } catch {
+      // 손상 값은 빈 배열로 취급.
+    }
+  }
+  return [];
+}
+
 alarmMutation.patch('/:id', async (c) => {
   const userId = c.get('userId');
   const db = getDB(c.env);
@@ -602,7 +614,8 @@ alarmMutation.patch('/:id', async (c) => {
   if (fieldError) return c.json(fieldError, 400);
 
   const existing = await db.execute({
-    sql: `SELECT a.id, a.message_id, a.mode, a.wake_mode, a.voice_profile_id,
+    sql: `SELECT a.id, a.target_user_id, a.time, a.repeat_days, a.is_active,
+                 a.message_id, a.mode, a.wake_mode, a.voice_profile_id,
                  a.speaker_id, a.raw_audio_url, a.bucket_id, u.plan AS user_plan
           FROM alarms a
           LEFT JOIN users u ON u.google_id = a.user_id OR u.id = a.user_id
@@ -614,6 +627,10 @@ alarmMutation.patch('/:id', async (c) => {
   }
 
   const current = typedRow<{
+    target_user_id?: string | null;
+    time?: string | null;
+    repeat_days?: string | null;
+    is_active?: number | null;
     message_id: string | null;
     mode: string | null;
     wake_mode: string | null;
@@ -669,6 +686,15 @@ alarmMutation.patch('/:id', async (c) => {
     return c.json({ error: 'Voice profile not found', error_code: 'VOICE_PROFILE_NOT_FOUND' }, 404);
   }
 
+  // raw_audio_url 소유권 검증(B): 새 값으로 교체할 때 타인 R2 키를 기록해 이후 삭제
+  // 벡터를 열지 못하게 한다. null(클리어)은 소유권 검증이 필요 없어 통과.
+  if (
+    body.raw_audio_url != null &&
+    !rawAudioUrlBelongsToCaller(body.raw_audio_url, ownerIds)
+  ) {
+    return c.json({ error: 'Raw audio not found', error_code: 'RAW_AUDIO_FORBIDDEN' }, 403);
+  }
+
   // greeting 버킷 정책: PATCH 로 bucket/voice/message 를 바꿔 '시스템 보이스 + greeting'
   // 조합(무료 우회)을 만들 수 없게, 수정 결과(effective) 기준으로 클론 여부를 검증한다.
   // 관련 필드를 건드리지 않는 PATCH(예: time 만 변경)는 검사하지 않는다.
@@ -692,6 +718,66 @@ alarmMutation.patch('/:id', async (c) => {
         },
         400,
       );
+    }
+  }
+
+  // 타인 발신(가족/친구) 알람 가드 재실행(A): 발신자가 PATCH 로 time/repeat_days/timezone 을
+  // 바꾸거나 비활성 알람을 재활성(is_active 0→1)해 POST 의 리드타임·quiet·수신자 시간대 가드를
+  // 우회하지 못하게, 수정 결과(effective)가 '활성'이 되는 경우에 한해 POST 와 동일한 헬퍼를 다시
+  // 돈다. 본인 알람(target_user_id 없음)·최종 비활성 알람은 대상 아님(울리지 않으므로).
+  const patchTargetUserId =
+    typeof current.target_user_id === 'string' && current.target_user_id.length > 0
+      ? current.target_user_id
+      : null;
+  const reactivating = body.is_active === true && Number(current.is_active) === 0;
+  const willBeActive =
+    body.is_active !== undefined ? body.is_active : Number(current.is_active) === 1;
+  const changesTiming =
+    body.time !== undefined || body.repeat_days !== undefined || body.timezone !== undefined;
+  // 통과 시 저장할 효과 시간대(발신자 body.timezone 대신 이 값을 행에 기록).
+  let familyGuardTimezone: string | null = null;
+  // (수신자, 새 time) 슬롯 원자 재점유 파라미터(time 변경 또는 재활성화 시).
+  let familyReclaim: { ids: [string, string]; time: string } | null = null;
+  if (patchTargetUserId && willBeActive && (changesTiming || reactivating)) {
+    // 수신자 재조회(allowFamilyAlarms·quiet). target_user_id 는 로그인 id(google_id) 또는 pk.
+    const recipientRes = await db.execute({
+      sql: `SELECT id, google_id, allow_family_alarms,
+                   family_alarm_quiet_days, family_alarm_quiet_start, family_alarm_quiet_end,
+                   family_alarm_quiet_windows
+            FROM users WHERE google_id = ? OR id = ? LIMIT 1`,
+      args: [patchTargetUserId, patchTargetUserId],
+    });
+    if (recipientRes.rows.length === 0) {
+      // 수신자를 확인할 수 없으면 수신 허용·quiet 를 검증할 수 없어 시각 변경/재활성화를 거부한다.
+      return c.json(
+        { error: '상대방이 알람 설정을 허용하지 않았습니다.', error_code: 'FAMILY_ALARM_DISABLED' },
+        403,
+      );
+    }
+    const recipient = recipientRes.rows[0]!;
+    const recipientPk = String(recipient.id);
+    const recipientLoginId = (recipient.google_id as string | null) ?? recipientPk;
+    const recipientSettings = familyAlarmSettingsFromRow(recipient as Record<string, unknown>);
+    // effective 값: PATCH 로 안 바꾼 필드는 기존 행 값을 쓴다(수정 결과 기준 판정).
+    const effectiveTime = body.time !== undefined ? body.time : String(current.time ?? '');
+    const effectiveRepeatDays =
+      body.repeat_days !== undefined
+        ? body.repeat_days
+        : parseStoredRepeatDays(current.repeat_days);
+    const guard = await evaluateFamilyAlarmTimingGuard(
+      db,
+      [recipientPk, recipientLoginId],
+      recipientSettings,
+      effectiveTime,
+      effectiveRepeatDays,
+    );
+    if (!guard.ok) {
+      return c.json({ error: guard.error, error_code: guard.error_code }, guard.status);
+    }
+    familyGuardTimezone = guard.effectiveTimezone;
+    // time 변경 또는 재활성화면 (수신자, 새 time) 슬롯을 원자 재점유해 이 알람만 활성으로 남긴다.
+    if (body.time !== undefined || reactivating) {
+      familyReclaim = { ids: [recipientPk, recipientLoginId], time: effectiveTime };
     }
   }
 
@@ -755,6 +841,19 @@ alarmMutation.patch('/:id', async (c) => {
     args.push(body.bucket_id);
   }
 
+  // 타인 발신 알람 가드가 돌았으면 저장 timezone 을 효과 시간대로 강제한다(발신자 body.timezone
+  // 무시 — 검증=저장 정합, cron 이 검증과 같은 시간대로 해석). body.timezone 절이 이미 있으면
+  // 그 값을 효과 시간대로 덮고, 없으면 새 절을 추가한다.
+  if (familyGuardTimezone !== null) {
+    const tzIdx = updates.indexOf('timezone = ?');
+    if (tzIdx >= 0) {
+      args[tzIdx] = familyGuardTimezone;
+    } else {
+      updates.push('timezone = ?');
+      args.push(familyGuardTimezone);
+    }
+  }
+
   if (updates.length === 0) {
     return c.json({ error: 'No fields to update', error_code: 'NO_UPDATE_FIELDS' }, 400);
   }
@@ -769,7 +868,8 @@ alarmMutation.patch('/:id', async (c) => {
     });
   const updateResult =
     (body.voice_profile_id !== undefined && body.voice_profile_id !== null) ||
-    (body.message_id !== undefined && body.message_id !== null)
+    (body.message_id !== undefined && body.message_id !== null) ||
+    familyReclaim
       ? await withWriteTransaction(db, async (tx) => {
           if (
             body.voice_profile_id !== undefined &&
@@ -784,6 +884,26 @@ alarmMutation.patch('/:id', async (c) => {
             !(await messageBelongsToCaller(tx, body.message_id, ownerIds))
           ) {
             return { status: 'message_not_found' as const, result: null };
+          }
+          if (familyReclaim) {
+            // (수신자, 새 time) 슬롯을 원자 재점유 — 이 알람(id)을 keeper 로 두고 같은 슬롯의
+            // 다른 활성 발신 알람(다른 발신자·이전 중복)을 비활성화한다. 같은 발신자가 그 시각에
+            // 다른 활성 알람을 이미 갖고 있으면(같은 시각 이중 예약) claim 이 그 행을 keeper 로
+            // 고를 수 있으므로, PATCH 대상(id)이 승자가 되도록 그 행도 비활성화한다.
+            const claimed = await claimTargetedAlarmSlot(
+              tx,
+              userId,
+              familyReclaim.ids,
+              familyReclaim.time,
+              id,
+            );
+            if (claimed.reused && claimed.alarmId !== id) {
+              await tx.execute({
+                sql: `UPDATE alarms SET is_active = 0, updated_at = datetime('now')
+                      WHERE id = ? AND target_user_id IN (?, ?)`,
+                args: [claimed.alarmId, familyReclaim.ids[0], familyReclaim.ids[1]],
+              });
+            }
           }
           return { status: 'ok' as const, result: await updateAlarm(tx) };
         })

--- a/packages/backend/src/routes/billing-google-rtdn.ts
+++ b/packages/backend/src/routes/billing-google-rtdn.ts
@@ -7,11 +7,13 @@ import { getGoogleAccessToken, parseServiceAccountJson } from '../lib/google-oau
 import { applyStoreEntitlement, loadPlanByKey } from '../lib/store-billing';
 import {
   cancelSubscriptionImmediate,
+  resolvePlanAfterSuspend,
   schedulePaidVoiceRetention,
   type ActiveSubscription,
 } from '../lib/billing-cancel';
 import { timingSafeEqualStr } from '../lib/timing-safe-equal';
 import {
+  acknowledgeGoogleSubscription,
   ANDROID_PUBLISHER_SCOPE,
   ENTITLED_STATES,
   googlePlanKeyFromProductId,
@@ -229,6 +231,17 @@ billingGoogleRtdn.post('/rtdn', async (c) => {
         rawPayload: JSON.stringify({ via: 'rtdn', state, notificationType: sub.notificationType }),
       }),
     );
+    // 권위 재조회 결과 acknowledgement 이 보류면 서버가 확인 처리한다 — 앱 미실행으로
+    // confirm 이 오지 않아도 RTDN(구매/갱신 알림)이 서버측 ack 재시도 경로가 된다
+    // (미확인 시 3일 후 Play 자동 환불). confirm 과 동일한 ack 헬퍼를 재사용한다.
+    if (subscription.acknowledgementState === 'ACKNOWLEDGEMENT_STATE_PENDING') {
+      await acknowledgeGoogleSubscription({
+        baseUrl,
+        productId: authoritativeProductId,
+        purchaseToken,
+        accessToken,
+      });
+    }
     logStructured('info', { at: 'billing.google.rtdn', action: 'entitle', state, userPk });
     return c.json({ success: true, action: 'entitled' });
   }
@@ -318,11 +331,21 @@ billingGoogleRtdn.post('/rtdn', async (c) => {
   const isRecoverable =
     state === 'SUBSCRIPTION_STATE_ON_HOLD' || state === 'SUBSCRIPTION_STATE_PAUSED';
   if (isRecoverable) {
-    await db.execute({
-      sql: `UPDATE users SET plan = 'free', updated_at = datetime('now') WHERE id = ?`,
-      args: [userPk],
+    // 매핑(정지된) 구독을 제외한 다른 활성 유료 구독이 있으면 그 plan 을 유지하고,
+    // 없을 때만 free 로 내린다 (deactivate 의 E2 잔여구독 유지와 대칭). 회복형 상태라
+    // 음성 접근 정리 없이 users.plan 만 보수적으로 회수한다 — 결제 복구 시 entitle 가 원복.
+    const keptPlanType = await resolvePlanAfterSuspend(
+      db,
+      userPk,
+      mappedSubscription.subscriptionId,
+    );
+    logStructured('info', {
+      at: 'billing.google.rtdn',
+      action: 'suspend',
+      state,
+      userPk,
+      keptPlanType,
     });
-    logStructured('info', { at: 'billing.google.rtdn', action: 'suspend', state, userPk });
     return c.json({ success: true, action: 'suspended' });
   }
 

--- a/packages/backend/src/routes/billing-google.ts
+++ b/packages/backend/src/routes/billing-google.ts
@@ -74,6 +74,56 @@ function parseConfirmRequest(value: unknown): ConfirmRequest | { error: string }
   return { purchase_token: purchaseToken, product_id: productId, package_name: packageName };
 }
 
+/** acknowledge 재시도 사이 백오프(ms). Workers 호환 — setTimeout 을 Promise 로 감싼다. */
+const ACK_BACKOFF_MS = [200, 1000];
+
+/**
+ * Play 구독 acknowledgement 확인. acknowledge 는 멱등하므로 일시 실패(5xx/네트워크) 시
+ * 위 백오프를 두고 최대 3회 시도한다. 4xx(이미 확인됨·잘못된 상태 등)는 재시도해도 동일하므로
+ * 즉시 중단한다.
+ *
+ * confirm(구매 직후)·RTDN(구매/갱신 알림) 양쪽에서 재사용한다 — 앱이 confirm 을 못 보내도
+ * RTDN 이 서버측 ack 재시도 경로가 되게 해, 미확인 시 3일 후 Play 자동 환불 위험을 줄인다.
+ * 반환값은 확인 성공 여부지만, 호출자는 실패해도 흐름을 막지 않는다(다음 RTDN/재confirm 이 보강).
+ */
+export async function acknowledgeGoogleSubscription(params: {
+  baseUrl: string;
+  productId: string;
+  purchaseToken: string;
+  accessToken: string;
+}): Promise<boolean> {
+  const { baseUrl, productId, purchaseToken, accessToken } = params;
+  const ackUrl = `${baseUrl}/purchases/subscriptions/${encodeURIComponent(productId)}/tokens/${encodeURIComponent(purchaseToken)}:acknowledge`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) {
+      // 직전 시도 실패 → 백오프 후 재시도 (200ms, 1000ms).
+      await new Promise((resolve) => setTimeout(resolve, ACK_BACKOFF_MS[attempt - 1]));
+    }
+    try {
+      const ackRes = await fetch(ackUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+      if (ackRes.ok) return true;
+      logStructured('warn', {
+        at: 'billing.google.acknowledge',
+        attempt,
+        status: ackRes.status,
+        detail: (await ackRes.text()).slice(0, 300),
+      });
+      // 4xx(이미 acknowledge 됨·잘못된 상태 등)는 재시도해도 동일하므로 즉시 중단. 5xx·네트워크만 재시도.
+      if (ackRes.status < 500) return false;
+    } catch (err) {
+      logStructured('error', { at: 'billing.google.acknowledge', attempt, error: String(err) });
+    }
+  }
+  return false;
+}
+
 const billingGoogle = new Hono<AppEnv>();
 
 billingGoogle.post('/google/confirm', async (c) => {
@@ -252,36 +302,15 @@ billingGoogle.post('/google/confirm', async (c) => {
   }
 
   // acknowledgement 보류 시 서버가 확인 처리 (3일 내 미확인 → Play 자동 환불).
-  // acknowledge 는 멱등하므로 일시 실패 시 최대 3회 재시도해 자동환불 위험을 줄인다.
+  // 전부 실패해도 success 는 유지한다(entitlement 는 이미 커밋됨) — RTDN entitle 경로가
+  // 서버측 ack 재시도로 보강한다.
   if (subscription.acknowledgementState === 'ACKNOWLEDGEMENT_STATE_PENDING') {
-    const ackUrl = `${baseUrl}/purchases/subscriptions/${encodeURIComponent(parsed.product_id)}/tokens/${encodeURIComponent(parsed.purchase_token)}:acknowledge`;
-    let acknowledged = false;
-    for (let attempt = 0; attempt < 3 && !acknowledged; attempt++) {
-      try {
-        const ackRes = await fetch(ackUrl, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({}),
-        });
-        if (ackRes.ok) {
-          acknowledged = true;
-        } else {
-          logStructured('warn', {
-            at: 'billing.google.acknowledge',
-            attempt,
-            status: ackRes.status,
-            detail: (await ackRes.text()).slice(0, 300),
-          });
-          // 4xx(이미 acknowledge 됨·잘못된 상태 등)는 재시도해도 동일하므로 즉시 중단. 5xx·네트워크만 재시도.
-          if (ackRes.status < 500) break;
-        }
-      } catch (err) {
-        logStructured('error', { at: 'billing.google.acknowledge', attempt, error: String(err) });
-      }
-    }
+    await acknowledgeGoogleSubscription({
+      baseUrl,
+      productId: parsed.product_id,
+      purchaseToken: parsed.purchase_token,
+      accessToken,
+    });
   }
 
   return c.json({

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -1515,11 +1515,13 @@ tts.post('/generate', async (c) => {
         502,
       );
     }
+    // K1: 제공자(ElevenLabs/Vertex) 응답 원문을 detail 로 반사하지 않는다. 원문은 위
+    // console.error 로만 남기고, 응답에는 안정 에러코드만 노출한다.
     return c.json(
       {
         error: 'TTS generation failed',
         error_code: 'TTS_GENERATION_FAILED',
-        detail: err instanceof Error ? err.message : 'Unknown error',
+        detail: 'TTS_GENERATION_FAILED',
       },
       500,
     );

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -5,7 +5,7 @@ import { getDB } from '../lib/db';
 import { typedRow, getFormFile } from '../lib/db-types';
 import { UUID_RE } from '../lib/validate';
 import { logRouteError } from '../lib/logger';
-import { R2VoiceStorage } from '../lib/r2-storage';
+import { R2VoiceStorage, MAX_VOICE_UPLOAD_BYTES } from '../lib/r2-storage';
 import { createEnrollmentAttempts, UnsupportedVoiceProviderError } from '../lib/voice-provider';
 import { assertSameGroup, resolveUserPk } from '../lib/family-helpers';
 import { isPaidVoicePlan } from './billing-helpers';
@@ -1208,6 +1208,21 @@ voiceProfile.post('/clone', async (c) => {
       );
     }
 
+    // 크기 가드(J): arrayBuffer→R2→ElevenLabs 호출 전에 0바이트/과대 파일을 차단한다
+    // (voice-upload.ts /upload 와 동일 패턴·공용 상수).
+    if (audioFile.size === 0) {
+      return c.json({ error: 'audio file is empty', error_code: 'AUDIO_FILE_EMPTY' }, 400);
+    }
+    if (audioFile.size > MAX_VOICE_UPLOAD_BYTES) {
+      return c.json(
+        {
+          error: `audio file exceeds ${MAX_VOICE_UPLOAD_BYTES} bytes (got ${audioFile.size})`,
+          error_code: 'AUDIO_FILE_TOO_LARGE',
+        },
+        413,
+      );
+    }
+
     const durationCheck = validateCloneDuration(formData.get('durationMs'), isDraft);
     if (durationCheck) return c.json(durationCheck.body, durationCheck.status);
     // 검증 통과 후의 durationMs — 아래 voice_uploads 보관(재시도용 원본)에 기록한다.
@@ -1365,6 +1380,10 @@ voiceProfile.post('/clone', async (c) => {
     // R2 오브젝트·행을 함께 정리하고, 계정 삭제(account-deletion)·유료 음성 정리
     // (paid-voice-cleanup)도 voice_uploads 를 사용자 단위로 지운다. draft 가 승격 전에
     // 삭제돼 행이 남아도 같은 TTL sweep 이 거둔다.
+    // R2 저장은 성공했는데 아래 INSERT 가 실패하면 추적행 없는 고아 객체가 남는다
+    // (TTL sweep 은 voice_uploads 행 기준이라 회수 못 함) → catch 에서 보상 삭제 큐에
+    // 적재할 수 있도록 저장된 키를 바깥 스코프로 올린다.
+    let storedUploadKey: string | null = null;
     try {
       // 동의 철회 경쟁(H): 클론 완료(ready 전환)와 이 보관 사이에 사용자가 음성/국외이전
       // 동의를 철회했을 수 있다 — 철회됐으면 원본을 새로 보관하지 않는다(저장 스킵 + 로그).
@@ -1387,6 +1406,7 @@ voiceProfile.post('/clone', async (c) => {
           durationMs: cloneDurationMs,
           originalName: audioFile.name || undefined,
         });
+        storedUploadKey = uploadMeta.objectKey;
         await db.execute({
           sql: `INSERT INTO voice_uploads
                 (id, user_id, object_key, mime_type, size_bytes, duration_ms, original_name, voice_profile_id)
@@ -1405,6 +1425,14 @@ voiceProfile.post('/clone', async (c) => {
       }
     } catch (uploadErr) {
       logRouteError(c, uploadErr);
+      // R2 put 은 성공했는데 INSERT 가 실패한 경우(고아) 보상 삭제 큐에 적재해 누수를 막는다(C).
+      if (storedUploadKey) {
+        try {
+          await enqueueExternalDeletion(db, 'r2_object', storedUploadKey);
+        } catch (cleanupErr) {
+          logRouteError(c, cleanupErr);
+        }
+      }
     }
 
     // 화자 말투(사투리·존댓말·특징 어미) 분석 — 응답을 지연시키지 않도록 waitUntil 로
@@ -1501,12 +1529,15 @@ voiceProfile.post('/clone', async (c) => {
       }
     }
 
+    // K1: detail 에 제공자(ElevenLabs) 응답 원문(err.message)을 반사하지 않는다. 원문은
+    // 위 logRouteError 로만 남기고, 응답에는 안정 에러코드만 노출한다. 슬롯 소진 판별은
+    // throw 전 서버 내부(isVoiceSlotExhaustedError(detail))에서 하므로 그대로 동작한다.
     if (isVoiceSlotExhaustedError(detail)) {
       return c.json(
         {
           error: '서비스가 확장중이에요. 잠시만 기다려주세요!',
           error_code: 'VOICE_SLOT_EXHAUSTED',
-          detail,
+          detail: 'VOICE_SLOT_EXHAUSTED',
         },
         503,
       );
@@ -1516,7 +1547,7 @@ voiceProfile.post('/clone', async (c) => {
       {
         error: 'Voice cloning failed',
         error_code: 'VOICE_CLONING_FAILED',
-        detail,
+        detail: 'VOICE_CLONING_FAILED',
       },
       500,
     );

--- a/packages/backend/src/routes/voice-upload.ts
+++ b/packages/backend/src/routes/voice-upload.ts
@@ -4,7 +4,7 @@ import type { VoiceStorage } from '@alarmtalk/voice';
 import { getDB } from '../lib/db';
 import { getFormFile } from '../lib/db-types';
 import { getSharedInMemoryVoiceStorage } from '@alarmtalk/voice';
-import { R2VoiceStorage } from '../lib/r2-storage';
+import { R2VoiceStorage, MAX_VOICE_UPLOAD_BYTES } from '../lib/r2-storage';
 import { isPaidVoicePlan } from './billing-helpers';
 import { missingConsentType, SENSITIVE_REQUIRED_CONSENTS } from '../lib/consent';
 
@@ -14,7 +14,7 @@ function getStorage(env?: { VOICE_BUCKET?: R2Bucket }): VoiceStorage {
 }
 
 const voiceUpload = new Hono<AppEnv>();
-const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB for up to 2 minutes of voice audio.
+const MAX_UPLOAD_BYTES = MAX_VOICE_UPLOAD_BYTES; // 25 MiB for up to 2 minutes of voice audio (공용 상수).
 const MIN_UPLOAD_DURATION_MS = 60_000;
 const MAX_UPLOAD_DURATION_MS = 120_000;
 const UPLOAD_DURATION_TOLERANCE_MS = 5_000;

--- a/packages/backend/test/alarm-guard.test.ts
+++ b/packages/backend/test/alarm-guard.test.ts
@@ -385,6 +385,30 @@ describe('타인 발신 알람 — PATCH 가 POST 가드를 effective(수정 결
     expect(Number((await alarmRow(idB))!.is_active)).toBe(0); // 이전 활성(B) 비활성화
   });
 
+  it('같은 슬롯에 발신자 활성 알람이 둘이어도 PATCH 대상이 승자로 남고 나머지만 비활성화(Codex #563)', async () => {
+    // 비정상 상태((수신자, time) 슬롯에 발신자 A 의 활성 알람 2개)를 직접 만든 뒤 그 중 하나를
+    // PATCH 하면 대상이 유일 승자로 남아야 한다. 구버전은 POST 용 claimTargetedAlarmSlot 이
+    // 다른 행을 keeper 로 골라 PATCH 대상까지 비활성화해 둘 다 꺼지는 버그가 있었다.
+    const DBX = '11111111-1111-4111-8111-111111111111';
+    const DBY = '22222222-2222-4222-8222-222222222222';
+    // 무료 발신자 알람은 sound-only(POST 가 무료 플랜에 넣는 기본값)로 넣어 플랜 게이트를 피한다.
+    await db.execute({
+      sql: `INSERT INTO alarms (id, user_id, target_user_id, time, is_active, timezone, mode)
+            VALUES (?, ?, ?, '23:00', 1, 'Asia/Seoul', 'sound-only'),
+                   (?, ?, ?, '23:00', 1, 'Asia/Seoul', 'sound-only')`,
+      args: [DBX, SENDER_A.login, RECIPIENT.login, DBY, SENDER_A.login, RECIPIENT.login],
+    });
+    const res = await patchAlarm(SENDER_A, DBX, { time: '23:00' });
+    expect(res.status).toBe(200);
+    expect(Number((await alarmRow(DBX))!.is_active)).toBe(1); // 대상 = 승자
+    expect(Number((await alarmRow(DBY))!.is_active)).toBe(0); // 나머지 비활성화
+    const active = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM alarms WHERE target_user_id = ? AND time = '23:00' AND is_active = 1`,
+      args: [RECIPIENT.login],
+    });
+    expect(Number(active.rows[0]!.cnt)).toBe(1); // 슬롯에 정확히 하나만 활성
+  });
+
   it('본인 알람(target 없음) PATCH 는 가드가 걸리지 않는다(리드타임 미만이어도 200)', async () => {
     // 본인 알람은 리드타임/quiet 가드 대상이 아니다 — target_user_id 가 없으면 재실행하지 않는다.
     const create = await postAlarm(SENDER_A, { time: '12:00', timezone: 'Asia/Seoul' });

--- a/packages/backend/test/alarm-guard.test.ts
+++ b/packages/backend/test/alarm-guard.test.ts
@@ -51,6 +51,20 @@ function postAlarm(
   );
 }
 
+function patchAlarm(
+  sender: { pk: string; login: string },
+  id: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return appFor(sender).request(
+    new Request(`http://localhost/alarms/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
 async function alarmRow(id: string) {
   const res = await db.execute({
     sql: `SELECT id, user_id, target_user_id, time, is_active, snooze_minutes, timezone
@@ -310,5 +324,75 @@ describe('타인 발신 알람 — quiet 요일을 수신자 시간대의 발사
         args: ['[{"days":[0,6],"start":"00:00","end":"08:00"}]', RECIPIENT_QUIET.pk],
       });
     }
+  });
+});
+
+describe('타인 발신 알람 — PATCH 가 POST 가드를 effective(수정 결과) 기준으로 재실행', () => {
+  it('PATCH time 을 리드타임 미만으로 바꾸면 400 FAMILY_ALARM_LEAD_TIME, 행 미변경', async () => {
+    // now = KST 09:00. 12:00 로 정상 생성 후 09:20(20분 뒤)로 PATCH → 리드타임 위반.
+    const create = await postAlarm(SENDER_A, {
+      time: '12:00',
+      target_user_id: RECIPIENT.login,
+      timezone: 'Asia/Seoul',
+    });
+    expect(create.status).toBe(201);
+    const id = ((await create.json()) as { alarm: { id: string } }).alarm.id;
+
+    const res = await patchAlarm(SENDER_A, id, { time: '09:20' });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error_code: string }).error_code).toBe('FAMILY_ALARM_LEAD_TIME');
+    expect(String((await alarmRow(id))!.time)).toBe('12:00'); // 거부됐으므로 변경 안 됨
+  });
+
+  it('PATCH time 을 수신자 quiet 시간대로 바꾸면 403 FAMILY_ALARM_QUIET_TIME, 행 미변경', async () => {
+    // now = UTC 금 14:00 = KST 금 23:00. 12:00 로 생성 후 00:30(다음 발사 KST 토 00:30)로 PATCH.
+    vi.setSystemTime(new Date('2026-07-17T14:00:00Z'));
+    const create = await postAlarm(SENDER_A, {
+      time: '12:00',
+      target_user_id: RECIPIENT_QUIET.login,
+      timezone: 'Asia/Seoul',
+    });
+    expect(create.status).toBe(201);
+    const id = ((await create.json()) as { alarm: { id: string } }).alarm.id;
+
+    const res = await patchAlarm(SENDER_A, id, { time: '00:30' });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error_code: string }).error_code).toBe('FAMILY_ALARM_QUIET_TIME');
+    expect(String((await alarmRow(id))!.time)).toBe('12:00');
+  });
+
+  it('PATCH is_active 0→1 재활성화 시 (수신자, time) 슬롯을 원자 재점유(이전 활성 비활성화)', async () => {
+    // A→R, B→R 를 같은 시각으로 생성하면 B 가 슬롯을 차지하고 A 는 비활성화된다.
+    // 이후 발신자 A 가 자기 알람을 is_active=1 로 재활성화하면 A 가 슬롯을 되찾고 B 는 비활성화돼야 한다.
+    const ra = await postAlarm(SENDER_A, {
+      time: '23:00',
+      target_user_id: RECIPIENT.login,
+      timezone: 'Asia/Seoul',
+    });
+    const idA = ((await ra.json()) as { alarm: { id: string } }).alarm.id;
+    const rb = await postAlarm(SENDER_B, {
+      time: '23:00',
+      target_user_id: RECIPIENT.login,
+      timezone: 'Asia/Seoul',
+    });
+    const idB = ((await rb.json()) as { alarm: { id: string } }).alarm.id;
+    expect(Number((await alarmRow(idA))!.is_active)).toBe(0); // B 가 A 를 교체
+    expect(Number((await alarmRow(idB))!.is_active)).toBe(1);
+
+    const res = await patchAlarm(SENDER_A, idA, { is_active: true });
+    expect(res.status).toBe(200);
+    expect(Number((await alarmRow(idA))!.is_active)).toBe(1); // A 재활성화(슬롯 되찾음)
+    expect(Number((await alarmRow(idB))!.is_active)).toBe(0); // 이전 활성(B) 비활성화
+  });
+
+  it('본인 알람(target 없음) PATCH 는 가드가 걸리지 않는다(리드타임 미만이어도 200)', async () => {
+    // 본인 알람은 리드타임/quiet 가드 대상이 아니다 — target_user_id 가 없으면 재실행하지 않는다.
+    const create = await postAlarm(SENDER_A, { time: '12:00', timezone: 'Asia/Seoul' });
+    expect(create.status).toBe(201);
+    const id = ((await create.json()) as { alarm: { id: string } }).alarm.id;
+
+    const res = await patchAlarm(SENDER_A, id, { time: '09:20' });
+    expect(res.status).toBe(200);
+    expect(String((await alarmRow(id))!.time)).toBe('09:20');
   });
 });

--- a/packages/backend/test/alarm-helpers.test.ts
+++ b/packages/backend/test/alarm-helpers.test.ts
@@ -540,4 +540,23 @@ describe('computeNextAlarmFire — DST 경계(달력 날짜 단위 전진)', () 
     expect(fire.fireAt.toISOString()).toBe('2026-03-08T11:00:00.000Z');
     expect(fire.fireDayOfWeek).toBe(0);
   });
+
+  it('gap(존재하지 않는 벽시계): 02:30 은 gap 이전(01:30)이 아니라 gap 이후(03:30 EDT)로 확정', () => {
+    // NY 2026-03-08 02:00 EST → 03:00 EDT 스프링포워드로 02:00-02:59 는 존재하지 않는다.
+    // now = 06:00Z(= 01:00 EST) → 오늘 '02:30' 발사. 2회 보정만으로는 01:30 EST(06:30Z)로
+    // 수렴하지만, gap 감지 보정으로 03:30 EDT(= UTC 07:30)로 확정돼야 한다.
+    const now = new Date('2026-03-08T06:00:00Z');
+    const fire = computeNextAlarmFire('02:30', [], 'America/New_York', now)!;
+    expect(fire.fireAt.toISOString()).toBe('2026-03-08T07:30:00.000Z');
+    expect(fire.fireDayOfWeek).toBe(0);
+  });
+
+  it('ambiguous(두 번 나타나는 벽시계): 01:30 은 이른 쪽(01:30 EDT)으로 확정', () => {
+    // NY 2026-11-01 02:00 EDT → 01:00 EST 폴백으로 01:00-01:59 는 두 번 나타난다.
+    // 정책상 이른 쪽(01:30 EDT = UTC 05:30)을 선택한다(늦은 쪽 01:30 EST = 06:30 아님).
+    const now = new Date('2026-11-01T04:00:00Z');
+    const fire = computeNextAlarmFire('01:30', [], 'America/New_York', now)!;
+    expect(fire.fireAt.toISOString()).toBe('2026-11-01T05:30:00.000Z');
+    expect(fire.fireDayOfWeek).toBe(0);
+  });
 });

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -602,6 +602,28 @@ describe('greeting 버킷 정책 (POST/PATCH)', () => {
     expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
   });
 
+  it('POST: 클론 voice_profile + 시스템 스톡 greeting message 혼합 → 400 (방어심화 G)', async () => {
+    // vp 분기가 통과해도 message_id 가 함께 있으면 그 message 의 voice_profile 이 시스템이면
+    // 혼합(무료 미리듣기 클립 우회)으로 거부해야 한다.
+    mockDB.pushResult([{ plan: 'personal' }]); // user plan
+    mockDB.pushResult([{ '1': 1 }]); // voiceProfileBelongsToCaller(클론 vp 접근 허용)
+    mockDB.pushResult([{ '1': 1 }]); // messageBelongsToCaller(프리셋 접근 허용)
+    mockDB.pushResult([{ '1': 1 }]); // greeting 게이트: vp 는 클론
+    mockDB.pushResult([]); // greeting 게이트: message 의 voice_profile 은 시스템 → 혼합 거부
+
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', {
+        time: '07:30',
+        voice_profile_id: vpId,
+        message_id: ID.message,
+        bucket_id: 'greeting',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('INVALID_BUCKET_ID');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+  });
+
   function pushExistingAlarmRow(overrides: Record<string, unknown> = {}) {
     mockDB.pushResult([
       {
@@ -1207,5 +1229,56 @@ describe('DELETE /alarms/:id', () => {
     expect(deleteCall).toBeDefined();
     expect(deleteCall!.sql).toContain('user_id');
     expect(deleteCall!.args).toContain('user-A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B: raw_audio_url 소유권 검증 (audit-hardening-3)
+//   isStoredAudioUrl 은 r2:// 형식만 확인하므로, 타인 R2 키를 자기 알람 raw_audio_url 에
+//   심어 두면 이후 DELETE/PATCH 교체 시 참조 0 판정으로 타인 객체가 삭제 큐에 적재된다.
+//   POST/PATCH 저장 전에 키의 소유자 segment 를 호출자와 대조해 차단한다.
+// ---------------------------------------------------------------------------
+describe('B: raw_audio_url 소유권', () => {
+  it('POST: 타인 소유 raw_audio_url → 403, 알람·삭제큐 미적재', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', {
+        time: '07:30',
+        raw_audio_url: 'r2://raw-alarms/victim-2/clip-abc',
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('RAW_AUDIO_FORBIDDEN');
+    // 타인 객체가 알람이나 삭제 큐에 전혀 적재되지 않아야 한다.
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+    expect(mockDB.calls.some((c) => c.sql.includes('pending_external_deletions'))).toBe(false);
+  });
+
+  it('POST: 본인 소유 raw_audio_url 은 통과(201) + 알람에 저장', async () => {
+    mockDB.pushResult([{ plan: 'personal' }]); // 생성자 plan
+    mockDB.pushResult([{ id: 'vp-1' }]); // firstVoice (raw 알람은 voice profile 필요)
+    mockDB.pushResult([], 1); // placeholder message INSERT
+    mockDB.pushResult([{ '1': 1 }]); // messageBelongsToCaller (placeholder)
+    mockDB.pushResult([], 1); // INSERT alarms
+    const ownKey = 'r2://raw-alarms/user-1/clip-mine';
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', raw_audio_url: ownKey }),
+    );
+    expect(res.status).toBe(201);
+    const insertAlarm = mockDB.calls.find((c) => c.sql.includes('INSERT INTO alarms'));
+    expect(insertAlarm).toBeDefined();
+    expect(insertAlarm!.args).toContain(ownKey);
+  });
+
+  it('PATCH: 타인 소유 raw_audio_url → 403, UPDATE·삭제큐 미적재', async () => {
+    mockDB.pushResult([{ id: ID.alarm }]); // 기존 알람 SELECT (소유 확인 통과)
+    const res = await buildApp().request(
+      jsonReq('PATCH', `/alarms/${ID.alarm}`, {
+        raw_audio_url: 'r2://raw-alarms/victim-2/clip-x',
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('RAW_AUDIO_FORBIDDEN');
+    expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms SET'))).toBe(false);
+    expect(mockDB.calls.some((c) => c.sql.includes('pending_external_deletions'))).toBe(false);
   });
 });

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -1281,4 +1281,31 @@ describe('B: raw_audio_url 소유권', () => {
     expect(mockDB.calls.some((c) => c.sql.includes('UPDATE alarms SET'))).toBe(false);
     expect(mockDB.calls.some((c) => c.sql.includes('pending_external_deletions'))).toBe(false);
   });
+
+  // 정리 경로 회귀(Codex #563): 쓰기 게이트 이전에 생성된 레거시 알람이 타인 키를
+  // 참조하더라도, DELETE 시 그 타인 객체를 삭제 큐에 넣지 않는다(cross-tenant 삭제 차단).
+  it('DELETE: 레거시 알람의 타인 raw_audio_url 은 삭제 큐에 미적재', async () => {
+    mockDB.pushResult([{ message_id: null, raw_audio_url: 'r2://raw-alarms/victim-2/legacy-clip' }]);
+    mockDB.pushResult([], 1); // DELETE FROM alarms
+    const res = await buildApp().request(
+      new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    // 소유권 불일치라 참조 카운트 조회도, 삭제 큐 적재도 하지 않는다.
+    expect(mockDB.calls.some((c) => c.sql.includes('pending_external_deletions'))).toBe(false);
+    expect(
+      mockDB.calls.some((c) => c.sql.includes('COUNT(*)') && c.sql.includes('raw_audio_url')),
+    ).toBe(false);
+  });
+
+  it('DELETE: 본인 raw_audio_url 은 참조 0이면 삭제 큐 적재', async () => {
+    mockDB.pushResult([{ message_id: null, raw_audio_url: 'r2://raw-alarms/user-1/own-clip' }]);
+    mockDB.pushResult([], 1); // DELETE FROM alarms
+    mockDB.pushResult([{ cnt: 0 }]); // 참조 카운트
+    const res = await buildApp().request(
+      new Request(`http://localhost/alarms/${ID.alarm}`, { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockDB.calls.some((c) => c.sql.includes('pending_external_deletions'))).toBe(true);
+  });
 });

--- a/packages/backend/test/alarm-mutation.test.ts
+++ b/packages/backend/test/alarm-mutation.test.ts
@@ -1269,6 +1269,15 @@ describe('B: raw_audio_url 소유권', () => {
     expect(insertAlarm!.args).toContain(ownKey);
   });
 
+  it('POST: 잘못된 퍼센트 인코딩 raw_audio_url 은 500 이 아니라 403(Codex #563)', async () => {
+    const res = await buildApp().request(
+      jsonReq('POST', '/alarms', { time: '07:30', raw_audio_url: 'r2://raw-alarms/%/clip' }),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('RAW_AUDIO_FORBIDDEN');
+    expect(mockDB.calls.some((c) => c.sql.includes('INSERT INTO alarms'))).toBe(false);
+  });
+
   it('PATCH: 타인 소유 raw_audio_url → 403, UPDATE·삭제큐 미적재', async () => {
     mockDB.pushResult([{ id: ID.alarm }]); // 기존 알람 SELECT (소유 확인 통과)
     const res = await buildApp().request(

--- a/packages/backend/test/billing-cancel-play.test.ts
+++ b/packages/backend/test/billing-cancel-play.test.ts
@@ -995,4 +995,66 @@ describe('POST /billing/google/confirm — 계정 바인딩 (C4)', () => {
     // 갱신 분기 — 기존 구독 만료를 스토어 값으로 연장한다.
     expect(findCall('SET expires_at = ?')).toBeDefined();
   });
+
+  // -------------------------------------------------------------------------
+  // D: acknowledgement 보류 시 서버 ack (백오프 재시도, 실패해도 success 유지)
+  // -------------------------------------------------------------------------
+  it('ack 가 PENDING 이면 서버가 :acknowledge 를 호출하고 성공 시 재시도하지 않는다 (D)', async () => {
+    const subBody = JSON.stringify({
+      ...CONFIRM_SUB,
+      acknowledgementState: 'ACKNOWLEDGEMENT_STATE_PENDING',
+      externalAccountIdentifiers: { obfuscatedExternalAccountId: await sha256HexOf('google-1') },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(subBody, { status: 200 })) // 구독 lookup
+      .mockResolvedValueOnce(new Response('{}', { status: 200 })); // :acknowledge 성공
+    vi.stubGlobal('fetch', fetchMock);
+    pushConfirmHappyPathResults();
+
+    const res = await buildGoogleApp().request(
+      jsonReq('POST', '/billing/google/confirm', CONFIRM_BODY),
+      undefined,
+      PLAY_ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    // lookup + ack 1회 — 성공했으므로 재시도 없음.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]![0])).toContain(
+      '/purchases/subscriptions/personal_monthly/tokens/play-token-1:acknowledge',
+    );
+  });
+
+  it('ack 가 PENDING 인데 재시도 3회 모두 실패해도 confirm 은 success 를 반환한다 (D)', async () => {
+    const subBody = JSON.stringify({
+      ...CONFIRM_SUB,
+      acknowledgementState: 'ACKNOWLEDGEMENT_STATE_PENDING',
+      externalAccountIdentifiers: { obfuscatedExternalAccountId: await sha256HexOf('google-1') },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(subBody, { status: 200 })) // 구독 lookup
+      .mockResolvedValue(new Response('{}', { status: 500 })); // :acknowledge 3회 모두 5xx
+    vi.stubGlobal('fetch', fetchMock);
+    pushConfirmHappyPathResults();
+
+    const res = await buildGoogleApp().request(
+      jsonReq('POST', '/billing/google/confirm', CONFIRM_BODY),
+      undefined,
+      PLAY_ENV,
+    );
+
+    // entitlement 는 이미 커밋됐고, ack 실패는 success 를 막지 않는다(RTDN 이 보강).
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(findCall('INSERT OR REPLACE INTO store_transactions')).toBeDefined();
+    // lookup 1 + ack 재시도 3 = 4회 (백오프 후 3회 재시도 유지).
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const ackCalls = fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes(':acknowledge'),
+    );
+    expect(ackCalls).toHaveLength(3);
+  });
 });

--- a/packages/backend/test/billing-google-rtdn.test.ts
+++ b/packages/backend/test/billing-google-rtdn.test.ts
@@ -334,5 +334,117 @@ describe('billing google RTDN', () => {
       expect(renewCall).toBeDefined();
       expect(renewCall!.args).toContain('sub-old');
     });
+
+    // -------------------------------------------------------------------------
+    // D: RTDN entitle 경로 서버측 ack — 앱 미실행으로 confirm 이 안 와도 RTDN 이
+    //    ack 재시도 경로가 되게 한다 (미ack → 3일 후 Play 자동 환불 방지).
+    // -------------------------------------------------------------------------
+    const PLAN_ROW = {
+      id: 'plan-1',
+      key: 'personal',
+      name: '개인',
+      plan_type: 'personal',
+      period_days: 30,
+      max_members: 1,
+      price_krw: 4900,
+    };
+
+    it('entitle 시 acknowledgement 이 PENDING 이면 서버가 :acknowledge 를 호출한다 (D)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+              acknowledgementState: 'ACKNOWLEDGEMENT_STATE_PENDING',
+              lineItems: [{ productId: 'personal_monthly', expiryTime: FUTURE }],
+            }),
+            { status: 200 },
+          ),
+        ) // 권위 재조회
+        .mockResolvedValueOnce(new Response('{}', { status: 200 })); // :acknowledge 성공
+      vi.stubGlobal('fetch', fetchMock);
+      mockDB.pushResult([TXN_ROW]); // store_transactions 매핑
+      mockDB.pushResult([PLAN_ROW]); // loadPlanByKey
+      mockDB.pushResult([TXN_ROW]); // applyStoreEntitlement 기존 트랜잭션
+      mockDB.pushResult([{ plan_id: 'plan-1' }]); // currentSubscriptionPlanId — 동일 plan → 갱신 분기
+
+      const res = await buildApp().request(rtdnRequest(2), undefined, RTDN_ENV);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).action).toBe('entitled');
+      // 권위 lookup 다음 두 번째 fetch 가 :acknowledge 여야 한다.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[1]![0])).toContain(
+        '/purchases/subscriptions/personal_monthly/tokens/play-token-old:acknowledge',
+      );
+    });
+
+    it('entitle 시 이미 ACKNOWLEDGED 면 ack 를 호출하지 않는다 (D)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+            acknowledgementState: 'ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED',
+            lineItems: [{ productId: 'personal_monthly', expiryTime: FUTURE }],
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+      mockDB.pushResult([TXN_ROW]);
+      mockDB.pushResult([PLAN_ROW]);
+      mockDB.pushResult([TXN_ROW]);
+      mockDB.pushResult([{ plan_id: 'plan-1' }]);
+
+      const res = await buildApp().request(rtdnRequest(2), undefined, RTDN_ENV);
+
+      expect(res.status).toBe(200);
+      // lookup 한 번뿐 — ack 호출 없음.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // E: suspend(ON_HOLD/PAUSED)도 잔여 활성 유료 구독을 존중 (deactivate E2 와 대칭).
+    //    매핑(정지된) 구독을 제외한 다른 활성 유료 구독이 있으면 free 로 내리지 않는다.
+    // -------------------------------------------------------------------------
+    it('suspend 시 매핑 구독 외 다른 활성 유료 구독이 있으면 그 plan 을 유지한다 (E)', async () => {
+      stubPlayLookup('SUBSCRIPTION_STATE_ON_HOLD', FUTURE);
+      mockDB.pushResult([TXN_ROW]); // store_transactions 매핑 (subscription_id='sub-old')
+      mockDB.pushResult([ACTIVE_MAPPED_ROW]); // 매핑 구독이 현재 활성 (게이트 통과)
+      mockDB.pushResult([
+        { sub_id: 'sub-other', user_id: 'user-pk-1', plan_id: 'plan-2', plan_group_id: null, plan_type: 'family' },
+        { sub_id: 'sub-old', user_id: 'user-pk-1', plan_id: 'plan-1', plan_group_id: null, plan_type: 'personal' },
+      ]); // 남은 활성 구독 (매핑 sub-old + 다른 유료 sub-other)
+
+      const res = await buildApp().request(rtdnRequest(5), undefined, RTDN_ENV);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).action).toBe('suspended');
+      // 매핑(sub-old) 제외한 다른 활성 유료 구독(family)의 plan 으로 유지 — free 강등 아님.
+      expect(findCall('UPDATE users SET plan = ?')?.args).toEqual(['family', 'user-pk-1']);
+      expect(findCall("plan = 'free'")).toBeUndefined();
+      // 회복형 상태 — 음성 접근 정리(is_shared 해제·타인 알람 강등)는 하지 않는다.
+      expect(findCall('UPDATE voice_profiles')).toBeUndefined();
+      expect(findCall('UPDATE alarms')).toBeUndefined();
+    });
+
+    it('suspend 시 매핑 구독뿐이면(다른 유료 구독 없음) free 로 내린다 (E)', async () => {
+      stubPlayLookup('SUBSCRIPTION_STATE_PAUSED', FUTURE);
+      mockDB.pushResult([TXN_ROW]);
+      mockDB.pushResult([ACTIVE_MAPPED_ROW]);
+      mockDB.pushResult([
+        { sub_id: 'sub-old', user_id: 'user-pk-1', plan_id: 'plan-1', plan_group_id: null, plan_type: 'personal' },
+      ]); // 남은 활성 구독은 매핑(정지된) 구독뿐 → 제외하면 유료 없음
+
+      const res = await buildApp().request(rtdnRequest(6), undefined, RTDN_ENV);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).action).toBe('suspended');
+      expect(findCall('UPDATE users SET plan = ?')?.args).toEqual(['free', 'user-pk-1']);
+      // 회복형 free 강등은 음성 접근 정리 없이 users.plan 만 회수한다.
+      expect(findCall('UPDATE voice_profiles')).toBeUndefined();
+      expect(findCall('UPDATE alarms')).toBeUndefined();
+    });
   });
 });

--- a/packages/backend/test/elevenlabs.test.ts
+++ b/packages/backend/test/elevenlabs.test.ts
@@ -59,7 +59,10 @@ describe('ElevenLabsClient', () => {
       await client.textToSpeech('voice-123', '안녕하세요');
 
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://api.elevenlabs.io/v1/text-to-speech/voice-123');
+      // K2: output_format 을 명시 고정한다(제공자 기본값 의존 제거).
+      expect(url).toBe(
+        'https://api.elevenlabs.io/v1/text-to-speech/voice-123?output_format=mp3_44100_128',
+      );
       expect(opts.method).toBe('POST');
       const body = JSON.parse(opts.body);
       expect(body.text).toBe('안녕하세요');

--- a/packages/backend/test/tts.test.ts
+++ b/packages/backend/test/tts.test.ts
@@ -870,7 +870,7 @@ describe('POST /tts/generate — edge cases', () => {
     expect(mockTextToSpeech).not.toHaveBeenCalled();
   });
 
-  it('ElevenLabs 실패 시 500 + detail 포함', async () => {
+  it('ElevenLabs 실패 시 500 + 제공자 원문 미노출(K1)', async () => {
     mockDB.pushResult([{ plan: 'plus' }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
     mockDB.pushResult([]); // cache lookup (miss)
@@ -883,10 +883,12 @@ describe('POST /tts/generate — edge cases', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error_code).toBe('TTS_GENERATION_FAILED');
-    expect(body.detail).toBe('ElevenLabs quota exceeded');
+    // K1: 제공자 응답 원문은 detail 로 반사하지 않고 안정 에러코드만 노출한다.
+    expect(body.detail).toBe('TTS_GENERATION_FAILED');
+    expect(JSON.stringify(body)).not.toContain('ElevenLabs quota exceeded');
   });
 
-  it('ElevenLabs가 비-Error를 throw하면 detail "Unknown error"', async () => {
+  it('ElevenLabs가 비-Error를 throw해도 detail 은 안정 코드(K1)', async () => {
     mockDB.pushResult([{ plan: 'plus' }]);
     mockDB.pushResult([{ id: V1, status: 'ready', elevenlabs_voice_id: 'el-voice-1' }]);
     mockDB.pushResult([]); // cache lookup (miss)
@@ -897,7 +899,7 @@ describe('POST /tts/generate — edge cases', () => {
       jsonReq('POST', '/tts/generate', { voice_profile_id: V1, text: 'hello' }),
     );
     expect(res.status).toBe(500);
-    expect((await res.json()).detail).toBe('Unknown error');
+    expect((await res.json()).detail).toBe('TTS_GENERATION_FAILED');
   });
 
   it('성공 시 201 + message_id, audio_base64, category 기본값 custom', async () => {

--- a/packages/backend/test/voice-profile.test.ts
+++ b/packages/backend/test/voice-profile.test.ts
@@ -709,7 +709,9 @@ describe('POST /clone — 음성 클론 (voice-profile)', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error_code).toBe('VOICE_CLONING_FAILED');
-    expect(body.detail).toBe('API down');
+    // K1: 제공자 응답 원문(err.message)은 detail 로 반사하지 않고 안정 에러코드만 노출한다.
+    expect(body.detail).toBe('VOICE_CLONING_FAILED');
+    expect(JSON.stringify(body)).not.toContain('API down');
 
     // 클론 실패 시 stuck 'processing' 방지: 해당 row 를 'failed' 로 정리해야 한다.
     const insertCall = mockDB.calls.find((call) =>
@@ -784,6 +786,52 @@ describe('POST /clone — 음성 클론 (voice-profile)', () => {
     const body = await res.json();
     expect(body.error_code).toBe('VOICE_SLOT_EXHAUSTED');
     expect(body.error).toContain('서비스가 확장중');
+  });
+
+  it('J: 0바이트 오디오 → 400 AUDIO_FILE_EMPTY (arrayBuffer/클론 전 차단)', async () => {
+    mockDB.pushResult([{ count: 0 }]); // 한도 체크 SELECT
+    const res = await req(buildApp(), cloneForm(new Uint8Array([]), 'name'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe('AUDIO_FILE_EMPTY');
+    expect(mockCreateInstantClone).not.toHaveBeenCalled();
+  });
+
+  it('J: 25 MiB 초과 오디오 → 413 AUDIO_FILE_TOO_LARGE', async () => {
+    mockDB.pushResult([{ count: 0 }]); // 한도 체크 SELECT
+    const big = new Uint8Array(25 * 1024 * 1024 + 1);
+    const res = await req(buildApp(), cloneForm(big, 'name'));
+    expect(res.status).toBe(413);
+    expect((await res.json()).error_code).toBe('AUDIO_FILE_TOO_LARGE');
+    expect(mockCreateInstantClone).not.toHaveBeenCalled();
+  });
+
+  it('C: 원본 R2 저장 성공 후 voice_uploads INSERT 실패 시 R2 삭제 큐 적재', async () => {
+    mockDB.pushResult([{ count: 0 }]);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockDB.pushResult([], 1);
+    mockCreateInstantClone.mockResolvedValue({ voice_id: 'elv-ok' });
+
+    // voice_uploads INSERT 만 실패시킨다(R2 put 은 이미 성공한 상태를 재현).
+    const origExecute = mockDB.client.execute;
+    mockDB.client.execute = async (q: { sql: string; args: (string | number | null)[] }) => {
+      if (q.sql.includes('INSERT INTO voice_uploads')) throw new Error('insert boom');
+      return origExecute(q);
+    };
+    try {
+      const res = await req(buildApp(), cloneForm(new Uint8Array([1, 2, 3]), '엄마'));
+      // 원본 보관은 best-effort — 클론 자체는 성공(201).
+      expect(res.status).toBe(201);
+      const enqueueCall = mockDB.calls.find((call) =>
+        call.sql.includes('INSERT OR IGNORE INTO pending_external_deletions'),
+      );
+      expect(enqueueCall).toBeDefined();
+      expect(enqueueCall!.args[1]).toBe('r2_object'); // kind
+      expect(String(enqueueCall!.args[2] ?? '')).not.toBe(''); // 고아 objectKey
+    } finally {
+      mockDB.client.execute = origExecute;
+    }
   });
 });
 
@@ -1084,14 +1132,14 @@ describe('POST /clone — edge cases (voice-profile)', () => {
     expect((await res.json()).profile.status).toBe('ready');
   });
 
-  it('non-Error throw → detail = "Unknown error"', async () => {
+  it('non-Error throw 여도 detail 은 안정 코드(K1)', async () => {
     mockDB.pushResult([{ count: 0 }]);
     mockDB.pushResult([], 1);
     mockDB.pushResult([], 1);
     mockCreateInstantClone.mockRejectedValue('string-error');
     const res = await req(buildApp(), cloneForm(new Uint8Array([1]), 'test'));
     expect(res.status).toBe(500);
-    expect((await res.json()).detail).toBe('Unknown error');
+    expect((await res.json()).detail).toBe('VOICE_CLONING_FAILED');
   });
 });
 

--- a/packages/backend/test/voice.test.ts
+++ b/packages/backend/test/voice.test.ts
@@ -625,6 +625,8 @@ describe('POST /voice/clone — 음성 클론', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error_code).toBe('VOICE_CLONING_FAILED');
-    expect(body.detail).toBe('API down');
+    // K1: 제공자 응답 원문(err.message)은 detail 로 반사하지 않고 안정 에러코드만 노출한다.
+    expect(body.detail).toBe('VOICE_CLONING_FAILED');
+    expect(JSON.stringify(body)).not.toContain('API down');
   });
 });


### PR DESCRIPTION
## 배경
PR#562 이후 독립 검토 지적 11건을 현 develop 코드로 재검증 → 실재 결함만 수정. **prod 승격 없음(dev까지).**

## 재검증 결과 (심각도 자체 판정)
| 지적 | 판정 | 실심각도 |
|---|---|---|
| A PATCH 가드 우회 | 사실 | **P1** (PR#562가 POST만 막고 PATCH 누락) |
| B raw_audio 소유권 | 부분사실 | P2 (삭제 벡터만, 읽기는 프리픽스/엔트로피로 차단) |
| C 동의철회+고아객체 | 부분사실 | P2 (동의 재확인은 이미 있음, 고아 1건만) |
| D Play ack 큐 | 부분사실 | P2 (클라 재전송 안전망 존재, 매출만) |
| E RTDN/suspend | 부분사실 | P3 (늦은 ACTIVE 덮어씀은 오류, suspend만) |
| F DST 없는 시각 | 부분사실 | P3 (발사 아닌 검증용 값) |
| G greeting 혼합 | 부분사실 | P3 (플랜 게이트가 선차단) |
| H 프리페치 | 부분사실 | P3 (온디맨드 폴백 존재) |
| I MIME octet-stream | 사실 | P2 |
| J 클론 size | 사실 | P2 |
| K 에러노출/포맷/nonce | 부분사실 | P3 |

## 수정
- **[P1] A**: PATCH에 POST와 동일 가드(리드타임·quiet·수신자tz·중복 원자교체) 공용 헬퍼로 재실행, is_active 0→1 재활성화 시 슬롯 재점유
- **[P2] B**: raw_audio_url 저장 전 R2 키 소유권 검증(403) — 타인 객체 삭제 차단
- **[P2] C**: R2 저장 후 DB 실패 시 보상 삭제 큐(고아 방지)
- **[P2] D**: confirm ack 백오프 + RTDN entitle 경로 PENDING 시 서버측 ack 재시도
- **[P2] I/J**: 낯선 오디오 컨테이너 MIME 정규화(클라)·트랜스코드 폴백, 클론 파일 크기 가드(0/25MiB)
- **[P3] E/F/G/H/K1/K2**: suspend plan 유지, DST gap 보정, greeting 혼합 방어심화, 프리페치 재시도, 제공자 에러 마스킹, TTS output_format 고정

## 무대응/후속
- **K3 구글 로그인 nonce/replay**: Android Credential Manager 마이그레이션 필요 → 별도 follow-up (deprecated GoogleSignIn 교체와 함께)
- E의 "늦은 ACTIVE RTDN 덮어씀": 검증 결과 성립 안 함(항상 권위 재조회) — 수정 불필요

## 검증
- 백엔드: typecheck ✅ · eslint ✅ · vitest **76파일 1499 passed / 0 failed** (PATCH 가드·DST gap·B/C/J/E 신규 테스트 포함)
- Android: 단위테스트·lint·assembleDevDebug **BUILD SUCCESSFUL**