### PR TITLE
chore: 메시지·캐릭터 기능 잔재 정리 + 계정 파기 FK 실패 수정

### DIFF
--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -95,12 +95,12 @@
     <string name="billing_manage_on_google_play">Manage subscription on Google Play</string>
     <string name="billing_monthly_subscription">Subscribe with Google Play</string>
     <string name="billing_plan_couple_feature_max_two">For 2 people together</string>
-    <string name="billing_plan_couple_feature_message">Set your partner\'s alarm · voice messages</string>
+    <string name="billing_plan_couple_feature_message">Set your partner\'s alarm</string>
     <string name="billing_plan_couple_feature_voice_share">Share each other\'s voices</string>
     <string name="billing_plan_couple_name">Couple</string>
     <string name="billing_plan_couple_price">$6.90/mo</string>
     <string name="billing_plan_family_feature_max_six">Up to 5 people together</string>
-    <string name="billing_plan_family_feature_message">Family alarms and voice messages</string>
+    <string name="billing_plan_family_feature_message">Send alarms to your family</string>
     <string name="billing_plan_family_feature_voice_share">Share family voices</string>
     <string name="billing_plan_feature_includes_personal">Everything in Personal</string>
     <string name="billing_plan_family_name">Family</string>
@@ -112,7 +112,6 @@
     <string name="billing_plan_personal_feature_daily_prompt">Fresh lines every day: weather, fortune, and more</string>
     <string name="billing_plan_personal_feature_gift">Gift a Personal pass</string>
     <string name="billing_plan_personal_feature_voice">Register 1 voice of your choice</string>
-    <string name="billing_plan_personal_feature_voice_message">Voice message</string>
     <string name="billing_plan_personal_name">Personal</string>
     <string name="billing_plan_personal_price">$3.90/mo</string>
     <string name="billing_play_manage_description">We couldn\'t complete the cancellation in the app. You can cancel directly in Google Play subscriptions. Your subscription hasn\'t changed.</string>
@@ -201,7 +200,7 @@
     <string name="editor_error_audio_duration_unreadable">Files whose audio length can\'t be read can\'t be used.</string>
     <string name="editor_error_crop_save_failed">Couldn\'t save the selected section.</string>
     <string name="editor_error_deleted_voice_cannot_edit">This voice was deleted, so the phrase can\'t be edited. Please choose another voice.</string>
-    <string name="editor_error_enter_message_or_random">Please enter a voice message or use a random phrase.</string>
+    <string name="editor_error_enter_message_or_random">Please enter an alarm phrase or use a random phrase.</string>
     <string name="editor_error_family_alarm_lead_too_soon">Set alarms for others to %1$s or later — they need 30 min to get ready.</string>
     <string name="editor_error_family_alarm_time_unavailable">The other person can\'t receive alarms at this time.</string>
     <string name="editor_error_fortune_info_required">For phrases with fortune, please enter gender, date of birth, and time of birth.</string>
@@ -217,7 +216,7 @@
     <string name="editor_error_voice_alarm_login_required">Voice alarms are available after you sign in.</string>
     <string name="editor_error_voice_generation_failed">Voice generation failed.</string>
     <string name="editor_error_manual_tts_quota">You\'ve used up this month\'s custom-message creations. They refill next month.</string>
-    <string name="editor_error_voice_message_login_required">Voice messages are available after you sign in.</string>
+    <string name="editor_error_voice_message_login_required">Voice alarms are available after you sign in.</string>
     <string name="editor_error_weather_location_required">For phrases with weather, please enter a city.</string>
     <string name="editor_existing_voice_cache_used">An existing voice cache was used.</string>
     <string name="editor_expand">Expand</string>
@@ -316,7 +315,7 @@
     <string name="editorp_weather_save_button">Save</string>
     <string name="alarms_target_sheet_title">Who is this alarm for?</string>
     <string name="alarms_target_self_title">Set my alarm</string>
-    <string name="hs_delete_account_body">Are you sure you want to delete your account? 30 days after you request it, all your data—including alarms, voices, and messages—is permanently deleted. You can cancel and restore it by signing back in before then.</string>
+    <string name="hs_delete_account_body">Are you sure you want to delete your account? 30 days after you request it, all your data—including alarms and voices—is permanently deleted. You can cancel and restore it by signing back in before then.</string>
     <string name="hs_delete_account_confirm">Delete</string>
     <string name="hs_delete_account_title">Delete account</string>
     <string name="hs_greeting_each_other_bottom">let\'s schedule mornings</string>
@@ -329,7 +328,7 @@
     <string name="hs_greeting_voice_top">We\'ll wake you</string>
     <string name="hs_nickname_char_counter">%1$d/30</string>
     <string name="hs_nickname_dialog_title">Edit nickname</string>
-    <string name="hs_nickname_display_name_desc">This name is used on alarm, message, and shared pass screens.</string>
+    <string name="hs_nickname_display_name_desc">This name is used on alarm and shared pass screens.</string>
     <string name="hs_nickname_display_name_title">Name shown in the app</string>
     <string name="hs_nickname_field_label">Nickname</string>
     <string name="hs_nickname_field_placeholder">e.g. Gyuwon</string>
@@ -423,7 +422,6 @@
     <string name="msg_gb_code_registered">Code registered</string>
     <string name="msg_gb_promo_redeemed">Promo code applied</string>
     <string name="msg_gb_promo_redeem_failed">Couldn\'t apply the promo code.</string>
-    <string name="msg_gb_free_plan_voice_alarms_deleted">You\'ve switched to the free plan, so your voice alarms were deleted.</string>
     <string name="msg_gb_free_plan_voice_alarms_locked">You\'ve switched to the free plan, so your voice alarms are locked. They\'ll be restored when you resubscribe.</string>
     <string name="msg_gb_gift_failed">Couldn\'t send the gift.</string>
     <string name="msg_gb_google_play_start_failed">Couldn\'t start the Google Play payment. Please try again in a moment.</string>
@@ -433,16 +431,11 @@
     <string name="msg_gb_login_required_create_share_code">Please log in first to create a share code.</string>
     <string name="msg_gb_login_required_generic">Please log in to use this.</string>
     <string name="msg_gb_login_required_growth_info">Please log in first to load your growth info</string>
-    <string name="msg_gb_login_required_load_voice_messages">Please log in first to load your voice messages.</string>
-    <string name="msg_gb_login_required_mark_message_read">Please log in first to mark messages as read.</string>
-    <string name="msg_gb_login_required_play_voice_message">Please log in first to play voice messages.</string>
+
     <string name="msg_gb_login_required_purchase_plan">Please log in first to purchase a plan.</string>
     <string name="msg_gb_login_required_register_code">Please log in first to register a code</string>
-    <string name="msg_gb_login_required_send_message">Please log in first to send a message.</string>
     <string name="msg_gb_login_required_share_code_info">Please log in first to load the share code info</string>
-    <string name="msg_gb_message_input_required">Please enter a message.</string>
-    <string name="msg_gb_message_send_failed">Couldn\'t send your message.</string>
-    <string name="msg_gb_message_sent">Your message was sent.</string>
+
     <string name="msg_gb_no_active_subscription_apply_new">You don\'t have an active plan, so we\'ll apply this as a new one.</string>
     <string name="msg_gb_payment_confirm_failed">Couldn\'t confirm your payment.</string>
     <string name="msg_gb_payment_confirm_failed_retry">Couldn\'t confirm your payment. Please try again in a moment.</string>
