### PR TITLE
feat: 웰컴 코드 등록기한 2026-08-31 (마이그레이션 #74)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1572,6 +1572,19 @@ export const migrations: Migration[] = [
          AND redemption_group IS NULL`,
     ],
   },
+  {
+    // 웰컴 3종 등록기한: 2026-08-31(KST)까지 — 2026-08-31T15:00:00Z = 2026-09-01 00:00 KST 부터
+    // 등록 불가(valid_until 은 배타 비교: datetime(valid_until) > datetime('now') 일 때만 허용).
+    // #72 시드는 이미 dev 에 적용돼 본문을 바꿀 수 없으므로(불변) 별도 스탬프로 수렴한다.
+    // valid_until IS NULL 조건: 운영자가 이후 admin 에서 기한을 조정했다면 존중한다.
+    id: 74,
+    name: 'promo-welcome-deadline-2026-08-31',
+    statements: [
+      `UPDATE promo_codes SET valid_until = '2026-08-31T15:00:00Z', updated_at = datetime('now')
+       WHERE code COLLATE NOCASE IN ('WELCOME_PERSONAL', 'WELCOME_COUPLE', 'WELCOME_FAMILY')
+         AND valid_until IS NULL`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/test/promo-welcome-group.test.ts
+++ b/packages/backend/test/promo-welcome-group.test.ts
@@ -184,3 +184,26 @@ describe('배포→마이그레이션 창 호환 (#72 적용 전 스키마)', ()
     legacyDb.close();
   });
 });
+
+describe('마이그레이션 #74 — 웰컴 등록기한 (2026-08-31 KST 까지)', () => {
+  it('웰컴 3종의 valid_until 이 2026-08-31T15:00:00Z(= 9/1 00:00 KST)로 스탬프된다', async () => {
+    const res = await db.execute(
+      `SELECT code, valid_until FROM promo_codes WHERE redemption_group = 'welcome' ORDER BY code`,
+    );
+    expect(res.rows).toHaveLength(3);
+    for (const r of res.rows) {
+      expect(r.valid_until).toBe('2026-08-31T15:00:00Z');
+    }
+  });
+
+  it('기한이 지난 웰컴 코드는 CODE_NOT_IN_WINDOW 로 거부된다', async () => {
+    // datetime('now') 는 주입할 수 없으므로 이미 지난 기한의 웰컴 그룹 코드로 윈도우 판정을 검증.
+    await db.execute(
+      `INSERT INTO promo_codes (id, code, plan_id, duration_days, is_active, valid_until, redemption_group)
+       SELECT 'pw-expired', 'WELCOME_EXPIRED_TEST', id, 30, 1, '2020-01-01T00:00:00Z', 'welcome'
+       FROM plans WHERE key = 'personal'`,
+    );
+    await insertUser('pw-d');
+    await expectPromoError(redeem('pw-d', 'WELCOME_EXPIRED_TEST'), 'CODE_NOT_IN_WINDOW');
+  });
+});


### PR DESCRIPTION
웰컴 3종의 valid_until 을 2026-08-31T15:00:00Z(= 9/1 00:00 KST)로 스탬프. 기존 유효창 검사(사전검사+원자 claim)가 그대로 기한을 집행하므로 코드 변경 없이 데이터만 수렴. 테스트 2건 추가, 백엔드 1534 그린.