### PR TITLE
feat: 웰컴 프로모 3종(개인/커플/가족 1개월) + 리딤 그룹 계정당 1회

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -153,6 +153,8 @@ private fun codeRegistrationFailureMessage(context: android.content.Context, err
         "CODE_INACTIVE" -> context.getString(R.string.msg2_promo_fail_code_inactive)
         "CODE_NOT_IN_WINDOW" -> context.getString(R.string.msg2_promo_fail_not_in_window)
         "CODE_EXHAUSTED" -> context.getString(R.string.msg2_promo_fail_code_exhausted)
+        // 리딤 그룹(예: 웰컴 3종) — 같은 계열 코드를 이미 썼으면 다른 코드도 불가.
+        "CODE_GROUP_ALREADY_REDEEMED" -> context.getString(R.string.msg2_promo_fail_group_already_redeemed)
         "OWNS_ACTIVE_GROUP" -> context.getString(R.string.msg2_promo_fail_owns_active_group)
         else -> fallback
     }
@@ -165,6 +167,8 @@ private fun promoRedeemFailureMessage(context: android.content.Context, errorCod
         "CODE_NOT_IN_WINDOW" -> context.getString(R.string.msg2_promo_fail_not_in_window)
         "CODE_ALREADY_REDEEMED_BY_YOU" -> context.getString(R.string.msg2_code_fail_code_already_redeemed_by_you)
         "CODE_EXHAUSTED" -> context.getString(R.string.msg2_promo_fail_code_exhausted)
+        // 리딤 그룹(예: 웰컴 3종) — 같은 계열 코드를 이미 썼으면 다른 코드도 불가.
+        "CODE_GROUP_ALREADY_REDEEMED" -> context.getString(R.string.msg2_promo_fail_group_already_redeemed)
         "OWNS_ACTIVE_GROUP" -> context.getString(R.string.msg2_promo_fail_owns_active_group)
         "PROMO_REDEEM_FAILED" -> context.getString(R.string.msg2_promo_fail_generic)
         else -> fallback

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -908,6 +908,7 @@ We\'ll play it for you as soon as it\'s ready.</string>
     <string name="msg2_promo_fail_code_inactive">This promo code isn\'t available right now</string>
     <string name="msg2_promo_fail_not_in_window">This promo code isn\'t active yet or has ended</string>
     <string name="msg2_promo_fail_code_exhausted">This promo code has reached its usage limit</string>
+    <string name="msg2_promo_fail_group_already_redeemed">You\'ve already used a promo code from this promotion. This benefit is limited to once per account</string>
     <string name="msg2_promo_fail_owns_active_group">You already have an active group plan, so this promo code can\'t be applied</string>
     <string name="msg2_promo_fail_generic">Couldn\'t apply the promo code. Please try again in a moment</string>
     <string name="onb_voice_title">Pick your default voice</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -916,6 +916,7 @@
     <string name="msg2_promo_fail_code_inactive">現在は使用できないプロモコードです</string>
     <string name="msg2_promo_fail_not_in_window">まだ利用期間ではないか、終了したプロモコードです</string>
     <string name="msg2_promo_fail_code_exhausted">利用回数の上限に達したプロモコードです</string>
+    <string name="msg2_promo_fail_group_already_redeemed">同じキャンペーンのプロモコードをすでに使用しています。この特典はアカウントごとに1回のみです</string>
     <string name="msg2_promo_fail_owns_active_group">すでに利用中のグループプランがあるため、プロモコードを適用できません</string>
     <string name="msg2_promo_fail_generic">プロモコードを適用できませんでした。しばらくしてからもう一度お試しください</string>
     <string name="onb_voice_title">基本の声を選んでください</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -936,6 +936,7 @@
     <string name="msg2_promo_fail_code_inactive">지금은 사용할 수 없는 프로모 코드예요</string>
     <string name="msg2_promo_fail_not_in_window">아직 사용 기간이 아니거나 종료된 프로모 코드예요</string>
     <string name="msg2_promo_fail_code_exhausted">사용 가능 횟수가 모두 소진된 프로모 코드예요</string>
+    <string name="msg2_promo_fail_group_already_redeemed">이미 같은 계열의 프로모 코드를 사용했어요. 이 혜택은 계정당 한 번만 받을 수 있어요</string>
     <string name="msg2_promo_fail_owns_active_group">이미 이용 중인 그룹 이용권이 있어 프로모 코드를 적용할 수 없어요</string>
     <string name="msg2_promo_fail_generic">프로모 코드를 적용하지 못했어요. 잠시 후 다시 시도해 주세요</string>
     <string name="onb_voice_title">기본 목소리를 골라보세요</string>

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1530,6 +1530,34 @@ export const migrations: Migration[] = [
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_push_tokens_token ON push_tokens(token)',
     ],
   },