@@ -456,7 +449,6 @@
     <string name="msg_gb_plan_label_couple">Couple</string>
     <string name="msg_gb_plan_label_family">Family</string>
     <string name="msg_gb_plan_label_shared">Shared</string>
-    <string name="msg_gb_receiver_required">Please choose a recipient.</string>
     <string name="msg_gb_same_plan_in_use">You\'re already on this plan.</string>
     <string name="msg_gb_share_code_info_load_failed">Couldn\'t load the share code info</string>
     <string name="msg_gb_share_code_load_failed">Couldn\'t load the %1$s share code.</string>
@@ -464,17 +456,12 @@
     <string name="msg_gb_share_code_regenerated">Issued a new %1$s share code. The old code no longer works.</string>
     <string name="msg_gb_subscription_cancel_at_period_end">You can keep using your pass until the end of this period. There\'s no next payment.</string>
     <string name="msg_gb_subscription_cancel_failed">Couldn\'t cancel your plan.</string>
-    <string name="msg_gb_subscription_canceled">Your plan has been canceled. The remaining time is refunded on a prorated basis.</string>
-    <string name="msg_gb_subscription_canceled_voice_retained">Your plan has been canceled. The remaining time is refunded, and your voice data is kept until %1$s.</string>
+
     <string name="msg_gb_subscription_canceled_voice_locked">Your plan has been canceled. Your voices aren\'t deleted — they\'re locked and become usable again when you resubscribe.</string>
-    <string name="msg_gb_voice_data_delete_blocked_active">You can\'t delete this while your subscription is active.</string>
-    <string name="msg_gb_voice_data_delete_failed">Couldn\'t delete your voice data.</string>
-    <string name="msg_gb_voice_data_deleted_now">Your voice data has been deleted.</string>
-    <string name="msg_gb_voice_message_max_length">Voice messages can be up to 200 characters.</string>
-    <string name="msg_gb_voice_message_send_failed">Couldn\'t send your voice message.</string>
-    <string name="msg_gb_voice_message_sent">Your voice message was sent.</string>
-    <string name="msg_gb_voice_messages_load_failed">Couldn\'t load your voice messages.</string>
-    <string name="msg_gb_voice_required">Please choose a voice.</string>
+
+
+
+
     <string name="msg_google_login_failed">Couldn\'t complete your Google login. Please try again.</string>
     <string name="msg_google_login_not_confirmed">Couldn\'t confirm your Google login. Please try again.</string>
     <string name="msg_leave_group_failed">Couldn\'t leave the plan.</string>
@@ -578,38 +565,29 @@
     <string name="social_allow_partner_alarm_couple">Let your partner set my alarms</string>
     <string name="social_back_cd">Back</string>
     <string name="social_capacity_full_no_share">The plan is full, so you can\'t share any more.</string>
-    <string name="social_compose_button">Compose</string>
-    <string name="social_composer_message">Message</string>
-    <string name="social_composer_recipient">Recipient</string>
-    <string name="social_composer_send_method">Send method</string>
+
+
     <string name="social_cancel_button">Cancel</string>
-    <string name="social_composer_voice">Voice to send</string>
-    <string name="social_connect_button">Connect</string>
+
     <string name="social_create_share_code">Create share code</string>
     <string name="social_edit_button">Edit</string>
-    <string name="social_invite_code_label">Invite code</string>
-    <string name="social_join_button">Join</string>
+
     <string name="social_leave_and_register_button">Leave &amp; register</string>
     <string name="social_leave_and_register_new_code">Leave current plan &amp; register a new code</string>
     <string name="social_leave_dialog_message">Leave your current plan and register a new code?</string>
     <string name="social_leave_dialog_title">Leave current plan &amp; register new code</string>
-    <string name="social_loading_voices">Loading voices…</string>
     <string name="social_managing_shared_plan">You\'re managing a shared plan.</string>
     <string name="social_member_fallback">Member</string>
     <string name="social_members_section_title">Members</string>
-    <string name="social_message_placeholder">Type what you\'d like to say</string>
-    <string name="social_message_requires_plan">Messages are available with a Couple or Family plan.</string>
-    <string name="social_new_message_title">New message</string>
-    <string name="social_no_available_voices">No voices available.</string>
+
+
     <string name="social_no_share_code_yet">No share code yet. Create an invite code to invite %1$s members.</string>
     <string name="social_no_shared_plan">You\'re not sharing a plan right now.</string>
     <string name="social_plan_label_couple">Couple</string>
     <string name="social_plan_label_family">Family</string>
     <string name="social_plan_label_shared">Shared</string>
-    <string name="social_play_cd">Play</string>
     <string name="social_quiet_time_label">Do-not-disturb hours</string>
-    <string name="social_received_messages_title">Received messages</string>
-    <string name="social_refresh_cd">Refresh</string>
+
     <string name="social_regenerate_share_code">Regenerate</string>
     <string name="social_regenerate_share_code_dialog_message">Regenerating disables the current code. You\'ll need to resend the new code to anyone you already shared it with.</string>
     <string name="social_regenerate_share_code_dialog_title">Regenerate share code</string>
@@ -624,19 +602,14 @@
     <string name="social_remove_member_dialog_title">Remove member</string>
     <string name="social_role_me">Me</string>
     <string name="social_role_owner">Admin</string>
-    <string name="social_send_button">Send</string>
-    <string name="social_send_mode_text">Text</string>
-    <string name="social_send_mode_voice">Voice message</string>
-    <string name="social_sender_fallback">Sender</string>
-    <string name="social_sending">Sending</string>
+
+
     <string name="social_share_button">Share</string>
     <string name="social_share_code_chooser_title">Share code</string>
     <string name="social_share_code_section_title">Share code</string>
     <string name="social_share_unavailable">Can\'t share</string>
     <string name="social_shared_plan_title">Invite &amp; manage members</string>
-    <string name="social_stop_cd">Stop</string>
-    <string name="social_view_plan_button">View plan</string>
-    <string name="social_voucher_code_label">Plan code</string>
+
     <string name="social_code_input_label">Enter a code</string>
     <string name="social_code_input_hint">Invite codes, gifted pass codes, and promo codes all work here.</string>
     <string name="social_voucher_usage">%1$d/%2$d in use</string>
@@ -724,7 +697,7 @@ We\'ll play it for you as soon as it\'s ready.</string>
     <string name="voicesr_delete">Delete</string>
     <string name="voicesr_delete_dialog_confirm">Delete the \'%1$s\' voice?</string>
     <string name="voicesr_delete_dialog_title">Delete voice</string>
-    <string name="voicesr_delete_dialog_warning">Messages using this voice will keep only their text, and their alarms will switch to the default alarm sound. The saved audio files will also be deleted.</string>
+    <string name="voicesr_delete_dialog_warning">Alarms using this voice will switch to the default alarm sound. The saved audio files will also be deleted.</string>
     <string name="voicesr_edit_info">Edit info</string>
     <string name="voicesr_edit_my_info">Edit my info</string>
     <string name="voicesr_listener_title_example_a">e.g. Minji, honey</string>
