### PR TITLE
fix: 온보딩 목소리 선택 — 대사 숨김 + 선택 후 홈 진입

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -674,13 +674,7 @@ internal fun AlarmTalkApp(
           )
           return@Scaffold
       }
-      // 목소리 선택 직후 실제 알람 에디터를 1회 자동으로 연다 — 별도 온보딩 화면 대신
-      // 진짜 설정 화면(+첫 방문 코치마크)에서 직접 첫 알람을 맞춰보게 한다.
-      LaunchedEffect(viewModel.navigateFirstAlarmEditorTick) {
-          if (viewModel.navigateFirstAlarmEditorTick > 0) {
-              navController.navigate(AppRoute.alarmCreate(familyTargetMode = false))
-          }
-      }
+      // 목소리 선택 후에는 홈(알람 탭)으로 바로 들어간다 — 첫 알람 에디터 자동 진입/코치마크 없앰.
       Box(modifier = Modifier.fillMaxSize()) {
           NavHost(
               navController = navController,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -252,11 +252,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var showVoiceSetup by mutableStateOf(false)
         internal set
 
-    // 목소리 선택 직후 실제 알람 에디터를 1회 자동으로 열기 위한 one-shot 틱.
-    // (별도 온보딩 화면 대신, 진짜 설정 화면 + 첫 방문 코치마크로 첫 알람을 만들게 한다)
-    var navigateFirstAlarmEditorTick by mutableStateOf(0)
-        internal set
-
     // 사용자가 고른 기본 목소리 id(시스템 보이스). 새 알람 에디터 미리선택 + 목소리 탭 표시에 사용.
     var defaultVoiceId by mutableStateOf<String?>(null)
         internal set
@@ -364,13 +359,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /** 온보딩 목소리 스텝에서 기본 목소리를 정했을 때. 기기 설정에 저장하고 스텝을 닫는다.
-     *  (호칭은 따로 받지 않는다 — 시스템 음성 TTS 는 계정 닉네임으로 부른다.) */
+     *  (호칭은 따로 받지 않는다 — 시스템 음성 TTS 는 계정 닉네임으로 부른다.)
+     *  선택 후에는 홈(알람 탭)으로 바로 진입한다 — 첫 알람 에디터 자동 진입/코치마크는 없앴다. */
     fun completeVoiceSetup(voiceId: String) {
         // setDefaultVoice 가 무료 버킷 클립 프리페치까지 함께 태운다(온보딩·목소리 탭 동일 경로).
         setDefaultVoice(voiceId)
         showVoiceSetup = false
-        // 목소리를 고른 흐름에서만 첫 알람 만들기(에디터 자동 진입)로 이어간다(건너뛰기 시엔 홈).
-        navigateFirstAlarmEditorTick++
     }
 
     /** 목소리 스텝을 건너뛸 때(저장 없이 닫기). 나중에 목소리 탭에서 고를 수 있다. */

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/VoiceOnboardingScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/VoiceOnboardingScreen.kt
@@ -30,12 +30,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.alarmtalk.app.network.StockClip
 import com.alarmtalk.app.network.TtsMessageAudioResponse
@@ -67,12 +65,6 @@ internal fun VoiceOnboardingScreen(
         mutableStateOf(systemVoices.firstOrNull()?.id)
     }
     val voiceLoadFinished = voiceProfileLoadFinished && !voiceProfileBusy
-    // greeting 은 3개 언어가 있으므로 앱 언어로 골라야 한다(무필터 firstOrNull 이면 항상 en).
-    val appVoiceLanguage = com.alarmtalk.app.data.appVoiceLanguageOf(
-        LocalConfiguration.current.locales.takeIf { !it.isEmpty }?.get(0)?.language,
-    )
-    fun sampleText(profile: VoiceProfile): String? =
-        com.alarmtalk.app.data.greetingStockClipFor(stockClips, profile.id, appVoiceLanguage)?.text
 
     Column(
         modifier = Modifier
@@ -129,7 +121,6 @@ internal fun VoiceOnboardingScreen(
                     systemVoices.forEach { profile ->
                         VoiceChoiceRow(
                             name = profile.name,
-                            sample = sampleText(profile),
                             selected = profile.id == selectedId,
                             preparing = previewController.preparingVoiceId == profile.id,
                             // 별도 재생 버튼 없이, 카드를 누르면 선택과 동시에 샘플이 재생된다.
@@ -182,7 +173,6 @@ internal fun VoiceOnboardingScreen(
 @Composable
 private fun VoiceChoiceRow(
     name: String,
-    sample: String?,
     selected: Boolean,
     preparing: Boolean,
     onSelect: () -> Unit,
@@ -202,34 +192,17 @@ private fun VoiceChoiceRow(
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 14.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(
+            Text(
+                text = name,
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(3.dp),
-            ) {
-                Text(
-                    text = name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (selected) {
-                        MaterialTheme.colorScheme.onSecondaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    },
-                )
-                if (!sample.isNullOrBlank()) {
-                    Text(
-                        text = sample,
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        color = if (selected) {
-                            MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.78f)
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
-                }
-            }
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+            )
             Spacer(Modifier.width(8.dp))
             // 샘플 준비 중에만 자리 표시 — 평소엔 선택 점만 남겨 카드가 조용하다.
             if (preparing) {


### PR DESCRIPTION
## 변경
1. **목소리 4개 선택 화면에서 대사(greeting 샘플 텍스트) 숨김** — 카드에 목소리 이름 + 선택 점만 표시. 탭 시 오디오 미리듣기는 유지.
2. **선택 후 홈으로 바로 진입** — 코치마크를 없앴으므로 첫 알람 에디터 자동 진입(navigateFirstAlarmEditorTick)을 제거. 선택 즉시 홈(알람 탭).

## 정리
- 죽은 코드 제거: navigateFirstAlarmEditorTick 상태·증가·LaunchedEffect, VoiceChoiceRow sampleText/sample 파라미터, 미사용 import(LocalConfiguration/TextOverflow).

## 검증
- assembleDevDebug · testDevDebugUnitTest · lintDevDebug 통과. 기기 스크린샷 검증은 폰 재연결 후 진행 예정(변경이 단순 UI/nav 제거라 저위험).