### PR TITLE
release: 푸시 토큰 단일 소유 수정(#568) main 반영 — 마이그레이션 #71

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -24,6 +24,6 @@
     "@types/react-dom": "^19.0.0",
     "postcss": "^8.5.19",
     "tailwindcss": "^4.0.0",
-    "typescript": "^7.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,42 +37,7 @@
         "@types/react-dom": "^19.0.0",
         "postcss": "^8.5.19",
         "tailwindcss": "^4.0.0",
-        "typescript": "^7.0.2"
-      }
-    },
-    "apps/landing/node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alarmtalk/landing": {
@@ -5935,7 +5900,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1507,10 +1507,13 @@ export const migrations: Migration[] = [
     id: 71,
     name: 'push-tokens-global-unique-token',
     statements: [
+      // 타이브레이커는 rowid(삽입 순서 근사) — 레이스로 남은 중복은 대부분 같은 초에 찍혀
+      // updated_at/created_at 이 동률인데, UUID(id) 비교는 삽입 순서와 무관해 이른 소유자가
+      // 남을 수 있다. rowid 가 크면 나중 INSERT = 마지막 등록이 승자.
       `DELETE FROM push_tokens WHERE id NOT IN (
         SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
-            PARTITION BY token ORDER BY updated_at DESC, created_at DESC, id DESC
+            PARTITION BY token ORDER BY updated_at DESC, created_at DESC, rowid DESC
           ) AS rn FROM push_tokens
         ) WHERE rn = 1
       )`,

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1499,6 +1499,28 @@ export const migrations: Migration[] = [
         WHERE id IN (${STALE_STOCK_PRESET_SUBQUERY_2026_07_19})`,
     ],
   },
+  {
+    // /push/register 의 'DELETE 타소유자 → UPSERT(user_id, token)' 2문장은 같은 기기의 빠른 계정
+    // 전환에서 두 세션의 등록이 인터리빙되면 한 token 에 소유자 2행이 남아 가족알람 push 가 두
+    // 계정 모두에게 가는 레이스가 있었다(Codex #567 P1). token 을 전역 UNIQUE 로 만들고 라우트를
+    // ON CONFLICT(token) 단일 UPSERT 로 교체한다. 기존 중복은 최신(updated_at) 행만 남긴다.
+    id: 71,
+    name: 'push-tokens-global-unique-token',
+    statements: [
+      `DELETE FROM push_tokens WHERE id NOT IN (
+        SELECT id FROM (
+          SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY token ORDER BY updated_at DESC, created_at DESC, id DESC
+          ) AS rn FROM push_tokens
+        ) WHERE rn = 1
+      )`,
+      // #63 의 비유니크 token 인덱스를 유니크로 교체(이름 유지). CREATE ... IF NOT EXISTS 는
+      // '이름' 존재만 보므로 반드시 DROP 후 CREATE — 안 그러면 비유니크 인덱스가 그대로 남아
+      // ON CONFLICT(token) 이 매칭할 유니크 제약이 없어 등록이 실패한다.
+      'DROP INDEX IF EXISTS idx_push_tokens_token',
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_push_tokens_token ON push_tokens(token)',
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1500,13 +1500,23 @@ export const migrations: Migration[] = [
     ],
   },
   {
-    // /push/register 의 'DELETE 타소유자 → UPSERT(user_id, token)' 2문장은 같은 기기의 빠른 계정
-    // 전환에서 두 세션의 등록이 인터리빙되면 한 token 에 소유자 2행이 남아 가족알람 push 가 두
-    // 계정 모두에게 가는 레이스가 있었다(Codex #567 P1). token 을 전역 UNIQUE 로 만들고 라우트를
-    // ON CONFLICT(token) 단일 UPSERT 로 교체한다. 기존 중복은 최신(updated_at) 행만 남긴다.
+    // /push/register 의 비트랜잭션 'DELETE 타소유자 → UPSERT(user_id, token)' 2문장은 같은 기기의
+    // 빠른 계정 전환에서 두 세션의 등록이 인터리빙되면 한 token 에 소유자 2행이 남아 가족알람
+    // push 가 두 계정 모두에게 가는 레이스가 있었다(Codex #567 P1). 라우트는 쓰기 트랜잭션으로
+    // 원자화했고(push.ts), 여기서 token 전역 UNIQUE 를 더해 DB 수준 불변식으로 이중 방어한다.
+    // 기존 중복은 최신 행만 남긴다.
+    //
+    // 원자성 노트(Codex #570): runMigrations 는 문장을 개별 실행하므로 dedupe→CREATE 사이가
+    // 완전 원자는 아니다. 대신 (1) 배포가 먼저 나가는 새 라우트는 트랜잭션 재배정이라 신규
+    // 중복을 만들 수 없고(옛 코드 in-flight 는 배포 후 수초 내 소진, 마이그레이션은 그 뒤 실행),
+    // (2) dedupe 를 CREATE 바로 앞에 붙여 갭을 한 문장 경계로 최소화했으며, (3) 세 문장 모두
+    // 멱등이라 혹시 CREATE 가 UNIQUE 위반으로 실패해도 다음 migrate 재실행에서 수렴한다.
     id: 71,
     name: 'push-tokens-global-unique-token',
     statements: [
+      // #63 의 비유니크 token 인덱스를 유니크로 교체(이름 유지). CREATE ... IF NOT EXISTS 는
+      // '이름' 존재만 보므로 반드시 DROP 후 CREATE — 안 그러면 비유니크 인덱스가 그대로 남는다.
+      'DROP INDEX IF EXISTS idx_push_tokens_token',
       // 타이브레이커는 rowid(삽입 순서 근사) — 레이스로 남은 중복은 대부분 같은 초에 찍혀
       // updated_at/created_at 이 동률인데, UUID(id) 비교는 삽입 순서와 무관해 이른 소유자가
       // 남을 수 있다. rowid 가 크면 나중 INSERT = 마지막 등록이 승자.
@@ -1517,10 +1527,6 @@ export const migrations: Migration[] = [
           ) AS rn FROM push_tokens
         ) WHERE rn = 1
       )`,
-      // #63 의 비유니크 token 인덱스를 유니크로 교체(이름 유지). CREATE ... IF NOT EXISTS 는
-      // '이름' 존재만 보므로 반드시 DROP 후 CREATE — 안 그러면 비유니크 인덱스가 그대로 남아
-      // ON CONFLICT(token) 이 매칭할 유니크 제약이 없어 등록이 실패한다.
-      'DROP INDEX IF EXISTS idx_push_tokens_token',
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_push_tokens_token ON push_tokens(token)',
     ],
   },

--- a/packages/backend/src/routes/push.ts
+++ b/packages/backend/src/routes/push.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
+import { withWriteTransaction } from '../lib/transactions';
 
 const push = new Hono<AppEnv>();
 
@@ -39,18 +40,25 @@ push.post('/register', async (c) => {
 
   // 이 기기 토큰을 현재 사용자 전용으로 재배정한다. 같은 기기에서 A 로그아웃→B 로그인 시 Firebase 등록
   // 토큰은 그대로라, 옛 소유자(A) 행이 남으면 A 의 알람 push 가 이 기기로 잘못 배달된다(P1).
-  // 이전의 'DELETE 타소유자 → UPSERT(user_id, token)' 2문장은 빠른 계정 전환으로 두 세션의 등록이
-  // 동시에 도착하면 서로의 DELETE 가 상대 INSERT 앞에 실행돼 소유자 2행이 남는 레이스가 있었다
-  // (Codex #567 P1). token 전역 UNIQUE(마이그레이션 #71) 위에서 단일 UPSERT 로 원자 재배정한다 —
-  // 마지막 등록이 유일 승자이고, 어떤 인터리빙에서도 토큰당 소유자는 1행이다.
-  await db.execute({
-    sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
-          VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
-          ON CONFLICT(token) DO UPDATE SET
-            user_id = excluded.user_id,
-            platform = excluded.platform,
-            updated_at = datetime('now')`,
-    args: [crypto.randomUUID(), userPk, token, platform],
+  // 이전의 비트랜잭션 'DELETE 타소유자 → UPSERT' 2문장은 빠른 계정 전환으로 두 세션의 등록이 동시에
+  // 도착하면 서로의 DELETE 가 상대 INSERT 앞에 실행돼 소유자 2행이 남는 레이스가 있었다(Codex #567 P1).
+  // 쓰기 트랜잭션(단일 writer 락)으로 두 문장을 원자화해 어떤 인터리빙에서도 마지막 커밋이 유일 승자다.
+  // ON CONFLICT 타깃은 #14 부터 존재하는 (user_id, token) 유니크를 유지한다 — deploy-backend.yml 이
+  // 배포 '후' 마이그레이션을 돌리므로, ON CONFLICT(token) 을 쓰면 #71(token 전역 UNIQUE) 적용 전
+  // 창에서 모든 등록이 500 난다(Codex #568 P2). #71 이후엔 token 전역 UNIQUE 가 DB 수준 이중 방어.
+  await withWriteTransaction(db, async (tx) => {
+    await tx.execute({
+      sql: 'DELETE FROM push_tokens WHERE token = ? AND user_id != ?',
+      args: [token, userPk],
+    });
+    await tx.execute({
+      sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+            VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+            ON CONFLICT(user_id, token) DO UPDATE SET
+              platform = excluded.platform,
+              updated_at = datetime('now')`,
+      args: [crypto.randomUUID(), userPk, token, platform],
+    });
   });
 
   return c.json({ success: true });

--- a/packages/backend/src/routes/push.ts
+++ b/packages/backend/src/routes/push.ts
@@ -38,17 +38,16 @@ push.post('/register', async (c) => {
   }
 
   // 이 기기 토큰을 현재 사용자 전용으로 재배정한다. 같은 기기에서 A 로그아웃→B 로그인 시 Firebase 등록
-  // 토큰은 그대로라, 옛 소유자(A) 행이 남으면 A 의 알람 push 가 이 기기로 잘못 배달된다(P1). 그러니 이
-  // 토큰의 다른 소유자 행을 먼저 제거해 (user, token) 이 전역에서 현재 사용자 하나만 남게 한다.
-  await db.execute({
-    sql: 'DELETE FROM push_tokens WHERE token = ? AND user_id != ?',
-    args: [token, userPk],
-  });
-  // 같은 (user, token) 이면 platform/updated_at 만 갱신(멱등). 고유 인덱스 idx_push_tokens_unique(user_id, token).
+  // 토큰은 그대로라, 옛 소유자(A) 행이 남으면 A 의 알람 push 가 이 기기로 잘못 배달된다(P1).
+  // 이전의 'DELETE 타소유자 → UPSERT(user_id, token)' 2문장은 빠른 계정 전환으로 두 세션의 등록이
+  // 동시에 도착하면 서로의 DELETE 가 상대 INSERT 앞에 실행돼 소유자 2행이 남는 레이스가 있었다
+  // (Codex #567 P1). token 전역 UNIQUE(마이그레이션 #71) 위에서 단일 UPSERT 로 원자 재배정한다 —
+  // 마지막 등록이 유일 승자이고, 어떤 인터리빙에서도 토큰당 소유자는 1행이다.
   await db.execute({
     sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
           VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
-          ON CONFLICT(user_id, token) DO UPDATE SET
+          ON CONFLICT(token) DO UPDATE SET
+            user_id = excluded.user_id,
             platform = excluded.platform,
             updated_at = datetime('now')`,
     args: [crypto.randomUUID(), userPk, token, platform],

--- a/packages/backend/test/push-token-unique.test.ts
+++ b/packages/backend/test/push-token-unique.test.ts
@@ -113,4 +113,25 @@ describe('push_tokens 전역 단일 소유 (마이그레이션 #71 + 원자 UPSE
       }),
     ).rejects.toThrow(/UNIQUE/i);
   });
+
+  it('#71 dedupe 는 타임스탬프 동률이면 나중에 삽입된 행(rowid)이 이긴다 — UUID 순서에 좌우되지 않음', async () => {
+    // 레이스 중복은 대부분 같은 초에 찍힌다. id(UUID) DESC 타이브레이커라면 'z-first' 가
+    // 남았을 어긋난 케이스: 먼저 삽입된 행의 UUID 가 사전순으로 더 크게 만들어 둔다.
+    await db.execute('DROP INDEX IF EXISTS idx_push_tokens_token');
+    const sameTime = "datetime('now','-30 minutes')";
+    await db.execute(
+      `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+       VALUES ('z-first', 'pt-a', 'tok-tie', 'android', ${sameTime}, ${sameTime})`,
+    );
+    await db.execute(
+      `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+       VALUES ('a-second', 'pt-b', 'tok-tie', 'android', ${sameTime}, ${sameTime})`,
+    );
+
+    for (const sql of migration71.statements) {
+      await db.execute(sql);
+    }
+    // 나중 INSERT(pt-b, rowid 큼)가 유일 승자 — 마지막 등록 보존 의도와 일치.
+    expect(await ownersOf('tok-tie')).toEqual(['pt-b']);
+  });
 });

--- a/packages/backend/test/push-token-unique.test.ts
+++ b/packages/backend/test/push-token-unique.test.ts
@@ -1,0 +1,107 @@
+// 마이그레이션 #71(push_tokens token 전역 UNIQUE) + /push/register 원자 UPSERT 실동작 검증.
+// 실제 libsql 파일 DB 에 전체 마이그레이션을 올리고, 라우트가 쓰는 것과 동일한 SQL 로
+// '계정 전환 시 마지막 등록이 유일 승자' 불변식을 DB 제약 수준에서 확인한다.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createClient, type Client } from '@libsql/client';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { migrations, runMigrations } from '../src/lib/migrations';
+
+const DB_PATH = join(tmpdir(), 'alarmtalk-push-token-unique.db');
+const db: Client = createClient({ url: `file:${DB_PATH}` });
+
+const migration71 = migrations.find((m) => m.id === 71)!;
+
+// 라우트(push.ts /register)와 동일한 UPSERT
+async function registerLike(userId: string, token: string, platform = 'android') {
+  await db.execute({
+    sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+          VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+          ON CONFLICT(token) DO UPDATE SET
+            user_id = excluded.user_id,
+            platform = excluded.platform,
+            updated_at = datetime('now')`,
+    args: [crypto.randomUUID(), userId, token, platform],
+  });
+}
+
+async function ownersOf(token: string): Promise<string[]> {
+  const res = await db.execute({
+    sql: 'SELECT user_id FROM push_tokens WHERE token = ? ORDER BY user_id',
+    args: [token],
+  });
+  return res.rows.map((r) => String(r.user_id));
+}
+
+beforeAll(async () => {
+  await runMigrations(db);
+  await db.execute('DELETE FROM push_tokens');
+  for (const u of ['pt-a', 'pt-b']) {
+    await db.execute({
+      sql: 'INSERT OR IGNORE INTO users (id, google_id, email) VALUES (?, ?, ?)',
+      args: [u, u, `${u}@test`],
+    });
+  }
+});
+
+describe('push_tokens 전역 단일 소유 (마이그레이션 #71 + 원자 UPSERT)', () => {
+  it('같은 토큰을 다른 계정이 등록하면 소유자가 교체된다 — 항상 1행', async () => {
+    await registerLike('pt-a', 'tok-shared');
+    expect(await ownersOf('tok-shared')).toEqual(['pt-a']);
+    await registerLike('pt-b', 'tok-shared', 'ios');
+    expect(await ownersOf('tok-shared')).toEqual(['pt-b']);
+    const row = await db.execute({
+      sql: 'SELECT platform FROM push_tokens WHERE token = ?',
+      args: ['tok-shared'],
+    });
+    expect(row.rows[0]!.platform).toBe('ios');
+  });
+
+  it('토큰 UNIQUE 제약이 소유자 2행 삽입을 DB 수준에서 차단한다', async () => {
+    await registerLike('pt-a', 'tok-guard');
+    await expect(
+      db.execute({
+        sql: `INSERT INTO push_tokens (id, user_id, token, platform) VALUES (?, ?, ?, 'android')`,
+        args: [crypto.randomUUID(), 'pt-b', 'tok-guard'],
+      }),
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+
+  it('한 사용자의 여러 기기(서로 다른 토큰)는 그대로 공존한다', async () => {
+    await registerLike('pt-a', 'tok-device-1');
+    await registerLike('pt-a', 'tok-device-2');
+    const res = await db.execute({
+      sql: "SELECT COUNT(*) AS n FROM push_tokens WHERE user_id = 'pt-a' AND token LIKE 'tok-device-%'",
+      args: [],
+    });
+    expect(Number(res.rows[0]!.n)).toBe(2);
+  });
+
+  it('#71 dedupe 는 레이스로 남은 중복 소유 행에서 최신(updated_at) 행만 남긴다', async () => {
+    // 레거시 상태 재현: 유니크 인덱스를 잠시 내리고 중복 소유 2행 삽입
+    await db.execute('DROP INDEX IF EXISTS idx_push_tokens_token');
+    await db.execute({
+      sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+            VALUES ('dup-old', 'pt-a', 'tok-dup', 'android', datetime('now','-2 hours'), datetime('now','-2 hours'))`,
+      args: [],
+    });
+    await db.execute({
+      sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+            VALUES ('dup-new', 'pt-b', 'tok-dup', 'android', datetime('now','-1 hour'), datetime('now','-1 hour'))`,
+      args: [],
+    });
+    expect((await ownersOf('tok-dup')).length).toBe(2);
+
+    for (const sql of migration71.statements) {
+      await db.execute(sql);
+    }
+    expect(await ownersOf('tok-dup')).toEqual(['pt-b']);
+    // 인덱스가 유니크로 복원됐는지 — 중복 삽입이 다시 막혀야 한다
+    await expect(
+      db.execute({
+        sql: `INSERT INTO push_tokens (id, user_id, token, platform) VALUES (?, 'pt-a', 'tok-dup', 'android')`,
+        args: [crypto.randomUUID()],
+      }),
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+});

--- a/packages/backend/test/push-token-unique.test.ts
+++ b/packages/backend/test/push-token-unique.test.ts
@@ -12,17 +12,26 @@ const db: Client = createClient({ url: `file:${DB_PATH}` });
 
 const migration71 = migrations.find((m) => m.id === 71)!;
 
-// 라우트(push.ts /register)와 동일한 UPSERT
+// 라우트(push.ts /register)와 동일한 트랜잭션 재배정(DELETE 타소유자 + UPSERT(user_id, token))
 async function registerLike(userId: string, token: string, platform = 'android') {
-  await db.execute({
-    sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
-          VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
-          ON CONFLICT(token) DO UPDATE SET
-            user_id = excluded.user_id,
-            platform = excluded.platform,
-            updated_at = datetime('now')`,
-    args: [crypto.randomUUID(), userId, token, platform],
-  });
+  const tx = await db.transaction('write');
+  try {
+    await tx.execute({
+      sql: 'DELETE FROM push_tokens WHERE token = ? AND user_id != ?',
+      args: [token, userId],
+    });
+    await tx.execute({
+      sql: `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+            VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+            ON CONFLICT(user_id, token) DO UPDATE SET
+              platform = excluded.platform,
+              updated_at = datetime('now')`,
+      args: [crypto.randomUUID(), userId, token, platform],
+    });
+    await tx.commit();
+  } finally {
+    if (!tx.closed) tx.close();
+  }
 }
 
 async function ownersOf(token: string): Promise<string[]> {

--- a/packages/backend/test/push.test.ts
+++ b/packages/backend/test/push.test.ts
@@ -21,23 +21,25 @@ function buildApp(userId = 'user-1') {
 describe('POST /push/register — FCM 토큰 등록', () => {
   beforeEach(() => mockDB.reset());
 
-  it('유효 토큰+플랫폼 → success, ON CONFLICT(token) 단일 원자 UPSERT 로 재배정', async () => {
-    mockDB.pushResult([], 1); // INSERT ... ON CONFLICT(token) push_tokens
+  it('유효 토큰+플랫폼 → success, 쓰기 트랜잭션 안에서 DELETE+UPSERT 원자 재배정', async () => {
+    mockDB.pushResult([], 0); // DELETE 다른 소유자 행
+    mockDB.pushResult([], 1); // INSERT ... ON CONFLICT(user_id, token)
     const res = await buildApp('user-1').request(
       jsonReq('POST', '/push/register', { token: 'fcm-token-abc', platform: 'android' }),
     );
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
-    // 재배정은 별도 DELETE 없이 단일 UPSERT 여야 한다 — 'DELETE 후 INSERT' 2문장은 동시 등록
-    // (빠른 계정 전환) 인터리빙에서 소유자 2행이 남는 레이스가 있었다(Codex #567 P1).
+    // 비트랜잭션 'DELETE 후 INSERT' 2문장은 동시 등록(빠른 계정 전환) 인터리빙에서 소유자 2행이
+    // 남는 레이스가 있었다(Codex #567 P1) — 반드시 한 쓰기 트랜잭션으로 커밋돼야 한다.
+    expect(mockDB.transactions.commits).toBe(1);
     const del = mockDB.calls.find((c) => c.sql.startsWith('DELETE FROM push_tokens'));
-    expect(del).toBeUndefined();
+    expect(del).toBeDefined();
+    expect(del!.args).toEqual(['fcm-token-abc', 'user-1']);
     const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO push_tokens'));
     expect(insert).toBeDefined();
-    expect(insert!.sql).toContain('ON CONFLICT(token)');
-    // 충돌 시 소유자까지 갈아탄다 — 마지막 등록이 유일 승자.
-    expect(insert!.sql).toContain('user_id = excluded.user_id');
-    // args = [uuid, userPk, token, platform] — 소유자 스코프(userPk)로 저장.
+    // 컨플릭트 타깃은 (user_id, token) 유지 — 배포가 마이그레이션(#71 token 전역 UNIQUE)보다
+    // 먼저 나가는 창에서 ON CONFLICT(token) 은 매칭 제약이 없어 500 이 된다(Codex #568 P2).
+    expect(insert!.sql).toContain('ON CONFLICT(user_id, token)');
     expect(insert!.args).toContain('user-1');
     expect(insert!.args).toContain('fcm-token-abc');
     expect(insert!.args).toContain('android');

--- a/packages/backend/test/push.test.ts
+++ b/packages/backend/test/push.test.ts
@@ -21,23 +21,22 @@ function buildApp(userId = 'user-1') {
 describe('POST /push/register — FCM 토큰 등록', () => {
   beforeEach(() => mockDB.reset());
 
-  it('유효 토큰+플랫폼 → success, 재배정 DELETE 후 upsert', async () => {
-    mockDB.pushResult([], 0); // DELETE 다른 소유자 행
-    mockDB.pushResult([], 1); // INSERT ... ON CONFLICT push_tokens
+  it('유효 토큰+플랫폼 → success, ON CONFLICT(token) 단일 원자 UPSERT 로 재배정', async () => {
+    mockDB.pushResult([], 1); // INSERT ... ON CONFLICT(token) push_tokens
     const res = await buildApp('user-1').request(
       jsonReq('POST', '/push/register', { token: 'fcm-token-abc', platform: 'android' }),
     );
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
-    // 이 토큰의 다른 소유자 행을 먼저 제거(전역 단일 소유자) — A→B 로그인 시 오배달 방지.
+    // 재배정은 별도 DELETE 없이 단일 UPSERT 여야 한다 — 'DELETE 후 INSERT' 2문장은 동시 등록
+    // (빠른 계정 전환) 인터리빙에서 소유자 2행이 남는 레이스가 있었다(Codex #567 P1).
     const del = mockDB.calls.find((c) => c.sql.startsWith('DELETE FROM push_tokens'));
-    expect(del).toBeDefined();
-    expect(del!.sql).toContain('token = ?');
-    expect(del!.sql).toContain('user_id != ?');
-    expect(del!.args).toEqual(['fcm-token-abc', 'user-1']);
+    expect(del).toBeUndefined();
     const insert = mockDB.calls.find((c) => c.sql.includes('INSERT INTO push_tokens'));
     expect(insert).toBeDefined();
-    expect(insert!.sql).toContain('ON CONFLICT(user_id, token)');
+    expect(insert!.sql).toContain('ON CONFLICT(token)');
+    // 충돌 시 소유자까지 갈아탄다 — 마지막 등록이 유일 승자.
+    expect(insert!.sql).toContain('user_id = excluded.user_id');
     // args = [uuid, userPk, token, platform] — 소유자 스코프(userPk)로 저장.
     expect(insert!.args).toContain('user-1');
     expect(insert!.args).toContain('fcm-token-abc');


### PR DESCRIPTION
#567 승격에서 Codex가 지적한 FCM 토큰 동시 등록 레이스(P1)의 수정분(#568, Codex 2라운드 통과)을 prod에 반영. 전체 승격 델타는 리뷰 전용 PR #569에서 'no major issues' 재검증 완료. 머지 시 prod 배포 + 마이그레이션 #71(push_tokens token 전역 UNIQUE, 중복 정리) 실행.