### PR TITLE
feat: 편집기 제한 보이스 선택 시 버킷 클립 프리페치

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -806,6 +806,7 @@ internal fun AlarmTalkApp(
                       onGenerateTts = viewModel::generateTtsAudio,
                       onLoadManualQuota = viewModel::loadManualQuota,
                       onDownloadStockAudio = { messageId -> viewModel.downloadTtsMessageAudio(messageId) },
+                      onPrefetchRestrictedVoiceClips = viewModel::prefetchFreeBucketClips,
                       onUpdateDynamicPromptSettings = viewModel::updateDynamicPromptSettings,
                       onSave = { draft ->
                           if (!permissions.alarmReady) {
@@ -845,6 +846,7 @@ internal fun AlarmTalkApp(
                           onGenerateTts = viewModel::generateTtsAudio,
                           onLoadManualQuota = viewModel::loadManualQuota,
                           onDownloadStockAudio = { messageId -> viewModel.downloadTtsMessageAudio(messageId) },
+                          onPrefetchRestrictedVoiceClips = viewModel::prefetchFreeBucketClips,
                           onUpdateDynamicPromptSettings = viewModel::updateDynamicPromptSettings,
                           onSave = { draft ->
                               if (!permissions.alarmReady) {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -127,6 +127,10 @@ internal fun AlarmEditorScreen(
     onGenerateTts: suspend (TtsGenerateRequest) -> TtsGenerateResponse,
     onLoadManualQuota: (suspend () -> ManualQuotaResponse?)? = null,
     onDownloadStockAudio: suspend (String) -> TtsMessageAudioResponse,
+    // 제한(날씨+약) 보이스를 편집기에서 고른 순간 그 보이스의 버킷 클립 전체를 백그라운드
+    // 프리페치한다 — 기본 목소리 변경 시 프리페치(setDefaultVoice)와 같은 경로. 이미 캐시된
+    // 클립은 건너뛰므로 반복 호출해도 재다운로드는 없다.
+    onPrefetchRestrictedVoiceClips: (String) -> Unit = {},
     onUpdateDynamicPromptSettings: (DynamicPromptSettings) -> Unit,
     onSave: (AlarmDraft) -> Unit,
 ) {
@@ -826,6 +830,15 @@ internal fun AlarmEditorScreen(
                 editor.voiceTranslationEnabled = automaticTranslation
                 if (!editor.voiceRandomPrompt) editor.clearTtsMeta()
             }
+        }
+    }
+
+    // 제한 보이스 선택 시 버킷 클립 프리페치 — 편집 중 문구를 고르거나 저장할 때 11개를
+    // 그 자리에서 받는 대신, 보이스를 고른 순간부터 백그라운드로 받아 둔다(캐시분 스킵).
+    LaunchedEffect(editor.voiceProfileId, restrictToWeatherMedication) {
+        val profileId = editor.voiceProfileId
+        if (restrictToWeatherMedication && !profileId.isNullOrBlank()) {
+            onPrefetchRestrictedVoiceClips(profileId)
         }
     }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -835,9 +835,11 @@ internal fun AlarmEditorScreen(
 
     // 제한 보이스 선택 시 버킷 클립 프리페치 — 편집 중 문구를 고르거나 저장할 때 11개를
     // 그 자리에서 받는 대신, 보이스를 고른 순간부터 백그라운드로 받아 둔다(캐시분 스킵).
-    LaunchedEffect(editor.voiceProfileId, restrictToWeatherMedication) {
+    // stockClips 를 키에 포함: 매니페스트가 아직 안 온 상태로 진입하면 프리페치가 빈손으로
+    // 끝나므로, 매니페스트 도착 시 재시도한다(Codex #607).
+    LaunchedEffect(editor.voiceProfileId, restrictToWeatherMedication, stockClips) {
         val profileId = editor.voiceProfileId
-        if (restrictToWeatherMedication && !profileId.isNullOrBlank()) {
+        if (restrictToWeatherMedication && !profileId.isNullOrBlank() && stockClips.isNotEmpty()) {
             onPrefetchRestrictedVoiceClips(profileId)
         }
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
@@ -540,10 +540,13 @@ internal fun MainViewModel.prefetchFreeBucketClips(voiceProfileId: String) {
         try {
             val language = deviceAppVoiceLanguage()
             val audioStore = com.alarmtalk.app.data.AlarmAudioStore(getApplication<Application>())
+            // 무료 버킷에서 실제로 쓰이는 카테고리(날씨·약)만 받는다 — greeting 제외 전부를 받으면
+            // 무료 사용자의 클론처럼 운세/사랑 사전렌더가 섞인 보이스에서 제한 편집기가 노출하지
+            // 않는 유료 전용 클립까지 내려받아 저장 공간만 차지한다(Codex #607).
             val clips = stockClips.filter {
                 it.voiceProfileId == voiceProfileId &&
                     (it.language ?: "ko") == language &&
-                    it.category != com.alarmtalk.app.data.STOCK_GREETING_CATEGORY
+                    it.category in FreeBucketOrder
             }
             if (clips.isEmpty()) return@launch
             // 이미 캐시된 클립도 진행 수에 포함해 n/전체가 실제 준비율을 보여주게 한다.

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -1481,8 +1481,13 @@ internal fun VoiceProfileManagementPanel(
                                     placeholder = { Text(stringResource(R.string.voices_name_placeholder)) },
                                     singleLine = true,
                                     isError = nameRequiredError,
-                                    supportingText = {
-                                        if (nameRequiredError) Text(stringResource(R.string.voices_required_field))
+                                    // supportingText 람다를 항상 넘기면 에러가 없어도 그 자리(약 16dp)가
+                                    // 예약돼 이름↔관계 간격만 넓어진다 — 에러일 때만 붙여 3개 필드의
+                                    // 간격(부모 spacedBy 14dp)을 균일하게 유지한다.
+                                    supportingText = if (nameRequiredError) {
+                                        { Text(stringResource(R.string.voices_required_field)) }
+                                    } else {
+                                        null
                                     },
                                     shape = WakerInputShape,
                                     colors = wakerOutlinedTextFieldColors(),


### PR DESCRIPTION
기본 목소리 변경 시 11클립(날씨9+약2) 프리페치·영구 캐시는 기존 동작입니다. 남아 있던 구멍 — 편집기에서 '기본 목소리가 아닌' 시스템 보이스를 고르면 문구 확정 시점에 그 자리에서 다운로드 — 을 메웁니다. 보이스 선택 즉시 같은 프리페치 경로를 백그라운드 실행, 캐시분은 스킵.