### PR TITLE
fix: 엣지투엣지 — API 26–28 내비바 스크림 앱 테마 반영 (Codex #590 P2)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/theme/AlarmTalkTheme.kt
@@ -3,6 +3,7 @@ package com.alarmtalk.app
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.os.Build
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -121,6 +122,11 @@ private data class SystemBarsSpec(val status: Color, val nav: Color)
 
 private val systemBarsOverride = mutableStateOf<SystemBarsSpec?>(null)
 
+// enableEdgeToEdge 가 API 29 미만에서 내비게이션 바에 까는 기본 스크림과 동일한 값.
+// 그 구간(26–28)에서만 앱 테마에 맞춰 내비바 색을 갱신할 때 재사용한다.
+private val NavBarScrimLight: Int = 0xE6FFFFFF.toInt()
+private val NavBarScrimDark: Int = 0x801B1B1B.toInt()
+
 /**
  * 고정 다크 씬(랜딩·인증 플로우)이 보이는 동안 시스템 바를 씬 색으로 덮어쓴다.
  * 테마는 상태바를 theme background 로 칠하므로 라이트 모드에선 네이비 씬 위에
@@ -141,19 +147,27 @@ internal fun SceneSystemBars(top: Color, bottom: Color) {
 }
 
 @Composable
+@Suppress("DEPRECATION") // navigationBarColor 는 API 26–28 경로에서만 쓰고, 35+ 지원중단은 회피한다.
 private fun AppSystemBars(isDark: Boolean) {
     val view = LocalView.current
     val override = systemBarsOverride.value
+    // 씬 오버라이드는 항상 어두운 배경(밝은 아이콘·어두운 스크림), 아니면 테마 명암을 따른다.
+    val barsDark = override != null || isDark
     SideEffect {
         val window = view.context.findActivity()?.window ?: return@SideEffect
         // 시스템 바 배경색은 더 이상 window.statusBarColor/navigationBarColor 로 칠하지 않는다
         // (Android 15/SDK 35 에서 지원중단·엣지투엣지 강제). MainActivity 의 enableEdgeToEdge()
         // 로 바가 투명해지고, 그 뒤로 콘텐츠가 그려진다 — 일반 화면은 Scaffold 배경(=background)이,
-        // 씬 화면(랜딩/울림)은 풀블리드 씬이 바 영역까지 채운다. 여기서는 아이콘 명암만 제어한다.
+        // 씬 화면(랜딩/울림)은 풀블리드 씬이 바 영역까지 채운다. 여기서는 아이콘 명암을 제어한다.
         WindowCompat.getInsetsController(window, view).apply {
-            // 씬 오버라이드는 항상 어두운 배경(밝은 아이콘), 아니면 테마 명암을 따른다.
-            isAppearanceLightStatusBars = if (override != null) false else !isDark
-            isAppearanceLightNavigationBars = if (override != null) false else !isDark
+            isAppearanceLightStatusBars = !barsDark
+            isAppearanceLightNavigationBars = !barsDark
+        }
+        // API 26–28 은 enableEdgeToEdge 가 시스템 야간모드 기준 내비바 스크림을 onCreate 때 한 번만
+        // 깔아, 앱 테마가 시스템과 다르거나 런타임에 바뀌면 내비바 배경이 어긋난다. 이 구간에서만
+        // (29+ 는 바가 투명해 불필요, 35+ 지원중단도 피함) 내비바 색을 앱 테마에 맞춰 갱신한다.
+        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.P) {
+            window.navigationBarColor = if (barsDark) NavBarScrimDark else NavBarScrimLight
         }
     }
 }


### PR DESCRIPTION
## 배경
PR #590(develop→main) Codex 리뷰에서 **P2** 지적:
> On API 26–28 devices, `enableEdgeToEdge()` still installs an opaque navigation-bar scrim based on the device's night-mode configuration. When a user selects the app's Light or Dark mode opposite to that system setting, this code now changes only the navigation-bar icon appearance and never updates that scrim.

## 유효성
앱에는 `ThemeMode { System, Light, Dark }` 수동 토글이 있어 앱 테마가 시스템 야간모드와 다를 수 있음 → API 26–28에서 내비바 배경 불일치. 유효한 지적.

## 수정
- `AppSystemBars` 에서 **API 26–28 구간에만** `window.navigationBarColor` 를 앱 테마(barsDark)에 맞춰 갱신. 스크림 값은 `enableEdgeToEdge` 기본값과 동일.
- 29+ 는 바가 투명해 불필요, 35+ 지원중단 경로도 이 가드(`in O..P`)로 회피(@Suppress).
- 아이콘 명암 판정을 `barsDark`(씬 오버라이드 || 다크테마)로 통일 — 기존 동작과 동치.

## 검증
- dev APK 빌드 성공. 가드가 26–28로 한정되어 29+ 기기(테스트폰 포함) 동작 불변.