@@ -952,7 +925,6 @@ We\'ll play it for you as soon as it\'s ready.</string>
     <string name="rd2_ringing_date">%3$s, %1$d/%2$d</string>
     <string name="r3app_bottom_tab_voices">Voices</string>
     <string name="r3app_bottom_tab_alarms">Alarms</string>
-    <string name="r3app_bottom_tab_messages">Messages</string>
     <string name="r3app_bottom_tab_menu">More</string>
     <string name="menu_profile_subtitle">My info · App settings</string>
     <string name="menu_language_label">App language</string>
@@ -981,7 +953,6 @@ for a smooth and secure experience.</string>
     <string name="r3app_permission_gate_body">To ring alarms at the exact time and show them right on your lock screen, the permissions below are needed.</string>
     <string name="r3app_google_signin_failed">Google sign-in failed</string>
     <string name="r3app_google_signin_no_info">We couldn\'t get your Google sign-in info. Please try again.</string>
-    <string name="r3app_messages_plan_gate">With a plan, you can send and receive voice messages with your loved ones.</string>
     <string name="r3app_messages_plan_gate_title">Couple/Family plan required</string>
     <string name="r3app_plan_gate_confirm">View plans</string>
     <string name="r3app_perm_required_notifications">Notification permission is needed to show the alarm screen and dismiss button.</string>
@@ -1027,8 +998,7 @@ for a smooth and secure experience.</string>
     <string name="r3misc_login_required_generic">Available after signing in</string>
     <string name="r3misc_google_signin_unavailable">Google sign-in isn\'t available right now. Please sign in with your email.</string>
     <string name="r3misc_google_signin_failed">Google sign-in failed</string>
-    <string name="r3misc_notif_new_message_title">New message</string>
-    <string name="r3misc_notif_new_message_body">A new message has arrived</string>
+
     <string name="r3misc_notif_received_alarm_time">Rings at %1$s</string>
     <string name="r3misc_notif_received_alarm_default">Your friend set an alarm for you</string>
     <string name="r3misc_ringing_action_snooze">Snooze</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -95,12 +95,12 @@
     <string name="billing_manage_on_google_play">Google Playで定期購入を管理</string>
     <string name="billing_monthly_subscription">Google Playで購読する</string>
     <string name="billing_plan_couple_feature_max_two">2人で一緒に利用</string>
-    <string name="billing_plan_couple_feature_message">相手のアラーム設定・音声メッセージ</string>
+    <string name="billing_plan_couple_feature_message">相手のアラーム設定</string>
     <string name="billing_plan_couple_feature_voice_share">お互いの声を共有</string>
     <string name="billing_plan_couple_name">カップル</string>
     <string name="billing_plan_couple_price">月額690円</string>
     <string name="billing_plan_family_feature_max_six">最大5人で一緒に利用</string>
-    <string name="billing_plan_family_feature_message">家族へのアラーム送信・音声メッセージ</string>
+    <string name="billing_plan_family_feature_message">家族へのアラーム送信</string>
     <string name="billing_plan_family_feature_voice_share">家族の声を共有</string>
     <string name="billing_plan_feature_includes_personal">パーソナルの全機能を含む</string>
     <string name="billing_plan_family_name">ファミリー</string>
@@ -112,7 +112,6 @@
     <string name="billing_plan_personal_feature_daily_prompt">天気・運勢など毎日新しいひとこと</string>
     <string name="billing_plan_personal_feature_gift">パーソナル利用券のプレゼント</string>
     <string name="billing_plan_personal_feature_voice">好きな声を1つ登録</string>
-    <string name="billing_plan_personal_feature_voice_message">音声メッセージ</string>
     <string name="billing_plan_personal_name">パーソナル</string>
     <string name="billing_plan_personal_price">月額390円</string>
     <string name="billing_play_manage_description">アプリで解約を完了できませんでした。Google Playの定期購入管理から直接解約できます。契約状態は変わっていません。</string>
@@ -201,7 +200,7 @@
     <string name="editor_error_audio_duration_unreadable">音声の長さを確認できないファイルは使用できません。</string>
     <string name="editor_error_crop_save_failed">選択した区間を保存できませんでした。</string>
     <string name="editor_error_deleted_voice_cannot_edit">削除された声のため、文を編集できません。別の声を選択してください。</string>
-    <string name="editor_error_enter_message_or_random">音声メッセージを入力するか、ランダム文を使用してください。</string>
+    <string name="editor_error_enter_message_or_random">アラーム文を入力するか、ランダム文を使用してください。</string>
     <string name="editor_error_family_alarm_lead_too_soon">相手のアラームは%1$s以降にしてください。相手が準備できるよう30分の余裕が必要です。</string>
     <string name="editor_error_family_alarm_time_unavailable">相手が受け取れない時間帯です。</string>
     <string name="editor_error_fortune_info_required">占いを含む文には、性別・生年月日・生まれた時間を入力してください。</string>
@@ -217,7 +216,7 @@
     <string name="editor_error_voice_alarm_login_required">音声アラームはログイン後にご利用いただけます。</string>
     <string name="editor_error_voice_generation_failed">音声の生成に失敗しました。</string>
     <string name="editor_error_manual_tts_quota">今月の手動メッセージ作成回数を使い切りました。来月また補充されます。</string>
-    <string name="editor_error_voice_message_login_required">音声メッセージはログイン後にご利用いただけます。</string>
+    <string name="editor_error_voice_message_login_required">音声アラームはログイン後にご利用いただけます。</string>
     <string name="editor_error_weather_location_required">天気を含む文には、都市を入力してください。</string>
     <string name="editor_existing_voice_cache_used">既存の音声キャッシュを使用しました。</string>
     <string name="editor_expand">広げる</string>
@@ -316,7 +315,7 @@
     <string name="editorp_weather_save_button">保存</string>
     <string name="alarms_target_sheet_title">誰を起こしますか？</string>
     <string name="alarms_target_self_title">自分のアラームを設定</string>
-    <string name="hs_delete_account_body">本当に退会しますか？申請から30日が過ぎると、アラーム・音声・メッセージなどすべてのデータが完全に削除されます。それまでに再ログインして退会を取り消せば復元できます。</string>
+    <string name="hs_delete_account_body">本当に退会しますか？申請から30日が過ぎると、アラーム・音声などすべてのデータが完全に削除されます。それまでに再ログインして退会を取り消せば復元できます。</string>
     <string name="hs_delete_account_confirm">退会する</string>
     <string name="hs_delete_account_title">退会</string>
     <string name="hs_greeting_each_other_bottom">朝を予約しましょう</string>
@@ -329,7 +328,7 @@
     <string name="hs_greeting_voice_top">お気に入りの声で</string>
     <string name="hs_nickname_char_counter">%1$d/30</string>
     <string name="hs_nickname_dialog_title">ニックネームを編集</string>
-    <string name="hs_nickname_display_name_desc">アラーム、メッセージ、共有利用券の画面でこの名前を使います。</string>
+    <string name="hs_nickname_display_name_desc">アラーム、共有利用券の画面でこの名前を使います。</string>
     <string name="hs_nickname_display_name_title">アプリに表示される名前</string>
     <string name="hs_nickname_field_label">ニックネーム</string>
     <string name="hs_nickname_field_placeholder">例：りん</string>
