### PR TITLE
feat: 확정 목소리의 클론 원본 오디오 보관 + 삭제 시 cascade 정리

### DIFF
--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -252,13 +252,20 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
     now.getTime() - GENERATED_TTS_TTL_DAYS * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  // 1) 클론 학습용 업로드 원본 — 클론 완료 후 보관 불필요.
-  //    voice_profile_id 로 프로필에 연결된 행(clone 등록 원본, 말투 분석 재시도 소스)도
-  //    동일하게 7일 후 정리된다 — draft/목소리 삭제 시 별도 정리가 필요 없는 이유.
-  //    재시도는 소스가 사라지면 409 SOURCE_AUDIO_MISSING 으로 재등록을 안내한다.
+  // 1) 클론 학습용 업로드 원본.
+  //    최종 확정(promote)된 목소리의 원본은 보관한다 — 나중에 프로바이더/API 키가 바뀌어도
+  //    이 원본으로 클론을 재생성할 수 있어야 하기 때문(voice_profile_id 로 연결·live·non-draft).
+  //    그 외(미승격 draft, 프로필과 무관한 raw 업로드, 삭제된 프로필의 잔여분)만 7일 후 정리한다.
+  //    확정 목소리를 명시적으로 삭제하면 DELETE /voice/:id 가 원본을 함께 cascade 삭제한다.
   const uploads = await db.execute({
     sql: `SELECT id, object_key FROM voice_uploads
           WHERE created_at <= ?
+            AND NOT EXISTS (
+              SELECT 1 FROM voice_profiles vp
+              WHERE vp.id = voice_uploads.voice_profile_id
+                AND vp.deleted_at IS NULL
+                AND COALESCE(vp.is_draft, 0) = 0
+            )
           ORDER BY created_at ASC
           LIMIT ?`,
     args: [uploadCutoff, TTL_BATCH_SIZE],

--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -272,9 +272,15 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
   });
   for (const row of uploads.rows) {
     const uploadId = String(row.id);
+    // FK 순서: 자식(voice_speakers.upload_id → voice_uploads.id)을 부모보다 먼저 지운다
+    // (foreign_keys 활성 시 부모 먼저 지우면 제약 위반으로 삭제가 실패한다).
+    await db.execute({
+      sql: 'DELETE FROM voice_speakers WHERE upload_id = ?',
+      args: [uploadId],
+    });
     // TOCTOU 하드닝: 위 SELECT 와 이 삭제 사이에 이 업로드의 draft 가 promote 되어 프로필이
     // live·non-draft(확정)가 됐다면 원본을 지우면 안 된다(재생성 소스 유실 방지). 삭제 조건을
-    // 다시 걸어, 실제로 지워졌을 때만 speaker 삭제·R2 삭제 큐잉을 진행한다.
+    // 다시 걸고, 실제로 지워졌을 때만 R2 삭제를 큐에 적재한다.
     const deletedUpload = await db.execute({
       sql: `DELETE FROM voice_uploads
             WHERE id = ?
@@ -286,11 +292,7 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
               )`,
       args: [uploadId],
     });
-    if ((deletedUpload.rowsAffected ?? 0) === 0) continue; // 그 사이 확정됨 → 보관
-    await db.execute({
-      sql: 'DELETE FROM voice_speakers WHERE upload_id = ?',
-      args: [uploadId],
-    });
+    if ((deletedUpload.rowsAffected ?? 0) === 0) continue; // 그 사이 확정됨 → 원본 보관
     await enqueueExternalDeletion(db, 'r2_object', row.object_key as string);
   }
 

