### PR TITLE
목소리 준비화면·마지막 문구 기억·무료강등/삭제/공유해제 통일·삭제 쿼터 모달

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
@@ -33,12 +33,17 @@ import com.alarmtalk.app.alarm.AlarmContract.ACTION_START_RINGING
 import com.alarmtalk.app.alarm.AlarmContract.EXTRA_ALARM_ID
 import com.alarmtalk.app.core.AlarmTalkLog
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
+import com.alarmtalk.app.AccessSnapshotStore
 import com.alarmtalk.app.data.AlarmAppContainer
 import com.alarmtalk.app.data.AlarmEntity
+import com.alarmtalk.app.data.AlarmOrigins
 import com.alarmtalk.app.data.AlarmPlayModes
 import com.alarmtalk.app.data.VibrationPatternLibrary
 import com.alarmtalk.app.data.VibrationPatterns
 import com.alarmtalk.app.data.decodeBucketClipKeys
+import com.alarmtalk.app.data.usesFreeSystemVoiceAlarm
+import com.alarmtalk.app.isPaidVoiceEntitledNow
+import com.alarmtalk.app.network.AuthSessionStore
 import com.alarmtalk.app.ringing.RingingActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -176,8 +181,23 @@ class RingingService : Service() {
                 voiceUriOverride != null,
             )
         }
-        val voiceUri = (voiceUriOverride ?: storedVoiceUri)?.takeIf { it.isNotBlank() }?.let(Uri::parse)
-        val playMode = alarm?.playMode ?: AlarmPlayModes.ALARM_ONLY
+        val rawVoiceUri = (voiceUriOverride ?: storedVoiceUri)?.takeIf { it.isNotBlank() }?.let(Uri::parse)
+        val rawPlayMode = alarm?.playMode ?: AlarmPlayModes.ALARM_ONLY
+        // 무료 전환/구독 만료가 아직 로컬 DB 잠금(preLockPlayMode)으로 반영되지 않았어도(앱 미실행·
+        // 오프라인이라 billing 재조회를 못 한 창), 울림 시점에 로컬 영속 구독으로 유료 권한을 재확인해
+        // 유료 목소리를 기본 톤으로 강등한다. 알람 자체는 그대로 울리고(톤/진동/화면). 본인 소유
+        // (LOCAL_OWNED) 알람만 대상 — 공유받은(RECEIVED_REMOTE) 알람은 소유자 구독으로 판단하지
+        // 않는다. 무료 시스템 보이스(버킷 등)는 강등 대상이 아니라 제외.
+        val downgradePaidVoice = alarm != null &&
+            alarm.origin == AlarmOrigins.LOCAL_OWNED &&
+            !alarm.usesFreeSystemVoiceAlarm() &&
+            alarmUsesPaidVoice(alarm) &&
+            !isPaidVoiceEntitledFromCache()
+        if (downgradePaidVoice) {
+            Log.i(TAG, "Free plan at ring time — downgrading paid voice to alarm tone id=${alarm?.id}")
+        }
+        val voiceUri = if (downgradePaidVoice) null else rawVoiceUri
+        val playMode = if (downgradePaidVoice) AlarmPlayModes.ALARM_ONLY else rawPlayMode
         val alarmVolumePercent = alarm?.alarmVolumePercent ?: 100
         val voiceVolumePercent = alarm?.voiceVolumePercent ?: 100
         // 알람음(기상 톤) 토글. off 면 톤을 재생하지 않는다(볼륨 0 과 동일 취급). 알람 자체는