@@ -432,7 +431,6 @@
     <string name="msg_gb_code_registered">コードを登録しました</string>
     <string name="msg_gb_promo_redeemed">プロモコードを適用しました</string>
     <string name="msg_gb_promo_redeem_failed">プロモコードを適用できませんでした。</string>
-    <string name="msg_gb_free_plan_voice_alarms_deleted">無料プランに切り替わったため、声のアラームを削除しました。</string>
     <string name="msg_gb_free_plan_voice_alarms_locked">無料プランに切り替わったため、声のアラームがロックされました。再び利用券を登録すると復元されます。</string>
     <string name="msg_gb_gift_failed">プレゼントの送信に失敗しました。</string>
     <string name="msg_gb_google_play_start_failed">Google Play決済を開始できませんでした。しばらくしてからもう一度お試しください。</string>
@@ -442,16 +440,11 @@
     <string name="msg_gb_login_required_create_share_code">共有コードを作成するには、まずログインしてください。</string>
     <string name="msg_gb_login_required_generic">ログインするとご利用いただけます。</string>
     <string name="msg_gb_login_required_growth_info">成長情報を読み込むには、まずログインしてください</string>
-    <string name="msg_gb_login_required_load_voice_messages">音声メッセージを読み込むには、まずログインしてください。</string>
-    <string name="msg_gb_login_required_mark_message_read">メッセージを既読にするには、まずログインしてください。</string>
-    <string name="msg_gb_login_required_play_voice_message">音声メッセージを再生するには、まずログインしてください。</string>
+
     <string name="msg_gb_login_required_purchase_plan">プランを購入するには、まずログインしてください。</string>
     <string name="msg_gb_login_required_register_code">コードを登録するには、まずログインしてください</string>
-    <string name="msg_gb_login_required_send_message">メッセージを送るには、まずログインしてください。</string>
     <string name="msg_gb_login_required_share_code_info">共有コード情報を読み込むには、まずログインしてください</string>
-    <string name="msg_gb_message_input_required">メッセージを入力してください。</string>
-    <string name="msg_gb_message_send_failed">メッセージの送信に失敗しました。</string>
-    <string name="msg_gb_message_sent">メッセージを送りました。</string>
+
     <string name="msg_gb_no_active_subscription_apply_new">現在適用中のプランがないため、新しいプランとして適用します。</string>
     <string name="msg_gb_payment_confirm_failed">決済の確認に失敗しました。</string>
     <string name="msg_gb_payment_confirm_failed_retry">決済の確認に失敗しました。しばらくしてからもう一度お試しください。</string>
@@ -465,7 +458,6 @@
     <string name="msg_gb_plan_label_couple">カップル</string>
     <string name="msg_gb_plan_label_family">ファミリー</string>
     <string name="msg_gb_plan_label_shared">共有</string>
-    <string name="msg_gb_receiver_required">受け取る人を選んでください。</string>
     <string name="msg_gb_same_plan_in_use">すでにご利用中のプランです。</string>
     <string name="msg_gb_share_code_info_load_failed">共有コード情報を読み込めませんでした</string>
     <string name="msg_gb_share_code_load_failed">%1$s共有コードを読み込めませんでした。</string>
@@ -473,17 +465,12 @@
     <string name="msg_gb_share_code_regenerated">%1$s共有コードを新しく発行しました。以前のコードは使えません。</string>
     <string name="msg_gb_subscription_cancel_at_period_end">今の利用期間まではそのまま使えます。次のお支払いはありません。</string>
     <string name="msg_gb_subscription_cancel_failed">解約に失敗しました。</string>
-    <string name="msg_gb_subscription_canceled">プランを解約しました。残り期間の料金は日割りで返金されます。</string>
-    <string name="msg_gb_subscription_canceled_voice_retained">プランを解約しました。残り期間の料金は日割りで返金され、声のデータは%1$sまで保管されます。</string>
+
     <string name="msg_gb_subscription_canceled_voice_locked">プランを解約しました。作成した声は削除されずロックされます。再び利用券を登録すると、そのまま使えます。</string>
-    <string name="msg_gb_voice_data_delete_blocked_active">定期購入のご利用中は削除できません。</string>
-    <string name="msg_gb_voice_data_delete_failed">声のデータを削除できませんでした。</string>
-    <string name="msg_gb_voice_data_deleted_now">声のデータを削除しました。</string>
-    <string name="msg_gb_voice_message_max_length">音声メッセージは200文字まで送れます。</string>
-    <string name="msg_gb_voice_message_send_failed">音声メッセージの送信に失敗しました。</string>
-    <string name="msg_gb_voice_message_sent">音声メッセージを送りました。</string>
-    <string name="msg_gb_voice_messages_load_failed">音声メッセージを読み込めませんでした。</string>
-    <string name="msg_gb_voice_required">声を選んでください。</string>
+
+
+
+
     <string name="msg_google_login_failed">Googleログインを完了できませんでした。もう一度お試しください。</string>
     <string name="msg_google_login_not_confirmed">Googleログインを確認できませんでした。もう一度お試しください。</string>
     <string name="msg_leave_group_failed">プランから退出できませんでした。</string>
@@ -586,38 +573,29 @@
     <string name="social_allow_partner_alarm_couple">パートナーが私のアラームを設定するのを許可</string>
     <string name="social_back_cd">戻る</string>
     <string name="social_capacity_full_no_share">定員に達したため、これ以上共有できません。</string>
-    <string name="social_compose_button">作成</string>
-    <string name="social_composer_message">メッセージ</string>
-    <string name="social_composer_recipient">宛先</string>
-    <string name="social_composer_send_method">送信方法</string>
+
+
     <string name="social_cancel_button">キャンセル</string>
-    <string name="social_composer_voice">送る声</string>
-    <string name="social_connect_button">連携する</string>
+
     <string name="social_create_share_code">共有コードを作成</string>
     <string name="social_edit_button">編集</string>
-    <string name="social_invite_code_label">招待コード</string>
-    <string name="social_join_button">参加</string>
+
     <string name="social_leave_and_register_button">退出して登録</string>
     <string name="social_leave_and_register_new_code">現在のプランから退出して新しいコードを登録</string>
     <string name="social_leave_dialog_message">現在のプランから退出して、新しいコードを登録しますか？</string>
     <string name="social_leave_dialog_title">現在のプランから退出して新しいコードを登録</string>
-    <string name="social_loading_voices">声を読み込み中です。</string>
     <string name="social_managing_shared_plan">共有プランを管理中です。</string>
     <string name="social_member_fallback">メンバー</string>
     <string name="social_members_section_title">メンバー</string>
-    <string name="social_message_placeholder">伝えたい言葉を入力してください</string>
-    <string name="social_message_requires_plan">メッセージは、カップル・家族プランでご利用いただけます。</string>
-    <string name="social_new_message_title">新しいメッセージ</string>
-    <string name="social_no_available_voices">利用できる声がありません。</string>
+
+
     <string name="social_no_share_code_yet">共有コードはまだありません。%1$sのメンバーを招待する招待コードを作成してください。</string>
     <string name="social_no_shared_plan">現在、一緒に使っているプランはありません。</string>
     <string name="social_plan_label_couple">カップル</string>
     <string name="social_plan_label_family">家族</string>
     <string name="social_plan_label_shared">共有</string>