+  {
+    // 웰컴 프로모 3종(개인/커플/가족, 각 30일). '웰컴 계열 전체에서 계정당 1회' 규칙을 위해
+    // promo_codes.redemption_group 을 추가한다 — 같은 group 의 어떤 코드든 한 번 사용한 계정은
+    // 그 group 의 다른 코드를 다시 사용할 수 없다(집행은 promo-redemption.ts 원자 claim).
+    // group 이 NULL 인 기존/일반 코드는 코드별 1회 규칙만 그대로 적용된다.
+    id: 72,
+    name: 'promo-welcome-codes-redemption-group',
+    statements: [
+      `ALTER TABLE promo_codes ADD COLUMN redemption_group TEXT`,
+      // 시드는 코드 문자열(UNIQUE NOCASE) 기준 멱등 — 이미 있으면 건드리지 않는다(운영자가
+      // admin 에서 상한/유효창을 조정했어도 재실행이 덮어쓰지 않음).
+      `INSERT OR IGNORE INTO promo_codes
+         (id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active, note, redemption_group)
+       SELECT '90000000-0000-4000-9000-000000000001', 'WELCOME_PERSONAL', id, 30, NULL, NULL, NULL, 1,
+              '웰컴 프로모 — 퍼스널 1개월 (웰컴 계열 계정당 1회)', 'welcome'
+       FROM plans WHERE key = 'personal'`,
+      `INSERT OR IGNORE INTO promo_codes
+         (id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active, note, redemption_group)
+       SELECT '90000000-0000-4000-9000-000000000002', 'WELCOME_COUPLE', id, 30, NULL, NULL, NULL, 1,
+              '웰컴 프로모 — 커플 1개월 (웰컴 계열 계정당 1회)', 'welcome'
+       FROM plans WHERE key = 'couple'`,
+      `INSERT OR IGNORE INTO promo_codes
+         (id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active, note, redemption_group)
+       SELECT '90000000-0000-4000-9000-000000000003', 'WELCOME_FAMILY', id, 30, NULL, NULL, NULL, 1,
+              '웰컴 프로모 — 패밀리 1개월 (웰컴 계열 계정당 1회)', 'welcome'
+       FROM plans WHERE key = 'family'`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/promo-redemption.ts
+++ b/packages/backend/src/lib/promo-redemption.ts
@@ -61,12 +61,27 @@ async function redeemPromoInTransaction(
   }
 
   // 코드 매칭은 대소문자 무시(발급 시 UNIQUE 도 NOCASE).
-  const promoRes = await db.execute({
-    sql: `SELECT id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions,
-                 is_active, redemption_group
-          FROM promo_codes WHERE code = ? COLLATE NOCASE`,
-    args: [code],
-  });
+  // deploy-backend.yml 이 배포 '후' 마이그레이션을 돌리므로, redemption_group(#72) 컬럼이
+  // 아직 없는 창에서도 리딤이 500 나지 않게 레거시 스키마로 폴백한다(Codex #574 P1).
+  // 그룹 코드는 #72 가 시드하므로 마이그레이션 전엔 존재할 수 없다 — 폴백 경로에서
+  // 그룹 규칙이 빠져도 잘못 통과되는 코드는 없다.
+  let promoRes;
+  try {
+    promoRes = await db.execute({
+      sql: `SELECT id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions,
+                   is_active, redemption_group
+            FROM promo_codes WHERE code = ? COLLATE NOCASE`,
+      args: [code],
+    });
+  } catch (err) {
+    if (!/no such column/i.test(String(err))) throw err;
+    promoRes = await db.execute({
+      sql: `SELECT id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions,
+                   is_active
+            FROM promo_codes WHERE code = ? COLLATE NOCASE`,
+      args: [code],
+    });
+  }
   if (promoRes.rows.length === 0) {
     throw new PromoRedemptionError(404, 'CODE_NOT_FOUND', 'Promo code not found');
   }
@@ -159,9 +174,18 @@ async function redeemPromoInTransaction(
     );
   }
 
-  // 원자 claim: 활성·유효창·총 상한·사용자당 1회·그룹당 1회 를 한 문장으로 gate 한다.
-  // SQLite/libSQL 단일 라이터에서 동시 사용 중 상한 초과가 발생하지 않는다.
+  // 원자 claim: 활성·유효창·총 상한·사용자당 1회·(그룹 코드면) 그룹당 1회 를 한 문장으로
+  // gate 한다. SQLite/libSQL 단일 라이터에서 동시 사용 중 상한 초과가 발생하지 않는다.
+  // 그룹 절은 이 코드가 그룹을 가질 때만 붙인다 — 그룹 코드는 #72 이후에만 존재하므로
+  // redemption_group 컬럼이 없는 배포 창에서 이 SQL 이 컬럼을 참조하는 일도 없다.
   const redemptionId = crypto.randomUUID();
+  const groupClause = redemptionGroup
+    ? `AND NOT EXISTS (
+         SELECT 1 FROM promo_code_redemptions r
+         JOIN promo_codes pg ON pg.id = r.promo_code_id
+         WHERE r.user_id = ? AND pg.redemption_group = ?
+       )`
+    : '';
   const claim = await db.execute({
     sql: `INSERT INTO promo_code_redemptions (id, promo_code_id, user_id, redeemed_at)
           SELECT ?, ?, ?, ?
@@ -179,13 +203,7 @@ async function redeemPromoInTransaction(
           AND NOT EXISTS (
             SELECT 1 FROM promo_code_redemptions WHERE promo_code_id = ? AND user_id = ?
           )
-          AND NOT EXISTS (
-            SELECT 1 FROM promo_code_redemptions r
-            JOIN promo_codes pg ON pg.id = r.promo_code_id
-            WHERE r.user_id = ?
-              AND pg.redemption_group IS NOT NULL
-              AND pg.redemption_group = (SELECT redemption_group FROM promo_codes WHERE id = ?)
-          )`,
+          ${groupClause}`,
     args: [
       redemptionId,
       promoId,
@@ -194,8 +212,7 @@ async function redeemPromoInTransaction(
       promoId,
       promoId,
       params.userPk,
-      params.userPk,
-      promoId,
+      ...(redemptionGroup ? [params.userPk, redemptionGroup] : []),
     ],
   });
   if ((claim.rowsAffected ?? 0) === 0) {

--- a/packages/backend/src/lib/promo-redemption.ts
+++ b/packages/backend/src/lib/promo-redemption.ts
@@ -62,7 +62,8 @@ async function redeemPromoInTransaction(
 
   // 코드 매칭은 대소문자 무시(발급 시 UNIQUE 도 NOCASE).
   const promoRes = await db.execute({
-    sql: `SELECT id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active
+    sql: `SELECT id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions,
+                 is_active, redemption_group
           FROM promo_codes WHERE code = ? COLLATE NOCASE`,
     args: [code],
   });
@@ -109,6 +110,27 @@ async function redeemPromoInTransaction(
     );
   }
 
