### PR TITLE
chore(android): versionCode 17 / versionName 1.1.2 (수동 버전 관리)

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -99,8 +99,10 @@ android {
         applicationId = "com.alarmtalk.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "1.1.1"
+        // 릴리스마다 수동으로 versionCode +1, versionName 갱신. (Play 는 업로드마다 더 큰
+        // versionCode 를 요구 — 이전 업로드값보다 반드시 크게.) 1.1.2 = 17, 다음 릴리스는 18.
+        versionCode = 17
+        versionName = "1.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
versionCode 자동 생성(#633)은 숫자가 커지는 게 걸려 보류 → **수동 관리 유지**.

develop 이 1.1.1/15 로 뒤처져 있어 현재 릴리스에 맞춰 갱신:
- `versionCode = 17`, `versionName = "1.1.2"` (디스크의 릴리스 AAB와 동일)
- 다음 릴리스부터 손으로 versionCode +1(18…), versionName 갱신.

Play 는 업로드마다 더 큰 versionCode 를 요구 — 이전 업로드값보다 크게만 유지하면 됨.