### PR TITLE
fix: 엣지투엣지 마이그레이션 + 지원중단 시스템바 색 API 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ test/*
 !apps/android-native/**/res/raw/**
 
 handoff
+# 로컬 전용(커밋 안 함): omo 툴 스크래치, 목소리 프리뷰 클립(30MB, 로컬 청취용)
+.omo/
+voice-preview/

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/MainActivity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 
 class MainActivity : ComponentActivity() {
@@ -16,6 +17,11 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // SDK 35 는 Android 15+ 에서 엣지투엣지가 기본 강제다. enableEdgeToEdge() 로 하위 버전
+        // (예: Android 13)에서도 동일하게 투명 시스템 바 + 콘텐츠 뒤 그리기를 적용해, 지원중단된
+        // window.statusBarColor/navigationBarColor 없이 일관된 화면을 만든다. 인셋은 앱 전역
+        // Scaffold(contentPadding)가 소비하고, 바 아이콘 명암은 AlarmTalkTheme 이 제어한다.
+        enableEdgeToEdge()
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         inAppUpdateManager = InAppUpdateManager(this, viewModel)
         // 민감정보 보호(보안 감사 대응): 이 액티비티는 이메일·운세 생년월일 등 PII 와

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
@@ -3,7 +3,6 @@ package com.alarmtalk.app
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.os.Build
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -14,7 +13,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -145,17 +143,13 @@ internal fun SceneSystemBars(top: Color, bottom: Color) {
 @Composable
 private fun AppSystemBars(isDark: Boolean) {
     val view = LocalView.current
-    val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
     val override = systemBarsOverride.value
     SideEffect {
         val window = view.context.findActivity()?.window ?: return@SideEffect
-        val status = override?.status?.toArgb() ?: backgroundColor
-        val nav = override?.nav?.toArgb() ?: backgroundColor
-        window.statusBarColor = status
-        window.navigationBarColor = nav
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            window.navigationBarDividerColor = nav
-        }
+        // 시스템 바 배경색은 더 이상 window.statusBarColor/navigationBarColor 로 칠하지 않는다
+        // (Android 15/SDK 35 에서 지원중단·엣지투엣지 강제). MainActivity 의 enableEdgeToEdge()
+        // 로 바가 투명해지고, 그 뒤로 콘텐츠가 그려진다 — 일반 화면은 Scaffold 배경(=background)이,
+        // 씬 화면(랜딩/울림)은 풀블리드 씬이 바 영역까지 채운다. 여기서는 아이콘 명암만 제어한다.
         WindowCompat.getInsetsController(window, view).apply {
             // 씬 오버라이드는 항상 어두운 배경(밝은 아이콘), 아니면 테마 명암을 따른다.
             isAppearanceLightStatusBars = if (override != null) false else !isDark


### PR DESCRIPTION
## Play 콘솔 경고 대응 (대형 화면/Android 15)
- **지원중단 API 제거**: `window.statusBarColor`·`navigationBarColor`·`navigationBarDividerColor`(Android 15 deprecated) 를 `AlarmTalkTheme` 에서 제거 → `enableEdgeToEdge()` + 투명 바 + 아이콘 명암만 제어
- **엣지투엣지 미처리 경고 해소**: MainActivity 에서 `enableEdgeToEdge()` 호출(하위 버전도 일관). 인셋은 앱 전역 Scaffold(contentPadding)가 이미 소비 중이라 안전
- **실기기 검증**: S23U(Android 16·SDK 36)·A32(Android 13) 모두 스크린샷으로 콘텐츠 미절단·씬 풀블리드·아이콘 명암·CTA 도달 확인

## 의도적으로 유지한 것 (경고에 있으나 미수정)
- `screenOrientation=portrait`(Main/Ringing), `resizeableActivity=false`(Ringing): 세로 알람앱 + 잠금화면 풀스크린 울림이라는 **의도된 설계**. Android 16 은 대형 화면에서 이를 무시하므로 태블릿 UX 영향도 제한적이고, 폰에서는 세로 고정이 의도. 태블릿 실기기 없이 무단 제거는 위험 → 별도 프로젝트로 분리
- Firebase `ProtoEncoderDoNotUse`: 서드파티 라이브러리 내부, 수정 불가

## 참고
심사 중인 vc12(1.0.0) 릴리스는 건드리지 않음 — 다음 버전 반영용.