### PR TITLE
feat: 무료 전환 시 유료 음성 데이터 삭제 대신 보존 + 즉시삭제 제거

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAppContainer.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAppContainer.kt
@@ -2,10 +2,18 @@ package com.alarmtalk.app.data
 
 import android.content.Context
 import com.alarmtalk.app.alarm.AlarmScheduler
+import com.alarmtalk.app.network.AuthSessionStore
 
 object AlarmAppContainer {
     @Volatile
     private var repository: AlarmRepository? = null
+    @Volatile
+    private var authSessionStore: AuthSessionStore? = null
+
+    private fun authSessionStore(context: Context): AuthSessionStore =
+        authSessionStore ?: synchronized(this) {
+            authSessionStore ?: AuthSessionStore(context.applicationContext).also { authSessionStore = it }
+        }
 
     fun repository(context: Context): AlarmRepository =
         repository ?: synchronized(this) {
@@ -16,6 +24,8 @@ object AlarmAppContainer {
                 alarmScheduler = AlarmScheduler(context.applicationContext),
                 alarmAudioStore = AlarmAudioStore(context.applicationContext),
                 context = context.applicationContext,
+                // 알람 생성 시 소유자 기록·무료 잠금 스코프용 현재 로그인 계정 id.
+                currentUserIdProvider = { authSessionStore(context).read()?.user?.id },
             ).also { repository = it }
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
@@ -210,12 +210,12 @@ abstract class AlarmDatabase : RoomDatabase() {
         }
 
         // 무료 전환 시 유료 목소리 알람을 삭제 대신 사운드온리로 '잠글' 때 원래 재생모드를 보관하고,
-        // 잠금을 건 세션 소유자를 함께 기록한다(다른 계정 로그인 시 남의 잠금을 복원하지 않도록).
-        // 재유료 시 소유자가 일치하는 잠금만 복원한다. null = 잠기지 않음.
+        // 알람을 만든 계정(ownerUserId)을 기록한다. 잠금/복원은 현재 세션이 소유자일 때만 수행해,
+        // 다른 계정 로그인 시 남의 알람을 잠그거나 복원하지 않게 한다. null = 잠기지 않음/소유자 미기록.
         private val MIGRATION_20_21 = object : Migration(20, 21) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE alarms ADD COLUMN preLockPlayMode TEXT")
-                db.execSQL("ALTER TABLE alarms ADD COLUMN preLockOwnerId TEXT")
+                db.execSQL("ALTER TABLE alarms ADD COLUMN ownerUserId TEXT")
             }
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [AlarmEntity::class, HolidayEntity::class],
-    version = 20,
+    version = 21,
     exportSchema = false,
 )
 abstract class AlarmDatabase : RoomDatabase() {
@@ -46,6 +46,7 @@ abstract class AlarmDatabase : RoomDatabase() {
                     MIGRATION_17_18,
                     MIGRATION_18_19,
                     MIGRATION_19_20,
+                    MIGRATION_20_21,
                 )
                     // 캐릭터/성장 기능 제거에 따른 스키마 변경. 개발 중 미정의 마이그레이션은
                     // 파괴적 재생성으로 처리한다(출시 전이라 보존할 데이터 없음).
@@ -205,6 +206,14 @@ abstract class AlarmDatabase : RoomDatabase() {
         private val MIGRATION_19_20 = object : Migration(19, 20) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE alarms ADD COLUMN contextResolvedAtMillis INTEGER")
+            }
+        }
+
+        // 무료 전환 시 유료 목소리 알람을 삭제 대신 사운드온리로 '잠글' 때 원래 재생모드를 보관.
+        // 재유료 시 이 값으로 복원한다. null = 잠기지 않음.
+        private val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE alarms ADD COLUMN preLockPlayMode TEXT")
             }
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDatabase.kt
@@ -209,11 +209,13 @@ abstract class AlarmDatabase : RoomDatabase() {
             }
         }
 
-        // 무료 전환 시 유료 목소리 알람을 삭제 대신 사운드온리로 '잠글' 때 원래 재생모드를 보관.
-        // 재유료 시 이 값으로 복원한다. null = 잠기지 않음.
+        // 무료 전환 시 유료 목소리 알람을 삭제 대신 사운드온리로 '잠글' 때 원래 재생모드를 보관하고,
+        // 잠금을 건 세션 소유자를 함께 기록한다(다른 계정 로그인 시 남의 잠금을 복원하지 않도록).
+        // 재유료 시 소유자가 일치하는 잠금만 복원한다. null = 잠기지 않음.
         private val MIGRATION_20_21 = object : Migration(20, 21) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE alarms ADD COLUMN preLockPlayMode TEXT")
+                db.execSQL("ALTER TABLE alarms ADD COLUMN preLockOwnerId TEXT")
             }
         }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
