### PR TITLE
test(backend): testTimeout 5s→20s + api-latency CI 완화 (CI 플레이크 확정 제거)

### DIFF
--- a/packages/backend/test/api-latency.test.ts
+++ b/packages/backend/test/api-latency.test.ts
@@ -18,8 +18,13 @@ import codeRoutes from '../src/routes/code';
 import userRoutes from '../src/routes/user';
 import giftRoutes from '../src/routes/gift';
 
-const LATENCY_THRESHOLD_MS = 75;
-const WRITE_LATENCY_THRESHOLD_MS = 80;
+// 이 스위트는 mock DB 로 라우트 핸들러의 **절대 벽시계 지연**을 assert 한다(회귀 감지용
+// 마이크로벤치). 로컬에선 엄격하게 유지하되, 공유 CI 러너는 부하로 6~10배 느려져 정상 코드도
+// 임계를 넘겨 플레이크가 된다(타임아웃 상향으로는 안 잡히는 별개 클래스). CI 에서만 배수를
+// 곱해 "치명적 회귀만 잡고 부하 노이즈는 흡수"하도록 한다. 로컬(CI 아님) 임계는 그대로.
+const CI_LATENCY_FACTOR = process.env.CI ? 8 : 1;
+const LATENCY_THRESHOLD_MS = 75 * CI_LATENCY_FACTOR;
+const WRITE_LATENCY_THRESHOLD_MS = 80 * CI_LATENCY_FACTOR;
 
 function buildApp(route: string, handler: Hono<AppEnv>, userId = 'user-1') {
   const app = new Hono<AppEnv>();

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     // 전체 마이그레이션 체인(72+개)을 파일 기반 libSQL DB 에 실행한다. 느린 CI 러너에서 이게
     // vitest 기본 훅 타임아웃(10s)을 간헐적으로 넘겨 "Hook timed out" 으로 스위트가 로드
     // 실패했다(개별 테스트는 전부 통과). 여유를 두어 이 플레이크를 제거한다.
+    // (hook 최악 실측 ~0.95s → CI 6~10배 부하시 ~7.6s. 30s 는 그 위 ~4배 마진.)
     hookTimeout: 30_000,
+    // promo-welcome-group 등 일부 테스트는 **본문에서** runMigrationsRange(1,71~73) 로
+    // 파일 DB 에 수십 개 마이그레이션을 재실행한다. 로컬 ~1.9s 가 CI 부하에서 5s(기본
+    // testTimeout)를 넘겨 "Test timed out in 5000ms" 로 실패했다. 전수 감사에서 대상 전건이
+    // 유한작업(hang 아님)으로 확인되어, 최악 추정(~10s) 위에 ~2배 마진인 20s 로 올린다.
+    testTimeout: 20_000,
   },
 });


### PR DESCRIPTION
## 배경
#619(hookTimeout 10s→30s) 머지 후에도 develop CI 가 실패했다. 원인이 훅이 아니라 **개별 테스트 본문**의 마이그레이션 재실행이 기본 testTimeout 5s 를 넘긴 것(`Test timed out in 5000ms`). 전체 83개 테스트 파일을 워크플로로 전수 감사(적대적 hang 검증 포함)해 근본값을 확정했다.

## 감사 결론
- **진짜 hang: 0건.** 감사 37건 + 적대적 검증 25건 전부 유한작업(무한루프·미mock 네트워크·fake-timer 교착·미해결 프로미스 전무). → 타임아웃 상향이 실제 버그를 가리지 않음.
- test 본문 최악: promo-welcome-group 의 `runMigrationsRange` 재실행 3종, CI 부하 worst ≈ 7~10s.
- hook 최악 ≈ 7.6s → 30s 로 충분.
- 별개 플레이크: `api-latency` 는 절대 벽시계 assert 라 타임아웃과 무관, CI 부하에서 깨질 잠재 위험.

## 변경
1. `vitest.config.ts`: **testTimeout 5s → 20s** (최악 ~10s 위 ~2배 마진). hookTimeout 30s 유지.
2. `api-latency.test.ts`: 절대지연 임계를 **`process.env.CI` 일 때만 8배 완화**. 로컬 엄격성 유지, CI 는 치명적 회귀만 감지.

## 검증
- 로컬 전체: **83 files / 1550 passed** (62 skipped).
- `CI=true` 경로: api-latency 14 passed.

## 후속(선택, 이번 PR 미포함)
감사가 제안한 근본 개선: promo 본문 마이그레이션 중복 제거, 일부 file: DB → :memory:, 마이그레이션 배치화/템플릿 캐시. 지금은 저위험 타임아웃/임계 조정으로 플레이크만 확정 제거.