--- a/packages/backend/src/lib/audio-retention.ts
+++ b/packages/backend/src/lib/audio-retention.ts
@@ -272,15 +272,26 @@ export async function cleanupExpiredAudio(db: Client, now: Date): Promise<void> 
   });
   for (const row of uploads.rows) {
     const uploadId = String(row.id);
-    await enqueueExternalDeletion(db, 'r2_object', row.object_key as string);
+    // TOCTOU 하드닝: 위 SELECT 와 이 삭제 사이에 이 업로드의 draft 가 promote 되어 프로필이
+    // live·non-draft(확정)가 됐다면 원본을 지우면 안 된다(재생성 소스 유실 방지). 삭제 조건을
+    // 다시 걸어, 실제로 지워졌을 때만 speaker 삭제·R2 삭제 큐잉을 진행한다.
+    const deletedUpload = await db.execute({
+      sql: `DELETE FROM voice_uploads
+            WHERE id = ?
+              AND NOT EXISTS (
+                SELECT 1 FROM voice_profiles vp
+                WHERE vp.id = voice_uploads.voice_profile_id
+                  AND vp.deleted_at IS NULL
+                  AND COALESCE(vp.is_draft, 0) = 0
+              )`,
+      args: [uploadId],
+    });
+    if ((deletedUpload.rowsAffected ?? 0) === 0) continue; // 그 사이 확정됨 → 보관
     await db.execute({
       sql: 'DELETE FROM voice_speakers WHERE upload_id = ?',
       args: [uploadId],
     });
-    await db.execute({
-      sql: 'DELETE FROM voice_uploads WHERE id = ?',
-      args: [uploadId],
-    });
+    await enqueueExternalDeletion(db, 'r2_object', row.object_key as string);
   }
 
   // 2) TTS 캐시 — 알람이 참조 중인 오브젝트는 보존한다.

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -1937,6 +1937,24 @@ voiceProfile.delete('/:id', async (c) => {
     for (const asset of assets.rows) {
       await enqueueExternalDeletion(tx, 'r2_object', asset.audio_object_key as string | null);
     }
+    // 확정 목소리의 원본 업로드(voice_uploads + voice_speakers + R2 오브젝트)도 함께 삭제한다.
+    // 확정분 원본은 TTL 스윕에서 제외돼 목소리 수명 동안 보관되므로(재생성용), 목소리를 지울 때
+    // 여기서 cascade 로 정리하지 않으면 영구히 남는다.
+    const sourceUploads = await tx.execute({
+      sql: 'SELECT id, object_key FROM voice_uploads WHERE voice_profile_id = ?',
+      args: [id],
+    });
+    for (const upload of sourceUploads.rows) {
+      await enqueueExternalDeletion(tx, 'r2_object', upload.object_key as string | null);
+      await tx.execute({
+        sql: 'DELETE FROM voice_speakers WHERE upload_id = ?',
+        args: [String(upload.id)],
+      });
+      await tx.execute({
+        sql: 'DELETE FROM voice_uploads WHERE id = ?',
+        args: [String(upload.id)],
+      });
+    }
     return {
       status: 'deleted' as const,
       profile: currentProfile,

--- a/packages/backend/test/audio-retention-source-keep.test.ts
+++ b/packages/backend/test/audio-retention-source-keep.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { createClient } from '@libsql/client';
+import { cleanupExpiredAudio } from '../src/lib/audio-retention';
+
+// 확정(promote)된 목소리의 클론 원본 업로드는 API 키/프로바이더 교체 후 재생성용으로 보관해야 하므로
+// 7일 TTL 스윕에서 제외된다. 그 외(미승격 draft / 프로필과 무관한 raw 업로드 / 삭제된 프로필 잔여분)만
+// 정리된다. 실제 인메모리 libSQL 로 스윕 쿼리를 검증한다.
+async function setupDb() {
+  const db = createClient({ url: ':memory:' });
+  await db.executeMultiple(`
+    CREATE TABLE voice_profiles (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      status TEXT DEFAULT 'ready',
+      is_draft INTEGER DEFAULT 0,
+      deleted_at TEXT
+    );
+    CREATE TABLE voice_uploads (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      object_key TEXT NOT NULL,
+      mime_type TEXT NOT NULL DEFAULT 'audio/mpeg',
+      size_bytes INTEGER NOT NULL DEFAULT 1,
+      duration_ms INTEGER,
+      original_name TEXT,
+      voice_profile_id TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE voice_speakers (
+      id TEXT PRIMARY KEY,
+      upload_id TEXT NOT NULL,
+      label TEXT NOT NULL DEFAULT 'A',
+      start_ms INTEGER NOT NULL DEFAULT 0,
+      end_ms INTEGER NOT NULL DEFAULT 1,
+      confidence REAL NOT NULL DEFAULT 1,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE pending_external_deletions (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      ref TEXT NOT NULL,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    -- generated_audio_assets 스윕 파트가 참조하는 테이블(빈 채로 존재만 하면 됨)
+    CREATE TABLE generated_audio_assets (
+      id TEXT PRIMARY KEY,
+      audio_object_key TEXT,
+      audio_url TEXT,
+      message_id TEXT,
+      user_id TEXT,
+      voice_profile_id TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE alarms (id TEXT PRIMARY KEY, raw_audio_url TEXT, message_id TEXT);
+    CREATE TABLE messages (id TEXT PRIMARY KEY, audio_url TEXT, is_preset INTEGER DEFAULT 0);
+    CREATE TABLE raw_alarm_uploads (id TEXT PRIMARY KEY, object_key TEXT NOT NULL, created_at TEXT NOT NULL);
+  `);
+  return db;
+}
+
+const OLD = '2020-01-01 00:00:00'; // 확실히 7일 TTL 경과
+
+async function insertProfile(
+  db: Awaited<ReturnType<typeof setupDb>>,
+  id: string,
+  opts: { isDraft?: boolean; deleted?: boolean } = {},
+) {
+  await db.execute({
+    sql: `INSERT INTO voice_profiles (id, user_id, name, is_draft, deleted_at)
+          VALUES (?, 'u1', ?, ?, ?)`,
+    args: [id, id, opts.isDraft ? 1 : 0, opts.deleted ? OLD : null],
+  });
+}
+
+async function insertUpload(
+  db: Awaited<ReturnType<typeof setupDb>>,
+  id: string,
+  profileId: string | null,
+) {
+  await db.execute({
+    sql: `INSERT INTO voice_uploads (id, user_id, object_key, voice_profile_id, created_at)
+          VALUES (?, 'u1', ?, ?, ?)`,
+    args: [id, `voice-src/${id}.mp3`, profileId, OLD],
+  });
+}
+
+describe('cleanupExpiredAudio — 확정 목소리 원본 보관', () => {
+  it('확정(live·non-draft) 프로필의 원본은 TTL 경과에도 보관하고, 나머지는 정리한다', async () => {
+    const db = await setupDb();
+    await insertProfile(db, 'p_final'); // 확정
+    await insertProfile(db, 'p_draft', { isDraft: true }); // 미승격 draft
+    await insertProfile(db, 'p_deleted', { deleted: true }); // 삭제됨
+
+    await insertUpload(db, 'up_final', 'p_final');
+    await insertUpload(db, 'up_draft', 'p_draft');
+    await insertUpload(db, 'up_deleted', 'p_deleted');
+    await insertUpload(db, 'up_orphan', null); // 프로필과 무관한 raw 업로드
+    await db.execute({
+      sql: `INSERT INTO voice_speakers (id, upload_id) VALUES ('sp_final', 'up_final')`,
+    });
+
+    await cleanupExpiredAudio(db, new Date('2020-02-01T00:00:00Z'));
+
+    const remaining = await db.execute('SELECT id FROM voice_uploads ORDER BY id');
+    expect(remaining.rows.map((r) => String(r.id))).toEqual(['up_final']);
+
+    // 확정분에 딸린 speaker 도 보존
+    const speakers = await db.execute('SELECT id FROM voice_speakers');
+    expect(speakers.rows.map((r) => String(r.id))).toEqual(['sp_final']);
+
+    // 정리된 3건만 R2 삭제 큐에 적재되고, 확정분 키는 큐에 없다
+    const queued = await db.execute(
+      `SELECT ref FROM pending_external_deletions WHERE kind = 'r2_object' ORDER BY ref`,
+    );
+    const refs = queued.rows.map((r) => String(r.ref));
+    expect(refs).toEqual([
+      'voice-src/up_deleted.mp3',
+      'voice-src/up_draft.mp3',
+      'voice-src/up_orphan.mp3',
+    ]);
+    expect(refs).not.toContain('voice-src/up_final.mp3');
+
+    db.close();
+  });
+});


### PR DESCRIPTION
## 배경
음성 프로바이더/API 키가 나중에 바뀌어도 **원본 오디오로 클론을 재생성**할 수 있어야 한다. 클론 생성 시 이미 업로드 원본을 R2+`voice_uploads`에 저장하고 `voice_profile_id`로 연결하고 있었지만, **7일 TTL 스윕이 확정 여부와 무관하게 원본을 지워** 재생성 소스가 사라졌다.

## 변경
- **원본 보관**: `cleanupExpiredAudio`의 `voice_uploads` 스윕에서 **live·non-draft 프로필에 연결된 원본을 제외**. 미승격 draft / 프로필 무관 raw 업로드 / 삭제된 프로필 잔여분만 7일 후 정리.
- **삭제 cascade**: `DELETE /voice/:id`가 그 프로필의 원본(`voice_uploads` + `voice_speakers` + R2 오브젝트)도 함께 삭제. 그동안 삭제 경로가 원본을 안 지워 영구 잔존했음 → "목소리 삭제 시 원본도 자동 삭제" 충족.

## 정책 요약
원본 오디오는 **확정된 목소리가 사는 동안 보관**, **명시적 삭제 시에만** 원본도 제거. (미확정·고아·삭제분은 기존 TTL로 정리.)

## 검증
- 새 테스트: 확정 원본은 TTL 경과에도 보관, draft/고아/삭제-프로필 원본 3종은 정리 + R2 삭제 큐 적재.
- 백엔드 전체 테스트 1536 passed (회귀 없음).