-    <string name="social_play_cd">再生</string>
     <string name="social_quiet_time_label">アラームを受け取らない時間</string>
-    <string name="social_received_messages_title">受信メッセージ</string>
-    <string name="social_refresh_cd">更新</string>
+
     <string name="social_regenerate_share_code">再発行</string>
     <string name="social_regenerate_share_code_dialog_message">再発行すると現在のコードは使えなくなります。すでに共有した相手には新しいコードを送り直してください。</string>
     <string name="social_regenerate_share_code_dialog_title">共有コードの再発行</string>
@@ -632,19 +610,14 @@
     <string name="social_remove_member_dialog_title">メンバーを退出させる</string>
     <string name="social_role_me">自分</string>
     <string name="social_role_owner">管理者</string>
-    <string name="social_send_button">送信</string>
-    <string name="social_send_mode_text">テキスト</string>
-    <string name="social_send_mode_voice">音声メッセージ</string>
-    <string name="social_sender_fallback">送信者</string>
-    <string name="social_sending">送信中</string>
+
+
     <string name="social_share_button">共有する</string>
     <string name="social_share_code_chooser_title">コードを共有</string>
     <string name="social_share_code_section_title">共有コード</string>
     <string name="social_share_unavailable">共有できません</string>
     <string name="social_shared_plan_title">招待・メンバー管理</string>
-    <string name="social_stop_cd">停止</string>
-    <string name="social_view_plan_button">プランを見る</string>
-    <string name="social_voucher_code_label">プランコード</string>
+
     <string name="social_code_input_label">コード入力</string>
     <string name="social_code_input_hint">招待コード・利用券ギフトコード・プロモコードのすべてを登録できます。</string>
     <string name="social_voucher_usage">%1$d/%2$d人が使用中</string>
@@ -732,7 +705,7 @@
     <string name="voicesr_delete">削除</string>
     <string name="voicesr_delete_dialog_confirm">「%1$s」の声を削除しますか?</string>
     <string name="voicesr_delete_dialog_title">声を削除</string>
-    <string name="voicesr_delete_dialog_warning">この声を使うメッセージはテキストだけが残り、アラームは基本のアラーム音に変わります。保存された音源ファイルも一緒に削除されます。</string>
+    <string name="voicesr_delete_dialog_warning">この声を使うアラームは基本のアラーム音に変わります。保存された音源ファイルも一緒に削除されます。</string>
     <string name="voicesr_edit_info">情報を編集</string>
     <string name="voicesr_edit_my_info">自分の情報を編集</string>
     <string name="voicesr_listener_title_example_a">例:ミンジ、あなた</string>
@@ -960,7 +933,6 @@
     <string name="rd2_ringing_date">%1$d月%2$d日 %3$s</string>
     <string name="r3app_bottom_tab_voices">声</string>
     <string name="r3app_bottom_tab_alarms">アラーム</string>
-    <string name="r3app_bottom_tab_messages">メッセージ</string>
     <string name="r3app_bottom_tab_menu">その他</string>
     <string name="menu_profile_subtitle">マイ情報・アプリ設定</string>
     <string name="menu_language_label">アプリの言語</string>
@@ -989,7 +961,6 @@
     <string name="r3app_permission_gate_body">正確な時刻にアラームを鳴らし、ロック画面にもすぐ表示するには、以下の権限が必要です。</string>
     <string name="r3app_google_signin_failed">Googleログインに失敗しました</string>
     <string name="r3app_google_signin_no_info">Googleログイン情報を取得できませんでした。もう一度お試しください。</string>
-    <string name="r3app_messages_plan_gate">プランに加入すると、家族や恋人と声のメッセージをやり取りできます。</string>
     <string name="r3app_messages_plan_gate_title">カップル・ファミリープランが必要です</string>
     <string name="r3app_plan_gate_confirm">プランを見る</string>
     <string name="r3app_perm_required_notifications">アラーム画面と停止ボタンを表示するには、通知の権限が必要です。</string>
@@ -1035,8 +1006,7 @@
     <string name="r3misc_login_required_generic">ログイン後にご利用いただけます</string>
     <string name="r3misc_google_signin_unavailable">現在Googleログインはご利用いただけません。メールでログインしてください。</string>
     <string name="r3misc_google_signin_failed">Googleログインに失敗しました</string>
-    <string name="r3misc_notif_new_message_title">新着メッセージ</string>
-    <string name="r3misc_notif_new_message_body">新しいメッセージが届きました</string>
+
     <string name="r3misc_notif_received_alarm_time">%1$sに鳴ります</string>
     <string name="r3misc_notif_received_alarm_default">相手があなたのアラームを設定しました</string>
     <string name="r3misc_ringing_action_snooze">再通知</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -97,12 +97,12 @@
     <string name="billing_manage_on_google_play">Google Play 구독 관리</string>
     <string name="billing_monthly_subscription">Google Play로 구독하기</string>
     <string name="billing_plan_couple_feature_max_two">2명이 함께 사용</string>
-    <string name="billing_plan_couple_feature_message">상대 알람 맞춰주기·음성 메시지</string>
+    <string name="billing_plan_couple_feature_message">상대 알람 맞춰주기</string>
     <string name="billing_plan_couple_feature_voice_share">서로의 목소리 공유</string>
     <string name="billing_plan_couple_name">커플</string>
     <string name="billing_plan_couple_price">월 6,900원</string>
     <string name="billing_plan_family_feature_max_six">최대 5명이 함께 사용</string>
-    <string name="billing_plan_family_feature_message">가족에게 알람 보내기·음성 메시지</string>
+    <string name="billing_plan_family_feature_message">가족에게 알람 보내기</string>
     <string name="billing_plan_family_feature_voice_share">가족 목소리 공유</string>
     <string name="billing_plan_feature_includes_personal">개인 이용권 기능 전부 포함</string>
     <string name="billing_plan_family_name">가족</string>
@@ -114,7 +114,6 @@
     <string name="billing_plan_personal_feature_daily_prompt">날씨·운세 등 매일 다른 문구</string>
     <string name="billing_plan_personal_feature_gift">개인 이용권 선물</string>
     <string name="billing_plan_personal_feature_voice">원하는 목소리 1개 등록</string>
-    <string name="billing_plan_personal_feature_voice_message">음성 메시지</string>
     <string name="billing_plan_personal_name">개인</string>
     <string name="billing_plan_personal_price">월 3,900원</string>
     <string name="billing_play_manage_description">앱에서 해지를 완료하지 못했어요. Google Play 구독 관리에서 직접 해지할 수 있어요. 구독 상태는 바뀌지 않았어요.</string>
@@ -203,7 +202,7 @@
     <string name="editor_error_audio_duration_unreadable">오디오 길이를 확인할 수 없는 파일은 사용할 수 없어요.</string>
     <string name="editor_error_crop_save_failed">선택한 구간을 저장하지 못했어요.</string>
     <string name="editor_error_deleted_voice_cannot_edit">삭제된 목소리라 문구를 수정할 수 없어요. 다른 목소리를 선택해 주세요.</string>
