### PR TITLE
fix(android): 울림 채널 음소거 시 전체 울림 화면 폴백 (Codex #623 P1)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
@@ -2,6 +2,7 @@ package com.alarmtalk.app.alarm
 
 import android.app.KeyguardManager
 import android.app.Notification
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
@@ -499,12 +500,26 @@ class RingingService : Service() {
         return interactive && !locked
     }
 
+    /**
+     * 울림 알림이 실제로 헤드업 배너로 뜰 수 있는 상태인지. 앱 알림이 켜져 있고 울림 채널
+     * (RINGING_CHANNEL_ID) importance 가 HIGH 이상이어야 한다. 사용자가 채널을 음소거·강등하면
+     * areNotificationsEnabled() 는 여전히 true 여도 헤드업은 안 뜨므로 채널 importance 를 직접 본다.
+     */
+    private fun ringingChannelCanShowHeadsUp(): Boolean {
+        if (!NotificationManagerCompat.from(this).areNotificationsEnabled()) return false
+        val channel = getSystemService<NotificationManager>()
+            ?.getNotificationChannel(NotificationChannels.RINGING_CHANNEL_ID)
+        // 아직 채널 생성 전이면 곧 IMPORTANCE_HIGH 로 만들어지므로 헤드업 가능으로 본다.
+        return channel == null || channel.importance >= NotificationManager.IMPORTANCE_HIGH
+    }
+
     private fun openRingingActivity(alarmId: String) {
-        // 화면 켜짐 + 잠금 해제 상태면 전체화면을 띄우지 않고 헤드업 알림에 맡긴다.
-        // (알림은 IMPORTANCE_HIGH + PRIORITY_MAX + fullScreenIntent 라 사용 중일 때 헤드업으로 뜬다.)
-        // 전체화면 인텐트와 이 직접 실행이 함께 떠서 '헤드업 + 전체화면'이 동시 표시되던 것을 막는다.
-        if (isDeviceActivelyInUse()) {
-            Log.i(TAG, "Device in active use; relying on heads-up notification instead of full-screen ringing")
+        // 화면 켜짐 + 잠금 해제 상태이고 '울림 알림이 헤드업으로 뜰 수 있을 때'만 전체화면 직접 실행을
+        // 생략하고 헤드업에 맡긴다(헤드업 + 전체화면 동시 표시 방지). 화면이 꺼졌거나 잠겼거나,
+        // 사용자가 울림 채널을 음소거·강등해 헤드업이 안 뜨는 경우엔 소리만 나고 해제 UI가 사라지지
+        // 않도록 잠금화면 위 전체 울림 화면을 직접 띄운다.
+        if (isDeviceActivelyInUse() && ringingChannelCanShowHeadsUp()) {
+            Log.i(TAG, "Device in active use with heads-up-capable channel; relying on heads-up notification")
             return
         }
         val intent = Intent(this, RingingActivity::class.java).apply {


### PR DESCRIPTION
## 배경
Codex #623 P1 리뷰 반영.

## 문제
알람 표시 분리 가드(#622)가 화면 켜짐+잠금해제 상태면 직접 전체화면(`RingingActivity`) 실행을 생략하고 헤드업 알림에 맡긴다. 그런데 사용자가 울림 채널(`voice_alarm_ringing_v2`)을 **음소거·강등**하면 헤드업이 안 뜨는데, 앱 단위 `areNotificationsEnabled()`는 여전히 true라 이 케이스를 못 걸렀다. 결과적으로 **소리만 나고 해제 UI(헤드업·전체화면)가 전혀 없는** 상태가 될 수 있었다.

## 수정
- `ringingChannelCanShowHeadsUp()` 추가: 앱 알림 on + 울림 채널 `importance >= HIGH` 일 때만 헤드업 가능으로 판정.
- 직접 실행 생략 조건을 `isDeviceActivelyInUse() && ringingChannelCanShowHeadsUp()` 로 강화.
- 채널이 강등돼 헤드업이 안 뜨는 경우(또는 화면 꺼짐/잠금)엔 전체 울림 화면을 직접 띄워 **해제 UI를 항상 보장**.

## 검증
- `compileDevDebugKotlin` ✅
