### PR TITLE
test(backend): vitest hookTimeout 10s → 30s (CI 플레이크 제거)

### DIFF
--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    // 일부 스위트(alarm-guard/family-alarm-guard/promo-welcome-group 등)는 beforeAll 에서
+    // 전체 마이그레이션 체인(72+개)을 파일 기반 libSQL DB 에 실행한다. 느린 CI 러너에서 이게
+    // vitest 기본 훅 타임아웃(10s)을 간헐적으로 넘겨 "Hook timed out" 으로 스위트가 로드
+    // 실패했다(개별 테스트는 전부 통과). 여유를 두어 이 플레이크를 제거한다.
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## 문제
`test/alarm-guard`, `test/family-alarm-guard`, `test/promo-welcome-group` 스위트가 `beforeAll` 에서 전체 마이그레이션 체인(72+개)을 파일 기반 libSQL DB 에 실행 → 느린 CI 러너에서 vitest 기본 훅 타임아웃(10s)을 간헐적으로 초과 → **"Hook timed out in 10000ms"** 로 스위트 로드 실패.

- 개별 테스트 1516개는 매번 전부 통과 → 코드 결함 아님, 순수 인프라 플레이크.
- #615·#618 릴리스 PR 에서 각각 재실행을 유발한 원인.

## 수정
`vitest.config.ts` 에 `hookTimeout: 30_000` 추가. 마이그레이션 훅에 여유를 줘 플레이크 제거.

## 검증
3개 스위트 로컬 재실행 → 3 files / 34 tests 통과(4.8s).