### PR TITLE
fix(android): '다시 녹음' 시 미리듣기 먼저 정지 (Codex #628 P2)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -1213,6 +1213,11 @@ internal fun AlarmEditorScreen(
                                     }
                                 },
                                 onPreviewAudio = { playCachedAudio() },
+                                onDiscardRecording = {
+                                    // 미리듣기가 재생 중이면 먼저 멈춘 뒤 녹음을 비운다(소리 잔존 방지).
+                                    stopPreview()
+                                    editor.clearAudio()
+                                },
                                 onCreateVoiceProfileClick = onCreateVoiceProfile,
                                 onOpenRandomPromptSettings = ::openRandomPromptSettings,
                                 onOpenFreeBucketSettings = { settingsDetailPanel = "free_bucket" },

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/VoiceAudioCard.kt
@@ -87,6 +87,8 @@ internal fun VoiceAudioCard(
     isPreviewPreparing: Boolean,
     onRecord: () -> Unit,
     onPreviewAudio: () -> Unit,
+    // '다시 녹음' — 재생 중인 미리듣기를 멈추고 기존 녹음을 비워 대기(멈춘) 상태로 되돌린다.
+    onDiscardRecording: () -> Unit,
     onCreateVoiceProfileClick: () -> Unit,
     onOpenRandomPromptSettings: () -> Unit,
     // 무료 문구 행 — 테마(버킷) 선택 pane 을 연다(유료의 문구 pane 과 같은 자리).
@@ -284,9 +286,9 @@ internal fun VoiceAudioCard(
                         isPreviewActive = isCachedAudioPreviewActive,
                         isPreparing = isPreviewPreparing,
                         onPlay = onPreviewAudio,
-                        // '다시 녹음'은 즉시 녹음을 시작하지 않고 기존 녹음을 비워 대기(멈춘) 상태로
-                        // 되돌린다 → VoiceRecordControls(마이크 대기)로 전환. 사용자가 마이크를 눌러 녹음 시작.
-                        onRedo = { editor.clearAudio() },
+                        // '다시 녹음'은 즉시 녹음을 시작하지 않고 재생 중인 미리듣기를 멈춘 뒤 기존 녹음을
+                        // 비워 대기(멈춘) 상태로 되돌린다 → VoiceRecordControls(마이크 대기)로 전환.
+                        onRedo = onDiscardRecording,
                     )
                 } else {
                     VoiceRecordControls(


### PR DESCRIPTION
## 배경
Codex #628 P2 리뷰 반영. (#628 P1 은 #629 로 이미 develop 머지됨 — 이 PR 은 P2 만.)

## 문제
녹음 미리듣기 재생 중 '다시 녹음'을 누르면 URI 만 비우고 `AlarmEditorScreen` 이 소유한 `MediaPlayer` 는 계속 재생돼, 대기(마이크) 상태로 바뀐 뒤에도 방금 지운 녹음 소리가 끝날 때까지 들렸다.

## 수정
- `VoiceAudioCard` 에 `onDiscardRecording` 콜백 추가, redo 를 여기로 연결.
- `AlarmEditorScreen` 이 `stopPreview()` 후 `editor.clearAudio()` 를 하도록 배선(옛 onRecord 경로처럼 미리듣기 먼저 정지).

## 검증
- `compileDevDebugKotlin` ✅