-    <string name="editor_error_enter_message_or_random">음성 메시지를 입력하거나 랜덤 문구를 사용해 주세요.</string>
+    <string name="editor_error_enter_message_or_random">알람 문구를 입력하거나 랜덤 문구를 사용해 주세요.</string>
     <string name="editor_error_family_alarm_lead_too_soon">상대 알람은 %1$s 이후로 맞춰 주세요. 상대가 준비할 수 있게 30분 여유가 필요해요.</string>
     <string name="editor_error_family_alarm_time_unavailable">상대가 받을 수 없는 시간이에요.</string>
     <string name="editor_error_fortune_info_required">운세가 들어간 문구는 성별, 생년월일, 태어난 시간을 입력해 주세요.</string>
@@ -219,7 +218,7 @@
     <string name="editor_error_voice_alarm_login_required">음성 알람은 로그인 후 사용할 수 있어요.</string>
     <string name="editor_error_voice_generation_failed">음성 생성에 실패했어요.</string>
     <string name="editor_error_manual_tts_quota">이번 달 직접 입력 문구 만들기 횟수를 다 썼어요. 다음 달에 다시 채워져요.</string>
-    <string name="editor_error_voice_message_login_required">음성 메시지는 로그인 후 사용할 수 있어요.</string>
+    <string name="editor_error_voice_message_login_required">음성 알람은 로그인 후 사용할 수 있어요.</string>
     <string name="editor_error_weather_location_required">날씨가 들어간 문구는 도시를 입력해 주세요.</string>
     <string name="editor_existing_voice_cache_used">기존 음성 캐시를 사용했어요.</string>
     <string name="editor_expand">펼치기</string>
@@ -318,7 +317,7 @@
     <string name="editorp_weather_save_button">저장</string>
     <string name="alarms_target_sheet_title">누구를 깨울까요?</string>
     <string name="alarms_target_self_title">내 알람 맞추기</string>
-    <string name="hs_delete_account_body">정말 탈퇴할까요? 신청 후 30일이 지나면 알람, 음성, 메시지 등 모든 데이터가 영구 삭제돼요. 그 전에 다시 로그인해 탈퇴를 취소하면 복구할 수 있어요.</string>
+    <string name="hs_delete_account_body">정말 탈퇴할까요? 신청 후 30일이 지나면 알람, 목소리 등 모든 데이터가 영구 삭제돼요. 그 전에 다시 로그인해 탈퇴를 취소하면 복구할 수 있어요.</string>
     <string name="hs_delete_account_confirm">탈퇴</string>
     <string name="hs_delete_account_title">회원 탈퇴</string>
     <string name="hs_greeting_each_other_bottom">아침을 예약해요</string>
@@ -331,7 +330,7 @@
     <string name="hs_greeting_voice_top">좋아하는 목소리로</string>
     <string name="hs_nickname_char_counter">%1$d/30</string>
     <string name="hs_nickname_dialog_title">닉네임 수정</string>
-    <string name="hs_nickname_display_name_desc">알람, 메시지, 공유 이용권 화면에서 이 이름을 사용해요.</string>
+    <string name="hs_nickname_display_name_desc">알람, 공유 이용권 화면에서 이 이름을 사용해요.</string>
     <string name="hs_nickname_display_name_title">앱에서 보일 이름</string>
     <string name="hs_nickname_field_label">닉네임</string>
     <string name="hs_nickname_field_placeholder">예: 규원</string>
@@ -435,7 +434,6 @@
     <string name="msg_gb_code_registered">코드를 등록했어요</string>
     <string name="msg_gb_promo_redeemed">프로모 코드를 적용했어요</string>
     <string name="msg_gb_promo_redeem_failed">프로모 코드를 적용하지 못했어요</string>
-    <string name="msg_gb_free_plan_voice_alarms_deleted">무료 이용권으로 전환되어 목소리 알람을 삭제했어요.</string>
     <string name="msg_gb_free_plan_voice_alarms_locked">무료 이용권으로 전환되어 목소리 알람이 잠겼어요. 다시 이용권을 등록하면 복구돼요.</string>
     <string name="msg_gb_gift_failed">선물하기에 실패했어요</string>
     <string name="msg_gb_google_play_start_failed">Google Play 결제를 시작하지 못했어요. 잠시 후 다시 시도해 주세요.</string>
@@ -445,16 +443,11 @@
     <string name="msg_gb_login_required_create_share_code">공유 코드를 만들려면 먼저 로그인해 주세요</string>
     <string name="msg_gb_login_required_generic">로그인 후 사용할 수 있어요</string>
     <string name="msg_gb_login_required_growth_info">성장 정보를 불러오려면 먼저 로그인해 주세요</string>
-    <string name="msg_gb_login_required_load_voice_messages">음성 메시지를 불러오려면 먼저 로그인해 주세요</string>
-    <string name="msg_gb_login_required_mark_message_read">메시지를 읽음 처리하려면 먼저 로그인해 주세요</string>
-    <string name="msg_gb_login_required_play_voice_message">음성 메시지를 재생하려면 먼저 로그인해 주세요</string>
+
     <string name="msg_gb_login_required_purchase_plan">이용권을 구매하려면 먼저 로그인해 주세요</string>
     <string name="msg_gb_login_required_register_code">코드를 등록하려면 먼저 로그인해 주세요</string>
-    <string name="msg_gb_login_required_send_message">메시지를 보내려면 먼저 로그인해 주세요</string>
     <string name="msg_gb_login_required_share_code_info">공유 코드 정보를 불러오려면 먼저 로그인해 주세요</string>
-    <string name="msg_gb_message_input_required">메시지를 입력해 주세요</string>
-    <string name="msg_gb_message_send_failed">메시지 전송에 실패했어요</string>
-    <string name="msg_gb_message_sent">메시지를 보냈어요</string>
+
     <string name="msg_gb_no_active_subscription_apply_new">현재 적용된 이용권이 없어 새 이용권으로 적용할게요</string>
     <string name="msg_gb_payment_confirm_failed">결제 확인에 실패했어요</string>
     <string name="msg_gb_payment_confirm_failed_retry">결제 확인에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
@@ -468,7 +461,6 @@
     <string name="msg_gb_plan_label_couple">커플</string>
     <string name="msg_gb_plan_label_family">가족</string>
     <string name="msg_gb_plan_label_shared">공유</string>
-    <string name="msg_gb_receiver_required">받는 사람을 선택해 주세요</string>
     <string name="msg_gb_same_plan_in_use">이미 사용 중인 이용권이에요</string>
     <string name="msg_gb_share_code_info_load_failed">공유 코드 정보를 불러오지 못했어요</string>
     <string name="msg_gb_share_code_load_failed">%1$s 공유 코드를 불러오지 못했어요</string>
@@ -476,17 +468,12 @@
     <string name="msg_gb_share_code_regenerated">%1$s 공유 코드를 새로 발급했어요. 기존 코드는 더 이상 쓸 수 없어요</string>
     <string name="msg_gb_subscription_cancel_at_period_end">이번 이용 기간까지 그대로 쓸 수 있어요. 다음 결제는 없어요</string>
     <string name="msg_gb_subscription_cancel_failed">해지에 실패했어요</string>
-    <string name="msg_gb_subscription_canceled">이용권을 해지했어요. 남은 기간 요금은 비례 환불돼요</string>
-    <string name="msg_gb_subscription_canceled_voice_retained">이용권을 해지했어요. 남은 기간 요금은 비례 환불되고, 목소리 데이터는 %1$s까지 보관돼요</string>
+
     <string name="msg_gb_subscription_canceled_voice_locked">이용권을 해지했어요. 만든 목소리는 삭제되지 않고 잠겨요 — 다시 이용권을 등록하면 그대로 다시 쓸 수 있어요</string>
