### PR TITLE
fix: 랜딩 typescript ^6 고정 — Vercel(Next 16) 빌드 실패 복구

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -24,6 +24,6 @@
     "@types/react-dom": "^19.0.0",
     "postcss": "^8.5.19",
     "tailwindcss": "^4.0.0",
-    "typescript": "^7.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,42 +37,7 @@
         "@types/react-dom": "^19.0.0",
         "postcss": "^8.5.19",
         "tailwindcss": "^4.0.0",
-        "typescript": "^7.0.2"
-      }
-    },
-    "apps/landing/node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alarmtalk/landing": {
@@ -5935,7 +5900,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
main 승격 후 Vercel 랜딩 빌드가 TS7 비호환으로 실패한 건 복구. 랜딩만 ^6.0.3 고정 + lockfile 낡은 중첩 항목 제거. 로컬 next build 통과(26페이지). 랜딩은 CI 체크에 없어 사전에 안 잡혔음 — follow-up으로 CI에 랜딩 빌드 추가 고려.