+  // 리딤 그룹(예: 웰컴 3종) 규칙: 같은 group 의 어떤 코드든 이미 사용한 계정은 다른 코드도
+  // 사용할 수 없다 — 개인/커플/가족 웰컴을 갈아타며 무한 연장하는 것을 막는다. 여기는
+  // 사용자 친화 에러 목적의 사전 검사이고, 최종 판정은 아래 원자 claim 이 담당한다.
+  const redemptionGroup = (promo.redemption_group as string | null) ?? null;
+  if (redemptionGroup) {
+    const groupDupRes = await db.execute({
+      sql: `SELECT 1 FROM promo_code_redemptions r
+            JOIN promo_codes pg ON pg.id = r.promo_code_id
+            WHERE r.user_id = ? AND pg.redemption_group = ?
+            LIMIT 1`,
+      args: [params.userPk, redemptionGroup],
+    });
+    if (groupDupRes.rows.length > 0) {
+      throw new PromoRedemptionError(
+        409,
+        'CODE_GROUP_ALREADY_REDEEMED',
+        'You already redeemed a code from this promotion',
+      );
+    }
+  }
+
   const planRes = await db.execute({
     sql: `SELECT id, key, name, plan_type, max_members FROM plans WHERE id = ? AND is_active = 1`,
     args: [planId],
@@ -137,8 +159,8 @@ async function redeemPromoInTransaction(
     );
   }
 
-  // 원자 claim: 활성·유효창·총 상한·사용자당 1회 를 한 문장으로 gate 한다. SQLite/libSQL
-  // 단일 라이터에서 동시 사용 중 상한 초과가 발생하지 않는다.
+  // 원자 claim: 활성·유효창·총 상한·사용자당 1회·그룹당 1회 를 한 문장으로 gate 한다.
+  // SQLite/libSQL 단일 라이터에서 동시 사용 중 상한 초과가 발생하지 않는다.
   const redemptionId = crypto.randomUUID();
   const claim = await db.execute({
     sql: `INSERT INTO promo_code_redemptions (id, promo_code_id, user_id, redeemed_at)
@@ -156,8 +178,25 @@ async function redeemPromoInTransaction(
           )
           AND NOT EXISTS (
             SELECT 1 FROM promo_code_redemptions WHERE promo_code_id = ? AND user_id = ?
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM promo_code_redemptions r
+            JOIN promo_codes pg ON pg.id = r.promo_code_id
+            WHERE r.user_id = ?
+              AND pg.redemption_group IS NOT NULL
+              AND pg.redemption_group = (SELECT redemption_group FROM promo_codes WHERE id = ?)
           )`,
-    args: [redemptionId, promoId, params.userPk, now.toISOString(), promoId, promoId, params.userPk],
+    args: [
+      redemptionId,
+      promoId,
+      params.userPk,
+      now.toISOString(),
+      promoId,
+      promoId,
+      params.userPk,
+      params.userPk,
+      promoId,
+    ],
   });
   if ((claim.rowsAffected ?? 0) === 0) {
     throw new PromoRedemptionError(409, 'CODE_EXHAUSTED', 'Promo code is no longer redeemable');

--- a/packages/backend/src/routes/admin.ts
+++ b/packages/backend/src/routes/admin.ts
@@ -113,7 +113,7 @@ admin.get('/promo', async (c) => {
   });
   const codesRes = await db.execute({
     sql: `SELECT p.id, p.code, p.duration_days, p.valid_from, p.valid_until,
-                 p.max_redemptions, p.is_active, p.note, p.created_at,
+                 p.max_redemptions, p.is_active, p.note, p.created_at, p.redemption_group,
                  pl.key AS plan_key, pl.name AS plan_name,
                  (SELECT COUNT(*) FROM promo_code_redemptions r WHERE r.promo_code_id = p.id) AS used
           FROM promo_codes p
@@ -141,6 +141,7 @@ admin.get('/promo', async (c) => {
         <td>${escapeHtml(r.duration_days)}일</td>
         <td>${escapeHtml(r.used)} / ${max}</td>
         <td>${from}<br>~ ${until}</td>
+        <td>${r.redemption_group ? `<code>${escapeHtml(r.redemption_group)}</code>` : '—'}</td>
         <td>${active ? '✅' : '⛔'}</td>
         <td class="muted">${escapeHtml(r.note ?? '')}</td>
         <td>
@@ -180,6 +181,9 @@ ${renderMsg(c)}
   </label>
   <input type="hidden" name="valid_from">
   <input type="hidden" name="valid_until">
+  <label>리딤 그룹(빈칸=없음)
+    <input name="redemption_group" placeholder="예: welcome" maxlength="64" autocomplete="off">
+  </label>
   <label class="full">메모(관리용)
     <input name="note" placeholder="예: 6월 런칭 프로모" maxlength="200">
   </label>
@@ -187,8 +191,8 @@ ${renderMsg(c)}
 </form>
 <h2>발급된 코드</h2>
 <table>
-  <thead><tr><th>코드</th><th>플랜</th><th>기간</th><th>사용/상한</th><th>유효창</th><th>활성</th><th>메모</th><th></th></tr></thead>
-  <tbody>${rows || '<tr><td colspan="8" class="muted">아직 발급된 코드가 없습니다.</td></tr>'}</tbody>
+  <thead><tr><th>코드</th><th>플랜</th><th>기간</th><th>사용/상한</th><th>유효창</th><th>그룹</th><th>활성</th><th>메모</th><th></th></tr></thead>
+  <tbody>${rows || '<tr><td colspan="9" class="muted">아직 발급된 코드가 없습니다.</td></tr>'}</tbody>
 </table>
 <script>
 (function () {
@@ -222,6 +226,8 @@ admin.post('/promo', async (c) => {
     const validFrom = String(form.valid_from ?? '').trim() || null;
     const validUntil = String(form.valid_until ?? '').trim() || null;
     const note = String(form.note ?? '').trim() || null;
+    // 리딤 그룹: 같은 그룹의 코드는 계정당 통틀어 1회만 사용 가능(예: 웰컴 3종).
+    const redemptionGroup = String(form.redemption_group ?? '').trim() || null;
 
     if (!code) return c.redirect('/admin/promo?err=' + encodeURIComponent('코드를 입력하세요'), 303);
     if (!Number.isInteger(durationDays) || durationDays <= 0) {
@@ -247,9 +253,19 @@ admin.post('/promo', async (c) => {
 
     await db.execute({
       sql: `INSERT INTO promo_codes
-              (id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active, note)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)`,
-      args: [crypto.randomUUID(), code, plan.id, durationDays, validFrom, validUntil, maxRedemptions, note],
+              (id, code, plan_id, duration_days, valid_from, valid_until, max_redemptions, is_active, note, redemption_group)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+      args: [
+        crypto.randomUUID(),
+        code,
+        plan.id,
+        durationDays,
+        validFrom,
+        validUntil,
+        maxRedemptions,
+        note,
+        redemptionGroup,
+      ],
     });
     return c.redirect('/admin/promo?ok=' + encodeURIComponent('코드 발급 완료: ' + code), 303);
   } catch (err) {

--- a/packages/backend/test/promo-welcome-group.test.ts
+++ b/packages/backend/test/promo-welcome-group.test.ts
@@ -1,0 +1,96 @@
+// 마이그레이션 #72(웰컴 프로모 3종 + redemption_group) 실동작 검증 — 실제 libsql 파일 DB 에
+// 전체 마이그레이션을 올리고 redeemPromoCode 실경로로:
+//  1) 시드 3종(개인/커플/가족, 30일, group=welcome)이 존재하는지,
+//  2) 웰컴 계열은 '계정당 통틀어 1회'인지(개인 사용 후 커플/가족 불가),
+//  3) 그룹 없는 일반 코드는 웰컴 사용 여부와 무관하게 코드별 1회 규칙만 적용되는지 확인한다.
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createClient, type Client } from '@libsql/client';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations } from '../src/lib/migrations';
+import { redeemPromoCode, PromoRedemptionError } from '../src/lib/promo-redemption';
+
+const DB_PATH = join(tmpdir(), 'alarmtalk-promo-welcome-group.db');
+// 리딤이 만드는 plan_groups/subscriptions 의 FK 그래프가 넓어 부분 정리가 취약하다 —
+// 항상 새 파일 DB 로 시작해 이전 실행 잔재를 원천 제거한다.
+rmSync(DB_PATH, { force: true });
+const db: Client = createClient({ url: `file:${DB_PATH}` });
+
+async function insertUser(id: string) {
+  await db.execute({
+    sql: 'INSERT OR IGNORE INTO users (id, google_id, email) VALUES (?, ?, ?)',
+    args: [id, id, `${id}@test`],
+  });
+}
+
+async function redeem(userPk: string, code: string) {
+  return redeemPromoCode(db, { userPk, rawCode: code });
+}
+
+async function expectPromoError(promise: Promise<unknown>, errorCode: string) {
+  try {
+    await promise;
+    throw new Error(`expected PromoRedemptionError(${errorCode}) but resolved`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(PromoRedemptionError);
+    expect((err as PromoRedemptionError).errorCode).toBe(errorCode);
+  }
+}
+
+beforeAll(async () => {
+  await runMigrations(db);
+  for (const u of ['pw-a', 'pw-b', 'pw-c']) await insertUser(u);
+  // 그룹 없는 일반 코드 1개 (대조군)
+  await db.execute(
+    `INSERT INTO promo_codes (id, code, plan_id, duration_days, is_active)
+     SELECT 'pw-plain-id', 'PLAIN_TEST_CODE', id, 7, 1 FROM plans WHERE key = 'personal'`,
+  );
+});
+
+describe('마이그레이션 #72 — 웰컴 프로모 시드', () => {
+  it('개인/커플/가족 3종이 30일·group=welcome·활성으로 시드된다', async () => {
+    const res = await db.execute(
+      `SELECT p.code, pl.key AS plan_key, p.duration_days, p.redemption_group, p.is_active, p.max_redemptions
+       FROM promo_codes p JOIN plans pl ON pl.id = p.plan_id
+       WHERE p.redemption_group = 'welcome' ORDER BY p.code`,
+    );
+    expect(res.rows.map((r) => [r.code, r.plan_key, Number(r.duration_days), Number(r.is_active)])).toEqual([
+      ['WELCOME_COUPLE', 'couple', 30, 1],
+      ['WELCOME_FAMILY', 'family', 30, 1],
+      ['WELCOME_PERSONAL', 'personal', 30, 1],
+    ]);
+  });
+});
+
+describe('웰컴 계열 계정당 1회 규칙', () => {
+  it('WELCOME_PERSONAL 사용 → 30일 personal 구독, 같은 코드 재사용 불가', async () => {
+    const result = await redeem('pw-a', 'WELCOME_PERSONAL');
+    expect(result.plan.key).toBe('personal');
+    expect(result.promo.duration_days).toBe(30);
+    await expectPromoError(redeem('pw-a', 'WELCOME_PERSONAL'), 'CODE_ALREADY_REDEEMED_BY_YOU');
+  });
+
+  it('웰컴을 이미 쓴 계정은 다른 웰컴 코드(커플/가족)도 불가', async () => {
+    await expectPromoError(redeem('pw-a', 'WELCOME_COUPLE'), 'CODE_GROUP_ALREADY_REDEEMED');
+    await expectPromoError(redeem('pw-a', 'WELCOME_FAMILY'), 'CODE_GROUP_ALREADY_REDEEMED');
+  });
+
+  it('대소문자를 바꿔도(welcome_couple) 그룹 규칙을 우회할 수 없다', async () => {
+    await expectPromoError(redeem('pw-a', 'welcome_couple'), 'CODE_GROUP_ALREADY_REDEEMED');
+  });
+
+  it('다른 계정은 자기 몫의 웰컴 1회를 정상 사용할 수 있다', async () => {
+    const result = await redeem('pw-b', 'WELCOME_FAMILY');
+    expect(result.plan.key).toBe('family');
+  });
+
+  it('그룹 없는 일반 코드는 웰컴 사용 여부와 무관하게 사용 가능(코드별 1회만 적용)', async () => {
+    const result = await redeem('pw-c', 'WELCOME_COUPLE');
+    expect(result.plan.key).toBe('couple');
+    // 웰컴을 쓴 계정도 일반 코드는 사용 가능
+    const plain = await redeem('pw-c', 'PLAIN_TEST_CODE');
+    expect(plain.plan.key).toBe('personal');
+    await expectPromoError(redeem('pw-c', 'PLAIN_TEST_CODE'), 'CODE_ALREADY_REDEEMED_BY_YOU');
+  });
+});

--- a/packages/backend/test/promo-welcome-group.test.ts
+++ b/packages/backend/test/promo-welcome-group.test.ts
@@ -8,7 +8,7 @@ import { createClient, type Client } from '@libsql/client';
 import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runMigrations } from '../src/lib/migrations';
+import { runMigrations, runMigrationsRange } from '../src/lib/migrations';
 import { redeemPromoCode, PromoRedemptionError } from '../src/lib/promo-redemption';
 
 const DB_PATH = join(tmpdir(), 'alarmtalk-promo-welcome-group.db');
@@ -92,5 +92,35 @@ describe('웰컴 계열 계정당 1회 규칙', () => {
     const plain = await redeem('pw-c', 'PLAIN_TEST_CODE');
     expect(plain.plan.key).toBe('personal');
     await expectPromoError(redeem('pw-c', 'PLAIN_TEST_CODE'), 'CODE_ALREADY_REDEEMED_BY_YOU');
+  });
+});
+
+describe('배포→마이그레이션 창 호환 (#72 적용 전 스키마)', () => {
+  // deploy-backend.yml 이 배포 후 마이그레이션을 돌리므로, 새 코드가 redemption_group 컬럼이
+  // 없는 DB(#71까지만 적용)를 만나도 리딤이 500 나지 않고 레거시 규칙으로 동작해야 한다.
+  it('redemption_group 컬럼이 없어도 리딤이 정상 동작한다(레거시 폴백)', async () => {
+    const LEGACY_PATH = join(tmpdir(), 'alarmtalk-promo-legacy-schema.db');
+    rmSync(LEGACY_PATH, { force: true });
+    const legacyDb = createClient({ url: `file:${LEGACY_PATH}` });
+    await runMigrationsRange(legacyDb, 1, 71);
+    await legacyDb.execute({
+      sql: 'INSERT INTO users (id, google_id, email) VALUES (?, ?, ?)',
+      args: ['legacy-u', 'legacy-u', 'legacy@test'],
+    });
+    await legacyDb.execute(
+      `INSERT INTO promo_codes (id, code, plan_id, duration_days, is_active)
+       SELECT 'legacy-code-id', 'LEGACY_WINDOW_CODE', id, 7, 1 FROM plans WHERE key = 'personal'`,
+    );
+
+    const result = await redeemPromoCode(legacyDb, {
+      userPk: 'legacy-u',
+      rawCode: 'LEGACY_WINDOW_CODE',
+    });
+    expect(result.plan.key).toBe('personal');
+    await expectPromoError(
+      redeemPromoCode(legacyDb, { userPk: 'legacy-u', rawCode: 'LEGACY_WINDOW_CODE' }),
+      'CODE_ALREADY_REDEEMED_BY_YOU',
+    );
+    legacyDb.close();
   });
 });


### PR DESCRIPTION
WELCOME_PERSONAL/COUPLE/FAMILY 각 30일 시드(마이그레이션 #72) + redemption_group 규칙(같은 그룹 코드는 계정당 통틀어 1회 — 원자 claim 게이트). admin 폼·목록 그룹 지원, Android 에러 문구 3언어. 실DB 테스트 6건. 백엔드 1527·Android 테스트/린트 그린.