### PR TITLE
fix(android): 음성 재생 실패 폴백에서도 알람음 토글 존중 (Codex #628 P1)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
@@ -181,8 +181,8 @@ class RingingService : Service() {
         val alarmVolumePercent = alarm?.alarmVolumePercent ?: 100
         val voiceVolumePercent = alarm?.voiceVolumePercent ?: 100
         // 알람음(기상 톤) 토글. off 면 톤을 재생하지 않는다(볼륨 0 과 동일 취급). 알람 자체는
-        // 화면·진동·음성(설정 시)으로 계속 울린다. 음성이 없는 폴백 경로는 무음 방지 안전망으로 유지.
-        val alarmToneAllowed = (alarm?.alarmSoundEnabled ?: true) && alarmVolumePercent > 0
+        // 화면·진동·음성(설정 시)으로 계속 울린다. 음성 실패/부재 폴백도 이 값으로 게이트한다.
+        val alarmToneAllowed = isAlarmToneAllowed(alarm)
         if (playMode == AlarmPlayModes.ALARM_ONLY && !alarmToneAllowed) {
             stopMediaOnly()
             Log.i(TAG, "Alarm tone off (soundEnabled=${alarm?.alarmSoundEnabled}, volume=$alarmVolumePercent) id=${alarm?.id}")
@@ -227,8 +227,12 @@ class RingingService : Service() {
         }
     }
 
+    /** 알람음(기상 톤)을 재생해도 되는지 — 알람음 토글이 켜져 있고 볼륨 > 0. 톤 재생/폴백 단일 판정. */
+    private fun isAlarmToneAllowed(alarm: AlarmEntity?): Boolean =
+        (alarm?.alarmSoundEnabled ?: true) && (alarm?.alarmVolumePercent ?: 100) > 0
+
     /**
-     * 음성 URI 가 없어 톤으로 폴백해야 하는 경로. 단 알람음이 켜져 있을 때만(alarmToneAllowed)
+     * 음성이 없거나 재생 실패해 톤으로 폴백해야 하는 경로. 단 알람음이 켜져 있을 때만(alarmToneAllowed)
      * 번들 톤을 재생하고, 꺼져 있으면 톤을 강제하지 않고 무음으로 둔다(진동·전체화면은 별도로 계속).
      */
     private fun startToneFallbackOrSilent(alarm: AlarmEntity?, alarmToneAllowed: Boolean, reason: String) {
@@ -304,8 +308,9 @@ class RingingService : Service() {
             start()
         }
         if (mediaPlayer == null) {
-            AlarmTalkLog.reportError("Failed to create voice MediaPlayer; falling back to bundled alarm")
-            startAlarmToneLoop(alarm)
+            AlarmTalkLog.reportError("Failed to create voice MediaPlayer")
+            // 알람음을 끈 사용자에겐 실패 시에도 톤을 강제하지 않는다(무음, 진동·화면은 계속).
+            startToneFallbackOrSilent(alarm, isAlarmToneAllowed(alarm), "voice MediaPlayer creation failed")
         }
     }
 
@@ -383,8 +388,8 @@ class RingingService : Service() {
         }
 
         if (nextPlayer == null) {
-            AlarmTalkLog.reportError("Failed to create sequence MediaPlayer; falling back to bundled alarm")
-            startAlarmToneLoop(alarm)
+            AlarmTalkLog.reportError("Failed to create sequence MediaPlayer")
+            startToneFallbackOrSilent(alarm, isAlarmToneAllowed(alarm), "sequence MediaPlayer creation failed")
             return
         }
 


### PR DESCRIPTION
## 배경
Codex #628 P1 리뷰 반영. (#627 P1 은 '음성 URI 부재' 폴백을 게이트했는데, 이번엔 '음성 재생 실패' 폴백이 남아 있었음.)

## 문제
`startVoiceLoop` 의 MediaPlayer 생성 실패 폴백(읽을 수 없는/회수된 로컬 URI·캐시 누락 등)과 `playSequenceStep` 의 실패 폴백이 **무조건 `startAlarmToneLoop`** 를 호출 → 알람음을 끈 음성 알람이 재생 실패 시 **번들 톤을 재생**.

## 수정
- `isAlarmToneAllowed(alarm)` 헬퍼로 톤 허용 판정(알람음 on + 볼륨>0)을 단일화.
- 두 실패 폴백을 모두 `startToneFallbackOrSilent` 로 게이트 — 알람음 켜짐일 때만 톤, 꺼짐이면 **무음**(진동·전체화면은 별도로 계속).
- 이제 RingingService 의 톤 재생은 (1) 의도된 톤 경로 (2) 게이트된 폴백만 남음.

## 검증
- `compileDevDebugKotlin` ✅
