### PR TITLE
chore: versionName 1.0.0 — 정식 출시 버전

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -99,7 +99,7 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 11
+        versionCode = 12
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -100,7 +100,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 11
-        versionName = "0.1.3"
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
프로덕션 첫 출시에 맞춰 사용자 노출 버전을 1.0.0 으로. versionCode 는 11 유지(Play 미등록 상태라 충돌 없음). 코드 변경 없음.