### PR TITLE
fix: 랜딩 자막 = 음성 대사 3문장 전체 (출시 반영)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -506,8 +506,9 @@ private fun VoicePreviewCard(accent: Color) {
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = TextOnScene,
-                    // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 그대로.
-                    maxLines = 3,
+                    // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 그대로. 좁은 기기(360dp)
+                    // 에서는 문장이 줄바꿈돼 논리 3줄이 시각 4~5줄이 되므로 줄 수 제한을 두지 않는다
+                    // — 어떤 로케일에서도 마지막 당부 문장이 잘리지 않아야 한다.
                 )
                 MiniWaveform(progress = progress, accent = accent)
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlin.math.PI
@@ -507,8 +508,11 @@ private fun VoicePreviewCard(accent: Color) {
                     fontWeight = FontWeight.Medium,
                     color = TextOnScene,
                     // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 그대로. 좁은 기기(360dp)
-                    // 에서는 문장이 줄바꿈돼 논리 3줄이 시각 4~5줄이 되므로 줄 수 제한을 두지 않는다
-                    // — 어떤 로케일에서도 마지막 당부 문장이 잘리지 않아야 한다.
+                    // 에서는 줄바꿈으로 논리 3줄이 시각 4~5줄이 되므로 상한을 6으로 잡는다 — 일반
+                    // 환경·전 로케일에서 전문이 다 보이고, 접근성 글꼴 확대/멀티윈도우 같은 극단
+                    // 케이스에서만 말줄임돼 비스크롤 랜딩의 '시작하기' CTA 가 화면 밖으로 밀리지 않는다.
+                    maxLines = 6,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 MiniWaveform(progress = progress, accent = accent)
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -12,7 +12,11 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -54,7 +58,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlin.math.PI
@@ -144,34 +147,50 @@ internal fun LandingScreen(
                     bottom = contentPadding.calculateBottomPadding() + 22.dp,
                 ),
         ) {
-            Text(
-                text = "AlarmTalk",
-                modifier = Modifier.padding(top = 18.dp),
-                style = MaterialTheme.typography.titleLarge,
-                color = TextOnScene.copy(alpha = 0.94f),
-                fontWeight = FontWeight.Bold,
-            )
-            Spacer(Modifier.weight(1f))
-            Text(
-                text = buildAnnotatedString {
-                    append(stringResource(R.string.auth_landing_headline_pre))
-                    withStyle(SpanStyle(color = BrandAccentOnScene, fontWeight = FontWeight.Bold)) {
-                        append(stringResource(R.string.auth_landing_headline_keyword))
+            // 접근성 글꼴 확대/좁은 멀티윈도우에서 히어로+미리듣기 카드가 화면보다 커져도
+            // '시작하기' CTA 는 아래에 고정으로 남도록, CTA 위 영역만 스크롤 가능하게 둔다.
+            // 공간이 충분한 일반 화면에서는 heightIn(min=뷰포트) + SpaceBetween 이 기존과 동일한
+            // '타이틀 상단·히어로 하단' 배치를 재현하고 스크롤도 생기지 않는다.
+            BoxWithConstraints(Modifier.weight(1f)) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .heightIn(min = this.maxHeight),
+                    verticalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = "AlarmTalk",
+                        modifier = Modifier.padding(top = 18.dp),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = TextOnScene.copy(alpha = 0.94f),
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Column {
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            text = buildAnnotatedString {
+                                append(stringResource(R.string.auth_landing_headline_pre))
+                                withStyle(SpanStyle(color = BrandAccentOnScene, fontWeight = FontWeight.Bold)) {
+                                    append(stringResource(R.string.auth_landing_headline_keyword))
+                                }
+                                append(stringResource(R.string.auth_landing_headline_post))
+                            },
+                            style = MaterialTheme.typography.headlineLarge,
+                            color = TextOnScene,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(Modifier.height(10.dp))
+                        Text(
+                            text = stringResource(R.string.auth_landing_subcopy),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextOnSceneDim,
+                        )
+                        Spacer(Modifier.height(20.dp))
+                        VoicePreviewCard(accent = BrandAccentOnScene)
                     }
-                    append(stringResource(R.string.auth_landing_headline_post))
-                },
-                style = MaterialTheme.typography.headlineLarge,
-                color = TextOnScene,
-                fontWeight = FontWeight.Bold,
-            )
-            Spacer(Modifier.height(10.dp))
-            Text(
-                text = stringResource(R.string.auth_landing_subcopy),
-                style = MaterialTheme.typography.bodyMedium,
-                color = TextOnSceneDim,
-            )
-            Spacer(Modifier.height(20.dp))
-            VoicePreviewCard(accent = BrandAccentOnScene)
+                }
+            }
             Spacer(Modifier.height(18.dp))
             GradientCta(
                 text = stringResource(R.string.auth_landing_get_started),
@@ -507,12 +526,9 @@ private fun VoicePreviewCard(accent: Color) {
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = TextOnScene,
-                    // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 그대로. 좁은 기기(360dp)
-                    // 에서는 줄바꿈으로 논리 3줄이 시각 4~5줄이 되므로 상한을 6으로 잡는다 — 일반
-                    // 환경·전 로케일에서 전문이 다 보이고, 접근성 글꼴 확대/멀티윈도우 같은 극단
-                    // 케이스에서만 말줄임돼 비스크롤 랜딩의 '시작하기' CTA 가 화면 밖으로 밀리지 않는다.
-                    maxLines = 6,
-                    overflow = TextOverflow.Ellipsis,
+                    // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 전문. 줄 수 제한 없음 —
+                    // 카드가 커지는 극단 케이스(접근성 확대 등)는 랜딩 콘텐츠 영역 스크롤이 흡수하고
+                    // '시작하기' CTA 는 스크롤 밖에 고정이라 항상 도달 가능하다.
                 )
                 MiniWaveform(progress = progress, accent = accent)
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/LandingScreen.kt
@@ -506,7 +506,8 @@ private fun VoicePreviewCard(accent: Color) {
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = TextOnScene,
-                    maxLines = 2,
+                    // 자막 = 실제 미리듣기 음성 대사 3문장(인사·날씨·당부) 그대로.
+                    maxLines = 3,
                 )
                 MiniWaveform(progress = progress, accent = accent)
             }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -50,7 +50,7 @@
     <string name="auth_landing_login_with_email">Log in with email</string>
     <string name="auth_landing_preview_pause">Pause preview</string>
     <string name="auth_landing_preview_play">Preview voice</string>
