### PR TITLE
fix: 목소리 클론 '이 목소리로 할게요' 크래시 수정 + 승격 로딩 표시

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -99,8 +99,8 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 12
-        versionName = "1.0.0"
+        versionCode = 13
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
@@ -191,8 +191,14 @@ internal fun MainViewModel.promoteVoiceDraft(profileId: String) {
             }
         }.onSuccess { profile ->
             val draft = pendingVoiceDraft
+            // 서버 PATCH 응답은 변경된 필드만 돌려준다 — 승격은 is_draft 만 보내므로 name 이 빠진다.
+            // Gson 은 누락 필드에 (기본값 "" 을 무시하고) null 을 주입할 수 있어, non-null 로 선언된
+            // profile.name 이 런타임에 null 이 되면 ifBlank 가 NPE 를 냈다(버튼 눌러도 앱이 죽음).
+            // nullable 로 넓혀 안전하게 판정하고, 서버가 안 준 이름은 draft 값으로 폴백한다.
+            val serverName: String? = profile.name
+            val resolvedName = if (serverName.isNullOrBlank()) draft?.name.orEmpty() else serverName
             val official = profile.copy(
-                name = profile.name.ifBlank { draft?.name.orEmpty() },
+                name = resolvedName,
                 isShared = profile.isShared ?: draft?.isShared,
                 isDraft = false,
                 relationshipLabel = profile.relationshipLabel ?: draft?.relationshipLabel,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -1791,7 +1791,20 @@ internal fun VoiceProfileManagementPanel(
                                     modifier = Modifier.weight(1f),
                                     shape = WakerButtonShape,
                                 ) {
-                                    Text(stringResource(R.string.voices_confirm_new_keep))
+                                    // 승격 API 가 나가는 동안(voiceProfileBusy) 버튼에 진행 표시를 남겨
+                                    // "눌러도 아무 반응 없다"는 인상을 없앤다. 성공하면 다이얼로그가 닫히고
+                                    // 스낵바로 완료를 알린다.
+                                    if (voiceProfileBusy) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(18.dp),
+                                            strokeWidth = 2.dp,
+                                            color = MaterialTheme.colorScheme.onPrimary,
+                                        )
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text(stringResource(R.string.voices_confirm_new_keep_saving))
+                                    } else {
+                                        Text(stringResource(R.string.voices_confirm_new_keep))
+                                    }
                                 }
                             }
                         }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -676,9 +676,10 @@
     <string name="voices_confirm_new_body">Listen to the voice first — if it\'s not right, you can delete it.\nYou can register a voice once a month.</string>
     <string name="voices_confirm_new_preview">Replay</string>
     <string name="voices_confirm_new_keep">Use this voice</string>
+    <string name="voices_confirm_new_keep_saving">Saving…</string>
     <string name="voices_confirm_new_delete">Delete</string>
     <string name="voices_creating_title">Creating your voice</string>
-    <string name="voices_creating_body">Hang tight — this usually takes under a minute.
+    <string name="voices_creating_body">Hang tight.
 We\'ll play it for you as soon as it\'s ready.</string>
     <string name="voices_preview_text_loading">Preparing the line…</string>
     <string name="voices_preview_text_retry_hint">The line isn\'t ready yet. Tap Preview to try again.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -684,9 +684,10 @@
     <string name="voices_confirm_new_body">声を聞いてみて、気に入らなければ削除できます。\n声の登録は月に1回できます。</string>
     <string name="voices_confirm_new_preview">もう一度聞く</string>
     <string name="voices_confirm_new_keep">この声にする</string>
+    <string name="voices_confirm_new_keep_saving">登録中…</string>
     <string name="voices_confirm_new_delete">削除</string>
     <string name="voices_creating_title">声を作成しています</string>
-    <string name="voices_creating_body">少々お待ちください。通常1分以内に完了します。
+    <string name="voices_creating_body">少々お待ちください。
 完成したらすぐお聞かせします。</string>
     <string name="voices_preview_text_loading">フレーズを準備しています…</string>
     <string name="voices_preview_text_retry_hint">フレーズをまだ準備できていません。試聴を押してもう一度お試しください。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -688,9 +688,10 @@
     <string name="voices_confirm_new_body">목소리를 들어보고 마음에 들지 않으면 삭제할 수 있어요.\n목소리 등록은 한 달에 한 번 가능해요.</string>
     <string name="voices_confirm_new_preview">다시 듣기</string>
     <string name="voices_confirm_new_keep">이 목소리로 할게요</string>
+    <string name="voices_confirm_new_keep_saving">등록 중…</string>
     <string name="voices_confirm_new_delete">삭제</string>
     <string name="voices_creating_title">목소리를 만드는 중이에요</string>
-    <string name="voices_creating_body">잠시만 기다려 주세요. 보통 1분 안에 끝나요.
+    <string name="voices_creating_body">잠시만 기다려 주세요.
 완성되면 바로 들려드릴게요.</string>
     <string name="voices_preview_text_loading">문구를 준비하고 있어요…</string>
     <string name="voices_preview_text_retry_hint">문구를 아직 준비하지 못했어요. 미리듣기를 눌러 다시 시도해 주세요.</string>


### PR DESCRIPTION
## 요약
유료 계정에서 클론 목소리 미리듣기 후 **'이 목소리로 할게요'(승격)** 를 누르면 앱이 즉시 크래시하던 버그를 수정한다. 사용자 체감은 "버튼을 눌러도 아무 반응 없음"이지만, 실제로는 **서버 승격이 성공한 직후 클라이언트에서 죽는 것**이라 목소리는 만들어져 있는 혼란스러운 상태였다.

> A32(Android 13, 유료 계정)에서 크래시(`FATAL EXCEPTION … StringsKt.isBlank … MainViewModelVoiceActions.kt:195`)를 재현하고 수정본으로 검증 완료.

## 원인
`PATCH /voice/:id` 응답은 **변경된 필드만** 돌려준다(승격은 `is_draft`만 보내므로 `name`이 빠짐). Gson은 누락 필드에 기본값(`""`)을 무시하고 `null`을 주입할 수 있어, non-null로 선언된 `profile.name`이 런타임에 `null`이 되고 `profile.name.ifBlank { … }` 에서 NPE가 발생했다.

## 변경
- **크래시 수정**: `promoteVoiceDraft` onSuccess 병합에서 `profile.name`을 nullable로 넓혀 `isNullOrBlank`로 안전 판정하고, 서버가 주지 않은 이름은 draft 값으로 폴백. (성공 스낵바 이름도 정상 노출)
- **로딩 표시**: 승격 API가 나가는 동안 '이 목소리로 할게요' 버튼에 스피너 + `등록 중…`을 표시. 성공 시 다이얼로그가 닫히고 스낵바로 완료를 알림.
- **문구 정리**: 생성 로딩 문구에서 "보통 1분 안에 끝나요" 제거(ko/en/ja).

## 검증 (A32, 유료)
- `PATCH /api/voice/… → 200`, **크래시 없음**, 프로세스 유지
- '등록 중…' 로딩 → 다이얼로그 닫힘 → 성공 스낵바 `'heonamjun' 목소리를 만들었어요`(이름 정상)
- dev APK 빌드 성공

## 참고 — 프로덕션 영향
이 크래시는 현재 프로덕션 출시본(versionCode 12)에도 존재한다. 유료 사용자가 클론 목소리를 최종 등록할 때 크래시하므로 **hotfix(versionCode 13) 릴리스 검토 필요**.
