### PR TITLE
fix: #71 dedupe 타이브레이커 rowid 로 (Codex #570 P2)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1507,10 +1507,13 @@ export const migrations: Migration[] = [
     id: 71,
     name: 'push-tokens-global-unique-token',
     statements: [
+      // 타이브레이커는 rowid(삽입 순서 근사) — 레이스로 남은 중복은 대부분 같은 초에 찍혀
+      // updated_at/created_at 이 동률인데, UUID(id) 비교는 삽입 순서와 무관해 이른 소유자가
+      // 남을 수 있다. rowid 가 크면 나중 INSERT = 마지막 등록이 승자.
       `DELETE FROM push_tokens WHERE id NOT IN (
         SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
-            PARTITION BY token ORDER BY updated_at DESC, created_at DESC, id DESC
+            PARTITION BY token ORDER BY updated_at DESC, created_at DESC, rowid DESC
           ) AS rn FROM push_tokens
         ) WHERE rn = 1
       )`,

--- a/packages/backend/test/push-token-unique.test.ts
+++ b/packages/backend/test/push-token-unique.test.ts
@@ -113,4 +113,25 @@ describe('push_tokens 전역 단일 소유 (마이그레이션 #71 + 원자 UPSE
       }),
     ).rejects.toThrow(/UNIQUE/i);
   });
+
+  it('#71 dedupe 는 타임스탬프 동률이면 나중에 삽입된 행(rowid)이 이긴다 — UUID 순서에 좌우되지 않음', async () => {
+    // 레이스 중복은 대부분 같은 초에 찍힌다. id(UUID) DESC 타이브레이커라면 'z-first' 가
+    // 남았을 어긋난 케이스: 먼저 삽입된 행의 UUID 가 사전순으로 더 크게 만들어 둔다.
+    await db.execute('DROP INDEX IF EXISTS idx_push_tokens_token');
+    const sameTime = "datetime('now','-30 minutes')";
+    await db.execute(
+      `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+       VALUES ('z-first', 'pt-a', 'tok-tie', 'android', ${sameTime}, ${sameTime})`,
+    );
+    await db.execute(
+      `INSERT INTO push_tokens (id, user_id, token, platform, created_at, updated_at)
+       VALUES ('a-second', 'pt-b', 'tok-tie', 'android', ${sameTime}, ${sameTime})`,
+    );
+
+    for (const sql of migration71.statements) {
+      await db.execute(sql);
+    }
+    // 나중 INSERT(pt-b, rowid 큼)가 유일 승자 — 마지막 등록 보존 의도와 일치.
+    expect(await ownersOf('tok-tie')).toEqual(['pt-b']);
+  });
 });


### PR DESCRIPTION
Codex #570 지적 반영: 타임스탬프 동률 시 UUID 대신 rowid(삽입 순서)로 마지막 등록을 보존. 실DB 동률 테스트 추가. prod는 #71 미적용이라 수정이 그대로 반영됩니다.