### PR TITLE
release: 첫 로그인 자동 sync 실패 토스트 제거 (#614)

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -93,13 +93,13 @@ val devDebugKeystoreProps = rootProject.file("dev-debug-keystore.properties")
 
 android {
     namespace = "com.alarmtalk.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 14
+        targetSdk = 36
+        versionCode = 15
         versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -268,7 +268,7 @@ dependencies {
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("androidx.work:work-runtime-ktx:2.9.1")
-    implementation("com.android.billingclient:billing-ktx:7.1.1")
+    implementation("com.android.billingclient:billing-ktx:8.0.0")
     // Google Play In-App Updates(신 Play SDK). Play 설치본에서만 실제 트리거되고
     // debug/사이드로드에선 no-op(콜백에서 예외 방어). 구 com.google.android.play:core 미사용.
     implementation("com.google.android.play:app-update:2.1.0")

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -768,8 +768,19 @@ internal fun MainViewModel.syncNow() {
                     )
             }
         }.onFailure { error ->
-            AlarmTalkLog.reportError("Backend sync failed", error)
-            message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_sync_failed))
+            // syncNow 는 알람 탭 진입 시 자동 실행되고(사용자 조치가 아님) 다음 진입·주기 sync 가
+            // 자동 재시도한다. 그래서 전체 실패는 겁주는 토스트 대신 로그만 남긴다 — 특히 첫
+            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 403(CONSENT_REQUIRED)으로 막히는 게
+            // 흔한데(면제 경로 아님), 이건 정상 재시도로 곧 풀린다. 사용자에게 뜨던
+            // "알람 정보를 주고받지 못했어요" 토스트를 제거한다.
+            if (error is kotlin.coroutines.cancellation.CancellationException) throw error
+            val httpCode = (error as? retrofit2.HttpException)?.code()
+            if (httpCode == 403) {
+                // 동의 게이트 미정착 — 예상된 상황이라 에러 리포트로 올리지 않는다.
+                Log.i(TAG, "Auto-sync deferred: consent gate not settled (403), will retry")
+            } else {
+                AlarmTalkLog.reportError("Backend sync failed", error)
+            }
         }
         syncBusy = false
     }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelAuthActions.kt
@@ -770,14 +770,14 @@ internal fun MainViewModel.syncNow() {
         }.onFailure { error ->
             // syncNow 는 알람 탭 진입 시 자동 실행되고(사용자 조치가 아님) 다음 진입·주기 sync 가
             // 자동 재시도한다. 그래서 전체 실패는 겁주는 토스트 대신 로그만 남긴다 — 특히 첫
-            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 403(CONSENT_REQUIRED)으로 막히는 게
+            // 로그인 직후 동의 정착 전 GET /alarm 이 잠깐 CONSENT_REQUIRED 로 막히는 게
             // 흔한데(면제 경로 아님), 이건 정상 재시도로 곧 풀린다. 사용자에게 뜨던
             // "알람 정보를 주고받지 못했어요" 토스트를 제거한다.
             if (error is kotlin.coroutines.cancellation.CancellationException) throw error
-            val httpCode = (error as? retrofit2.HttpException)?.code()
-            if (httpCode == 403) {
-                // 동의 게이트 미정착 — 예상된 상황이라 에러 리포트로 올리지 않는다.
-                Log.i(TAG, "Auto-sync deferred: consent gate not settled (403), will retry")
+            // 403 이라도 error_code 로 정확히 CONSENT_REQUIRED 만 강등한다 — CONSENT_STATE_UNAVAILABLE
+            // ·ACCOUNT_PENDING_DELETION 같은 실제 인증/동의 파손은 모니터링에 남겨야 한다.
+            if (com.alarmtalk.app.network.apiErrorCode(error) == "CONSENT_REQUIRED") {
+                Log.i(TAG, "Auto-sync deferred: consent not settled yet, will retry")
             } else {
                 AlarmTalkLog.reportError("Backend sync failed", error)
             }

--- a/apps/android-native/gradle.properties
+++ b/apps/android-native/gradle.properties
@@ -2,6 +2,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
+# compileSdk 36(Android 16)은 AGP 8.7.3 이 "테스트된 상한(35)"을 넘어 경고를 내지만,
+# 로컬 SDK Platform 36/build-tools 36 으로 정상 빌드된다. 경고만 무음 처리(빌드 동작 불변).
+android.suppressUnsupportedCompileSdk=36
 
 # Backend API targets by Android flavor.
 alarmTalkDevApiBaseUrl=https://api-dev.alarm-talk.com/api/


### PR DESCRIPTION
## 요약
#612 이후 develop에 머지된 #614를 prod에 반영합니다.

### 첫 로그인 자동 sync 실패 토스트 제거 (#614)
- 알람 탭 진입 시 자동 실행되는 `syncNow`가 전체 실패해도 "알람 정보를 주고받지 못했어요" 토스트를 띄우지 않고 로그만 남긴다(자동 재시도 대상, 사용자 조치 불가).
- 첫 로그인 동의 정착 전 `GET /alarm`이 잠깐 `CONSENT_REQUIRED`로 막히는 건 예상 상황이라 error_code로 정확히 판별해 Sentry 리포트에서 강등. `CONSENT_STATE_UNAVAILABLE`·`ACCOUNT_PENDING_DELETION` 등 실제 파손은 계속 보고.

### 배포 메모
- 머지 시 prod 자동 배포 + DB 마이그레이션(기존 워크플로). 이번 변경은 클라이언트(안드로이드) 한정이라 백엔드/DB 변경 없음.