-    <string name="msg_gb_voice_data_delete_blocked_active">구독 이용 중에는 삭제할 수 없어요</string>
-    <string name="msg_gb_voice_data_delete_failed">목소리 데이터를 삭제하지 못했어요</string>
-    <string name="msg_gb_voice_data_deleted_now">목소리 데이터를 삭제했어요</string>
-    <string name="msg_gb_voice_message_max_length">음성 메시지는 200자까지 보낼 수 있어요</string>
-    <string name="msg_gb_voice_message_send_failed">음성 메시지 전송에 실패했어요</string>
-    <string name="msg_gb_voice_message_sent">음성 메시지를 보냈어요</string>
-    <string name="msg_gb_voice_messages_load_failed">음성 메시지를 불러오지 못했어요</string>
-    <string name="msg_gb_voice_required">목소리를 선택해 주세요</string>
+
+
+
+
     <string name="msg_google_login_failed">Google 로그인을 완료하지 못했어요. 다시 시도해 주세요.</string>
     <string name="msg_google_login_not_confirmed">Google 로그인을 확인하지 못했어요. 다시 시도해 주세요.</string>
     <string name="msg_leave_group_failed">이용권에서 나가지 못했어요</string>
@@ -587,38 +574,29 @@
     <string name="social_allow_partner_alarm_couple">커플이 내 알람 맞추기 허용</string>
     <string name="social_back_cd">뒤로</string>
     <string name="social_capacity_full_no_share">정원이 가득 차서 더 이상 공유할 수 없어요.</string>
-    <string name="social_compose_button">작성</string>
-    <string name="social_composer_message">메시지</string>
-    <string name="social_composer_recipient">받는 사람</string>
-    <string name="social_composer_send_method">보내기 방식</string>
+
+
     <string name="social_cancel_button">취소</string>
-    <string name="social_composer_voice">보낼 목소리</string>
-    <string name="social_connect_button">연결하기</string>
+
     <string name="social_create_share_code">공유 코드 만들기</string>
     <string name="social_edit_button">수정</string>
-    <string name="social_invite_code_label">초대 코드</string>
-    <string name="social_join_button">참여</string>
+
     <string name="social_leave_and_register_button">나가고 등록하기</string>
     <string name="social_leave_and_register_new_code">현재 이용권 나가고 새 코드 등록하기</string>
     <string name="social_leave_dialog_message">현재 이용권에서 나가고 새 코드를 등록할까요?</string>
     <string name="social_leave_dialog_title">현재 이용권 나가고 새 코드 등록</string>
-    <string name="social_loading_voices">목소리를 불러오는 중이에요.</string>
     <string name="social_managing_shared_plan">공유 이용권을 관리 중이에요.</string>
     <string name="social_member_fallback">멤버</string>
     <string name="social_members_section_title">구성원</string>
-    <string name="social_message_placeholder">전하고 싶은 말을 입력하세요</string>
-    <string name="social_message_requires_plan">메시지는 커플/가족 이용권에서 사용할 수 있어요.</string>
-    <string name="social_new_message_title">새 메시지</string>
-    <string name="social_no_available_voices">사용 가능한 목소리가 없어요.</string>
+
+
     <string name="social_no_share_code_yet">공유 코드가 아직 없어요. %1$s 구성원을 초대할 초대 코드를 만들어 주세요.</string>
     <string name="social_no_shared_plan">현재 함께 쓰는 이용권이 없어요.</string>
     <string name="social_plan_label_couple">커플</string>
     <string name="social_plan_label_family">가족</string>
     <string name="social_plan_label_shared">공유</string>
-    <string name="social_play_cd">재생</string>
     <string name="social_quiet_time_label">알람 받지 않을 시간</string>
-    <string name="social_received_messages_title">받은 메시지</string>
-    <string name="social_refresh_cd">새로고침</string>
+
     <string name="social_regenerate_share_code">재발급</string>
     <string name="social_regenerate_share_code_dialog_message">재발급하면 지금 코드는 더 이상 쓸 수 없어요. 이미 코드를 보낸 사람에게는 새 코드를 다시 보내야 해요.</string>
     <string name="social_regenerate_share_code_dialog_title">공유 코드 재발급</string>
@@ -633,19 +611,14 @@
     <string name="social_remove_member_dialog_title">구성원 내보내기</string>
     <string name="social_role_me">나</string>
     <string name="social_role_owner">관리자</string>
-    <string name="social_send_button">보내기</string>
-    <string name="social_send_mode_text">텍스트</string>
-    <string name="social_send_mode_voice">음성 메시지</string>
-    <string name="social_sender_fallback">보낸 사람</string>
-    <string name="social_sending">보내는 중</string>
+
+
     <string name="social_share_button">공유하기</string>
     <string name="social_share_code_chooser_title">코드 공유</string>
     <string name="social_share_code_section_title">공유 코드</string>
     <string name="social_share_unavailable">공유 불가</string>
     <string name="social_shared_plan_title">초대 및 구성원 관리</string>
-    <string name="social_stop_cd">정지</string>
-    <string name="social_view_plan_button">이용권 보기</string>
-    <string name="social_voucher_code_label">이용권 코드</string>
+
     <string name="social_code_input_label">코드 입력</string>
     <string name="social_code_input_hint">초대 코드, 이용권 선물 코드, 프로모션 코드 모두 등록할 수 있어요.</string>
     <string name="social_voucher_usage">%1$d/%2$d명 사용</string>
@@ -736,7 +709,7 @@
     <string name="voicesr_delete">삭제</string>
     <string name="voicesr_delete_dialog_confirm">\'%1$s\' 목소리를 삭제할까요?</string>
     <string name="voicesr_delete_dialog_title">목소리 삭제</string>
-    <string name="voicesr_delete_dialog_warning">이 목소리를 쓰는 메시지는 텍스트만 남고, 알람은 기본 알람음으로 바뀌어요. 저장된 음원 파일도 함께 삭제돼요.</string>
+    <string name="voicesr_delete_dialog_warning">이 목소리를 쓰는 알람은 기본 알람음으로 바뀌어요. 저장된 음원 파일도 함께 삭제돼요.</string>
     <string name="voicesr_edit_info">정보 수정</string>
     <string name="voicesr_edit_my_info">내 정보 수정</string>
     <string name="voicesr_listener_title_example_a">예: 민지야, 여보</string>
@@ -980,7 +953,6 @@
     <string name="rd2_ringing_date">%1$d월 %2$d일 %3$s</string>
     <string name="r3app_bottom_tab_voices">목소리</string>
     <string name="r3app_bottom_tab_alarms">알람</string>
-    <string name="r3app_bottom_tab_messages">메시지</string>
     <string name="r3app_bottom_tab_menu">더보기</string>
     <string name="menu_profile_subtitle">내 정보 · 앱 설정</string>
     <string name="menu_language_label">앱 언어</string>
