### PR TITLE
release: vc14 추가분 — 로그인/회원가입 실패 인라인 안내

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -92,6 +92,10 @@ internal fun AlarmTalkApp(
     fun authResetToLanding() {
         authBackStack = listOf(AuthRoute.Landing)
     }
+    // 인증 화면 전환 시 이전 로그인 실패 안내가 새 화면까지 따라오지 않게 정리한다.
+    LaunchedEffect(authRoute) {
+        viewModel.loginError = null
+    }
     // 회원가입 시도 이메일이 이미 가입돼 있으면(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환한다.
     // 입력한 이메일은 AuthScreen 의 remember 상태로 유지되므로 다시 입력할 필요가 없다.
     LaunchedEffect(viewModel.authRedirectToLogin) {
@@ -618,6 +622,8 @@ internal fun AlarmTalkApp(
                   busy = authBusy,
                   emailVerificationSentTo = viewModel.registerEmailVerificationSentTo,
                   emailVerified = viewModel.registerEmailVerified,
+                  loginError = viewModel.loginError,
+                  onClearLoginError = { viewModel.loginError = null },
                   onBack = { authBack() },
                   onLogin = viewModel::login,
                   onRegister = viewModel::register,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -92,9 +92,16 @@ internal fun AlarmTalkApp(
     fun authResetToLanding() {
         authBackStack = listOf(AuthRoute.Landing)
     }
-    // 인증 화면 전환 시 이전 로그인 실패 안내가 새 화면까지 따라오지 않게 정리한다.
+    // 인증 화면 전환 시 이전 실패 안내가 새 화면까지 따라오지 않게 정리한다.
+    // authNotice 는 '회원가입→로그인 전환 이유' 안내라 로그인 화면으로 가는 전환에서는 남기고,
+    // 그 외 화면으로 벗어날 때만 지운다.
     LaunchedEffect(authRoute) {
         viewModel.loginError = null
+        viewModel.registerError = null
+        val route = authRoute
+        if (!(route is AuthRoute.Auth && route.mode == AuthMode.Login)) {
+            viewModel.authNotice = null
+        }
     }
     // 회원가입 시도 이메일이 이미 가입돼 있으면(AUTH_EMAIL_TAKEN) 로그인 화면으로 전환한다.
     // 입력한 이메일은 AuthScreen 의 remember 상태로 유지되므로 다시 입력할 필요가 없다.
@@ -623,7 +630,13 @@ internal fun AlarmTalkApp(
                   emailVerificationSentTo = viewModel.registerEmailVerificationSentTo,
                   emailVerified = viewModel.registerEmailVerified,
                   loginError = viewModel.loginError,
-                  onClearLoginError = { viewModel.loginError = null },
+                  registerError = viewModel.registerError,
+                  authNotice = viewModel.authNotice,
+                  onClearLoginError = {
+                      viewModel.loginError = null
+                      viewModel.registerError = null
+                      viewModel.authNotice = null
+                  },
                   onBack = { authBack() },
                   onLogin = viewModel::login,
                   onRegister = viewModel::register,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -62,6 +62,11 @@ private val AuthFieldGlass = Color(0x14FFFFFF)
 internal val AuthLine = Color(0x3DFFFFFF)
 internal val AuthLineSoft = Color(0x29FFFFFF)
 internal val AuthTextMuted = Color(0x99FFFFFF)
+
+// 이 화면은 고정 다크 비주얼(문서화된 예외)이라 테마 error/primary 대신 밝은 고정색을 쓴다 —
+// 라이트 테마 기기에서도 남색 배경 위에서 안내가 보이도록.
+internal val AuthErrorText = Color(0xFFFFB4AB)
+internal val AuthNoticeText = Color(0xFFA8C8FF)
 private val AuthSceneTop = Color(0xFF1A2A52)
 private val AuthSceneBottom = Color(0xFF070C1D)
 
@@ -116,7 +121,11 @@ internal fun authFieldColors() = OutlinedTextFieldDefaults.colors(
     unfocusedTrailingIconColor = AuthTextMuted,
     errorTextColor = TextOnScene,
     errorContainerColor = AuthFieldGlass,
-    errorCursorColor = MaterialTheme.colorScheme.error,
+    errorCursorColor = AuthErrorText,
+    errorBorderColor = AuthErrorText,
+    errorLabelColor = AuthErrorText,
+    errorSupportingTextColor = AuthErrorText,
+    errorTrailingIconColor = TextOnSceneDim,
 )
 
 @Composable
@@ -141,8 +150,11 @@ internal fun AuthScreen(
     busy: Boolean,
     emailVerificationSentTo: String?,
     emailVerified: String?,
-    // 로그인 실패 인라인 안내 — 전역 스낵바는 열려 있는 키보드에 가려 안 보여서 화면 안에 띄운다.
+    // 로그인/회원가입 실패 인라인 안내 — 전역 스낵바는 열려 있는 키보드에 가려 안 보여서 화면 안에 띄운다.
     loginError: String? = null,
+    registerError: String? = null,
+    // 회원가입 → 로그인 자동 전환(이미 가입된 이메일) 때 로그인 화면에 남는 이유 안내.
+    authNotice: String? = null,
     onClearLoginError: () -> Unit = {},
     onBack: () -> Unit,
     onLogin: (String, String) -> Unit,
@@ -226,6 +238,16 @@ internal fun AuthScreen(
                 color = TextOnSceneDim,
             )
 
+            // 회원가입에서 이미 가입된 이메일로 인증을 시도해 로그인으로 전환된 경우 —
+            // 왜 화면이 바뀌었는지 여기서 설명한다(스낵바는 키보드에 가려 안 보인다).
+            if (mode == AuthMode.Login && authNotice != null) {
+                Text(
+                    text = authNotice,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = AuthNoticeText,
+                )
+            }
+
             if (mode == AuthMode.Register) {
                 OutlinedTextField(
                     value = name,
@@ -247,7 +269,7 @@ internal fun AuthScreen(
                 value = email,
                 onValueChange = {
                     email = it
-                    if (loginError != null) onClearLoginError()
+                    onClearLoginError()
                 },
                 label = { Text(stringResource(R.string.auth_label_email)) },
                 singleLine = true,
@@ -291,7 +313,10 @@ internal fun AuthScreen(
                     ) {
                         OutlinedTextField(
                             value = emailCode,
-                            onValueChange = { emailCode = it.filter(Char::isDigit).take(6) },
+                            onValueChange = {
+                                emailCode = it.filter(Char::isDigit).take(6)
+                                onClearLoginError()
+                            },
                             label = { Text(stringResource(R.string.auth_label_verification_code)) },
                             singleLine = true,
                             enabled = !busy,
@@ -328,13 +353,22 @@ internal fun AuthScreen(
                         pendingColor = AuthTextMuted,
                     )
                 }
+
+                // 인증 요청/코드 확인/가입 실패 안내 — 스낵바는 키보드에 가려 안 보인다.
+                if (registerError != null) {
+                    Text(
+                        text = registerError,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = AuthErrorText,
+                    )
+                }
             }
 
             OutlinedTextField(
                 value = password,
                 onValueChange = {
                     password = it
-                    if (loginError != null) onClearLoginError()
+                    onClearLoginError()
                 },
                 label = { Text(stringResource(R.string.auth_label_password)) },
                 singleLine = true,
@@ -343,7 +377,7 @@ internal fun AuthScreen(
                 colors = authFieldColors(),
                 isError = mode == AuthMode.Login && loginError != null,
                 supportingText = if (mode == AuthMode.Login && loginError != null) {
-                    { Text(loginError, color = MaterialTheme.colorScheme.error) }
+                    { Text(loginError, color = AuthErrorText) }
                 } else {
                     null
                 },
@@ -364,12 +398,7 @@ internal fun AuthScreen(
             )
 
             if (mode == AuthMode.Register) {
-                PasswordRules(
-                    passwordAtLeastMin = passwordAtLeastMin,
-                    passwordHasLetterAndDigit = passwordHasLetterAndDigit,
-                    passwordMatches = passwordMatches,
-                )
-
+                // 비밀번호·비밀번호 확인 입력창을 붙여 두고, 조건 안내는 확인 필드 아래에 모은다.
                 OutlinedTextField(
                     value = confirmPassword,
                     onValueChange = { confirmPassword = it },
@@ -410,6 +439,12 @@ internal fun AuthScreen(
                         imeAction = ImeAction.Done,
                     ),
                     modifier = Modifier.fillMaxWidth(),
+                )
+
+                PasswordRules(
+                    passwordAtLeastMin = passwordAtLeastMin,
+                    passwordHasLetterAndDigit = passwordHasLetterAndDigit,
+                    passwordMatches = passwordMatches,
                 )
             }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/auth/AuthScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -140,6 +141,9 @@ internal fun AuthScreen(
     busy: Boolean,
     emailVerificationSentTo: String?,
     emailVerified: String?,
+    // 로그인 실패 인라인 안내 — 전역 스낵바는 열려 있는 키보드에 가려 안 보여서 화면 안에 띄운다.
+    loginError: String? = null,
+    onClearLoginError: () -> Unit = {},
     onBack: () -> Unit,
     onLogin: (String, String) -> Unit,
     onRegister: (String, String, String, String) -> Unit,
@@ -169,6 +173,12 @@ internal fun AuthScreen(
     val passwordMatches = password.isNotBlank() && password == confirmPassword
     val isEmailVerified = mode == AuthMode.Login || emailVerified == normalizedEmail
     val codeSentForEmail = emailVerificationSentTo == normalizedEmail
+    // 로그인 실패 시 비밀번호만 비운다 — 오타 대부분이 비밀번호 쪽이고, 이메일까지 비우면
+    // 맞게 입력한 이메일을 다시 치는 마찰만 생긴다(문구가 이메일 확인도 함께 안내).
+    LaunchedEffect(loginError) {
+        if (loginError != null) password = ""
+    }
+
     val canSubmit = if (mode == AuthMode.Login) {
         email.isNotBlank() && password.isNotBlank()
     } else {
@@ -235,12 +245,16 @@ internal fun AuthScreen(
 
             OutlinedTextField(
                 value = email,
-                onValueChange = { email = it },
+                onValueChange = {
+                    email = it
+                    if (loginError != null) onClearLoginError()
+                },
                 label = { Text(stringResource(R.string.auth_label_email)) },
                 singleLine = true,
                 enabled = !busy,
                 shape = WakerInputShape,
                 colors = authFieldColors(),
+                isError = mode == AuthMode.Login && loginError != null,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next,
@@ -318,12 +332,21 @@ internal fun AuthScreen(
 
             OutlinedTextField(
                 value = password,
-                onValueChange = { password = it },
+                onValueChange = {
+                    password = it
+                    if (loginError != null) onClearLoginError()
+                },
                 label = { Text(stringResource(R.string.auth_label_password)) },
                 singleLine = true,
                 enabled = !busy,
                 shape = WakerInputShape,
                 colors = authFieldColors(),
+                isError = mode == AuthMode.Login && loginError != null,
+                supportingText = if (mode == AuthMode.Login && loginError != null) {
+                    { Text(loginError, color = MaterialTheme.colorScheme.error) }
+                } else {
+                    null
+                },
                 visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
                 trailingIcon = {
                     IconButton(onClick = { passwordVisible = !passwordVisible }) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -162,6 +162,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var authRedirectToLogin by mutableStateOf(false)
         internal set
 
+    // 이메일 로그인 실패 안내 — 전역 스낵바 대신 로그인 화면 안 인라인으로 보여준다.
+    // (스낵바는 하단이라 로그인 직후 열려 있는 키보드에 가려 아무 피드백도 없는 것처럼 보인다.)
+    var loginError by mutableStateOf<String?>(null)
+        internal set
+
     var syncBusy by mutableStateOf(false)
         internal set
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -167,6 +167,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     var loginError by mutableStateOf<String?>(null)
         internal set
 
+    // 회원가입 흐름(인증 요청·코드 확인·가입) 실패 안내 — 같은 이유로 회원가입 화면 인라인.
+    var registerError by mutableStateOf<String?>(null)
+        internal set
+
+    // 회원가입 → 로그인 자동 전환(AUTH_EMAIL_TAKEN) 때 로그인 화면에 남기는 이유 안내.
+    // 전환 '후' 화면에 보여야 하므로 화면 전환 시 정리되는 loginError/registerError 와 분리한다.
+    var authNotice by mutableStateOf<String?>(null)
+        internal set
+
     var syncBusy by mutableStateOf(false)
         internal set
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -30,6 +30,7 @@ internal fun MainViewModel.login(email: String, password: String) {
     }
     viewModelScope.launch {
         authBusy = true
+        loginError = null
         runCatching {
             api.login(LoginRequest(email = normalizedEmail, password = password))
         }.onSuccess { response ->
@@ -40,7 +41,14 @@ internal fun MainViewModel.login(email: String, password: String) {
             com.alarmtalk.app.fcm.AlarmTalkMessagingService.registerCurrentToken(getApplication())
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email login failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_login_failed))
+            val app = getApplication<android.app.Application>()
+            // 스낵바(전역 message) 대신 로그인 화면 인라인 에러로 — 키보드가 열려 있어도 보인다.
+            // 서버는 미가입/비밀번호 불일치를 구분하지 않고 AUTH_INVALID_CREDENTIALS 401 하나로
+            // 응답한다(계정 존재 여부 노출 방지) — 안내 문구도 이메일·비밀번호를 함께 확인하게 쓴다.
+            loginError = when (com.alarmtalk.app.network.apiError(error).code) {
+                "AUTH_INVALID_CREDENTIALS" -> app.getString(R.string.auth_error_invalid_credentials)
+                else -> userFacingError(error, app.getString(R.string.msg_login_failed))
+            }
         }
         authBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -31,6 +31,7 @@ internal fun MainViewModel.login(email: String, password: String) {
     viewModelScope.launch {
         authBusy = true
         loginError = null
+        authNotice = null
         runCatching {
             api.login(LoginRequest(email = normalizedEmail, password = password))
         }.onSuccess { response ->
@@ -62,6 +63,7 @@ internal fun MainViewModel.requestEmailVerification(email: String) {
     }
     viewModelScope.launch {
         authBusy = true
+        registerError = null
         runCatching {
             api.requestEmailVerification(EmailVerificationRequest(email = normalizedEmail))
         }.onSuccess { response ->
@@ -73,8 +75,15 @@ internal fun MainViewModel.requestEmailVerification(email: String) {
                 ?: getApplication<android.app.Application>().getString(R.string.msg_verification_code_sent)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email verification request failed", error)
-            message = duplicateEmailMessage(error)
-                ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_send_failed))
+            // 스낵바는 키보드에 가려 '아무 반응 없음'처럼 보인다 — 화면 인라인으로 안내한다.
+            // AUTH_EMAIL_TAKEN 은 로그인 화면으로 전환되므로 안내를 authNotice 로 넘긴다.
+            val friendly = duplicateEmailMessage(error)
+            if (authRedirectToLogin) {
+                authNotice = friendly
+            } else {
+                registerError = friendly
+                    ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_send_failed))
+            }
         }
         authBusy = false
     }
@@ -102,11 +111,12 @@ private fun MainViewModel.duplicateEmailMessage(error: Throwable): String? {
 internal fun MainViewModel.confirmEmailVerification(email: String, code: String) {
     val normalizedEmail = email.trim().lowercase()
     if (normalizedEmail.isBlank() || code.trim().length != 6) {
-        message = getApplication<android.app.Application>().getString(R.string.msg_verification_code_six_digits_required)
+        registerError = getApplication<android.app.Application>().getString(R.string.msg_verification_code_six_digits_required)
         return
     }
     viewModelScope.launch {
         authBusy = true
+        registerError = null
         runCatching {
             api.confirmEmailVerification(
                 EmailVerificationConfirmRequest(
@@ -119,7 +129,7 @@ internal fun MainViewModel.confirmEmailVerification(email: String, code: String)
             message = getApplication<android.app.Application>().getString(R.string.msg_email_verification_completed)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email verification confirm failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_mismatch))
+            registerError = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_verification_code_mismatch))
         }
         authBusy = false
     }
@@ -135,15 +145,16 @@ internal fun MainViewModel.register(
     val trimmedName = name.trim()
     val trimmedCode = emailVerificationCode.trim()
     if (normalizedEmail.isBlank() || password.isBlank() || trimmedName.isBlank() || trimmedCode.isBlank()) {
-        message = getApplication<android.app.Application>().getString(R.string.msg_register_all_fields_required)
+        registerError = getApplication<android.app.Application>().getString(R.string.msg_register_all_fields_required)
         return
     }
     if (registerEmailVerified != normalizedEmail) {
-        message = getApplication<android.app.Application>().getString(R.string.msg_register_verify_email_first)
+        registerError = getApplication<android.app.Application>().getString(R.string.msg_register_verify_email_first)
         return
     }
     viewModelScope.launch {
         authBusy = true
+        registerError = null
         runCatching {
             api.register(
                 RegisterRequest(
@@ -164,8 +175,13 @@ internal fun MainViewModel.register(
             message = getApplication<android.app.Application>().getString(R.string.msg_register_success, response.user.email)
         }.onFailure { error ->
             AlarmTalkLog.reportError("Email registration failed", error)
-            message = duplicateEmailMessage(error)
-                ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_register_failed))
+            val friendly = duplicateEmailMessage(error)
+            if (authRedirectToLogin) {
+                authNotice = friendly
+            } else {
+                registerError = friendly
+                    ?: userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_register_failed))
+            }
         }
         authBusy = false
     }

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -53,6 +53,7 @@
     <string name="auth_landing_sample_message">Good morning, Grandpa\nIt\'s going to rain today\nDon\'t forget your umbrella</string>
     <string name="auth_password_hide">Hide password</string>
     <string name="auth_password_mismatch">Passwords don\'t match.</string>
+    <string name="auth_error_invalid_credentials">Email or password doesn\'t match. Please check and try again.</string>
     <string name="auth_password_rule_alnum">Letters and numbers</string>
     <string name="auth_password_rule_match">Passwords match</string>
     <string name="auth_password_rule_max">128 characters or fewer</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -53,6 +53,7 @@
     <string name="auth_landing_sample_message">おじいちゃん、おはようございます\n今日は雨が降るそうです\n出かけるときは傘を忘れずに</string>
     <string name="auth_password_hide">パスワードを隠す</string>
     <string name="auth_password_mismatch">パスワードが一致しません。</string>
+    <string name="auth_error_invalid_credentials">メールアドレスまたはパスワードが正しくありません。ご確認のうえ、もう一度お試しください。</string>
     <string name="auth_password_rule_alnum">英字と数字を含む</string>
     <string name="auth_password_rule_match">パスワードが一致</string>
     <string name="auth_password_rule_max">128文字以下</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="auth_landing_sample_message">할아버지, 좋은 아침이에요\n오늘은 비가 온대요\n나가실 때 우산 꼭 챙기세요</string>
     <string name="auth_password_hide">비밀번호 숨기기</string>
     <string name="auth_password_mismatch">비밀번호가 일치하지 않아요.</string>
+    <string name="auth_error_invalid_credentials">이메일 또는 비밀번호가 맞지 않아요. 다시 확인해 주세요.</string>
     <string name="auth_password_rule_alnum">영문·숫자 포함</string>
     <string name="auth_password_rule_match">비밀번호 확인 일치</string>
     <string name="auth_password_rule_max">128자 이하</string>


### PR DESCRIPTION
vc14 릴리스 QA에서 발견된 인증 UX 수정 2건을 릴리스에 포함합니다 (#604, versionCode 14 유지 — Play 미업로드 상태).

- 로그인 실패(401)가 키보드에 가린 스낵바로만 표시되던 문제 → 화면 인라인 안내 + 비밀번호만 초기화
- 회원가입 이메일 인증 실패(이미 가입/소셜 가입 등)도 동일하게 인라인 안내, AUTH_EMAIL_TAKEN 은 로그인 전환 이유를 로그인 화면에 표시
- 비밀번호·비밀번호 확인 입력창을 붙이고 조건 안내를 확인 필드 아래로 이동

A32 실기기 검증 완료. 머지 시 prod 백엔드 재배포(백엔드 변경 없음, 무해).