### PR TITLE
fix: 첫 로그인 자동 sync 실패 토스트 제거

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -768,8 +768,19 @@ internal fun MainViewModel.syncNow() {
                     )
             }
         }.onFailure { error ->
-            AlarmTalkLog.reportError("Backend sync failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_sync_failed))
+            // syncNow 는 알람 탭 진입 시 자동 실행되고(사용자 조치가 아님) 다음 진입·주기 sync 가
+            // 자동 재시도한다. 그래서 전체 실패는 겁주는 토스트 대신 로그만 남긴다 — 특히 첫
+            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 403(CONSENT_REQUIRED)으로 막히는 게
+            // 흔한데(면제 경로 아님), 이건 정상 재시도로 곧 풀린다. 사용자에게 뜨던
+            // "알람 정보를 주고받지 못했어요" 토스트를 제거한다.
+            if (error is kotlin.coroutines.cancellation.CancellationException) throw error
+            val httpCode = (error as? retrofit2.HttpException)?.code()
+            if (httpCode == 403) {
+                // 동의 게이트 미정착 — 예상된 상황이라 에러 리포트로 올리지 않는다.
+                Log.i(TAG, "Auto-sync deferred: consent gate not settled (403), will retry")
+            } else {
+                AlarmTalkLog.reportError("Backend sync failed", error)
+            }
         }
         syncBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -770,14 +770,14 @@ internal fun MainViewModel.syncNow() {
         }.onFailure { error ->
             // syncNow 는 알람 탭 진입 시 자동 실행되고(사용자 조치가 아님) 다음 진입·주기 sync 가
             // 자동 재시도한다. 그래서 전체 실패는 겁주는 토스트 대신 로그만 남긴다 — 특히 첫
-            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 403(CONSENT_REQUIRED)으로 막히는 게
+            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 CONSENT_REQUIRED 로 막히는 게
             // 흔한데(면제 경로 아님), 이건 정상 재시도로 곧 풀린다. 사용자에게 뜨던
             // "알람 정보를 주고받지 못했어요" 토스트를 제거한다.
             if (error is kotlin.coroutines.cancellation.CancellationException) throw error
-            val httpCode = (error as? retrofit2.HttpException)?.code()
-            if (httpCode == 403) {
-                // 동의 게이트 미정착 — 예상된 상황이라 에러 리포트로 올리지 않는다.
-                Log.i(TAG, "Auto-sync deferred: consent gate not settled (403), will retry")
+            // 403 이라도 error_code 로 정확히 CONSENT_REQUIRED 만 강등한다 — CONSENT_STATE_UNAVAILABLE
+            // ·ACCOUNT_PENDING_DELETION 같은 실제 인증/동의 파손은 모니터링에 남겨야 한다.
+            if (com.alarmtalk.app.network.apiErrorCode(error) == "CONSENT_REQUIRED") {
+                Log.i(TAG, "Auto-sync deferred: consent not settled yet, will retry")
             } else {
                 AlarmTalkLog.reportError("Backend sync failed", error)
             }


### PR DESCRIPTION
## 문제
첫 로그인 직후 "일시적인 오류로 알람 정보를 주고받지 못했어요" 토스트가 뜬다.

## 원인
- 이 토스트(`msg_sync_failed`)는 `syncNow()`의 `onFailure`에서만 발생한다.
- `syncNow()`는 **알람 탭(로그인 후 착지 화면) 진입 시 자동 실행**된다(유일한 호출부, 수동 트리거 없음). 즉 사용자가 조치할 수 있는 실패가 아니고, 다음 탭 진입·주기 sync가 자동 재시도한다.
- push(`syncWithBackend`)는 알람별 오류를 삼키고 첫 로그인엔 로컬 알람이 없어 네트워크 호출도 없다 → 전체 실패는 pull에서 온다.
- `pullReceivedAlarmsLocked`는 `api.listAlarms(...)`를 try/catch 없이 호출하고, `GET /api/alarm`은 **동의 게이트 면제 대상이 아니다**. 첫 로그인 동의 정착 전이면 **403 CONSENT_REQUIRED**로 잠깐 막혀 그대로 토스트가 된다(기존 계정은 첫 로그인 요청 버스트의 일시 오류로도 동일).

## 수정
- 자동 sync의 전체 실패 시 토스트를 띄우지 않고 로그만 남긴다.
- 예상된 403(동의 게이트 미정착)은 Sentry 에러 리포트에서도 강등한다.
- `CancellationException`은 rethrow.

부분 push 실패(내 알람이 서버에 안 올라감) 안내는 그대로 유지 — 이번 변경은 첫 로그인의 전체 실패 토스트만 조준한다.