@@ -1009,7 +981,6 @@
     <string name="r3app_permission_gate_body">정확한 시간에 알람을 울리고 잠금 화면에서도 바로 보이려면 아래 권한이 필요해요.</string>
     <string name="r3app_google_signin_failed">Google 로그인에 실패했어요</string>
     <string name="r3app_google_signin_no_info">Google 로그인 정보를 받지 못했어요. 다시 시도해 주세요.</string>
-    <string name="r3app_messages_plan_gate">이용권을 연결하면 가족·연인과 목소리 메시지를 주고받을 수 있어요.</string>
     <string name="r3app_messages_plan_gate_title">커플/가족 이용권이 필요해요</string>
     <string name="r3app_plan_gate_confirm">이용권 보기</string>
     <string name="r3app_perm_required_notifications">알람 화면과 종료 버튼을 표시하려면 알림 권한이 필요해요.</string>
@@ -1055,8 +1026,7 @@
     <string name="r3misc_login_required_generic">로그인 후 사용할 수 있어요</string>
     <string name="r3misc_google_signin_unavailable">현재 Google 로그인을 사용할 수 없어요. 이메일로 로그인해 주세요.</string>
     <string name="r3misc_google_signin_failed">Google 로그인에 실패했어요</string>
-    <string name="r3misc_notif_new_message_title">새 메시지</string>
-    <string name="r3misc_notif_new_message_body">새 메시지가 도착했어요</string>
+
     <string name="r3misc_notif_received_alarm_time">%1$s에 울려요</string>
     <string name="r3misc_notif_received_alarm_default">상대가 내 알람을 설정했어요</string>
     <string name="r3misc_ringing_action_snooze">다시 울리기</string>

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -408,7 +408,9 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
         }
       }
       let rendered = 0;
+      let subrequestExhausted = false;
       for (const voice of cloneVoices) {
+        if (subrequestExhausted) break;
         const claim = claimByVoiceId.get(voice.id);
         if (!claim) continue;
         if (await missingConsentType(db, claim.ownerUserId, SENSITIVE_REQUIRED_CONSENTS)) {
@@ -437,6 +439,14 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
             // 건너뛰고 계속한다. 진전이 있으면 pending 유지(다음 틱 재시도), 진전 0+에러면 실패 처리.
             captureCron('scheduled.stock_clips.generate', genErr);
             voiceError = true;
+            // 이 틱의 서브리퀘스트 한도가 소진되면 남은 시도는 전부 같은 오류다 — 즉시 중단해
+            // 오류 반복을 줄인다. 뒤따르는 상태 갱신(DB 호출)도 실패할 수 있지만, 그 경우
+            // 15분 임대 만료가 회수해 다음 틱에 재시도된다. (7/11~ dev 실사례: 매 틱 실패하던
+            // account_purge 가 파기 시퀀스로 예산을 태워 프리렌더가 항상 이 오류로 죽었다.)
+            if (String(genErr).includes('Too many subrequests')) {
+              subrequestExhausted = true;
+              break;
+            }
           }
         }
         // 재조회 없이 판정: 이번 틱에 이 보이스의 남은 대상을 전부(에러 없이) 만들었으면 완료.

--- a/packages/backend/src/lib/account-deletion.ts
+++ b/packages/backend/src/lib/account-deletion.ts
@@ -213,6 +213,14 @@ export async function purgeUserAccount(
       sql: `DELETE FROM voice_profile_change_ledger WHERE owner_user_id IN (?, ?)`,
       args: userIds,
     });
+    // 관계/호칭 행은 voice_profiles FK 라 프로필 삭제 전에 지운다 — 내 행과,
+    // '내 프로필'을 참조하는 타인 행(공유 보이스 뷰어 호칭) 모두.
+    await tx.execute({
+      sql: `DELETE FROM voice_profile_relationships
+            WHERE user_id IN (?, ?)
+               OR voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (?, ?))`,
+      args: [...userIds, ...userIds],
+    });
     await tx.execute({
       sql: `DELETE FROM voice_profiles WHERE user_id IN (?, ?)`,
       args: userIds,
@@ -225,6 +233,29 @@ export async function purgeUserAccount(
     await tx.execute({
       sql: `DELETE FROM user_consents WHERE user_id IN (?, ?)`,
       args: userIds,
+    });
+    // FK 는 없지만 사용자 식별자가 남는 테이블들 — 개인정보 파기 범위에 포함한다.
+    await tx.execute({
+      sql: `DELETE FROM alarm_recipient_state WHERE recipient_user_id IN (?, ?)`,
+      args: userIds,
+    });
+    await tx.execute({
+      sql: `DELETE FROM dub_jobs WHERE user_id IN (?, ?)`,
+      args: userIds,
+    });
+    await tx.execute({
+      sql: `DELETE FROM promo_code_redemptions WHERE user_id IN (?, ?)`,
+      args: userIds,
+    });
+    await tx.execute({
+      sql: `DELETE FROM paid_voice_retention WHERE user_id IN (?, ?)`,
+      args: userIds,
+    });
+    // 인증 코드(이메일 키)는 users 행 삭제 전에 이메일을 역참조해 지운다.
+    await tx.execute({
+      sql: `DELETE FROM email_verification_codes
+            WHERE email IN (SELECT email FROM users WHERE id = ? OR google_id = ?)`,
+      args: [userPk, userId],
     });
   }
 

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1612,6 +1612,19 @@ export const migrations: Migration[] = [
     name: 'voice-profiles-evicted-provider-voice-id',
     statements: [`ALTER TABLE voice_profiles ADD COLUMN evicted_provider_voice_id TEXT`],
   },
+  {
+    // 출시 전 제거된 캐릭터/성장 기능의 잔재 테이블 정리. characters.user_id 가
+    // users FK 로 남아 있어 계정 영구파기(account purge)가 FOREIGN KEY constraint 로
+    // 실패하고 있었다(파기 cron 이 매 틱 실패 반복). 자식(FK→characters)부터 지운다.
+    id: 77,
+    name: 'drop-removed-character-tables',
+    statements: [
+      `DROP TABLE IF EXISTS character_xp_logs`,
+      `DROP TABLE IF EXISTS character_stats`,
+      `DROP TABLE IF EXISTS streak_achievements`,
+      `DROP TABLE IF EXISTS characters`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so


### PR DESCRIPTION
## 발견
- 제거된 '음성 메시지' 기능의 문자열 잔재가 사용자 노출 화면(이용권 플랜 소개, 편집기 에러, 탈퇴/닉네임 안내)과 죽은 리소스('새 메시지' 알림 문구, 하단 탭 '메시지' 등 48키)에 남아 있었음
- 제거된 캐릭터/성장 기능의 DB 테이블(characters 등 4개)이 남아 users FK 때문에 **계정 영구파기 cron 이 매 틱 실패**(dev에서 purge 시퀀스 재현으로 확정: `DELETE FROM users` → FOREIGN KEY constraint)

## 변경
- 죽은 문자열 48키 × 3로케일 삭제, 살아있는 문구 6종 리워딩
- 마이그레이션 77: 캐릭터 잔재 테이블 4개 DROP
- purgeUserAccount 파기 범위 보강(관계 테이블·수신자 상태·더빙 잡·프로모 사용·보존 스케줄·이메일 인증 코드)

## 검증
- 삭제 키 전부 코드 미참조 스캔 후 devDebug 빌드 통과
- 백엔드 1546 테스트 + tsc 클린