@@ -230,6 +250,27 @@ class RingingService : Service() {
     /** 알람음(기상 톤)을 재생해도 되는지 — 알람음 토글이 켜져 있고 볼륨 > 0. 톤 재생/폴백 단일 판정. */
     private fun isAlarmToneAllowed(alarm: AlarmEntity?): Boolean =
         (alarm?.alarmSoundEnabled ?: true) && (alarm?.alarmVolumePercent ?: 100) > 0
+
+    /** 유료(무료 강등 대상) 목소리를 쓰는 알람인지 — lockPaidAlarmTalks 의 usesVoice 기준과 동일. */
+    private fun alarmUsesPaidVoice(alarm: AlarmEntity): Boolean =
+        alarm.playMode != AlarmPlayModes.ALARM_ONLY ||
+            !alarm.localAudioUri.isNullOrBlank() ||
+            !alarm.rawAudioUri.isNullOrBlank() ||
+            !alarm.voiceProfileId.isNullOrBlank() ||
+            !alarm.ttsMessageId.isNullOrBlank()
+
+    /**
+     * 울림 시점에 로컬 영속 구독으로 유료 목소리 권한을 재확인한다(오프라인·앱 미실행 안전).
+     * 절대 예외를 던지지 않는다 — 암호화 저장소 읽기/복호화가 실패해도 true(강등 안 함)로 떨어뜨려
+     * 알람이 무음화되지 않게 한다(fail-open). 구독 정보가 없으면(미조회·가족 구성원·transient) 강등하지
+     * 않고, '마지막으로 활성이던 구독의 만료시각이 지났을 때'만 무권한으로 본다.
+     */
+    private fun isPaidVoiceEntitledFromCache(): Boolean = runCatching {
+        val userId = AuthSessionStore(applicationContext).read()?.user?.id ?: return@runCatching true
+        val sub = AccessSnapshotStore(applicationContext).read(userId).subscriptionResponse
+        if (sub?.subscription == null) return@runCatching true
+        isPaidVoiceEntitledNow(sub, System.currentTimeMillis())
+    }.getOrDefault(true)
 
     /**
      * 음성이 없거나 재생 실패해 톤으로 폴백해야 하는 경로. 단 알람음이 켜져 있을 때만(alarmToneAllowed)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -392,21 +392,36 @@ class AlarmRepository(
      * 호출부(refreshSocial 신선 성공)에서 가드한다. 버킷 회전·녹음(LOCAL_AUDIO)·수신 알람은 대상이 아니다.
      * 반환값은 강등된 알람 수.
      */
-    suspend fun degradeAlarmsWithInaccessibleVoice(accessibleVoiceIds: Set<String>): Int {
-        val candidates = alarmDao.getAllAlarms().filter { alarm ->
-            alarm.origin == AlarmOrigins.LOCAL_OWNED &&
-                alarm.voiceSource == VoiceSources.TTS_PROFILE &&
-                !alarm.voiceProfileId.isNullOrBlank() &&
+    suspend fun degradeAlarmsWithInaccessibleVoice(accessibleVoiceIds: Set<String>): Int =
+        degradeMatchingLocalOwnedVoiceAlarms { alarm ->
+            !alarm.voiceProfileId.isNullOrBlank() &&
                 // 시스템 스톡 버킷/보이스는 영구라 보존. 클론(비-system) 보이스는 단일클립·버킷 모두
                 // 접근권 상실(공유해제·제공자취소·삭제) 시 강등 대상.
                 !isSystemVoiceId(alarm.voiceProfileId) &&
                 alarm.voiceProfileId !in accessibleVoiceIds
+        }
+
+    // 방금 삭제한 특정 목소리를 쓰는 내 알람만 즉시 강등한다 — 소셜 목록 신선도(reconcile 가드)와
+    // 무관하게 삭제 확정 정보로 바로 기본 알람으로 변환한다.
+    suspend fun degradeAlarmsUsingVoiceProfile(voiceProfileId: String): Int =
+        degradeMatchingLocalOwnedVoiceAlarms { alarm ->
+            alarm.voiceProfileId == voiceProfileId && !isSystemVoiceId(alarm.voiceProfileId)
+        }
+
+    private suspend fun degradeMatchingLocalOwnedVoiceAlarms(match: (AlarmEntity) -> Boolean): Int {
+        val candidates = alarmDao.getAllAlarms().filter { alarm ->
+            alarm.origin == AlarmOrigins.LOCAL_OWNED &&
+                alarm.voiceSource == VoiceSources.TTS_PROFILE &&
+                match(alarm)
         }
         var degraded = 0
         for (current in candidates) {
             val cacheKey = current.audioCacheKey
             val updated = current.copy(
                 playMode = AlarmPlayModes.ALARM_ONLY,
+                // '기본 알람으로 변환됨' 마커 — 무료 강등과 동일하게 리스트 배지·목소리 숨김에 쓴다.
+                // 복원은 하지 않으므로(영구 변환) 순수 표시용 마커다.
+                preLockPlayMode = current.preLockPlayMode ?: current.playMode,
                 voiceSource = VoiceSources.LOCAL_AUDIO,
                 voiceProfileId = null,
                 localAudioUri = null,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/DynamicPromptPreferenceStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/DynamicPromptPreferenceStore.kt
@@ -54,6 +54,16 @@ class DynamicPromptPreferenceStore(context: Context) {
             .apply()
     }
 
+    // 마지막에 고른 문구 종류(랜덤 컨텍스트). 새 알람의 기본값으로 이어받는다 — 없으면
+    // 호출측이 '기본 인사말'(preset)로 폴백한다. '직접 입력'은 저장하지 않아(호출측이 랜덤일 때만
+    // 저장) 새 알람이 빈 직접입력으로 시작하지 않는다.
+    fun readLastMessageContext(): String? =
+        prefs.getString(KEY_LAST_MESSAGE_CONTEXT, null)?.trim()?.ifEmpty { null }
+
+    fun saveLastMessageContext(context: String) {
+        prefs.edit().putString(KEY_LAST_MESSAGE_CONTEXT, context.trim()).apply()
+    }
+
     companion object {
         private const val PREFS_NAME = "dynamic_prompt_preferences"
         private const val KEY_WEATHER_COUNTRY = "weather_country"
@@ -61,5 +71,6 @@ class DynamicPromptPreferenceStore(context: Context) {
         private const val KEY_FORTUNE_GENDER = "fortune_gender"
         private const val KEY_FORTUNE_BIRTH_DATE = "fortune_birth_date"
         private const val KEY_FORTUNE_BIRTH_TIME = "fortune_birth_time"
+        private const val KEY_LAST_MESSAGE_CONTEXT = "last_message_context"
     }
 }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceProfileApi.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/VoiceProfileApi.kt
@@ -26,6 +26,13 @@ data class VoiceProfileDraftResponse(
     val profile: VoiceProfile? = null,
 )
 
+// 이번 달(KST) 목소리 초안 생성 쿼터. 삭제 전 '이번 달 재생성 가능 여부' 판정에 쓴다.
+data class VoiceDraftQuotaResponse(
+    val limit: Int = 0,
+    val used: Int = 0,
+    val remaining: Int = 0,
+)
+
 data class VoiceUploadResponse(
     val upload: VoiceUpload,
 )
@@ -191,6 +198,11 @@ interface VoiceProfileApi {
         // draft 정리 전용 삭제 — 서버는 아직 is_draft=1 인 경우에만 실제 삭제한다(등록된 보이스 보호).
         @Query("draftOnly") draftOnly: Boolean? = null,
     )
+
+    @GET("voice/draft-quota")
+    suspend fun getVoiceDraftQuota(
+        @Header("Authorization") authorization: String,
+    ): VoiceDraftQuotaResponse
 
     @GET("voice/family")
     suspend fun listFamilyVoiceProfiles(@Header("Authorization") authorization: String): FamilyVoiceProfileListResponse

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/alarms/AlarmListScreen.kt
@@ -54,6 +54,7 @@ internal fun AlarmListScreen(
     familyVoices: List<FamilyVoiceProfile>,
     billingBusy: Boolean,
     subscriptionResponse: BillingSubscriptionResponse?,
+    voiceDraftQuotaExhausted: Boolean = false,
     vouchers: List<VoucherItem>,
     onCreateVoiceProfile: (String, CachedAlarmAudio, Boolean, String, String, String) -> Boolean,
     onCreateVoiceProfiles: (List<VoiceProfileCreationDraft>) -> Unit,
@@ -150,6 +151,7 @@ internal fun AlarmListScreen(
                         familyVoices = familyVoices,
                         voiceProfileBusy = voiceProfileBusy,
                         subscriptionResponse = subscriptionResponse,
+                        voiceDraftQuotaExhausted = voiceDraftQuotaExhausted,
                         familyGroup = familyGroup,
                         authSession = authSession,
                         onCreateVoiceProfile = onCreateVoiceProfile,
@@ -198,8 +200,10 @@ internal fun AlarmListScreen(
                 }
                 items(sortedAlarms, key = { it.id }) { alarm ->
                     // TTS 알람만 프로필 이름을 찾는다(녹음·파일 알람은 이름 없이 날짜만).
+                    // 무료 전환으로 사운드온리 잠금된 알람(preLockPlayMode≠null)은 더는 그 목소리로
+                    // 울리지 않으므로 목소리 이름을 숨긴다(대신 '기본 알람으로 변환' 배지가 뜬다).
                     val voiceName = alarm.voiceProfileId
-                        ?.takeIf { alarm.voiceSource != VoiceSources.LOCAL_AUDIO }
+                        ?.takeIf { alarm.voiceSource != VoiceSources.LOCAL_AUDIO && alarm.preLockPlayMode == null }
                         ?.let { profileId ->
                             voiceProfiles.firstOrNull { it.id == profileId }?.name
                                 ?: familyVoices.firstOrNull { it.id == profileId }?.name

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -374,19 +374,25 @@ internal fun AlarmTalkApp(
 
     LaunchedEffect(
         authSession?.user?.id,
+        // 서버 users.plan(만료 확정 시 cron 이 'free' 로 세팅)이 바뀌면 재평가하도록 키에 포함.
+        authSession?.user?.plan,
         subscriptionResponse?.subscription?.id,
         subscriptionResponse?.subscription?.status,
         subscriptionResponse?.plan?.key,
         subscriptionResponse?.plan?.planType,
     ) {
-        if (authSession != null && subscriptionResponse != null) {
-            if (hasPaidVoiceAccess(subscriptionResponse)) {
-                // 다시 유료가 되면 무료 동안 잠근 목소리 알람을 복원한다.
-                viewModel.restorePaidVoiceAlarmsIfLocked()
-            } else {
-                // 무료면 유료 목소리 알람을 삭제 대신 사운드온리로 잠근다.
-                viewModel.applyFreePlanVoiceLock()
-            }
+        // 유료 목소리 알람을 기본 알람(사운드온리)으로 '영구' 변환하는 건 서버가 무료로 '확정'한
+        // 신호에서만 한다(다시 유료가 돼도 되돌리지 않는 사용자 정책이라, 오변환이 곧 영구 피해다).
+        // 세 조건을 모두 만족해야 변환: (a) billing 에 유료 구독 없음, (b) 가족/커플 접근도 없음,
+        // (c) 서버 users.plan 이 무료. 이래야 갱신 지연·읽기리플리카 지연으로 subscription 이 잠깐
+        // null 인 유료 사용자가 영구 오변환되지 않는다. 만료~반영 전 창의 '울림'은 RingingService 게이트가 방어.
+        val plan = authSession?.user?.plan
+        val genuinelyFree = authSession != null && subscriptionResponse != null &&
+            !hasPaidVoiceAccess(subscriptionResponse) &&
+            !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup) &&
+            (plan.isNullOrBlank() || plan == "free")
+        if (genuinelyFree) {
+            viewModel.applyFreePlanVoiceLock()
         }
     }
 
@@ -818,6 +824,7 @@ internal fun AlarmTalkApp(
                           familyVoices = familyVoices,
                           billingBusy = billingBusy,
                           subscriptionResponse = subscriptionResponse,
+                          voiceDraftQuotaExhausted = viewModel.voiceDraftQuota?.let { it.remaining <= 0 } == true,
                           vouchers = vouchers,
                           onCreateVoiceProfile = viewModel::createVoiceProfile,
                           onCreateVoiceProfiles = viewModel::createVoiceProfiles,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/app/AlarmTalkApp.kt
@@ -387,12 +387,17 @@ internal fun AlarmTalkApp(
         // (c) 서버 users.plan 이 무료. 이래야 갱신 지연·읽기리플리카 지연으로 subscription 이 잠깐
         // null 인 유료 사용자가 영구 오변환되지 않는다. 만료~반영 전 창의 '울림'은 RingingService 게이트가 방어.
         val plan = authSession?.user?.plan
-        val genuinelyFree = authSession != null && subscriptionResponse != null &&
+        val billingNotEntitled = authSession != null && subscriptionResponse != null &&
             !hasPaidVoiceAccess(subscriptionResponse) &&
-            !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup) &&
-            (plan.isNullOrBlank() || plan == "free")
-        if (genuinelyFree) {
-            viewModel.applyFreePlanVoiceLock()
+            !hasCoupleOrFamilyAccess(subscriptionResponse, familyGroup)
+        val planIsFree = plan.isNullOrBlank() || plan == "free"
+        when {
+            billingNotEntitled && planIsFree -> viewModel.applyFreePlanVoiceLock()
+            // billing 은 무권한인데 user.plan 이 아직 유료 → stale 가능(앱 살아있는 중 만료 시
+            // refreshBilling 은 구독만 갱신하고 plan 은 안 갱신). auth/me 로 plan 을 갱신해 진짜
+            // 무료인지 확정한다 — 갱신되면 이 이펙트가 user.plan 키 변화로 재실행돼 변환을 재판정.
+            // 진짜 무료면 plan=free 로 바뀌어 변환되고, 일시적 stale 이면 plan=유료 그대로라 변환 안 함.
+            billingNotEntitled -> viewModel.refreshAppSession()
         }
     }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/components/ControlsAndPermissions.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Fullscreen
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Notifications
@@ -313,7 +314,8 @@ internal fun AlarmRow(
         dampingRatio = Spring.DampingRatioNoBouncy,
         stiffness = Spring.StiffnessMediumLow,
     )
-    val warningText = alarmRowWarningResId(alarm)?.let { stringResource(it) }
+    val rowNotice = alarmRowNotice(alarm)
+    val warningText = rowNotice?.let { stringResource(it.textResId) }
     // 스와이프 외에 접근성(TalkBack/지체장애) 대체 삭제 수단: 길게 눌러 메뉴 노출.
     var menuExpanded by remember(alarm.id) { mutableStateOf(false) }
     val deleteVisible = offsetX.value < -0.5f
@@ -479,12 +481,22 @@ internal fun AlarmRow(
                         onCheckedChange = onToggleEnabled,
                     )
                 }
-                if (warningText != null) {
+                if (rowNotice != null && warningText != null) {
+                    // 에러(재예약/동기화 실패)는 경고색, 강등 안내는 정보색으로 톤을 구분한다.
+                    val isError = rowNotice.isError
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
                         shape = WakerTileShape,
-                        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.72f),
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        color = if (isError) {
+                            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.72f)
+                        } else {
+                            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.72f)
+                        },
+                        contentColor = if (isError) {
+                            MaterialTheme.colorScheme.onErrorContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        },
                     ) {
                         Row(
                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
@@ -492,7 +504,7 @@ internal fun AlarmRow(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Icon(
-                                imageVector = Icons.Outlined.ErrorOutline,
+                                imageVector = if (isError) Icons.Outlined.ErrorOutline else Icons.Outlined.Info,
                                 contentDescription = null,
                                 modifier = Modifier.size(18.dp),
                             )
@@ -529,9 +541,20 @@ internal fun AlarmRow(
     }
 }
 
-private fun alarmRowWarningResId(alarm: AlarmEntity): Int? = when {
-    alarm.state == AlarmStates.FAILED -> R.string.common_alarm_warning_reschedule_failed
-    alarm.syncState == AlarmSyncStates.FAILED -> R.string.common_alarm_warning_sync_failed
+private data class AlarmRowNotice(val textResId: Int, val isError: Boolean)
+
+private fun alarmRowNotice(alarm: AlarmEntity): AlarmRowNotice? = when {
+    alarm.state == AlarmStates.FAILED ->
+        AlarmRowNotice(R.string.common_alarm_warning_reschedule_failed, isError = true)
+    alarm.syncState == AlarmSyncStates.FAILED ->
+        AlarmRowNotice(R.string.common_alarm_warning_sync_failed, isError = true)
+    // 유료 목소리를 못 써 기본 알람(사운드온리)으로 변환됨(preLockPlayMode 마커, 영구).
+    // 무료 강등은 목소리 참조를 남겨두므로(voiceProfileId 유지) '무료 요금제' 안내, 공유 목소리
+    // 해제는 참조를 비우므로(voiceProfileId=null) 원인 무관 중립 안내.
+    alarm.preLockPlayMode != null && !alarm.voiceProfileId.isNullOrBlank() ->
+        AlarmRowNotice(R.string.common_alarm_notice_free_downgraded, isError = false)
+    alarm.preLockPlayMode != null ->
+        AlarmRowNotice(R.string.common_alarm_notice_default_converted, isError = false)
     else -> null
 }
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -148,7 +148,20 @@ internal fun AlarmEditorScreen(
         voiceProfiles
     }
     val defaultPlayMode = if (voicePlanLocked) AlarmPlayModes.ALARM_ONLY else AlarmPlayModes.ALARM_VOICE
-    val editor = remember(alarm?.id) { AlarmEditorState.from(alarm, defaultPlayMode = defaultPlayMode) }
+    // 새 알람은 마지막에 고른 문구 종류를 기본값으로 이어받는다(없으면 목록에 노출하지 않는
+    // '기본 인사말'=preset 으로 시작). '직접 입력'은 저장하지 않아 빈 직접입력으로 시작하지 않는다.
+    val messageDefaultsContext = LocalContext.current
+    val defaultRandomContext = remember(messageDefaultsContext) {
+        DynamicPromptPreferenceStore(messageDefaultsContext.applicationContext)
+            .readLastMessageContext() ?: DefaultRandomPromptContext
+    }
+    val editor = remember(alarm?.id) {
+        AlarmEditorState.from(
+            alarm,
+            defaultPlayMode = defaultPlayMode,
+            defaultRandomContext = defaultRandomContext,
+        )
+    }
     // 시스템(기본) 보이스가 선택되면 유료여도 문구를 무료 버킷과 동일하게 '날씨+약'으로 제한한다
     // (운세·사랑·직접 입력 숨김). 무료 tier 와 하나의 게이트로 묶어 렌더·상태강제·저장검증에 동일 주입.
     val isSystemVoiceSelected = isSystemVoiceId(editor.voiceProfileId) ||
@@ -1027,6 +1040,8 @@ internal fun AlarmEditorScreen(
         }
         editor.voiceRandomPrompt = true
         editor.voiceRandomContext = normalizedRandomPromptContext(result.randomContext)
+        // 마지막에 고른 문구 종류를 기억 → 다음 새 알람의 기본값으로 이어받는다.
+        dynamicPromptPreferenceStore.saveLastMessageContext(editor.voiceRandomContext)
         editor.voiceLanguage = appVoiceLanguage
         editor.voiceText = ""
         editor.voiceWeatherCountry = result.weatherCountry

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorState.kt
@@ -431,6 +431,9 @@ internal class AlarmEditorState(
         fun from(
             alarm: AlarmEntity?,
             defaultPlayMode: String = AlarmPlayModes.ALARM_ONLY,
+            // 새 알람의 기본 문구 종류. 호출측이 '마지막에 고른 문구'를 넘기고, 없으면
+            // '기본 인사말'(preset)로 폴백한다. 기존 알람은 자신의 voiceRandomContext 를 쓴다.
+            defaultRandomContext: String = DefaultRandomPromptContext,
         ): AlarmEditorState {
             val defaultTime = java.time.LocalTime.of(6, 0)
             return AlarmEditorState(
@@ -457,7 +460,13 @@ internal class AlarmEditorState(
                 voiceRandomPrompt = alarm?.voiceRandomPrompt ?: alarm?.let {
                     it.voiceSource == VoiceSources.TTS_PROFILE && it.voiceText.isNullOrBlank()
                 } ?: true,
-                voiceRandomContext = alarm?.voiceRandomContext ?: DefaultRandomPromptContext,
+                // 마지막 문구 기억은 '신규 알람'에만 적용. 기존 알람(수동/알람전용 등 context=null 포함)은
+                // 자기 값(없으면 기본 preset)을 그대로 써, 편집만 열어도 문구가 바뀌는 일이 없게 한다.
+                voiceRandomContext = if (alarm == null) {
+                    defaultRandomContext
+                } else {
+                    alarm.voiceRandomContext ?: DefaultRandomPromptContext
+                },
                 voiceWeatherCountry = alarm?.voiceWeatherCountry,
                 voiceWeatherCity = alarm?.voiceWeatherCity,
                 voiceFortuneGender = alarm?.voiceFortuneGender,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -27,6 +27,7 @@ import com.alarmtalk.app.network.CheckoutRequest
 import com.alarmtalk.app.network.CodeRegisterRequest
 import com.alarmtalk.app.network.FamilyGroupCurrentResponse
 import com.alarmtalk.app.network.FamilyVoiceProfile
+import com.alarmtalk.app.network.VoiceDraftQuotaResponse
 import com.alarmtalk.app.network.LoginRequest
 import com.alarmtalk.app.network.RegisterRequest
 import com.alarmtalk.app.network.TtsGenerateRequest
@@ -191,6 +192,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         internal set
 
     var pendingVoiceDraft by mutableStateOf<VoiceProfile?>(null)
+        internal set
+
+    // 이번 달 목소리 초안 생성 쿼터(삭제 전 '이번 달 재생성 가능 여부' 판정용). null=미조회.
+    var voiceDraftQuota by mutableStateOf<VoiceDraftQuotaResponse?>(null)
         internal set
 
     var voiceProfileBusy by mutableStateOf(false)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModelVoiceActions.kt
@@ -61,6 +61,8 @@ internal fun MainViewModel.fetchVoiceProfiles(showMessage: Boolean) {
                 // 내 음성 목록이 늦게 로드된 경우에도 접근권 잃은 목소리 알람 강등이 재실행되게 한다
                 // (공유 목소리 목록이 먼저 신선 로드돼 스킵됐을 수 있음). 빈 목록도 유효한 로드다.
                 reconcileInaccessibleVoiceAlarms()
+                // 삭제 화면에서 '이번 달 재생성 가능 여부'를 판정하도록 월 생성 쿼터도 함께 갱신.
+                loadVoiceDraftQuota()
             }.onFailure { error ->
                 AlarmTalkLog.reportError("Failed to load voice profiles", error)
                 if (showMessage) message = userFacingError(error, getApplication<android.app.Application>().getString(R.string.msg_voice_fetch_failed))
@@ -148,6 +150,9 @@ internal fun MainViewModel.createVoiceProfiles(items: List<VoiceProfileCreationD
             }
         }.onSuccess { profiles ->
             pendingVoiceDraft = profiles.firstOrNull()
+            // 클론 생성이 이번 달 생성 시도(쿼터)를 소모했으므로 잔여 횟수를 재조회한다
+            // (삭제 화면의 '이번 달 재생성 불가' 경고가 최신 잔여로 판정되게).
+            loadVoiceDraftQuota()
             // 클론 성공 직후 로컬 녹음 샘플(음성 생체정보 평문 .m4a)을 즉시 정리한다.
             withContext(Dispatchers.IO) {
                 drafts.forEach { draft ->
@@ -412,10 +417,15 @@ internal fun MainViewModel.deleteVoiceProfile(profileId: String) {
         }.onSuccess {
             voiceProfiles = voiceProfiles.filterNot { it.id == profileId }
             message = getApplication<android.app.Application>().getString(R.string.msg_voice_deleted)
+            // 삭제된 목소리를 쓰던 내 알람을 즉시 기본 알람으로 변환한다(공유해제·무료강등과 동일 결과).
+            // 서버는 sound-only 로 바꾸지만 본인 LOCAL_OWNED 알람은 pull 로 안 돌아오므로 로컬에서 강등.
+            // 삭제된 id 만 대상으로 하는 타깃 강등이라 소셜 목록 신선도(reconcile 가드)에 막히지 않는다.
+            viewModelScope.launch { runCatching { repository.degradeAlarmsUsingVoiceProfile(profileId) } }
         }.onFailure { error ->
             if (error is retrofit2.HttpException && error.code() == 404) {
                 voiceProfiles = voiceProfiles.filterNot { it.id == profileId }
                 message = getApplication<android.app.Application>().getString(R.string.msg_voice_already_deleted)
+                viewModelScope.launch { runCatching { repository.degradeAlarmsUsingVoiceProfile(profileId) } }
             } else {
                 if (originalProfile != null) {
                     voiceProfiles = voiceProfiles.map {
@@ -472,6 +482,19 @@ internal suspend fun MainViewModel.downloadTtsMessageAudio(messageId: String): T
     val session = authSession ?: throw IllegalStateException(getApplication<android.app.Application>().getString(R.string.msg_voice_tts_audio_load_login_required))
     return withContext(Dispatchers.IO) {
         api.getTtsMessageAudio(AlarmTalkApiClient.bearer(session.token), messageId)
+    }
+}
+
+// 이번 달 목소리 초안 생성 쿼터 조회 → voiceDraftQuota 상태 갱신(삭제 전 재생성 가능 판정용).
+// 실패/미로그인은 조용히 무시(기존 값 유지). fire-and-forget.
+internal fun MainViewModel.loadVoiceDraftQuota() {
+    val session = authSession ?: return
+    viewModelScope.launch {
+        runCatching {
+            withContext(Dispatchers.IO) {
+                api.getVoiceDraftQuota(AlarmTalkApiClient.bearer(session.token))
+            }
+        }.onSuccess { voiceDraftQuota = it }
     }
 }
 
@@ -598,7 +621,12 @@ internal fun MainViewModel.startPrerenderDrive(voiceId: String) {
                 // 3회 연속 무진전이면 여기서 더 붙잡지 않는다 — cron 이 이어받는다.
                 if (stagnantRounds >= 3) return@launch
             }
-            prerenderDrive = prerenderDrive?.copy(downloading = true)
+            // 다운로드 단계 진입: generated 를 0 으로 리셋한다(생성 완료값 total 을 이월하면 결합
+            // 진행바가 순간 100% 로 튀었다가 다운로드 0%(=50%)로 역행해 보인다). 리셋하면 생성 0~50%
+            // → 다운로드 50~100% 로 매끄럽게 이어진다.
+            prerenderDrive = prerenderDrive?.let {
+                PrerenderDriveState(it.voiceId, 0, it.total, downloading = true)
+            }
             runCatching {
                 downloadAllPresetClips(voiceId) { done, total ->
                     prerenderDrive = PrerenderDriveState(voiceId, done, total, downloading = true)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/util/PlatformAndLabelUtils.kt
@@ -209,6 +209,24 @@ internal fun hasPaidVoiceAccess(subscriptionResponse: BillingSubscriptionRespons
         plan.planType in setOf("personal", "individual", "plus", "couple", "family")
 }
 
+/**
+ * 유료 목소리 권한을 '만료시각까지' 고려해 판정한다. hasPaidVoiceAccess 는 status=="active" 만
+ * 보므로, 로컬에 마지막으로 저장된(=stale 가능) 구독이 active 로 남아 있어도 expiresAt 이 지났으면
+ * 무권한으로 본다. 앱 미실행/오프라인이라 서버 재조회를 못 해도 만료된 유료 목소리가 계속
+ * 재생되지 않게 하는 근거(울림 시점 게이트·무료 잠금 트리거 공용). 만료시각을 못 읽으면
+ * status 만 신뢰(기존 동작 유지 — 과차단 방지).
+ */
+internal fun isPaidVoiceEntitledNow(
+    subscriptionResponse: BillingSubscriptionResponse?,
+    nowMillis: Long,
+): Boolean {
+    if (!hasPaidVoiceAccess(subscriptionResponse)) return false
+    val expiresAt = subscriptionResponse?.subscription?.expiresAt ?: return true
+    val expiryMillis = runCatching { java.time.Instant.parse(expiresAt).toEpochMilli() }.getOrNull()
+        ?: return true
+    return expiryMillis > nowMillis
+}
+
 internal fun familyAlarmRecipients(
     familyGroup: FamilyGroupCurrentResponse?,
     authSession: AuthSession?,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/voices/VoiceProfileManagementPanel.kt
@@ -7,6 +7,9 @@ import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.rememberScrollState
@@ -60,6 +63,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -185,6 +189,8 @@ internal fun VoiceProfileManagementPanel(
     familyVoices: List<FamilyVoiceProfile>,
     voiceProfileBusy: Boolean,
     subscriptionResponse: BillingSubscriptionResponse?,
+    // 이번 달 목소리 생성 횟수 소진 여부 — 삭제 시 '지금 지우면 이번 달엔 다시 못 만든다' 경고 게이트.
+    voiceDraftQuotaExhausted: Boolean = false,
     familyGroup: FamilyGroupCurrentResponse?,
     authSession: AuthSession?,
     // 반환값: 클론 생성 요청을 실제로 시작했는지 — false 면 '만드는 중' 스텝에 진입하지 않는다.
@@ -1643,47 +1649,63 @@ internal fun VoiceProfileManagementPanel(
                             }
 
                             VoiceRegistrationStep.Prerendering -> {
+                                // 생성(서버)→다운로드(기기 저장)를 한 화면·한 진행률로 합친다.
+                                // 문구도 하나로 통일하고, 나가기=백그라운드는 부제로 안내한다(전용 버튼 없앰
+                                // — 이 스텝은 voiceProfileBusy=false 라 X/뒤로가기로 닫으면 드라이브는
+                                // viewModelScope 에서 그대로 계속된다).
+                                val drive = prerenderDrive
+                                // 생성 0~50%, 다운로드 50~100% 로 이어붙여 매끄러운 하나의 진행률.
+                                val target = if (drive != null && drive.total > 0) {
+                                    val frac = (drive.generated.toFloat() / drive.total.toFloat())
+                                        .coerceIn(0f, 1f)
+                                    if (drive.downloading) 0.5f + frac * 0.5f else frac * 0.5f
+                                } else {
+                                    null
+                                }
+                                val animatedProgress by animateFloatAsState(
+                                    targetValue = target ?: 0f,
+                                    animationSpec = tween(durationMillis = 550, easing = FastOutSlowInEasing),
+                                    label = "prerenderProgress",
+                                )
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(vertical = 72.dp),
+                                        .padding(vertical = 72.dp, horizontal = 24.dp),
                                     horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                                    verticalArrangement = Arrangement.spacedBy(12.dp),
                                 ) {
                                     Text(
-                                        text = if (prerenderDrive?.downloading == true) {
-                                            stringResource(R.string.voices_prerender_downloading_title)
-                                        } else {
-                                            stringResource(R.string.voices_prerender_generating_title)
-                                        },
+                                        text = stringResource(R.string.voices_prerender_ready_title),
                                         style = MaterialTheme.typography.titleMedium,
                                         fontWeight = FontWeight.SemiBold,
                                     )
-                                    // 'n/21 준비' 카운트 텍스트 대신 진행 로딩바만 — 총량을 알면
-                                    // 확정 진행률, 아직 모르면(시작 직후) 인디터미넌트.
-                                    val drive = prerenderDrive
-                                    if (drive != null && drive.total > 0) {
+                                    Text(
+                                        text = stringResource(R.string.voices_prerender_ready_body),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        textAlign = TextAlign.Center,
+                                    )
+                                    Spacer(Modifier.height(6.dp))
+                                    if (target != null) {
                                         LinearProgressIndicator(
-                                            progress = {
-                                                drive.generated.toFloat() / drive.total.toFloat()
-                                            },
-                                            modifier = Modifier.fillMaxWidth(0.72f),
+                                            progress = { animatedProgress },
+                                            modifier = Modifier
+                                                .fillMaxWidth(0.78f)
+                                                .height(8.dp),
+                                            strokeCap = StrokeCap.Round,
+                                            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            gapSize = 0.dp,
+                                            drawStopIndicator = {},
                                         )
                                     } else {
+                                        // 시작 직후(총량 미상): 흐르는 인디터미넌트 바.
                                         LinearProgressIndicator(
-                                            modifier = Modifier.fillMaxWidth(0.72f),
+                                            modifier = Modifier
+                                                .fillMaxWidth(0.78f)
+                                                .height(8.dp),
+                                            strokeCap = StrokeCap.Round,
+                                            trackColor = MaterialTheme.colorScheme.surfaceVariant,
                                         )
-                                    }
-                                    // 하단 고정 대신 로딩 블록에서 조금 떨어져 바로 아래에 둔다 —
-                                    // 닫아도 드라이브는 ViewModel 에서 계속된다.
-                                    Spacer(Modifier.height(10.dp))
-                                    TextButton(
-                                        onClick = {
-                                            promotedForPrerenderId = null
-                                            closeCreateDialog()
-                                        },
-                                    ) {
-                                        Text(stringResource(R.string.voices_prerender_continue_background_action))
                                     }
                                 }
                             }
@@ -2068,14 +2090,38 @@ internal fun VoiceProfileManagementPanel(
     }
 
     deleteTarget?.let { profile ->
-        VoiceProfileDeleteDialog(
-            profileName = profile.name,
-            onDismiss = { deleteTarget = null },
-            onDelete = {
-                onDeleteVoiceProfile(profile.id)
-                deleteTarget = null
-            },
-        )
+        if (voiceDraftQuotaExhausted) {
+            // 이번 달 생성 횟수를 다 썼으면 iOS 스타일 경고 모달 — 지워도 이번 달엔 다시 못 만든다는
+            // 안내. 그래도 본인 목소리이므로 삭제 자체는 허용한다(경고형).
+            IosAlertDialog(
+                title = stringResource(R.string.voices_delete_quota_title),
+                message = stringResource(R.string.voices_delete_quota_message),
+                actions = listOf(
+                    IosAlertAction(
+                        label = stringResource(R.string.editor_cancel),
+                        onClick = { deleteTarget = null },
+                    ),
+                    IosAlertAction(
+                        label = stringResource(R.string.voicesr_delete),
+                        destructive = true,
+                        onClick = {
+                            onDeleteVoiceProfile(profile.id)
+                            deleteTarget = null
+                        },
+                    ),
+                ),
+                onDismiss = { deleteTarget = null },
+            )
+        } else {
+            VoiceProfileDeleteDialog(
+                profileName = profile.name,
+                onDismiss = { deleteTarget = null },
+                onDelete = {
+                    onDeleteVoiceProfile(profile.id)
+                    deleteTarget = null
+                },
+            )
+        }
     }
 }
 

--- a/apps/android-native/app/src/main/res/values-en/strings.xml
+++ b/apps/android-native/app/src/main/res/values-en/strings.xml
@@ -147,6 +147,8 @@
     <string name="common_alarm_delete">Delete</string>
     <string name="common_alarm_warning_reschedule_failed">We couldn\'t reschedule the alarm. Please check the time and save again.</string>
     <string name="common_alarm_warning_sync_failed">Saving is briefly delayed. Your alarm will still ring, and we\'ll retry automatically.</string>
+    <string name="common_alarm_notice_free_downgraded">Switched to the free plan, so this alarm now uses the default sound.</string>
+    <string name="common_alarm_notice_default_converted">The voice is no longer available, so this alarm now uses the default sound.</string>
     <string name="common_day_fri">Fri</string>
     <string name="common_day_mon">Mon</string>
     <string name="common_day_sat">Sat</string>
@@ -619,10 +621,8 @@
     <string name="voices_mic_permission_required">Microphone permission is required.</string>
     <string name="voices_my_voices_title">My Voices</string>
     <string name="voices_name_label">Voice name</string>
-    <string name="voices_prerender_generating_title">Creating your voice</string>
-    <string name="voices_prerender_downloading_title">Saving to your device</string>
-    <string name="voices_prerender_continue_background_action">Continue in background</string>
-    <string name="voices_prerender_continue_background">The remaining phrases will keep generating in the background.</string>
+    <string name="voices_prerender_ready_title">Getting your alarm voice ready</string>
+    <string name="voices_prerender_ready_body">This will be ready shortly.\nYou can close this — it keeps going in the background.</string>
     <string name="voices_language_label">Message language</string>
     <string name="voices_name_placeholder">e.g. Mom\'s voice</string>
     <string name="voices_next">Next</string>
@@ -678,6 +678,8 @@ We\'ll play it for you as soon as it\'s ready.</string>
     <string name="voices_upload_zone_subtitle">Prepare an audio or video at least 1 minute long</string>
     <string name="voicesr_close">Close</string>
     <string name="voicesr_delete">Delete</string>
+    <string name="voices_delete_quota_title">Delete this voice?</string>
+    <string name="voices_delete_quota_message">You\'ve used all of this month\'s voice creations, so if you delete it now you can\'t make a new one until next month.</string>
     <string name="voicesr_delete_dialog_confirm">Delete the \'%1$s\' voice?</string>
     <string name="voicesr_delete_dialog_title">Delete voice</string>
     <string name="voicesr_delete_dialog_warning">Alarms using this voice will switch to the default alarm sound. The saved audio files will also be deleted.</string>

--- a/apps/android-native/app/src/main/res/values-ja/strings.xml
+++ b/apps/android-native/app/src/main/res/values-ja/strings.xml
@@ -147,6 +147,8 @@
     <string name="common_alarm_delete">削除</string>
     <string name="common_alarm_warning_reschedule_failed">アラームを再設定できませんでした。時間を確認して、もう一度保存してください。</string>
     <string name="common_alarm_warning_sync_failed">保存が少し遅れています。アラームはそのまま鳴り、自動で再保存します。</string>
+    <string name="common_alarm_notice_free_downgraded">無料プランに変わったため、基本アラーム音に変換されました。</string>
+    <string name="common_alarm_notice_default_converted">声が使えなくなったため、基本アラーム音に変換されました。</string>
     <string name="common_day_fri">金</string>
     <string name="common_day_mon">月</string>
     <string name="common_day_sat">土</string>
@@ -627,10 +629,8 @@
     <string name="voices_mic_permission_required">マイクの権限が必要です。</string>
     <string name="voices_my_voices_title">マイボイス</string>
     <string name="voices_name_label">声の名前</string>
-    <string name="voices_prerender_generating_title">声を生成中</string>
-    <string name="voices_prerender_downloading_title">端末に保存中</string>
-    <string name="voices_prerender_continue_background_action">バックグラウンドで続行</string>
-    <string name="voices_prerender_continue_background">残りの文はバックグラウンドで作成され続けます。</string>
+    <string name="voices_prerender_ready_title">アラーム音声を準備しています</string>
+    <string name="voices_prerender_ready_body">まもなく準備できます。\nこの画面を閉じてもバックグラウンドで続きます。</string>
     <string name="voices_language_label">フレーズの言語</string>
     <string name="voices_name_placeholder">例:お母さんの声</string>
     <string name="voices_next">次へ</string>
@@ -686,6 +686,8 @@
     <string name="voices_upload_zone_subtitle">1分以上の音声か動画をご用意ください</string>
     <string name="voicesr_close">閉じる</string>
     <string name="voicesr_delete">削除</string>
+    <string name="voices_delete_quota_title">削除しますか？</string>
+    <string name="voices_delete_quota_message">今月の作成回数をすべて使ったため、今削除すると今月は新しい声を作れません。</string>
     <string name="voicesr_delete_dialog_confirm">「%1$s」の声を削除しますか?</string>
     <string name="voicesr_delete_dialog_title">声を削除</string>
     <string name="voicesr_delete_dialog_warning">この声を使うアラームは基本のアラーム音に変わります。保存された音源ファイルも一緒に削除されます。</string>

--- a/apps/android-native/app/src/main/res/values/strings.xml
+++ b/apps/android-native/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="common_alarm_delete">삭제</string>
     <string name="common_alarm_warning_reschedule_failed">알람을 다시 예약하지 못했어요. 시간을 확인하고 다시 저장해 주세요.</string>
     <string name="common_alarm_warning_sync_failed">저장이 잠시 미뤄졌어요. 알람은 정상적으로 울리고, 자동으로 다시 저장해요.</string>
+    <string name="common_alarm_notice_free_downgraded">무료 요금제로 바뀌어 기본 알람으로 변환되었어요.</string>
+    <string name="common_alarm_notice_default_converted">목소리를 쓸 수 없어 기본 알람으로 변환되었어요.</string>
     <string name="common_day_fri">금</string>
     <string name="common_day_mon">월</string>
     <string name="common_day_sat">토</string>
@@ -628,10 +630,8 @@
     <string name="voices_mic_permission_required">마이크 권한이 필요해요.</string>
     <string name="voices_my_voices_title">내 목소리</string>
     <string name="voices_name_label">목소리 이름</string>
-    <string name="voices_prerender_generating_title">목소리 생성 중</string>
-    <string name="voices_prerender_downloading_title">기기에 저장 중</string>
-    <string name="voices_prerender_continue_background_action">백그라운드에서 계속</string>
-    <string name="voices_prerender_continue_background">남은 문구는 백그라운드에서 계속 만들어져요.</string>
+    <string name="voices_prerender_ready_title">알람 목소리를 준비하고 있어요</string>
+    <string name="voices_prerender_ready_body">조금만 기다리면 준비돼요.\n이 화면을 닫아도 백그라운드에서 계속돼요.</string>
     <string name="voices_language_label">문구 언어</string>
     <string name="voices_lang_ko" translatable="false">한국어</string>
     <string name="voices_lang_en" translatable="false">English</string>
@@ -690,6 +690,8 @@
     <string name="voices_upload_zone_subtitle">1분 이상의 오디오나 영상으로 준비해 주세요</string>
     <string name="voicesr_close">닫기</string>
     <string name="voicesr_delete">삭제</string>
+    <string name="voices_delete_quota_title">정말 삭제할까요?</string>
+    <string name="voices_delete_quota_message">이번 달 생성 횟수를 모두 사용해, 지금 삭제하면 이번 달엔 새 목소리를 만들 수 없어요.</string>
     <string name="voicesr_delete_dialog_confirm">\'%1$s\' 목소리를 삭제할까요?</string>
     <string name="voicesr_delete_dialog_title">목소리 삭제</string>
     <string name="voicesr_delete_dialog_warning">이 목소리를 쓰는 알람은 기본 알람음으로 바뀌어요. 저장된 음원 파일도 함께 삭제돼요.</string>

--- a/packages/backend/src/routes/voice-profile.ts
+++ b/packages/backend/src/routes/voice-profile.ts
@@ -91,16 +91,39 @@ async function markMonthlyOfficialVoiceChange(
   });
 }
 
-async function reserveMonthlyDraftAttempt(
-  db: DbExecutor,
-  ownerUserId: string,
-): Promise<string | null> {
+// KST 기준 'YYYY-MM' — 월 생성(초안) 쿼터의 키. reserve/read 가 동일 월 문자열을 쓰도록 단일 출처.
+function currentKstAttemptMonth(): string {
   const monthParts = new Intl.DateTimeFormat('en', {
     timeZone: 'Asia/Seoul',
     year: 'numeric',
     month: '2-digit',
   }).formatToParts(new Date());
-  const attemptMonth = `${monthParts.find((part) => part.type === 'year')!.value}-${monthParts.find((part) => part.type === 'month')!.value}`;
+  return `${monthParts.find((part) => part.type === 'year')!.value}-${monthParts.find((part) => part.type === 'month')!.value}`;
+}
+
+// 이번 달(KST) 목소리 초안 생성 사용량 조회 — 클라가 삭제 전 '재생성 가능 여부'를 판정하는 데 쓴다.
+async function readMonthlyDraftAttemptUsage(
+  db: DbExecutor,
+  ownerUserId: string,
+): Promise<{ limit: number; used: number; remaining: number }> {
+  const res = await db.execute({
+    sql: `SELECT used_count FROM voice_draft_attempt_usage
+          WHERE owner_user_id = ? AND attempt_month = ?`,
+    args: [ownerUserId, currentKstAttemptMonth()],
+  });
+  const used = Number(res.rows[0]?.used_count ?? 0);
+  return {
+    limit: MAX_DRAFT_ATTEMPTS_PER_MONTH,
+    used,
+    remaining: Math.max(0, MAX_DRAFT_ATTEMPTS_PER_MONTH - used),
+  };
+}
+
+async function reserveMonthlyDraftAttempt(
+  db: DbExecutor,
+  ownerUserId: string,
+): Promise<string | null> {
+  const attemptMonth = currentKstAttemptMonth();
   const result = await db.execute({
     sql: `INSERT INTO voice_draft_attempt_usage
             (owner_user_id, attempt_month, used_count)
@@ -438,6 +461,16 @@ voiceProfile.get('/draft', async (c) => {
         }
       : null,
   });
+});
+
+// 이번 달(KST) 목소리 초안 생성 쿼터 — 클라가 삭제 전 '이번 달 재생성 가능 여부'를 판정한다.
+// '/:id' 보다 먼저 등록해야 draft-quota 가 id 로 잡히지 않는다.
+voiceProfile.get('/draft-quota', async (c) => {
+  const userId = c.get('userId');
+  const userPk = (c.get('userIdPK') as string | undefined) || userId;
+  const db = getDB(c.env);
+  const quota = await readMonthlyDraftAttemptUsage(db, userPk);
+  return c.json(quota);
 });
 
 voiceProfile.get('/family', async (c) => {

--- a/packages/backend/test/voice-profile.test.ts
+++ b/packages/backend/test/voice-profile.test.ts
@@ -178,6 +178,32 @@ describe('GET /draft — 드래프트 조회 (voice-profile)', () => {
   });
 });
 
+describe('GET /draft-quota — 월 생성 쿼터 (voice-profile)', () => {
+  it('사용 기록 없으면 remaining=limit(3)', async () => {
+    mockDB.pushResult([]); // used_count 조회 → 없음
+    const res = await req(buildApp(), new Request('http://localhost/vp/draft-quota'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ limit: 3, used: 0, remaining: 3 });
+  });
+
+  it('이번 달을 다 썼으면 remaining=0', async () => {
+    mockDB.pushResult([{ used_count: 3 }]);
+    const res = await req(buildApp(), new Request('http://localhost/vp/draft-quota'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ limit: 3, used: 3, remaining: 0 });
+  });
+
+  it("'/:id' 보다 먼저 매칭돼 draft-quota 가 프로필 id 로 잡히지 않는다", async () => {
+    mockDB.pushResult([{ used_count: 1 }]);
+    const res = await req(buildApp(), new Request('http://localhost/vp/draft-quota'));
+    // 400(잘못된 UUID) 이 아니라 200 쿼터 응답이어야 한다.
+    expect(res.status).toBe(200);
+    expect((await res.json()).remaining).toBe(2);
+  });
+});
+
 describe('GET /:id — 프로필 상세 (voice-profile)', () => {
   it('잘못된 UUID → 400', async () => {
     const res = await req(buildApp(), new Request(`http://localhost/vp/${V_BAD}`));


### PR DESCRIPTION
목소리·알람 UX 여러 건 + 무료 전환 관련 버그 수정 묶음.

## 1. 목소리 준비(다운로드) 화면 개편
- "목소리 생성 중"/"기기에 저장 중" 두 문구 → 하나로 통합 + 부제.
- 생성(0~50%)→다운로드(50~100%)를 **하나의 애니메이션 진행바**로 이어붙임(경계 역행 수정).
- "백그라운드에서 계속" 버튼 제거 — X/뒤로가기로 나가면 그대로 백그라운드 진행(원래 동작).

## 2. 새 알람 문구 기본값 = 마지막에 고른 종류
- 새 알람은 지난번 고른 문구 종류로 시작(직접입력은 저장 안 함 → 빈 직접입력으로 시작 X).
- `DynamicPromptPreferenceStore` 에 얹음. **기존 알람 편집엔 영향 없음**(신규만 주입).

## 3. 무료 전환/목소리 삭제/공유 해제 → 기본 알람 변환 (통일)
- 그 목소리 알람을 사운드온리로 변환 + 리스트 배지("기본 알람으로 변환") + 목소리 이름 숨김.
- **복원 안 함(영구)** — 목소리 프로필 자체는 새 알람에서 다시 사용 가능.
- 삭제는 소셜 목록 신선도와 무관하게 **삭제된 목소리만 타깃 강등**(즉시 반영).

## 4. 울림 시점 게이트 (무료인데 유료 목소리로 울리던 버그)
- 만료된 유료 목소리는 울릴 때 톤으로 강등(오프라인·앱 미실행에도). 알람은 화면/톤/진동으로 정상 울림.
- **안전 보강(자기검증 후)**: 어떤 예외에도 fail-open(무음화 절대 없음), 본인 소유(LOCAL_OWNED)만,
  구독 정보 없으면(가족 구성원·미조회·transient) 강등 안 함. 영구 변환은 '진짜 무료 확정'
  (유료구독 없음 + 가족/커플 아님 + 서버 user.plan=free)에서만 → 일시적 stale 로 유료 사용자 오변환 방지.

## 5. 목소리 삭제 시 이번 달 생성 횟수 소진 경고 모달
- 소진(remaining≤0)이면 삭제 시 iOS 스타일 경고 모달("지금 삭제하면 이번 달엔 새로 못 만들어요"),
  **그래도 삭제는 가능**(경고형). 생성 성공 후 잔여 쿼터 재조회.
- 백엔드 `GET /voice/draft-quota` 신설(수동TTS 쿼터 패턴), 미배포 시 클라는 조용히 무시(graceful).

## 검증
- 백엔드 전체 통과(신규 쿼터 테스트 3건 포함). Android devDebug 빌드 통과, 두 테스트폰 설치 확인.
- 15+ 에이전트 적대적 자기검증으로 발굴한 9건 중 HIGH 3·MEDIUM/실버그 4를 이 브랜치에서 수정 완료.

## 참고
- 쿼터 모달은 이 PR 머지→dev 배포 후 실제 동작(엔드포인트 배포 필요).