### PR TITLE
fix: evict 보이스 캐시 프로브 후 재클론 (Codex #602 P2)

### DIFF
--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1604,6 +1604,14 @@ export const migrations: Migration[] = [
          ON voice_profiles (last_used_at, created_at)`,
     ],
   },
+  {
+    // F1/F3(Codex #602): evict 직전의 provider 보이스 id 를 보관한다 — TTS 캐시 키가 provider
+    // voice id 를 포함하므로, evict된 프로필도 이 값으로 기존 생성 오디오 캐시를 프로브해
+    // 히트 시 재클론 없이 서빙할 수 있다(불필요한 외부 등록·연쇄 eviction 방지).
+    id: 76,
+    name: 'voice-profiles-evicted-provider-voice-id',
+    statements: [`ALTER TABLE voice_profiles ADD COLUMN evicted_provider_voice_id TEXT`],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/voice-slots.ts
+++ b/packages/backend/src/lib/voice-slots.ts
@@ -98,13 +98,26 @@ export async function evictLruClonesIfOverCapTx(
     // evicted_provider_voice_id: UPDATE 의 우변은 갱신 전 행 값으로 평가되므로(SQLite 의미론)
     // 같은 문장에서 기존 id 를 안전하게 보관한다 — evict 후에도 이 id 로 계산된 캐시 키의
     // 보관 오디오를 프로브해 재클론 없이 서빙할 수 있다(Codex #602).
-    await tx.execute({
-      sql: `UPDATE voice_profiles
-            SET evicted_provider_voice_id = elevenlabs_voice_id,
-                elevenlabs_voice_id = NULL, evicted_at = datetime('now'), updated_at = datetime('now')
-            WHERE id = ?`,
-      args: [victimId],
-    });
+    try {
+      await tx.execute({
+        sql: `UPDATE voice_profiles
+              SET evicted_provider_voice_id = elevenlabs_voice_id,
+                  elevenlabs_voice_id = NULL, evicted_at = datetime('now'), updated_at = datetime('now')
+              WHERE id = ?`,
+        args: [victimId],
+      });
+    } catch (err) {
+      // 배포 워크플로는 워커 배포 → 마이그레이션 순서라(마이그레이션이 새 워커의 /api/init-db 로
+      // 돌기 때문), 76 적용 전 짧은 창에서는 이 컬럼이 아직 없다. 그 창에서 상한 등록이 실패하지
+      // 않도록 구 스키마 폴백으로 evict 자체는 진행한다(캐시 프로브만 포기, Codex #603).
+      if (!/no such column/i.test(String(err))) throw err;
+      await tx.execute({
+        sql: `UPDATE voice_profiles
+              SET elevenlabs_voice_id = NULL, evicted_at = datetime('now'), updated_at = datetime('now')
+              WHERE id = ?`,
+        args: [victimId],
+      });
+    }
     if (oldVoiceId) {
       await enqueueExternalDeletion(tx, 'elevenlabs_voice', oldVoiceId);
     }

--- a/packages/backend/src/lib/voice-slots.ts
+++ b/packages/backend/src/lib/voice-slots.ts
@@ -95,9 +95,13 @@ export async function evictLruClonesIfOverCapTx(
   for (const victim of victims.rows) {
     const victimId = victim.id as string;
     const oldVoiceId = victim.elevenlabs_voice_id as string | null;
+    // evicted_provider_voice_id: UPDATE 의 우변은 갱신 전 행 값으로 평가되므로(SQLite 의미론)
+    // 같은 문장에서 기존 id 를 안전하게 보관한다 — evict 후에도 이 id 로 계산된 캐시 키의
+    // 보관 오디오를 프로브해 재클론 없이 서빙할 수 있다(Codex #602).
     await tx.execute({
       sql: `UPDATE voice_profiles
-            SET elevenlabs_voice_id = NULL, evicted_at = datetime('now'), updated_at = datetime('now')
+            SET evicted_provider_voice_id = elevenlabs_voice_id,
+                elevenlabs_voice_id = NULL, evicted_at = datetime('now'), updated_at = datetime('now')
             WHERE id = ?`,
       args: [victimId],
     });

--- a/packages/backend/src/routes/tts.ts
+++ b/packages/backend/src/routes/tts.ts
@@ -1159,58 +1159,74 @@ tts.post('/generate', async (c) => {
     // 모드별 보이스 세팅: sleep은 저에너지를 위해 speed 0.95(그 외는 elevenlabs v3 디폴트
     // stability 0.5/similarity 0.8/style 0.4/speed 1.0/use_speaker_boost 적용). sleep만
     // 오버라이드하므로 캐시 키도 다른 모드와 자연히 분리된다.
-    // F3: 이 프로필이 슬롯 상한(F1)으로 evict돼 provider 보이스가 없으면(elevenlabs_voice_id NULL
-    // + evicted_at 세팅), 보관된 R2 원본으로 자동 재클론해 복구한 뒤 합성한다. 위 게이트에서 소유자
-    // (비공유 클론=caller 본인)의 민감 동의를 이미 검증했다. 시스템 보이스는 evict 대상이 아니다.
-    let providerVoiceId = vp.elevenlabs_voice_id as string | null | undefined;
-    if (!providerVoiceId && vp.evicted_at) {
-      try {
-        providerVoiceId =
-          (await recloneEvictedVoiceProfile(c.env, db, body.voice_profile_id, String(vp.name ?? ''))) ??
-          undefined;
-      } catch (recloneErr) {
-        // 재클론 실패(일시적 공급자 오류 등)가 합성 요청 전체를 500 으로 만들지 않게 —
-        // 미복구 시 아래 NO_VOICE_ID 경로가 클라에 재등록을 안내한다.
-        console.error('[tts/generate] evicted voice reclone failed', recloneErr);
-      }
-    }
-
     const dynamicVoiceSettings =
       randomRequested && randomContext === 'sleep' ? { speed: 0.95 } : undefined;
-    const attempts = createSynthesisAttempts({
-      env: c.env,
-      profile: {
-        elevenlabs_voice_id: providerVoiceId,
-      },
-      text: synthesisText,
-      language: synthesisLanguage,
-      category,
-      voiceSettings: dynamicVoiceSettings,
-    });
+    const buildPreparedAttempts = async (voiceIdForSynthesis: string | null | undefined) => {
+      const attempts = createSynthesisAttempts({
+        env: c.env,
+        profile: {
+          elevenlabs_voice_id: voiceIdForSynthesis,
+        },
+        text: synthesisText,
+        language: synthesisLanguage,
+        category,
+        voiceSettings: dynamicVoiceSettings,
+      });
+      return Promise.all(
+        attempts.map(async (attempt) => {
+          const cacheKey = await computeTtsCacheKey({
+            provider: attempt.provider,
+            providerVoiceId: attempt.providerVoiceId,
+            voiceProfileId: body.voice_profile_id,
+            modelId: attempt.modelId,
+            language: synthesisLanguage,
+            languageCode: synthesisLanguage,
+            text: synthesisText,
+            outputFormat: attempt.outputFormat,
+            voiceSettings: attempt.voiceSettings,
+          });
+          return { attempt, cacheKey };
+        }),
+      );
+    };
 
-    if (attempts.length === 0) {
+    // F3: 이 프로필이 슬롯 상한(F1)으로 evict돼 provider 보이스가 없으면(elevenlabs_voice_id NULL
+    // + evicted_at 세팅) 곧바로 재클론하지 않는다 — 캐시 키는 provider voice id 를 포함하므로,
+    // evict 직전 id(evicted_provider_voice_id)로 캐시를 먼저 프로브해 보관 오디오가 있으면 재클론
+    // 없이 그대로 서빙한다(불필요한 외부 등록·연쇄 eviction 방지, Codex #602). 캐시 미스가 확정된
+    // 뒤(아래, 합성 직전)에만 R2 원본으로 재클론한다. 위 게이트에서 소유자(비공유 클론=caller
+    // 본인)의 민감 동의를 이미 검증했고, 재클론 직전 소유자 동의 재검증도 lib 안에서 수행된다.
+    // 시스템 보이스는 evict 대상이 아니다.
+    const recloneIfEvicted = async (): Promise<string | undefined> => {
+      try {
+        return (
+          (await recloneEvictedVoiceProfile(c.env, db, body.voice_profile_id, String(vp.name ?? ''))) ??
+          undefined
+        );
+      } catch (recloneErr) {
+        // 재클론 실패(일시적 공급자 오류 등)가 합성 요청 전체를 500 으로 만들지 않게 —
+        // 미복구 시 NO_VOICE_ID 경로가 클라에 재등록을 안내한다.
+        console.error('[tts/generate] evicted voice reclone failed', recloneErr);
+        return undefined;
+      }
+    };
+    let providerVoiceId = vp.elevenlabs_voice_id as string | null | undefined;
+    const isEvictedWithoutVoice = !providerVoiceId && Boolean(vp.evicted_at);
+    const evictedProbeVoiceId = isEvictedWithoutVoice
+      ? ((vp.evicted_provider_voice_id as string | null | undefined) ?? null)
+      : null;
+    if (isEvictedWithoutVoice && !evictedProbeVoiceId) {
+      // 프로브할 옛 id 가 없는 evict 행(마이그레이션 76 이전 evict 분) — 기존처럼 즉시 재클론.
+      providerVoiceId = await recloneIfEvicted();
+    }
+
+    let preparedAttempts = await buildPreparedAttempts(providerVoiceId ?? evictedProbeVoiceId);
+    if (preparedAttempts.length === 0) {
       return c.json(
         { error: 'No voice ID available for this profile', error_code: 'NO_VOICE_ID' },
         400,
       );
     }
-
-    const preparedAttempts = await Promise.all(
-      attempts.map(async (attempt) => {
-        const cacheKey = await computeTtsCacheKey({
-          provider: attempt.provider,
-          providerVoiceId: attempt.providerVoiceId,
-          voiceProfileId: body.voice_profile_id,
-          modelId: attempt.modelId,
-          language: synthesisLanguage,
-          languageCode: synthesisLanguage,
-          text: synthesisText,
-          outputFormat: attempt.outputFormat,
-          voiceSettings: attempt.voiceSettings,
-        });
-        return { attempt, cacheKey };
-      }),
-    );
 
     if (draftPreviewRequested && !vp.previewed_at) {
       const previewClaimToken = crypto.randomUUID();
@@ -1312,6 +1328,26 @@ tts.post('/generate', async (c) => {
             error_code: 'VOICE_PREVIEW_UNAVAILABLE',
           },
           409,
+        );
+      }
+    }
+
+    // F3(Codex #602): 캐시 미스 확정 — 프로브만 있고 실제 provider 보이스는 없는 상태라면
+    // 이제서야 R2 원본으로 재클론하고, 새 voice id 로 합성 attempt 를 다시 만든다.
+    // (쿼터 예약보다 앞: 재클론 실패 시 쿼터를 소모하지 않고 NO_VOICE_ID 로 재등록을 안내.)
+    if (!providerVoiceId && isEvictedWithoutVoice && evictedProbeVoiceId) {
+      providerVoiceId = await recloneIfEvicted();
+      if (!providerVoiceId) {
+        return c.json(
+          { error: 'No voice ID available for this profile', error_code: 'NO_VOICE_ID' },
+          400,
+        );
+      }
+      preparedAttempts = await buildPreparedAttempts(providerVoiceId);
+      if (preparedAttempts.length === 0) {
+        return c.json(
+          { error: 'No voice ID available for this profile', error_code: 'NO_VOICE_ID' },
+          400,
         );
       }
     }
@@ -1495,7 +1531,7 @@ tts.post('/generate', async (c) => {
       } catch (err) {
         lastError = err;
         if (err instanceof UnsupportedVoiceProviderError) continue;
-        if (attempt !== attempts[attempts.length - 1]) continue;
+        if (attempt !== preparedAttempts[preparedAttempts.length - 1]?.attempt) continue;
       }
     }
 

--- a/packages/backend/test/voice-slots.test.ts
+++ b/packages/backend/test/voice-slots.test.ts
@@ -25,6 +25,7 @@ async function setupDb() {
       user_id TEXT NOT NULL,
       name TEXT NOT NULL,
       elevenlabs_voice_id TEXT,
+      evicted_provider_voice_id TEXT,
       status TEXT DEFAULT 'processing',
       is_system INTEGER DEFAULT 0,
       is_shared INTEGER DEFAULT 0,
@@ -131,10 +132,13 @@ describe('evictLruClonesIfOverCap', () => {
     expect(result).toEqual({ evicted: 1, shortfall: 0 });
     const victim = (
       await db.execute({
-        sql: `SELECT elevenlabs_voice_id, evicted_at, deleted_at FROM voice_profiles WHERE id = 'v000'`,
+        sql: `SELECT elevenlabs_voice_id, evicted_provider_voice_id, evicted_at, deleted_at
+              FROM voice_profiles WHERE id = 'v000'`,
       })
     ).rows[0];
     expect(victim.elevenlabs_voice_id).toBeNull();
+    // evict 직전 id 보관 — TTS 가 이 id 로 기존 캐시를 프로브해 재클론 없이 서빙한다(Codex #602).
+    expect(victim.evicted_provider_voice_id).toBe('el-v000');
     expect(victim.evicted_at).not.toBeNull();
     // deleted_at 은 NULL 유지 — TTL 스윕이 R2 원본을 보존해야 F3 재클론이 가능하다.
     expect(victim.deleted_at).toBeNull();

--- a/packages/backend/test/voice-slots.test.ts
+++ b/packages/backend/test/voice-slots.test.ts
@@ -191,4 +191,39 @@ describe('evictLruClonesIfOverCap', () => {
     await fillToCap(db);
     expect(await evictLruClonesIfOverCap(db, 'v000')).toEqual({ evicted: 0, shortfall: 0 });
   });
+
+  it('falls back to the pre-76 schema during the deploy→migration window', async () => {
+    // 배포 워크플로는 워커 배포 후 마이그레이션을 돌리므로, 76 적용 전 짧은 창에서는
+    // evicted_provider_voice_id 컬럼이 없다 — 그래도 eviction(등록)이 실패하면 안 된다(Codex #603).
+    const db = await setupDb();
+    await db.executeMultiple(`
+      DROP TABLE voice_profiles;
+      CREATE TABLE voice_profiles (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        elevenlabs_voice_id TEXT,
+        status TEXT DEFAULT 'processing',
+        is_system INTEGER DEFAULT 0,
+        is_shared INTEGER DEFAULT 0,
+        is_draft INTEGER DEFAULT 0,
+        last_used_at TEXT,
+        evicted_at TEXT,
+        deleted_at TEXT,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
+    `);
+    await fillToCap(db);
+    await insertClone(db, { id: 'newbie' });
+    const result = await evictLruClonesIfOverCap(db, 'newbie');
+    expect(result).toEqual({ evicted: 1, shortfall: 0 });
+    const victim = (
+      await db.execute({
+        sql: `SELECT elevenlabs_voice_id, evicted_at FROM voice_profiles WHERE id = 'v000'`,
+      })
+    ).rows[0];
+    expect(victim.elevenlabs_voice_id).toBeNull();
+    expect(victim.evicted_at).not.toBeNull();
+  });
 });


### PR DESCRIPTION
릴리스 PR #602 리뷰에서 나온 P2 대응입니다.

- evict 시 직전 provider voice id 를 `evicted_provider_voice_id`(마이그레이션 76)에 보관
- TTS: evict된 프로필은 옛 id 로 캐시 프로브 → 히트면 재클론 없이 서빙, 미스 확정 후에만 재클론(쿼터 예약 전)
- 백엔드 1545 테스트 + tsc 클린