### PR TITLE
fix: #72 웰컴 시드 동명 충돌 수렴 (Codex #575 P2)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1556,10 +1556,17 @@ export const migrations: Migration[] = [
        SELECT '90000000-0000-4000-9000-000000000003', 'WELCOME_FAMILY', id, 30, NULL, NULL, NULL, 1,
               '웰컴 프로모 — 패밀리 1개월 (웰컴 계열 계정당 1회)', 'welcome'
        FROM plans WHERE key = 'family'`,
-      // 운영자가 이 마이그레이션 전에 같은 이름(대소문자 무관)의 코드를 이미 발급해뒀다면
-      // 위 INSERT OR IGNORE 는 그 행을 건드리지 않아 redemption_group 이 NULL 로 남는다 —
-      // 그러면 그 코드만 웰컴 1회 규칙에서 빠진다. 이름이 충돌하는 기존 행에도 그룹을
-      // 스탬프해 수렴시킨다(그 외 컬럼은 운영자 설정 존중).
+    ],
+  },
+  {
+    // #72 의 INSERT OR IGNORE 는 운영자가 그 전에 같은 이름(대소문자 무관)의 코드를 이미
+    // 발급해뒀으면 그 행을 건드리지 않아 redemption_group 이 NULL 로 남는다 — 그 코드만
+    // 웰컴 1회 규칙에서 빠진다. 이름 충돌 행에 그룹을 스탬프해 수렴시킨다(기간·상한 등
+    // 운영자 설정은 존중). #72 를 고치지 않고 별도 마이그레이션으로 두는 이유: #72 는 이미
+    // 적용된 DB(원장 기록)가 있어 본문을 바꿔도 재실행되지 않는다 — 백필은 새 id 로 돌린다.
+    id: 73,
+    name: 'promo-welcome-group-backfill',
+    statements: [
       `UPDATE promo_codes SET redemption_group = 'welcome', updated_at = datetime('now')
        WHERE code COLLATE NOCASE IN ('WELCOME_PERSONAL', 'WELCOME_COUPLE', 'WELCOME_FAMILY')
          AND redemption_group IS NULL`,

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1556,6 +1556,13 @@ export const migrations: Migration[] = [
        SELECT '90000000-0000-4000-9000-000000000003', 'WELCOME_FAMILY', id, 30, NULL, NULL, NULL, 1,
               '웰컴 프로모 — 패밀리 1개월 (웰컴 계열 계정당 1회)', 'welcome'
        FROM plans WHERE key = 'family'`,
+      // 운영자가 이 마이그레이션 전에 같은 이름(대소문자 무관)의 코드를 이미 발급해뒀다면
+      // 위 INSERT OR IGNORE 는 그 행을 건드리지 않아 redemption_group 이 NULL 로 남는다 —
+      // 그러면 그 코드만 웰컴 1회 규칙에서 빠진다. 이름이 충돌하는 기존 행에도 그룹을
+      // 스탬프해 수렴시킨다(그 외 컬럼은 운영자 설정 존중).
+      `UPDATE promo_codes SET redemption_group = 'welcome', updated_at = datetime('now')
+       WHERE code COLLATE NOCASE IN ('WELCOME_PERSONAL', 'WELCOME_COUPLE', 'WELCOME_FAMILY')
+         AND redemption_group IS NULL`,
     ],
   },
 ];

--- a/packages/backend/test/promo-welcome-group.test.ts
+++ b/packages/backend/test/promo-welcome-group.test.ts
@@ -106,7 +106,7 @@ describe('마이그레이션 #72 — 기존 동명 코드 충돌 수렴', () => 
       `INSERT INTO promo_codes (id, code, plan_id, duration_days, is_active)
        SELECT 'op-issued', 'welcome_personal', id, 14, 1 FROM plans WHERE key = 'personal'`,
     );
-    await runMigrationsRange(collideDb, 72, 72);
+    await runMigrationsRange(collideDb, 72, 73);
 
     const row = await collideDb.execute(
       `SELECT code, duration_days, redemption_group FROM promo_codes

--- a/packages/backend/test/promo-welcome-group.test.ts
+++ b/packages/backend/test/promo-welcome-group.test.ts
@@ -95,6 +95,36 @@ describe('웰컴 계열 계정당 1회 규칙', () => {
   });
 });
 
+describe('마이그레이션 #72 — 기존 동명 코드 충돌 수렴', () => {
+  it('운영자가 미리 발급해둔 동명 코드(대소문자 달라도)에 그룹이 스탬프된다', async () => {
+    const COLLIDE_PATH = join(tmpdir(), 'alarmtalk-promo-collide.db');
+    rmSync(COLLIDE_PATH, { force: true });
+    const collideDb = createClient({ url: `file:${COLLIDE_PATH}` });
+    await runMigrationsRange(collideDb, 1, 71);
+    // 마이그레이션 전 운영자 발급 시나리오: 소문자·그룹 없음·기간 14일(운영자 설정)
+    await collideDb.execute(
+      `INSERT INTO promo_codes (id, code, plan_id, duration_days, is_active)
+       SELECT 'op-issued', 'welcome_personal', id, 14, 1 FROM plans WHERE key = 'personal'`,
+    );
+    await runMigrationsRange(collideDb, 72, 72);
+
+    const row = await collideDb.execute(
+      `SELECT code, duration_days, redemption_group FROM promo_codes
+       WHERE code = 'welcome_personal' COLLATE NOCASE AND id = 'op-issued'`,
+    );
+    // INSERT OR IGNORE 가 기존 행을 존중하되(기간 14일 유지), 그룹은 스탬프돼 웰컴 규칙에 포함.
+    expect(row.rows).toHaveLength(1);
+    expect(Number(row.rows[0]!.duration_days)).toBe(14);
+    expect(row.rows[0]!.redemption_group).toBe('welcome');
+    // NOCASE 유니크라 시드가 중복 행을 만들지 않는다 — 나머지 2종만 새로 생긴다.
+    const count = await collideDb.execute(
+      `SELECT COUNT(*) AS n FROM promo_codes WHERE redemption_group = 'welcome'`,
+    );
+    expect(Number(count.rows[0]!.n)).toBe(3);
+    collideDb.close();
+  });
+});
+
 describe('배포→마이그레이션 창 호환 (#72 적용 전 스키마)', () => {
   // deploy-backend.yml 이 배포 후 마이그레이션을 돌리므로, 새 코드가 redemption_group 컬럼이
   // 없는 DB(#71까지만 적용)를 만나도 리딤이 500 나지 않고 레거시 규칙으로 동작해야 한다.


### PR DESCRIPTION
기존 동명 코드가 있어도 redemption_group 이 스탬프돼 웰컴 계정당 1회 규칙에 포함되도록 수렴 UPDATE 추가. 충돌 시나리오 실DB 테스트 포함. 백엔드 1532 그린.