-    <string name="auth_landing_sample_message">Good morning, Grandpa\nTake your umbrella when you go out!</string>
+    <string name="auth_landing_sample_message">Good morning, Grandpa\nRain is in the forecast for Seoul today\nTake your umbrella when you go out!</string>
     <string name="auth_password_hide">Hide password</string>
     <string name="auth_password_mismatch">Passwords don\'t match.</string>
     <string name="auth_password_rule_alnum">Letters and numbers</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -50,7 +50,7 @@
     <string name="auth_landing_login_with_email">メールでログイン</string>
     <string name="auth_landing_preview_pause">プレビューを一時停止</string>
     <string name="auth_landing_preview_play">声をプレビュー</string>
-    <string name="auth_landing_sample_message">おじいちゃん、おはようございます\n出かけるときは傘を忘れずに</string>
+    <string name="auth_landing_sample_message">おじいちゃん、おはようございます\n今日はソウルで雨の予報です\n出かけるときは傘を忘れずに</string>
     <string name="auth_password_hide">パスワードを隠す</string>
     <string name="auth_password_mismatch">パスワードが一致しません。</string>
     <string name="auth_password_rule_alnum">英字と数字を含む</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <string name="auth_landing_login_with_email">이메일로 로그인</string>
     <string name="auth_landing_preview_pause">미리듣기 일시정지</string>
     <string name="auth_landing_preview_play">목소리 미리듣기</string>
-    <string name="auth_landing_sample_message">할아버지, 좋은 아침이에요\n나가실 때 우산 꼭 챙기세요</string>
+    <string name="auth_landing_sample_message">할아버지, 좋은 아침이에요\n오늘은 서울에 비가 예보되어 있어요\n나가실 때 우산 꼭 챙기세요</string>
     <string name="auth_password_hide">비밀번호 숨기기</string>
     <string name="auth_password_mismatch">비밀번호가 일치하지 않아요.</string>
     <string name="auth_password_rule_alnum">영문·숫자 포함</string>


### PR DESCRIPTION
미리듣기 음성이 말하는 3문장(할아버지 인사·서울 비 예보·우산 당부)을 자막에 그대로 표기(ko/en/ja) + maxLines 2→3. 1.0.0 출시 AAB에 포함 예정 — #582 는 이 PR 머지 후 갱신·재리뷰.