@@ -72,9 +72,10 @@ data class AlarmEntity(
     // 여기에 저장한다(playMode 는 ALARM_ONLY 로 내림). 다시 유료가 되면 이 값으로 복원하고 null 로 되돌린다.
     // null = 잠기지 않은 정상 알람.
     val preLockPlayMode: String? = null,
-    // 잠금을 건 세션 소유자(로그인 user id). 로컬 알람은 로그아웃 후에도 남으므로, 다른 계정으로
-    // 로그인해 유료가 돼도 그 계정이 남의 잠긴 목소리 알람을 복원하지 못하게 소유자를 일치시킨다.
-    val preLockOwnerId: String? = null,
+    // 알람을 만든 계정(로그인 user id, 생성 시 1회 기록·불변). 로컬 알람은 로그아웃 후에도 남으므로,
+    // 잠금/복원은 현재 세션이 이 알람의 소유자일 때만 수행한다 — 다른 계정으로 로그인해 무료/유료가 돼도
+    // 남의 목소리 알람을 잠그거나(→소유자가 복원 못하는 영구 잠금) 복원하지(→남의 목소리 재생) 못하게 한다.
+    val ownerUserId: String? = null,
 )
 
 data class AlarmDraft(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
@@ -72,6 +72,9 @@ data class AlarmEntity(
     // 여기에 저장한다(playMode 는 ALARM_ONLY 로 내림). 다시 유료가 되면 이 값으로 복원하고 null 로 되돌린다.
     // null = 잠기지 않은 정상 알람.
     val preLockPlayMode: String? = null,
+    // 잠금을 건 세션 소유자(로그인 user id). 로컬 알람은 로그아웃 후에도 남으므로, 다른 계정으로
+    // 로그인해 유료가 돼도 그 계정이 남의 잠긴 목소리 알람을 복원하지 못하게 소유자를 일치시킨다.
+    val preLockOwnerId: String? = null,
 )
 
 data class AlarmDraft(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmEntity.kt
@@ -68,6 +68,10 @@ data class AlarmEntity(
     val state: String,
     val createdAtMillis: Long,
     val updatedAtMillis: Long,
+    // 무료 전환 시 유료 목소리 알람을 삭제하지 않고 사운드온리로 '잠글' 때, 원래 재생모드를
+    // 여기에 저장한다(playMode 는 ALARM_ONLY 로 내림). 다시 유료가 되면 이 값으로 복원하고 null 로 되돌린다.
+    // null = 잠기지 않은 정상 알람.
+    val preLockPlayMode: String? = null,
 )
 
 data class AlarmDraft(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -41,6 +41,8 @@ class AlarmRepository(
         alarmScheduler = alarmScheduler,
         alarmAudioStore = alarmAudioStore,
         context = context,
+        // 받은 알람에 수신자(현재 로그인 계정)를 소유자로 기록해 무료 잠금/복원을 스코프한다.
+        currentUserIdProvider = currentUserIdProvider,
     )
 
     fun observeAlarms(): Flow<List<AlarmEntity>> = alarmDao.observeAlarms()

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -440,7 +440,7 @@ class AlarmRepository(
      * 기본 알람음을 재생하게 한다. 캐시 오디오·목소리 참조는 그대로 보존해 재유료 시 복원한다.
      * 로컬만 갱신(upsertPreservingServerSyncFields)해 서버의 원본 목소리 알람은 백스톱으로 남긴다.
      */
-    suspend fun lockPaidAlarmTalks(): Int {
+    suspend fun lockPaidAlarmTalks(ownerId: String?): Int {
         val targets = alarmDao.getAllAlarms().filter { alarm ->
             val usesVoice = alarm.playMode != AlarmPlayModes.ALARM_ONLY ||
                 !alarm.localAudioUri.isNullOrBlank() ||
@@ -452,6 +452,7 @@ class AlarmRepository(
         targets.forEach { alarm ->
             val locked = alarm.copy(
                 preLockPlayMode = alarm.playMode,
+                preLockOwnerId = ownerId,
                 playMode = AlarmPlayModes.ALARM_ONLY,
                 updatedAtMillis = System.currentTimeMillis(),
             )
@@ -464,13 +465,20 @@ class AlarmRepository(
         return targets.size
     }
 
-    /** 다시 유료가 되면 잠근 알람(preLockPlayMode != null)의 원래 재생모드를 복원한다. */
-    suspend fun unlockPaidAlarmTalks(): Int {
-        val targets = alarmDao.getAllAlarms().filter { !it.preLockPlayMode.isNullOrBlank() }
+    /**
+     * 다시 유료가 되면 잠근 알람의 원래 재생모드를 복원한다. 로컬 알람은 로그아웃 후에도 남으므로,
+     * 잠금을 건 소유자(preLockOwnerId)가 현재 세션(ownerId)과 일치하는 것만 복원한다 — 다른 계정으로
+     * 로그인해 유료가 돼도 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다.
+     */
+    suspend fun unlockPaidAlarmTalks(ownerId: String?): Int {
+        val targets = alarmDao.getAllAlarms().filter {
+            !it.preLockPlayMode.isNullOrBlank() && it.preLockOwnerId == ownerId
+        }
         targets.forEach { alarm ->
             val restored = alarm.copy(
                 playMode = alarm.preLockPlayMode ?: alarm.playMode,
                 preLockPlayMode = null,
+                preLockOwnerId = null,
                 updatedAtMillis = System.currentTimeMillis(),
             )
             if (restored.enabled) alarmScheduler.schedule(restored)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -279,6 +279,12 @@ class AlarmRepository(
             bucketClipTextsJson = draft.bucketClipTextsJson,
             contextVariantIndex = weatherVariantState.index,
             contextResolvedAtMillis = weatherVariantState.resolvedAtMillis,
+            // 명시적 편집은 사용자의 최신 재생모드 의도를 확정하므로 무료 잠금 스냅샷을 비운다.
+            // 안 그러면 잠긴 알람을 사운드온리로 편집·저장해도 옛 목소리 모드가 preLockPlayMode 에
+            // 남아, 재구독 시 unlockPaidAlarmTalks 가 사용자의 편집을 덮어써 목소리로 되살린다.
+            // 무료 상태로 남아 편집 결과가 여전히 유료 목소리면, 다음 앱 시작의 재잠금이 실제
+            // playMode 기준으로 올바른 새 스냅샷을 다시 만든다.
+            preLockPlayMode = null,
             syncState = current.nextLocalSyncState(),
             alarmVolumePercent = draft.alarmVolumePercent,
             alarmSoundUri = draft.alarmSoundUri,
@@ -534,6 +540,10 @@ class AlarmRepository(
             syncState = AlarmSyncStates.LOCAL_ONLY,
             origin = AlarmOrigins.LOCAL_OWNED,
             ownerUserId = currentUserIdProvider(),
+            // 복사는 새 알람 생성이므로 원본의 무료 잠금 스냅샷을 물려받지 않는다(잠기지 않은 상태로
+            // 시작). 무료 사용자가 잠긴 알람을 복사하면 playMode 는 이미 ALARM_ONLY 라 사운드온리로
+            // 복사되고, 잠금이 필요하면 다음 앱 시작의 재잠금이 새 스냅샷을 만든다.
+            preLockPlayMode = null,
             enabled = true,
             state = AlarmStates.SCHEDULED,
             createdAtMillis = now,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -454,47 +454,52 @@ class AlarmRepository(
      */
     suspend fun lockPaidAlarmTalks(): Int {
         val currentUser = currentUserIdProvider() ?: return 0
-        val targets = alarmDao.getAllAlarms().filter { alarm ->
+        val now = System.currentTimeMillis()
+        var lockedCount = 0
+        alarmDao.getAllAlarms().forEach { alarm ->
             val usesVoice = alarm.playMode != AlarmPlayModes.ALARM_ONLY ||
                 !alarm.localAudioUri.isNullOrBlank() ||
                 !alarm.rawAudioUri.isNullOrBlank() ||
                 !alarm.voiceProfileId.isNullOrBlank() ||
                 !alarm.ttsMessageId.isNullOrBlank()
-            // 현재 세션이 소유한(ownerUserId 일치) 알람만 잠근다 — 같은 기기에 남아 있는 다른 계정의
-            // 알람을 잠가서 그 계정이 재유료해도 복원하지 못하게 되는 것을 막는다.
-            // 단 ownerUserId 가 null 인 레거시 행(소유자 추적 이전 릴리스에서 만든 알람)은
-            // 소유자를 알 수 없으므로 현재 세션이 잠글 수 있게 허용한다 — 안 그러면 무료 사용자가
-            // 옛 유료 목소리 알람을 계속 재생하는 우회가 생긴다. 복원 조건도 동일하게 null 을 허용해
-            // 가역성을 유지하고(백필하지 않음), 무료가 잠근 뒤 소유권이 고정돼 영구 잠기는 것을 막는다.
-            usesVoice && !alarm.usesFreeSystemVoiceAlarm() && alarm.preLockPlayMode == null &&
-                (alarm.ownerUserId == currentUser || alarm.ownerUserId == null)
-        }
-        targets.forEach { alarm ->
-            val locked = alarm.copy(
-                preLockPlayMode = alarm.playMode,
-                playMode = AlarmPlayModes.ALARM_ONLY,
-                updatedAtMillis = System.currentTimeMillis(),
+            if (!usesVoice || alarm.usesFreeSystemVoiceAlarm()) return@forEach
+            // 다른 계정이 소유한(ownerUserId 불일치) 알람은 건드리지 않는다. 소유자 미기록(레거시 null)
+            // 음성 알람은 현재 활성 계정으로 소유권을 backfill 한다 — 잠금 시점에 소유자를 확정해,
+            // 복원은 엄격히 ownerUserId 일치만 보고도 (1) 본인이 재유료 시 복원 가능(영구잠금 방지),
+            // (2) 같은 기기의 다른 계정이 남의 잠긴 알람을 복원·스케줄하지 못하게 한다. 이미 잠긴
+            // 레거시 행(구버전에서 소유자 없이 잠김)도 여기서 소유권만 backfill 해 복원 가능하게 만든다.
+            if (alarm.ownerUserId != null && alarm.ownerUserId != currentUser) return@forEach
+            val needsLock = alarm.preLockPlayMode == null
+            val needsClaim = alarm.ownerUserId == null
+            if (!needsLock && !needsClaim) return@forEach
+            val updated = alarm.copy(
+                preLockPlayMode = if (needsLock) alarm.playMode else alarm.preLockPlayMode,
+                playMode = if (needsLock) AlarmPlayModes.ALARM_ONLY else alarm.playMode,
+                ownerUserId = currentUser,
+                updatedAtMillis = now,
             )
-            if (locked.enabled) alarmScheduler.schedule(locked)
-            alarmDao.upsertPreservingServerSyncFields(locked)
+            // 새로 잠근 경우에만 재스케줄(사운드온리로). 소유권만 backfill 한 경우는 재생모드 불변이라 불필요.
+            if (updated.enabled && needsLock) alarmScheduler.schedule(updated)
+            alarmDao.upsertPreservingServerSyncFields(updated)
+            if (needsLock) lockedCount++
         }
-        if (targets.isNotEmpty()) {
-            Log.i(TAG, "Locked paid voice alarms on free plan count=${targets.size}")
+        if (lockedCount > 0) {
+            Log.i(TAG, "Locked paid voice alarms on free plan count=$lockedCount")
         }
-        return targets.size
+        return lockedCount
     }
 
     /**
      * 다시 유료가 되면 잠근 알람의 원래 재생모드를 복원한다. 로컬 알람은 로그아웃 후에도 남으므로,
      * 현재 세션이 소유한(ownerUserId 일치) 잠긴 알람만 복원한다 — 다른 계정으로 로그인해 유료가 돼도
-     * 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다. 잠금 조건과 대칭으로 ownerUserId 가 null 인
-     * 레거시 잠금(소유자 미기록 행)도 복원 대상에 포함해 가역성을 맞춘다.
+     * 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다. 잠금 시점에 소유자를 backfill 하므로(위
+     * lockPaidAlarmTalks), 잠긴 행은 항상 소유자가 있어 여기서 null 을 허용할 필요가 없다 — 엄격히
+     * ownerUserId 일치만 본다(null 허용 시 다른 계정이 레거시 잠금을 복원·스케줄하는 크로스계정 창).
      */
     suspend fun unlockPaidAlarmTalks(): Int {
         val currentUser = currentUserIdProvider() ?: return 0
         val targets = alarmDao.getAllAlarms().filter {
-            !it.preLockPlayMode.isNullOrBlank() &&
-                (it.ownerUserId == currentUser || it.ownerUserId == null)
+            !it.preLockPlayMode.isNullOrBlank() && it.ownerUserId == currentUser
         }
         targets.forEach { alarm ->
             val restored = alarm.copy(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -454,8 +454,12 @@ class AlarmRepository(
                 !alarm.ttsMessageId.isNullOrBlank()
             // 현재 세션이 소유한(ownerUserId 일치) 알람만 잠근다 — 같은 기기에 남아 있는 다른 계정의
             // 알람을 잠가서 그 계정이 재유료해도 복원하지 못하게 되는 것을 막는다.
-            usesVoice && !alarm.usesFreeSystemVoiceAlarm() &&
-                alarm.preLockPlayMode == null && alarm.ownerUserId == currentUser
+            // 단 ownerUserId 가 null 인 레거시 행(소유자 추적 이전 릴리스에서 만든 알람)은
+            // 소유자를 알 수 없으므로 현재 세션이 잠글 수 있게 허용한다 — 안 그러면 무료 사용자가
+            // 옛 유료 목소리 알람을 계속 재생하는 우회가 생긴다. 복원 조건도 동일하게 null 을 허용해
+            // 가역성을 유지하고(백필하지 않음), 무료가 잠근 뒤 소유권이 고정돼 영구 잠기는 것을 막는다.
+            usesVoice && !alarm.usesFreeSystemVoiceAlarm() && alarm.preLockPlayMode == null &&
+                (alarm.ownerUserId == currentUser || alarm.ownerUserId == null)
         }
         targets.forEach { alarm ->
             val locked = alarm.copy(
@@ -475,12 +479,14 @@ class AlarmRepository(
     /**
      * 다시 유료가 되면 잠근 알람의 원래 재생모드를 복원한다. 로컬 알람은 로그아웃 후에도 남으므로,
      * 현재 세션이 소유한(ownerUserId 일치) 잠긴 알람만 복원한다 — 다른 계정으로 로그인해 유료가 돼도
-     * 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다.
+     * 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다. 잠금 조건과 대칭으로 ownerUserId 가 null 인
+     * 레거시 잠금(소유자 미기록 행)도 복원 대상에 포함해 가역성을 맞춘다.
      */
     suspend fun unlockPaidAlarmTalks(): Int {
         val currentUser = currentUserIdProvider() ?: return 0
         val targets = alarmDao.getAllAlarms().filter {
-            !it.preLockPlayMode.isNullOrBlank() && it.ownerUserId == currentUser
+            !it.preLockPlayMode.isNullOrBlank() &&
+                (it.ownerUserId == currentUser || it.ownerUserId == null)
         }
         targets.forEach { alarm ->
             val restored = alarm.copy(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -32,6 +32,8 @@ class AlarmRepository(
     private val context: Context,
     // /holiday 는 인증이 필요 없어 토큰 없이 새 클라이언트를 생성한다(다른 워커와 동일).
     private val holidayApiProvider: () -> HolidayApi = { AlarmTalkApiClient.create() },
+    // 현재 로그인 계정 id(없으면 null). 알람 생성 시 소유자 기록·무료 잠금 스코프에 쓴다.
+    private val currentUserIdProvider: () -> String? = { null },
 ) {
     private val alarmSyncService = AlarmSyncService(alarmDao)
     private val remoteAlarmPullSyncService = RemoteAlarmPullSyncService(
@@ -93,6 +95,7 @@ class AlarmRepository(
             lastSyncedAtMillis = null,
             syncState = AlarmSyncStates.LOCAL_ONLY,
             origin = AlarmOrigins.LOCAL_OWNED,
+            ownerUserId = currentUserIdProvider(),
             alarmVolumePercent = 100,
             alarmSoundUri = null,
             alarmSoundLabel = null,
@@ -170,6 +173,7 @@ class AlarmRepository(
             lastSyncedAtMillis = null,
             syncState = AlarmSyncStates.LOCAL_ONLY,
             origin = AlarmOrigins.LOCAL_OWNED,
+            ownerUserId = currentUserIdProvider(),
             alarmVolumePercent = draft.alarmVolumePercent,
             alarmSoundUri = draft.alarmSoundUri,
             alarmSoundLabel = draft.alarmSoundLabel,
@@ -440,19 +444,22 @@ class AlarmRepository(
      * 기본 알람음을 재생하게 한다. 캐시 오디오·목소리 참조는 그대로 보존해 재유료 시 복원한다.
      * 로컬만 갱신(upsertPreservingServerSyncFields)해 서버의 원본 목소리 알람은 백스톱으로 남긴다.
      */
-    suspend fun lockPaidAlarmTalks(ownerId: String?): Int {
+    suspend fun lockPaidAlarmTalks(): Int {
+        val currentUser = currentUserIdProvider() ?: return 0
         val targets = alarmDao.getAllAlarms().filter { alarm ->
             val usesVoice = alarm.playMode != AlarmPlayModes.ALARM_ONLY ||
                 !alarm.localAudioUri.isNullOrBlank() ||
                 !alarm.rawAudioUri.isNullOrBlank() ||
                 !alarm.voiceProfileId.isNullOrBlank() ||
                 !alarm.ttsMessageId.isNullOrBlank()
-            usesVoice && !alarm.usesFreeSystemVoiceAlarm() && alarm.preLockPlayMode == null
+            // 현재 세션이 소유한(ownerUserId 일치) 알람만 잠근다 — 같은 기기에 남아 있는 다른 계정의
+            // 알람을 잠가서 그 계정이 재유료해도 복원하지 못하게 되는 것을 막는다.
+            usesVoice && !alarm.usesFreeSystemVoiceAlarm() &&
+                alarm.preLockPlayMode == null && alarm.ownerUserId == currentUser
         }
         targets.forEach { alarm ->
             val locked = alarm.copy(
                 preLockPlayMode = alarm.playMode,
-                preLockOwnerId = ownerId,
                 playMode = AlarmPlayModes.ALARM_ONLY,
                 updatedAtMillis = System.currentTimeMillis(),
             )
@@ -467,18 +474,18 @@ class AlarmRepository(
 
     /**
      * 다시 유료가 되면 잠근 알람의 원래 재생모드를 복원한다. 로컬 알람은 로그아웃 후에도 남으므로,
-     * 잠금을 건 소유자(preLockOwnerId)가 현재 세션(ownerId)과 일치하는 것만 복원한다 — 다른 계정으로
-     * 로그인해 유료가 돼도 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다.
+     * 현재 세션이 소유한(ownerUserId 일치) 잠긴 알람만 복원한다 — 다른 계정으로 로그인해 유료가 돼도
+     * 남의 잠긴 목소리 알람이 복원돼 울리지 않게 한다.
      */
-    suspend fun unlockPaidAlarmTalks(ownerId: String?): Int {
+    suspend fun unlockPaidAlarmTalks(): Int {
+        val currentUser = currentUserIdProvider() ?: return 0
         val targets = alarmDao.getAllAlarms().filter {
-            !it.preLockPlayMode.isNullOrBlank() && it.preLockOwnerId == ownerId
+            !it.preLockPlayMode.isNullOrBlank() && it.ownerUserId == currentUser
         }
         targets.forEach { alarm ->
             val restored = alarm.copy(
                 playMode = alarm.preLockPlayMode ?: alarm.playMode,
                 preLockPlayMode = null,
-                preLockOwnerId = null,
                 updatedAtMillis = System.currentTimeMillis(),
             )
             if (restored.enabled) alarmScheduler.schedule(restored)
@@ -518,6 +525,7 @@ class AlarmRepository(
             lastSyncedAtMillis = null,
             syncState = AlarmSyncStates.LOCAL_ONLY,
             origin = AlarmOrigins.LOCAL_OWNED,
+            ownerUserId = currentUserIdProvider(),
             enabled = true,
             state = AlarmStates.SCHEDULED,
             createdAtMillis = now,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -434,23 +434,50 @@ class AlarmRepository(
         alarmAudioStore.deleteCachedAudioIfUnreferenced(alarmDao, cacheKey)
     }
 
-    suspend fun deletePaidAlarmTalks(): Int {
+    /**
+     * 무료 전환 시 유료 목소리 알람을 삭제하지 않고 사운드온리로 '잠근다'. 원래 재생모드를
+     * preLockPlayMode 에 보관하고 playMode 를 ALARM_ONLY 로 내려, RingingService 가 목소리 대신
+     * 기본 알람음을 재생하게 한다. 캐시 오디오·목소리 참조는 그대로 보존해 재유료 시 복원한다.
+     * 로컬만 갱신(upsertPreservingServerSyncFields)해 서버의 원본 목소리 알람은 백스톱으로 남긴다.
+     */
+    suspend fun lockPaidAlarmTalks(): Int {
         val targets = alarmDao.getAllAlarms().filter { alarm ->
             val usesVoice = alarm.playMode != AlarmPlayModes.ALARM_ONLY ||
                 !alarm.localAudioUri.isNullOrBlank() ||
                 !alarm.rawAudioUri.isNullOrBlank() ||
                 !alarm.voiceProfileId.isNullOrBlank() ||
                 !alarm.ttsMessageId.isNullOrBlank()
-            usesVoice && !alarm.usesFreeSystemVoiceAlarm()
+            usesVoice && !alarm.usesFreeSystemVoiceAlarm() && alarm.preLockPlayMode == null
         }
         targets.forEach { alarm ->
-            alarmScheduler.cancel(alarm.id)
-            val cacheKey = alarm.audioCacheKey
-            alarmDao.delete(alarm)
-            alarmAudioStore.deleteCachedAudioIfUnreferenced(alarmDao, cacheKey)
+            val locked = alarm.copy(
+                preLockPlayMode = alarm.playMode,
+                playMode = AlarmPlayModes.ALARM_ONLY,
+                updatedAtMillis = System.currentTimeMillis(),
+            )
+            if (locked.enabled) alarmScheduler.schedule(locked)
+            alarmDao.upsertPreservingServerSyncFields(locked)
         }
         if (targets.isNotEmpty()) {
-            Log.i(TAG, "Deleted paid voice alarms after free-plan downgrade count=${targets.size}")
+            Log.i(TAG, "Locked paid voice alarms on free plan count=${targets.size}")
+        }
+        return targets.size
+    }
+
+    /** 다시 유료가 되면 잠근 알람(preLockPlayMode != null)의 원래 재생모드를 복원한다. */
+    suspend fun unlockPaidAlarmTalks(): Int {
+        val targets = alarmDao.getAllAlarms().filter { !it.preLockPlayMode.isNullOrBlank() }
+        targets.forEach { alarm ->
+            val restored = alarm.copy(
+                playMode = alarm.preLockPlayMode ?: alarm.playMode,
+                preLockPlayMode = null,
+                updatedAtMillis = System.currentTimeMillis(),
+            )
+            if (restored.enabled) alarmScheduler.schedule(restored)
+            alarmDao.upsertPreservingServerSyncFields(restored)
+        }
+        if (targets.isNotEmpty()) {
+            Log.i(TAG, "Restored paid voice alarms after re-subscription count=${targets.size}")
         }
         return targets.size
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
@@ -24,6 +24,10 @@ internal class RemoteAlarmPullSyncService(
     private val alarmScheduler: AlarmScheduler,
     private val alarmAudioStore: AlarmAudioStore,
     private val context: android.content.Context,
+    // 현재 로그인 계정(=받은 알람의 수신자) id. 새로 임포트하는 받은 알람에 소유자로 기록해,
+    // 무료 잠금/복원이 그 수신자에게만 스코프되게 한다(같은 기기에 다른 계정이 로그인해도 남의
+    // 받은 알람을 복원·스케줄하지 못하게 함). 없으면(null) 레거시처럼 미기록으로 둔다.
+    private val currentUserIdProvider: () -> String? = { null },
 ) {
     // pull 이 동시에 두 번 돌면(FCM 수신 + 주기 sync 등) 둘 다 '기존 행 없음'으로 보고
     // 같은 받은 알람을 서로 다른 로컬 id 로 두 번 임포트한다(같은 시각 중복 울림).
@@ -287,8 +291,9 @@ internal class RemoteAlarmPullSyncService(
             createdAtMillis = existing?.createdAtMillis ?: now,
             updatedAtMillis = now,
             // 무료 잠금 상태·소유자를 재구성 시에도 보존한다(resolveReceivedLockState 참조).
+            // 새 받은 알람은 현재 수신자를 소유자로 기록하고, 기존 행은 그 값을 보존한다.
             preLockPlayMode = lockState.preLockPlayMode,
-            ownerUserId = existing?.ownerUserId,
+            ownerUserId = resolveReceivedOwner(existing, currentUserIdProvider()),
         )
     }
 
@@ -304,6 +309,14 @@ internal class RemoteAlarmPullSyncService(
     private fun repeatDaysToMask(days: List<Int>): Int =
         days.filter { it in 0..6 }.fold(0) { mask, day -> mask or (1 shl day) }
 }
+
+/**
+ * 받은 알람의 소유자(무료 잠금 스코프용). 새 행(existing==null)은 현재 수신자(currentUserId)를 기록하고,
+ * 기존 행은 이미 기록된 소유자를 보존한다 — 없으면(레거시 null) 현재 수신자로 자가 치유한다. 이렇게
+ * 하면 같은 기기에 다른 계정이 로그인해도 남의 받은 목소리 알람을 복원·스케줄하지 못한다.
+ */
+internal fun resolveReceivedOwner(existing: AlarmEntity?, currentUserId: String?): String? =
+    existing?.ownerUserId ?: currentUserId
 
 internal data class ReceivedLockState(val playMode: String, val preLockPlayMode: String?)
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
@@ -230,11 +230,12 @@ internal class RemoteAlarmPullSyncService(
             holidayOff = false,
             nowMillis = now,
         )
-        val playMode = when {
+        val computedPlayMode = when {
             cachedAudio == null -> AlarmPlayModes.ALARM_ONLY
             remote.wakeMode == "voice_only" -> AlarmPlayModes.VOICE_ONLY
             else -> AlarmPlayModes.ALARM_VOICE
         }
+        val lockState = resolveReceivedLockState(computedPlayMode, existing)
         val label = receivedRemoteAlarmLabel(context, remote.senderName, remote.senderEmail)
 
         return AlarmEntity(
@@ -250,7 +251,7 @@ internal class RemoteAlarmPullSyncService(
             snoozeRepeatLimit = existing?.snoozeRepeatLimit ?: SnoozeRepeatLimits.THREE,
             snoozeCount = 0,
             vibrationPattern = remote.vibrationPattern ?: VibrationPatterns.DEFAULT,
-            playMode = playMode,
+            playMode = lockState.playMode,
             defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,
             localAudioUri = cachedAudio?.localAudioUri,
             audioCacheKey = cachedAudio?.cacheKey,
@@ -285,6 +286,9 @@ internal class RemoteAlarmPullSyncService(
             state = if (enabled) AlarmStates.SCHEDULED else AlarmStates.DISABLED,
             createdAtMillis = existing?.createdAtMillis ?: now,
             updatedAtMillis = now,
+            // 무료 잠금 상태·소유자를 재구성 시에도 보존한다(resolveReceivedLockState 참조).
+            preLockPlayMode = lockState.preLockPlayMode,
+            ownerUserId = existing?.ownerUserId,
         )
     }
 
@@ -299,6 +303,33 @@ internal class RemoteAlarmPullSyncService(
 
     private fun repeatDaysToMask(days: List<Int>): Int =
         days.filter { it in 0..6 }.fold(0) { mask, day -> mask or (1 shl day) }
+}
+
+internal data class ReceivedLockState(val playMode: String, val preLockPlayMode: String?)
+
+/**
+ * 받은 알람 재구성 시 무료 잠금 상태를 보존한다. 이전에 무료로 잠긴(existing.preLockPlayMode 설정)
+ * 받은 알람은 매 FCM/주기 pull 재구성 후에도 잠금(playMode=ALARM_ONLY)을 유지한다 — 안 그러면
+ * 동기화가 원격 목소리 모드로 되돌려 무료 사용자가 유료 목소리를 다시 듣게 된다. 잠금 설정/해제는
+ * 유료 여부(구독 응답)를 아는 앱 시작 로직(lock/unlockPaidAlarmTalks)이 관장하고, 동기화는
+ * 그 상태를 덮어쓰지 않는다. 잠기지 않았으면 재구성된 원격 모드를 그대로 쓴다.
+ *
+ * 잠긴 경우 복원용 preLockPlayMode 는: 이번 재구성으로 목소리 모드가 산출되면(computed != ALARM_ONLY)
+ * 그 최신 모드를 담아 재유료 시 정확히 복원되게 하고, 이번 pull 에서 오디오를 못 받아 사운드온리가
+ * 됐으면(computed == ALARM_ONLY) 기존 preLockPlayMode 를 보존해 잠금 마커 유실을 막는다.
+ */
+internal fun resolveReceivedLockState(
+    computedPlayMode: String,
+    existing: AlarmEntity?,
+): ReceivedLockState {
+    val wasLocked = !existing?.preLockPlayMode.isNullOrBlank()
+    if (!wasLocked) return ReceivedLockState(computedPlayMode, null)
+    val restoreMode = if (computedPlayMode != AlarmPlayModes.ALARM_ONLY) {
+        computedPlayMode
+    } else {
+        existing?.preLockPlayMode
+    }
+    return ReceivedLockState(AlarmPlayModes.ALARM_ONLY, restoreMode)
 }
 
 internal fun resolveReceivedRemoteEnabled(existing: AlarmEntity?, remoteIsActive: Boolean?): Boolean {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/BillingApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/BillingApi.kt
@@ -109,10 +109,6 @@ data class CancelSubscriptionResponse(
     @SerializedName("voice_retention_until") val voiceRetentionUntil: String? = null,
 )
 
-data class VoiceDataDeleteNowResponse(
-    val success: Boolean = false,
-)
-
 data class ChangePlanRequest(
     @SerializedName("plan_key") val planKey: String,
     val mode: String, // "immediate" | "at_period_end"
@@ -163,12 +159,6 @@ interface BillingApi {
         @Header("Authorization") authorization: String,
         @Body request: CancelSubscriptionRequest,
     ): CancelSubscriptionResponse
-
-    /** 보관 중인 유료 음성 데이터 즉시 삭제. 활성 유료 구독이 있으면 409 SUBSCRIPTION_STILL_ACTIVE. */
-    @POST("billing/voice-data/delete-now")
-    suspend fun deleteVoiceDataNow(
-        @Header("Authorization") authorization: String,
-    ): VoiceDataDeleteNowResponse
 
     @POST("billing/change-plan")
     suspend fun changePlan(

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
@@ -101,7 +101,6 @@ internal fun AlarmListScreen(
     onCancelSubscription: (Boolean) -> Unit,
     onChangePlan: (String, Boolean) -> Unit,
     onRefreshShareCodeData: suspend () -> List<VoucherItem>,
-    onDeleteVoiceDataNow: () -> Unit,
     permissions: PermissionSnapshot,
     onCreateAlarm: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -288,7 +287,6 @@ internal fun AlarmListScreen(
                         onChangePlan = onChangePlan,
                         onLeaveFamilyGroup = onLeaveFamilyGroup,
                         onRefreshShareCodeData = onRefreshShareCodeData,
-                        onDeleteVoiceDataNow = onDeleteVoiceDataNow,
                     )
                 }
             }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -290,8 +290,14 @@ internal fun AlarmTalkApp(
         subscriptionResponse?.plan?.key,
         subscriptionResponse?.plan?.planType,
     ) {
-        if (authSession != null && subscriptionResponse != null && !hasPaidVoiceAccess(subscriptionResponse)) {
-            viewModel.applyFreePlanVoiceLock()
+        if (authSession != null && subscriptionResponse != null) {
+            if (hasPaidVoiceAccess(subscriptionResponse)) {
+                // 다시 유료가 되면 무료 동안 잠근 목소리 알람을 복원한다.
+                viewModel.restorePaidVoiceAlarmsIfLocked()
+            } else {
+                // 무료면 유료 목소리 알람을 삭제 대신 사운드온리로 잠근다.
+                viewModel.applyFreePlanVoiceLock()
+            }
         }
     }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -726,7 +726,6 @@ internal fun AlarmTalkApp(
                           onCancelSubscription = viewModel::cancelSubscription,
                           onChangePlan = viewModel::changePlan,
                           onRefreshShareCodeData = viewModel::refreshShareCodeData,
-                          onDeleteVoiceDataNow = viewModel::deleteVoiceDataNow,
                           permissions = permissions,
                           onCreateAlarm = ::requestCreateAlarm,
                           onOpenSettings = { navController.navigate(AppRoute.Settings) },

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/billing/BillingPanels.kt
@@ -72,13 +72,11 @@ internal fun SubscriptionPanel(
     onChangePlan: (String, Boolean) -> Unit,
     onLeaveFamilyGroup: (String) -> Unit,
     onRefreshShareCodeData: suspend () -> List<VoucherItem>,
-    onDeleteVoiceDataNow: () -> Unit,
 ) {
     var purchaseTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
     var changeTarget by remember { mutableStateOf<SubscriptionPlanOption?>(null) }
     var showCancelDialog by remember { mutableStateOf(false) }
     var showLeaveDialog by remember { mutableStateOf(false) }
-    var showVoiceDataDeleteDialog by remember { mutableStateOf(false) }
     var shareTarget by remember { mutableStateOf<List<VoucherItem>>(emptyList()) }
     var shareBusy by remember { mutableStateOf(false) }
     val subscription = subscriptionResponse?.subscription
@@ -264,21 +262,8 @@ internal fun SubscriptionPanel(
                 )
             }
         }
-        // 즉시 해지 후 30일 보관 중인 유료 음성 데이터를 바로 지우는 파괴적 액션.
-        // 클라는 보관 데이터 존재 여부를 모르므로 상시 노출 — 활성 구독 중엔 서버가 409 로 거절한다.
-        if (subscriptionResponse != null && !isSharedMember) {
-            TextButton(
-                onClick = { showVoiceDataDeleteDialog = true },
-                enabled = !billingBusy,
-                modifier = Modifier.fillMaxWidth(),
-                shape = WakerButtonShape,
-            ) {
-                Text(
-                    text = stringResource(R.string.billing_voice_data_delete_now),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        }
+        // 정책 변경: 무료 전환 시 유료 음성 데이터를 삭제하지 않고 보존·잠금하므로
+        // '지금 삭제' 파괴적 액션은 제거했다(다시 이용권을 등록하면 그대로 복구된다).
     }
 
     purchaseTarget?.let { option ->
@@ -306,24 +291,6 @@ internal fun SubscriptionPanel(
                 onCancelSubscription(atPeriodEnd)
             },
         )
-    }
-
-    if (showVoiceDataDeleteDialog) {
-        BillingActionDialog(
-            title = stringResource(R.string.billing_voice_data_delete_title),
-            description = stringResource(R.string.billing_voice_data_delete_description),
-            onDismiss = { showVoiceDataDeleteDialog = false },
-        ) {
-            BillingDialogButton(
-                label = stringResource(R.string.billing_voice_data_delete_button),
-                primary = true,
-                destructive = true,
-                onClick = {
-                    showVoiceDataDeleteDialog = false
-                    onDeleteVoiceDataNow()
-                },
-            )
-        }
     }
 
     if (showLeaveDialog && sharedGroupId != null) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -461,13 +461,13 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
         billingBusy = true
         runCatching {
             api.cancelSubscription(authorization, CancelSubscriptionRequest(mode = mode))
-        }.onSuccess { response ->
-            val retentionDate = formatPass(response.voiceRetentionUntil, PassDateFormatter)
-            message = when {
-                atPeriodEnd -> getApplication<android.app.Application>().getString(R.string.msg_gb_subscription_cancel_at_period_end)
-                retentionDate != null ->
-                    getApplication<android.app.Application>().getString(R.string.msg_gb_subscription_canceled_voice_retained, retentionDate)
-                else -> getApplication<android.app.Application>().getString(R.string.msg_gb_subscription_canceled)
+        }.onSuccess { _ ->
+            // 정책 변경: 해지해도 만든 목소리는 삭제하지 않고 잠근다 — 다시 이용권을 등록하면
+            // 그대로 다시 쓸 수 있다(보관 후 삭제 안내 문구 제거).
+            message = if (atPeriodEnd) {
+                getApplication<android.app.Application>().getString(R.string.msg_gb_subscription_cancel_at_period_end)
+            } else {
+                getApplication<android.app.Application>().getString(R.string.msg_gb_subscription_canceled_voice_locked)
             }
             refreshBillingAfterMutation(authorization, "subscription cancellation")
             refreshAppSession()
@@ -488,49 +488,12 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
     }
 }
 
-/**
- * 보관 중인 유료 음성 데이터 즉시 삭제(/billing/voice-data/delete-now).
- * 활성 유료 구독이 있으면 서버가 409 SUBSCRIPTION_STILL_ACTIVE 로 거절한다.
- */
-internal fun MainViewModel.deleteVoiceDataNow() {
-    val authorization = bearerOrMessage(getApplication<android.app.Application>().getString(R.string.msg_gb_login_required_generic)) ?: return
-    viewModelScope.launch {
-        billingBusy = true
-        runCatching {
-            api.deleteVoiceDataNow(authorization)
-        }.onSuccess {
-            message = getApplication<android.app.Application>().getString(R.string.msg_gb_voice_data_deleted_now)
-        }.onFailure { error ->
-            AlarmTalkLog.reportError("Failed to delete voice data now", error)
-            message = if (apiErrorCode(error) == "SUBSCRIPTION_STILL_ACTIVE") {
-                getApplication<android.app.Application>().getString(R.string.msg_gb_voice_data_delete_blocked_active)
-            } else {
-                userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_gb_voice_data_delete_failed))
-            }
-        }
-        billingBusy = false
-    }
-}
-
+// 정책 변경: 무료 전환 시 유료 목소리/알람 데이터를 삭제하지 않고 보존한다 — 다시 이용권을
+// 등록하면 그대로 다시 쓸 수 있어야 하기 때문. 새 목소리 알람 생성·TTS 합성은 유료 게이트가
+// 이미 막는다. (무료 동안 기존 알람의 목소리 사용을 사운드온리로 잠그고 재유료 시 되돌리는
+// 처리는 후속 작업 — Room 스키마 추가가 필요.)
 internal fun MainViewModel.applyFreePlanVoiceLock() {
-    viewModelScope.launch {
-        runCatching {
-            repository.deletePaidAlarmTalks()
-        }.onSuccess { deletedAlarms ->
-            // 시스템(스톡) 목소리는 무료에서도 쓰는 "기본 목소리"다. 유료 음성만 제거하고
-            // 시스템 음성은 남긴다 — 온보딩 "기본 목소리 고르기"가 빈 목록으로 멈추는 것 방지(Codex P2).
-            if (voiceProfiles.any { it.isSystem != true }) {
-                voiceProfiles = voiceProfiles.filter { it.isSystem == true }
-            }
-            if (familyVoices.isNotEmpty()) familyVoices = emptyList()
-            if (ttsMessages.isNotEmpty()) ttsMessages = emptyList()
-            if (deletedAlarms > 0) {
-                message = getApplication<android.app.Application>().getString(R.string.msg_gb_free_plan_voice_alarms_deleted)
-            }
-        }.onFailure { error ->
-            AlarmTalkLog.reportError("Failed to apply free-plan voice lock", error)
-        }
-    }
+    // no-op: 유료 음성 데이터 보존(삭제하지 않음).
 }
 
 internal fun MainViewModel.changePlan(planKey: String, atPeriodEnd: Boolean) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -492,9 +492,10 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
 // 사운드온리로 '잠근다'(preLockPlayMode 에 원래 모드 보관). 다시 유료가 되면 그대로 복원한다.
 // 새 목소리 알람 생성·TTS 합성은 유료 게이트가 이미 막는다.
 internal fun MainViewModel.applyFreePlanVoiceLock() {
+    val ownerId = authSession?.user?.id
     viewModelScope.launch {
         runCatching {
-            repository.lockPaidAlarmTalks()
+            repository.lockPaidAlarmTalks(ownerId)
         }.onSuccess { locked ->
             if (locked > 0) {
                 message = getApplication<android.app.Application>().getString(R.string.msg_gb_free_plan_voice_alarms_locked)
@@ -507,9 +508,10 @@ internal fun MainViewModel.applyFreePlanVoiceLock() {
 
 /** 다시 유료가 되면 무료 동안 사운드온리로 잠갔던 목소리 알람을 원래 모드로 복원한다. */
 internal fun MainViewModel.restorePaidVoiceAlarmsIfLocked() {
+    val ownerId = authSession?.user?.id
     viewModelScope.launch {
         runCatching {
-            repository.unlockPaidAlarmTalks()
+            repository.unlockPaidAlarmTalks(ownerId)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Failed to restore locked paid voice alarms", error)
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -492,10 +492,9 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
 // 사운드온리로 '잠근다'(preLockPlayMode 에 원래 모드 보관). 다시 유료가 되면 그대로 복원한다.
 // 새 목소리 알람 생성·TTS 합성은 유료 게이트가 이미 막는다.
 internal fun MainViewModel.applyFreePlanVoiceLock() {
-    val ownerId = authSession?.user?.id
     viewModelScope.launch {
         runCatching {
-            repository.lockPaidAlarmTalks(ownerId)
+            repository.lockPaidAlarmTalks()
         }.onSuccess { locked ->
             if (locked > 0) {
                 message = getApplication<android.app.Application>().getString(R.string.msg_gb_free_plan_voice_alarms_locked)
@@ -508,10 +507,9 @@ internal fun MainViewModel.applyFreePlanVoiceLock() {
 
 /** 다시 유료가 되면 무료 동안 사운드온리로 잠갔던 목소리 알람을 원래 모드로 복원한다. */
 internal fun MainViewModel.restorePaidVoiceAlarmsIfLocked() {
-    val ownerId = authSession?.user?.id
     viewModelScope.launch {
         runCatching {
-            repository.unlockPaidAlarmTalks(ownerId)
+            repository.unlockPaidAlarmTalks()
         }.onFailure { error ->
             AlarmTalkLog.reportError("Failed to restore locked paid voice alarms", error)
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelGrowthBillingActions.kt
@@ -488,12 +488,32 @@ internal fun MainViewModel.cancelSubscription(atPeriodEnd: Boolean) {
     }
 }
 
-// 정책 변경: 무료 전환 시 유료 목소리/알람 데이터를 삭제하지 않고 보존한다 — 다시 이용권을
-// 등록하면 그대로 다시 쓸 수 있어야 하기 때문. 새 목소리 알람 생성·TTS 합성은 유료 게이트가
-// 이미 막는다. (무료 동안 기존 알람의 목소리 사용을 사운드온리로 잠그고 재유료 시 되돌리는
-// 처리는 후속 작업 — Room 스키마 추가가 필요.)
+// 정책 변경: 무료 전환 시 유료 목소리/알람 데이터를 삭제하지 않고, 기존 유료 목소리 알람을
+// 사운드온리로 '잠근다'(preLockPlayMode 에 원래 모드 보관). 다시 유료가 되면 그대로 복원한다.
+// 새 목소리 알람 생성·TTS 합성은 유료 게이트가 이미 막는다.
 internal fun MainViewModel.applyFreePlanVoiceLock() {
-    // no-op: 유료 음성 데이터 보존(삭제하지 않음).
+    viewModelScope.launch {
+        runCatching {
+            repository.lockPaidAlarmTalks()
+        }.onSuccess { locked ->
+            if (locked > 0) {
+                message = getApplication<android.app.Application>().getString(R.string.msg_gb_free_plan_voice_alarms_locked)
+            }
+        }.onFailure { error ->
+            AlarmTalkLog.reportError("Failed to lock paid voice alarms on free plan", error)
+        }
+    }
+}
+
+/** 다시 유료가 되면 무료 동안 사운드온리로 잠갔던 목소리 알람을 원래 모드로 복원한다. */
+internal fun MainViewModel.restorePaidVoiceAlarmsIfLocked() {
+    viewModelScope.launch {
+        runCatching {
+            repository.unlockPaidAlarmTalks()
+        }.onFailure { error ->
+            AlarmTalkLog.reportError("Failed to restore locked paid voice alarms", error)
+        }
+    }
 }
 
 internal fun MainViewModel.changePlan(planKey: String, atPeriodEnd: Boolean) {

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -69,7 +69,7 @@
     <string name="billing_cancel_description_no_date">Choose when to cancel. Canceling on the end date keeps your pass until the current period ends. Canceling now gives you a prorated refund for the remaining time.</string>
     <string name="billing_cancel_description_with_date">Canceling on the end date keeps your pass until %1$s. Canceling now ends your pass immediately with a prorated refund for the remaining time.</string>
     <string name="billing_cancel_dialog_title">Cancel your pass?</string>
-    <string name="billing_cancel_immediate_description">The remaining time is refunded on a prorated basis and your pass ends immediately. Your voice data is kept for 30 days and then permanently deleted.</string>
+    <string name="billing_cancel_immediate_description">The remaining time is refunded on a prorated basis and your pass ends immediately. Your voices aren\'t deleted — they\'re locked while you\'re on the free plan and become usable again when you resubscribe.</string>
     <string name="billing_cancel_immediate_title">Cancel right now?</string>
     <string name="billing_cancel_now">Cancel now</string>
     <string name="billing_cancel_pass">Cancel pass</string>
@@ -464,6 +464,7 @@
     <string name="msg_gb_subscription_cancel_failed">Couldn\'t cancel your plan.</string>
     <string name="msg_gb_subscription_canceled">Your plan has been canceled. The remaining time is refunded on a prorated basis.</string>
     <string name="msg_gb_subscription_canceled_voice_retained">Your plan has been canceled. The remaining time is refunded, and your voice data is kept until %1$s.</string>
+    <string name="msg_gb_subscription_canceled_voice_locked">Your plan has been canceled. Your voices aren\'t deleted — they\'re locked and become usable again when you resubscribe.</string>
     <string name="msg_gb_voice_data_delete_blocked_active">You can\'t delete this while your subscription is active.</string>
     <string name="msg_gb_voice_data_delete_failed">Couldn\'t delete your voice data.</string>
     <string name="msg_gb_voice_data_deleted_now">Your voice data has been deleted.</string>

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -423,6 +423,7 @@
     <string name="msg_gb_promo_redeemed">Promo code applied</string>
     <string name="msg_gb_promo_redeem_failed">Couldn\'t apply the promo code.</string>
     <string name="msg_gb_free_plan_voice_alarms_deleted">You\'ve switched to the free plan, so your voice alarms were deleted.</string>
+    <string name="msg_gb_free_plan_voice_alarms_locked">You\'ve switched to the free plan, so your voice alarms are locked. They\'ll be restored when you resubscribe.</string>
     <string name="msg_gb_gift_failed">Couldn\'t send the gift.</string>
     <string name="msg_gb_google_play_start_failed">Couldn\'t start the Google Play payment. Please try again in a moment.</string>
     <string name="msg_gb_growth_info_load_failed">Couldn\'t load your growth info</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -69,7 +69,7 @@
     <string name="billing_cancel_description_no_date">解約のタイミングを選択してください。終了日での解約は今の利用期間までそのまま使えます。今すぐ解約すると残り期間の料金は日割りで返金されます。</string>
     <string name="billing_cancel_description_with_date">終了日での解約は%1$sまでそのまま使えます。今すぐ解約すると残り期間の料金は日割りで返金され、利用券はすぐに終了します。</string>
     <string name="billing_cancel_dialog_title">利用券を解約しますか？</string>
-    <string name="billing_cancel_immediate_description">残り期間の料金は日割りで返金され、利用券はすぐに終了します。作成した声のデータは30日間保管された後、完全に削除されます。</string>
+    <string name="billing_cancel_immediate_description">残り期間の料金は日割りで返金され、利用券はすぐに終了します。作成した声は削除されず、無料の間はロックされ、再び利用券を登録するとそのまま使えます。</string>
     <string name="billing_cancel_immediate_title">今すぐ解約しますか？</string>
     <string name="billing_cancel_now">今すぐ解約</string>
     <string name="billing_cancel_pass">利用券を解約</string>
@@ -473,6 +473,7 @@
     <string name="msg_gb_subscription_cancel_failed">解約に失敗しました。</string>
     <string name="msg_gb_subscription_canceled">プランを解約しました。残り期間の料金は日割りで返金されます。</string>
     <string name="msg_gb_subscription_canceled_voice_retained">プランを解約しました。残り期間の料金は日割りで返金され、声のデータは%1$sまで保管されます。</string>
+    <string name="msg_gb_subscription_canceled_voice_locked">プランを解約しました。作成した声は削除されずロックされます。再び利用券を登録すると、そのまま使えます。</string>
     <string name="msg_gb_voice_data_delete_blocked_active">定期購入のご利用中は削除できません。</string>
     <string name="msg_gb_voice_data_delete_failed">声のデータを削除できませんでした。</string>
     <string name="msg_gb_voice_data_deleted_now">声のデータを削除しました。</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -432,6 +432,7 @@
     <string name="msg_gb_promo_redeemed">プロモコードを適用しました</string>
     <string name="msg_gb_promo_redeem_failed">プロモコードを適用できませんでした。</string>
     <string name="msg_gb_free_plan_voice_alarms_deleted">無料プランに切り替わったため、声のアラームを削除しました。</string>
+    <string name="msg_gb_free_plan_voice_alarms_locked">無料プランに切り替わったため、声のアラームがロックされました。再び利用券を登録すると復元されます。</string>
     <string name="msg_gb_gift_failed">プレゼントの送信に失敗しました。</string>
     <string name="msg_gb_google_play_start_failed">Google Play決済を開始できませんでした。しばらくしてからもう一度お試しください。</string>
     <string name="msg_gb_growth_info_load_failed">成長情報を読み込めませんでした</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="billing_cancel_description_no_date">해지 시점을 선택해 주세요. 종료일 해지는 이번 이용 기간까지 그대로 쓸 수 있어요. 지금 해지하면 남은 기간 요금은 비례 환불돼요.</string>
     <string name="billing_cancel_description_with_date">종료일 해지는 %1$s까지 그대로 쓰고 끝나요. 지금 해지하면 남은 기간 요금은 비례 환불되고 이용권이 바로 종료돼요.</string>
     <string name="billing_cancel_dialog_title">이용권을 해지할까요?</string>
-    <string name="billing_cancel_immediate_description">남은 기간 요금은 비례 환불되고 이용권이 바로 종료돼요. 만든 목소리 데이터는 30일간 보관된 뒤 완전히 삭제돼요.</string>
+    <string name="billing_cancel_immediate_description">남은 기간 요금은 비례 환불되고 이용권이 바로 종료돼요. 만든 목소리는 삭제되지 않고 잠기며, 다시 이용권을 등록하면 그대로 다시 쓸 수 있어요.</string>
     <string name="billing_cancel_immediate_title">지금 바로 해지할까요?</string>
     <string name="billing_cancel_now">지금 해지하기</string>
     <string name="billing_cancel_pass">이용권 해지</string>
@@ -476,6 +476,7 @@
     <string name="msg_gb_subscription_cancel_failed">해지에 실패했어요</string>
     <string name="msg_gb_subscription_canceled">이용권을 해지했어요. 남은 기간 요금은 비례 환불돼요</string>
     <string name="msg_gb_subscription_canceled_voice_retained">이용권을 해지했어요. 남은 기간 요금은 비례 환불되고, 목소리 데이터는 %1$s까지 보관돼요</string>
+    <string name="msg_gb_subscription_canceled_voice_locked">이용권을 해지했어요. 만든 목소리는 삭제되지 않고 잠겨요 — 다시 이용권을 등록하면 그대로 다시 쓸 수 있어요</string>
     <string name="msg_gb_voice_data_delete_blocked_active">구독 이용 중에는 삭제할 수 없어요</string>
     <string name="msg_gb_voice_data_delete_failed">목소리 데이터를 삭제하지 못했어요</string>
     <string name="msg_gb_voice_data_deleted_now">목소리 데이터를 삭제했어요</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -435,6 +435,7 @@
     <string name="msg_gb_promo_redeemed">프로모 코드를 적용했어요</string>
     <string name="msg_gb_promo_redeem_failed">프로모 코드를 적용하지 못했어요</string>
     <string name="msg_gb_free_plan_voice_alarms_deleted">무료 이용권으로 전환되어 목소리 알람을 삭제했어요.</string>
+    <string name="msg_gb_free_plan_voice_alarms_locked">무료 이용권으로 전환되어 목소리 알람이 잠겼어요. 다시 이용권을 등록하면 복구돼요.</string>
     <string name="msg_gb_gift_failed">선물하기에 실패했어요</string>
     <string name="msg_gb_google_play_start_failed">Google Play 결제를 시작하지 못했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="msg_gb_growth_info_load_failed">성장 정보를 불러오지 못했어요</string>

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
@@ -46,6 +46,42 @@ class RemoteAlarmPullSyncServiceTest {
     }
 
     @Test
+    fun unlockedReceivedAlarmKeepsRebuiltRemoteVoiceMode() {
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+
+        val state = resolveReceivedLockState(AlarmPlayModes.ALARM_VOICE, existing)
+
+        assertEquals(AlarmPlayModes.ALARM_VOICE, state.playMode)
+        assertEquals(null, state.preLockPlayMode)
+    }
+
+    @Test
+    fun lockedReceivedAlarmStaysLockedAfterPullAndSnapshotsRebuiltVoiceMode() {
+        // 무료로 잠긴 받은 알람: pull 이 원격 목소리 모드(ALARM_VOICE)를 재구성해도 잠금을 유지하고,
+        // 그 최신 모드를 복원용으로 스냅샷한다(재유료 시 unlockPaidAlarmTalks 가 이 값으로 복원).
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(playMode = AlarmPlayModes.ALARM_ONLY, preLockPlayMode = AlarmPlayModes.VOICE_ONLY)
+
+        val state = resolveReceivedLockState(AlarmPlayModes.ALARM_VOICE, existing)
+
+        assertEquals(AlarmPlayModes.ALARM_ONLY, state.playMode)
+        assertEquals(AlarmPlayModes.ALARM_VOICE, state.preLockPlayMode)
+    }
+
+    @Test
+    fun lockedReceivedAlarmPreservesLockMarkerWhenAudioMissingThisPull() {
+        // 이번 pull 에서 오디오를 못 받아 사운드온리(computed==ALARM_ONLY)가 돼도 기존 잠금 마커를
+        // 잃지 않는다 — 잃으면 다음 성공 pull 이 무료인데도 목소리로 되살린다.
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(playMode = AlarmPlayModes.ALARM_ONLY, preLockPlayMode = AlarmPlayModes.ALARM_VOICE)
+
+        val state = resolveReceivedLockState(AlarmPlayModes.ALARM_ONLY, existing)
+
+        assertEquals(AlarmPlayModes.ALARM_ONLY, state.playMode)
+        assertEquals(AlarmPlayModes.ALARM_VOICE, state.preLockPlayMode)
+    }
+
+    @Test
     fun remoteAlarmDoesNotDownloadMessageAudioWhenAudioUrlWasCleared() {
         val remote = RemoteAlarm(id = "remote-id", messageId = "message-id")
 

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
@@ -46,6 +46,29 @@ class RemoteAlarmPullSyncServiceTest {
     }
 
     @Test
+    fun newReceivedAlarmRecordsCurrentRecipientAsOwner() {
+        // 새 받은 알람은 현재 수신자를 소유자로 기록한다 — 같은 기기에 다른 계정이 로그인해도
+        // 남의 받은 목소리 알람을 복원·스케줄하지 못하게 스코프한다.
+        assertEquals("recipient-1", resolveReceivedOwner(existing = null, currentUserId = "recipient-1"))
+    }
+
+    @Test
+    fun existingReceivedAlarmPreservesRecordedOwner() {
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(ownerUserId = "owner-a")
+
+        assertEquals("owner-a", resolveReceivedOwner(existing, currentUserId = "recipient-b"))
+    }
+
+    @Test
+    fun legacyReceivedAlarmWithoutOwnerHealsToCurrentRecipient() {
+        val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(ownerUserId = null)
+
+        assertEquals("recipient-1", resolveReceivedOwner(existing, currentUserId = "recipient-1"))
+    }
+
+    @Test
     fun unlockedReceivedAlarmKeepsRebuiltRemoteVoiceMode() {
         val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
 

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -96,40 +96,17 @@ export async function clearPaidVoiceRetention(db: DbExecutor, userPk: string): P
 }
 
 /**
- * 보관 유예가 끝난(delete_after 경과) 사용자들의 유료 음성 데이터를 삭제한다.
- * cron(processSubscriptionExpiry 말미)에서 호출. 사용자별 트랜잭션으로 처리해
- * 한 명 실패가 나머지를 막지 않게 한다.
+ * 만료된(delete_after 경과) 유료 음성 보관 행을 거둔다.
+ * 정책 변경: 무료 전환 시 유료 음성 데이터를 더 이상 삭제하지 않는다 — 데이터는 그대로 보존하고
+ * 무료인 동안 사용을 잠글 뿐이며, 다시 유료가 되면 그대로 풀린다(잠금은 users.plan 에서 파생).
+ * 그래서 이 스윕은 하드삭제를 하지 않고, 유예가 지난 보관 행만 정리하는 청소부로 남는다.
+ * (계정 삭제 같은 명시 경로는 여전히 deletePaidVoiceDataForUser 로 직접 삭제한다.)
  */
 export async function sweepPaidVoiceRetention(db: Client, now: Date = new Date()): Promise<void> {
-  const dueRes = await db.execute({
-    sql: `SELECT user_id FROM paid_voice_retention WHERE delete_after <= ?`,
+  await db.execute({
+    sql: `DELETE FROM paid_voice_retention WHERE delete_after <= ?`,
     args: [now.toISOString()],
   });
-  for (const row of dueRes.rows) {
-    const userPk = String(row.user_id);
-    await withWriteTransaction(db, async (tx) => {
-      // 경합 하드닝: delete_after 조건을 다시 걸어 보관 행을 트랜잭션 안에서 선점 삭제한다.
-      // 위 목록 조회와 이 트랜잭션 사이에 재해지/연장으로 delete_after 가 미래로 밀렸다면
-      // rowsAffected=0 → 유예가 아직 남아 있으므로 음성 삭제를 스킵한다(다음 run 재평가).
-      const claimed = await tx.execute({
-        sql: `DELETE FROM paid_voice_retention WHERE user_id = ? AND delete_after <= ?`,
-        args: [userPk, now.toISOString()],
-      });
-      if (claimed.rowsAffected === 0) return;
-      // 재구독 안전망: 어떤 경로로든(스토어/바우처/프로모) 유료 구독이 되살아났는데
-      // 보관 행 해제가 누락됐다면, 음성은 삭제하지 않고 행만 거둔다.
-      const activeRes = await tx.execute({
-        sql: `SELECT s.id FROM subscriptions s JOIN plans p ON p.id = s.plan_id
-              WHERE s.user_id = ? AND s.status = 'active'
-                AND p.plan_type IN ('personal', 'family')
-              LIMIT 1`,
-        args: [userPk],
-      });
-      if (activeRes.rows.length === 0) {
-        await deletePaidVoiceDataForUser(tx, userPk, await resolveUserLoginId(tx, userPk));
-      }
-    });
-  }
 }
 
 export async function downgradeUserToFree(

--- a/packages/backend/src/routes/billing-mutation.ts
+++ b/packages/backend/src/routes/billing-mutation.ts
@@ -12,7 +12,6 @@ import {
 } from '../lib/billing-cancel';
 import { issueVoucherCode, type IssuedVoucherCode } from '../lib/voucher-issue';
 import { logStructured } from '../lib/logger';
-import { deletePaidVoiceDataForUser } from '../lib/paid-voice-cleanup';
 import {
   playCancelSubscription,
   playManageUrl,
@@ -831,43 +830,9 @@ billingMutation.post('/cancel', async (c) => {
   });
 });
 
-// MARK: - POST /billing/voice-data/delete-now
-//
-// 30일 보관 유예 중인 유료 음성 데이터를 사용자가 즉시 삭제한다.
-// 활성 유료 구독이 있으면 거부 — 구독 해지와 데이터 삭제는 별개 행위다.
-billingMutation.post('/voice-data/delete-now', async (c) => {
-  const userPk = await resolveUserPk(c);
-  if (!userPk) {
-    return c.json({ error: 'User not found', error_code: 'USER_NOT_FOUND' }, 404);
-  }
-
-  const db = getDB(c.env);
-  // 로그인 id(google_id)는 JWT sub — voice_profiles.user_id 가 로그인 id 로 저장된
-  // 일반 케이스를 함께 지우기 위해 PK 와 둘 다 넘긴다(deletePaidVoiceDataForUser 규약).
-  const loginId = c.get('userId');
-  // 활성 구독 확인을 삭제와 같은 쓰기 트랜잭션 안에서 수행한다(TOCTOU 하드닝) —
-  // 확인과 삭제 사이에 재구독(confirm/RTDN/바우처)이 끼어들어 유료 사용자의 음성이
-  // 지워지는 창을 없앤다.
-  const blocked = await withWriteTransaction(db, async (tx) => {
-    const activeSubscriptions = await findActiveSubscriptionsByUserPk(tx, userPk);
-    if (activeSubscriptions.some((s) => PAID_PLAN_TYPES.has(s.planType))) {
-      return true;
-    }
-    await deletePaidVoiceDataForUser(tx, userPk, loginId);
-    await clearPaidVoiceRetention(tx, userPk);
-    return false;
-  });
-  if (blocked) {
-    return c.json(
-      {
-        error: 'Cancel the active subscription before deleting voice data',
-        error_code: 'SUBSCRIPTION_STILL_ACTIVE',
-      },
-      409,
-    );
-  }
-  return c.json({ success: true });
-});
+// 정책 변경: 무료 전환 시 유료 음성 데이터를 삭제하지 않고 보존·잠금하므로,
+// 사용자 즉시 삭제(POST /billing/voice-data/delete-now)는 제거했다. 데이터는 다시 유료가 되면
+// 그대로 복구된다. (명시적 개별 삭제는 DELETE /voice/:id, 계정 삭제는 회원 탈퇴 경로.)
 
 billingMutation.post('/change-plan', async (c) => {
   if (!isBillingStubEnabled(c.env)) {

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -1628,18 +1628,21 @@ tts.get('/messages/:id/audio', async (c) => {
   }
 
   const result = await db.execute({
-    sql: `SELECT id, user_id, voice_profile_id, text, synthesis_text,
-                 delivery_tags_json, audio_url, category
+    sql: `SELECT messages.id, messages.user_id, messages.voice_profile_id, messages.text,
+                 messages.synthesis_text, messages.delivery_tags_json, messages.audio_url,
+                 messages.category,
+                 COALESCE(vp.is_system, 0) AS is_system,
+                 owner.plan AS owner_plan
           FROM messages
-          WHERE id = ?
-            AND EXISTS (
-              SELECT 1 FROM voice_profiles visible_vp
-              WHERE visible_vp.id = messages.voice_profile_id
-                AND visible_vp.deleted_at IS NULL
-                AND COALESCE(visible_vp.is_draft, 0) = 0
-            )
+          JOIN voice_profiles vp
+            ON vp.id = messages.voice_profile_id
+           AND vp.deleted_at IS NULL
+           AND COALESCE(vp.is_draft, 0) = 0
+          LEFT JOIN users owner
+            ON owner.id = vp.user_id OR owner.google_id = vp.user_id
+          WHERE messages.id = ?
             AND (
-              user_id IN (?, ?)
+              messages.user_id IN (?, ?)
               OR EXISTS (
                 SELECT 1 FROM alarms a
                 WHERE a.message_id = messages.id
@@ -1647,11 +1650,7 @@ tts.get('/messages/:id/audio', async (c) => {
               )
               OR (
                 COALESCE(messages.is_preset, 0) = 1
-                AND EXISTS (
-                  SELECT 1 FROM voice_profiles vp
-                  WHERE vp.id = messages.voice_profile_id
-                    AND COALESCE(vp.is_system, 0) = 1
-                )
+                AND COALESCE(vp.is_system, 0) = 1
               )
             )`,
     args: [id, ...ownerIds, ...ownerIds],
@@ -1669,7 +1668,25 @@ tts.get('/messages/:id/audio', async (c) => {
     delivery_tags_json: string | null;
     audio_url: string | null;
     category: string | null;
+    is_system: number | null;
+    owner_plan: string | null;
   }>(result.rows[0]!);
+
+  // 무료 플랜 잠금 강제: 유료 클론(비시스템) 보이스의 오디오는 그 보이스 소유자가 유료일 때만
+  // 내려준다. 소유자가 무료로 내려가면(다운그레이드) 데이터는 보존하되 재생은 잠기며, 소유자
+  // 본인은 물론 공유받은 대상에게도 서버가 오디오를 주지 않는다(삭제된 것과 동일하게 사라짐).
+  // 재유료가 되면 users.plan 이 복구돼 그대로 다시 풀린다. 시스템 스톡 보이스는 항상 허용.
+  const isSystemVoice = Number(message.is_system ?? 0) === 1;
+  if (!isSystemVoice && !isPaidVoicePlan(message.owner_plan)) {
+    return c.json(
+      {
+        error: 'This voice is locked on the free plan.',
+        error_code: 'VOICE_LOCKED_FREE_PLAN',
+      },
+      403,
+    );
+  }
+
   const audioUrl = message.audio_url;
   if (!audioUrl) {
     return c.json(

--- a/packages/backend/test/billing-cancel-play.test.ts
+++ b/packages/backend/test/billing-cancel-play.test.ts
@@ -583,81 +583,18 @@ describe('cancelSubscriptionImmediate — 가족 소유자 해지 (B)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// POST /billing/voice-data/delete-now
+// 보관 만료 sweep — 정책 변경: 무료 전환 시 음성 데이터를 삭제하지 않는다.
+// 데이터는 보존하고 무료 동안 잠글 뿐이며 재구독 시 그대로 풀린다. 스윕은 만기 지난
+// 보관 행만 청소하는 청소부로만 남는다(하드삭제 없음). 즉시 삭제 라우트(delete-now)도 제거.
 // ---------------------------------------------------------------------------
-describe('POST /billing/voice-data/delete-now', () => {
-  it('활성 유료 구독이 있으면 409 SUBSCRIPTION_STILL_ACTIVE', async () => {
-    mockDB.pushResult([{ id: 'user-pk-1' }]);
-    mockDB.pushResult([SUB_ROW]);
+describe('sweepPaidVoiceRetention (삭제 안 함, 만료 보관 행만 청소)', () => {
+  it('만기 도래 보관 행만 제거하고, 유료 음성 데이터는 삭제하지 않는다', async () => {
+    await sweepPaidVoiceRetention(mockDB.client as never, new Date());
 
-    const res = await buildApp().request(
-      jsonReq('POST', '/billing/voice-data/delete-now'),
-      undefined,
-      PLAY_ENV,
-    );
-
-    expect(res.status).toBe(409);
-    expect((await res.json()).error_code).toBe('SUBSCRIPTION_STILL_ACTIVE');
-    expect(mockDB.calls.some((c) => c.sql.includes('DELETE'))).toBe(false);
-  });
-
-  it('구독이 없으면 즉시 삭제 + 보관 행 제거', async () => {
-    mockDB.pushResult([{ id: 'user-pk-1' }]);
-    mockDB.pushResult([]); // 활성 구독 없음
-
-    const res = await buildApp().request(
-      jsonReq('POST', '/billing/voice-data/delete-now'),
-      undefined,
-      PLAY_ENV,
-    );
-
-    expect(res.status).toBe(200);
-    expect((await res.json()).success).toBe(true);
-    expect(findCall('DELETE FROM voice_profiles')).toBeDefined();
     expect(findCall('DELETE FROM paid_voice_retention')).toBeDefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 보관 만료 sweep
-// ---------------------------------------------------------------------------
-describe('sweepPaidVoiceRetention', () => {
-  it('delete_after 경과 행: 음성 삭제 + 보관 행 제거', async () => {
-    mockDB.pushResult([{ user_id: 'user-pk-9' }]); // 만기 도래 행
-    mockDB.pushResult([], 1); // 보관 행 선점 삭제(claim) 성공
-    mockDB.pushResult([]); // 활성 유료 구독 없음 (재구독 안전망)
-    mockDB.pushResult([{ google_id: 'google-9' }]); // resolveUserLoginId
-
-    await sweepPaidVoiceRetention(mockDB.client as never, new Date());
-
-    expect(findCall('DELETE FROM voice_profiles')).toBeDefined();
-    const retentionDelete = findCall('DELETE FROM paid_voice_retention');
-    expect(retentionDelete).toBeDefined();
-    expect(retentionDelete?.args[0]).toBe('user-pk-9');
-    expect(mockDB.transactions.commits).toBe(1);
-  });
-
-  it('재구독 안전망: 활성 유료 구독이 있으면 음성은 남기고 행만 거둔다', async () => {
-    mockDB.pushResult([{ user_id: 'user-pk-9' }]);
-    mockDB.pushResult([], 1); // claim 성공
-    mockDB.pushResult([{ id: 'sub-new' }]); // 활성 유료 구독 존재
-
-    await sweepPaidVoiceRetention(mockDB.client as never, new Date());
-
-    expect(findCall('DELETE FROM voice_profiles')).toBeUndefined();
-    expect(findCall('DELETE FROM paid_voice_retention')).toBeDefined();
-  });
-
-  it('C6 경합 하드닝: 목록 조회 후 유예가 연장됐으면(claim rowsAffected=0) 음성을 삭제하지 않는다', async () => {
-    mockDB.pushResult([{ user_id: 'user-pk-9' }]); // 목록 시점엔 만기 도래
-    mockDB.pushResult([], 0); // 그 사이 재해지/연장으로 delete_after 가 미래로 밀림 → claim 실패
-
-    await sweepPaidVoiceRetention(mockDB.client as never, new Date());
-
     expect(findCall('DELETE FROM voice_profiles')).toBeUndefined();
     expect(findCall('DELETE FROM messages')).toBeUndefined();
-    // 트랜잭션은 정상 커밋(스킵일 뿐 에러 아님) — 다음 run 에 재평가된다.
-    expect(mockDB.transactions.commits).toBe(1);
+    expect(findCall('DELETE FROM alarms')).toBeUndefined();
   });
 });
 

--- a/packages/backend/test/paid-voice-access.test.ts
+++ b/packages/backend/test/paid-voice-access.test.ts
@@ -119,4 +119,58 @@ describe('paid voice access gates', () => {
     expect(res.status).toBe(403);
     expect((await res.json()).error_code).toBe('VOICE_FEATURE_REQUIRES_PAID_PLAN');
   });
+
+  // GET /tts/messages/:id/audio 의 무료 잠금: 다운그레이드로 유료 데이터를 지우지 않고 보존만 하므로,
+  // 오디오 서빙 경로가 보이스 소유자의 plan 을 강제하지 않으면 무료 사용자가 유료 합성 오디오를
+  // 직접 내려받는 우회가 생긴다(Codex #594 P1). 소유자 plan 기준으로 잠근다.
+  function audioRow(overrides: Record<string, unknown>) {
+    return {
+      id: ID.message,
+      user_id: 'user-pk-1',
+      voice_profile_id: ID.alarm,
+      text: 'hi',
+      synthesis_text: 'hi',
+      delivery_tags_json: null,
+      audio_url: 'r2://generated/x.mp3',
+      category: 'custom',
+      is_system: 0,
+      owner_plan: 'plus',
+      ...overrides,
+    };
+  }
+
+  it('locks retained paid-voice audio when the voice owner is on the free plan', async () => {
+    mockDB.pushResult([audioRow({ is_system: 0, owner_plan: 'free' })]);
+
+    const res = await buildApp().request(
+      new Request(`http://localhost/tts/messages/${ID.message}/audio`),
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error_code).toBe('VOICE_LOCKED_FREE_PLAN');
+  });
+
+  it('serves paid-voice audio when the voice owner is still on a paid plan', async () => {
+    // audio_url=null 이면 잠금 게이트를 통과한 뒤 404(오디오 없음)로 떨어진다 — R2 목 없이
+    // '게이트를 통과했다'만 검증한다(403 이 아님).
+    mockDB.pushResult([audioRow({ is_system: 0, owner_plan: 'plus', audio_url: null })]);
+
+    const res = await buildApp().request(
+      new Request(`http://localhost/tts/messages/${ID.message}/audio`),
+    );
+
+    expect(res.status).not.toBe(403);
+    expect((await res.json()).error_code).toBe('MESSAGE_AUDIO_MISSING');
+  });
+
+  it('never locks system stock voice audio even for a free-plan owner', async () => {
+    mockDB.pushResult([audioRow({ is_system: 1, owner_plan: 'free', audio_url: null })]);
+
+    const res = await buildApp().request(
+      new Request(`http://localhost/tts/messages/${ID.message}/audio`),
+    );
+
+    expect(res.status).not.toBe(403);
+    expect((await res.json()).error_code).toBe('MESSAGE_AUDIO_MISSING');
+  });
 });


### PR DESCRIPTION
## 정책 변경
이용권 해지/무료 전환 시 유료 음성 데이터(목소리·알람·원본)를 **삭제하지 않고 보존**한다. 다시 이용권을 등록하면 그대로 다시 쓸 수 있어야 하기 때문. (기존: 30일 보관 후 하드삭제 + 사용자 '지금 삭제' 액션.)

## 백엔드
- `sweepPaidVoiceRetention`: `deletePaidVoiceDataForUser` 하드삭제 제거 — 만기 지난 보관 행만 청소(데이터 보존). 계정 삭제 등 명시 경로는 여전히 직접 삭제.
- `POST /billing/voice-data/delete-now` 라우트 제거.
- 테스트: 스윕이 음성 데이터를 삭제하지 않음 검증, delete-now 테스트 제거. (전체 백엔드 테스트 통과)

## 클라이언트(Android)
- 이용권 화면 '지금 삭제' 버튼·다이얼로그·`deleteVoiceDataNow` 액션·API 제거.
- `applyFreePlanVoiceLock`: 무료 전환 시 로컬 유료 알람 삭제 중단(데이터 보존).
- 해지/즉시취소 안내 문구를 '삭제' → '잠금·재등록 시 복구'로 변경(ko/en/ja).

## 범위 참고
무료 동안 **새** 목소리 알람 생성·TTS 합성은 기존 유료 게이트가 이미 차단. **기존 알람의 발사 시 사운드온리 잠금 + 재유료 자동 복원**은 Room 스키마 추가(플래그)가 필요해 **후속 PR**로 분리한다.

## 관련
데이터 보존 정책은 원본 오디오 보관(#593)과 함께 "확정 목소리는 살아있는 동안 보존, 명시적 삭제 시에만 제거" 원칙을 이룬다.