### PR TITLE
chore(android): Play 필수요건 대응 — targetSdk 36 + Billing 8.0.0

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -93,13 +93,13 @@ val devDebugKeystoreProps = rootProject.file("dev-debug-keystore.properties")
 
 android {
     namespace = "com.alarmtalk.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 14
+        targetSdk = 36
+        versionCode = 15
         versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -268,7 +268,7 @@ dependencies {
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("androidx.work:work-runtime-ktx:2.9.1")
-    implementation("com.android.billingclient:billing-ktx:7.1.1")
+    implementation("com.android.billingclient:billing-ktx:8.0.0")
     // Google Play In-App Updates(신 Play SDK). Play 설치본에서만 실제 트리거되고
     // debug/사이드로드에선 no-op(콜백에서 예외 방어). 구 com.google.android.play:core 미사용.
     implementation("com.google.android.play:app-update:2.1.0")

--- a/apps/android-native/gradle.properties
+++ b/apps/android-native/gradle.properties
@@ -2,6 +2,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
+# compileSdk 36(Android 16)은 AGP 8.7.3 이 "테스트된 상한(35)"을 넘어 경고를 내지만,
+# 로컬 SDK Platform 36/build-tools 36 으로 정상 빌드된다. 경고만 무음 처리(빌드 동작 불변).
+android.suppressUnsupportedCompileSdk=36
 
 # Backend API targets by Android flavor.
 alarmTalkDevApiBaseUrl=https://api-dev.alarm-talk.com/api/


### PR DESCRIPTION
## 배경
Play Console 필수요건 2건(마감 8/31, 40일 남음):
1. Android 16(API 36) 이상 타깃
2. Google Play 결제 라이브러리 8.0.0 이상

## 변경
- **compileSdk/targetSdk 35 → 36**
  - edge-to-edge 는 이미 SDK 35 대응(`enableEdgeToEdge()` + 전역 인셋)으로 커버됨 → Android 16 edge-to-edge 강제에 코드 변경 불필요.
- **billing-ktx 7.1.1 → 8.0.0**
  - `PlayBillingManager` 는 이미 8.0.0 호환 API(`PendingPurchasesParams`, `SubscriptionUpdateParams.ReplacementMode`, params형 `QueryPurchasesParams`/`QueryProductDetailsParams`)로 작성돼 있어 **코드 수정 없이 버전만 상향**.
  - 최신 8.3.0 은 Kotlin 2.2 메타데이터로 컴파일돼 현 Kotlin 2.0.21 과 충돌 → 요건을 만족하는 최신 호환 버전 **8.0.0** 채택.
- **versionCode 14 → 15** (새 업로드용).
- **gradle.properties**: `android.suppressUnsupportedCompileSdk=36` — AGP 8.7.3 의 "테스트 상한(35) 초과" 경고만 무음. 로컬 SDK Platform 36/build-tools 36 으로 정상 빌드.

## 검증
- `:app:compileDevDebugKotlin` ✅
- `:app:assembleDevDebug` ✅

## 후속
- 머지 후 **prod release AAB(versionCode 15) 재빌드→Play 업로드** 필요(이번 변경이 담긴 새 빌드라야 정책 충족).
