### PR TITLE
release: 1.1.1 — Play 필수요건(targetSdk 36 + Billing 8.0.0) + 버전 표기

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -100,7 +100,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 15
-        versionName = "1.1.0"
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/packages/backend/test/api-latency.test.ts
+++ b/packages/backend/test/api-latency.test.ts
@@ -18,8 +18,13 @@ import codeRoutes from '../src/routes/code';
 import userRoutes from '../src/routes/user';
 import giftRoutes from '../src/routes/gift';
 
-const LATENCY_THRESHOLD_MS = 75;
-const WRITE_LATENCY_THRESHOLD_MS = 80;
+// 이 스위트는 mock DB 로 라우트 핸들러의 **절대 벽시계 지연**을 assert 한다(회귀 감지용
+// 마이크로벤치). 로컬에선 엄격하게 유지하되, 공유 CI 러너는 부하로 6~10배 느려져 정상 코드도
+// 임계를 넘겨 플레이크가 된다(타임아웃 상향으로는 안 잡히는 별개 클래스). CI 에서만 배수를
+// 곱해 "치명적 회귀만 잡고 부하 노이즈는 흡수"하도록 한다. 로컬(CI 아님) 임계는 그대로.
+const CI_LATENCY_FACTOR = process.env.CI ? 8 : 1;
+const LATENCY_THRESHOLD_MS = 75 * CI_LATENCY_FACTOR;
+const WRITE_LATENCY_THRESHOLD_MS = 80 * CI_LATENCY_FACTOR;
 
 function buildApp(route: string, handler: Hono<AppEnv>, userId = 'user-1') {
   const app = new Hono<AppEnv>();

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     // 전체 마이그레이션 체인(72+개)을 파일 기반 libSQL DB 에 실행한다. 느린 CI 러너에서 이게
     // vitest 기본 훅 타임아웃(10s)을 간헐적으로 넘겨 "Hook timed out" 으로 스위트가 로드
     // 실패했다(개별 테스트는 전부 통과). 여유를 두어 이 플레이크를 제거한다.
+    // (hook 최악 실측 ~0.95s → CI 6~10배 부하시 ~7.6s. 30s 는 그 위 ~4배 마진.)
     hookTimeout: 30_000,
+    // promo-welcome-group 등 일부 테스트는 **본문에서** runMigrationsRange(1,71~73) 로
+    // 파일 DB 에 수십 개 마이그레이션을 재실행한다. 로컬 ~1.9s 가 CI 부하에서 5s(기본
+    // testTimeout)를 넘겨 "Test timed out in 5000ms" 로 실패했다. 전수 감사에서 대상 전건이
+    // 유한작업(hang 아님)으로 확인되어, 최악 추정(~10s) 위에 ~2배 마진인 20s 로 올린다.
+    testTimeout: 20_000,
   },
 });

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    // 일부 스위트(alarm-guard/family-alarm-guard/promo-welcome-group 등)는 beforeAll 에서
+    // 전체 마이그레이션 체인(72+개)을 파일 기반 libSQL DB 에 실행한다. 느린 CI 러너에서 이게
+    // vitest 기본 훅 타임아웃(10s)을 간헐적으로 넘겨 "Hook timed out" 으로 스위트가 로드
+    // 실패했다(개별 테스트는 전부 통과). 여유를 두어 이 플레이크를 제거한다.
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
develop 을 prod(main)에 반영하는 릴리스 PR.

## 포함 변경
- **targetSdk/compileSdk 36** (Android 16 타깃 필수, 마감 8/31)
- **billing-ktx 8.0.0** (Play 결제 라이브러리 8.0.0+ 필수)
- **versionCode 15 / versionName 1.1.1**
- 첫 로그인 자동 sync 실패 토스트 제거(#614)

## 참고
- main·develop 모두 up-to-date 요구(strict) 꺼져 있어 "Update branch" 는 머지 차단 조건 아님. 현재 main ⊆ develop 이라 clean.
- 머지 후 이미 빌드된 prod AAB(versionCode 15 / 1.1.1) 를 Play 업로드.