### PR TITLE
fix: 울림 게이트가 캐시된 '무료' 응답을 유권한으로 오판하던 문제 (Codex #638 P1)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/alarm/RingingService.kt
@@ -42,6 +42,7 @@ import com.alarmtalk.app.data.VibrationPatternLibrary
 import com.alarmtalk.app.data.VibrationPatterns
 import com.alarmtalk.app.data.decodeBucketClipKeys
 import com.alarmtalk.app.data.usesFreeSystemVoiceAlarm
+import com.alarmtalk.app.hasCoupleOrFamilyAccess
 import com.alarmtalk.app.isPaidVoiceEntitledNow
 import com.alarmtalk.app.network.AuthSessionStore
 import com.alarmtalk.app.ringing.RingingActivity
@@ -262,13 +263,20 @@ class RingingService : Service() {
     /**
      * 울림 시점에 로컬 영속 구독으로 유료 목소리 권한을 재확인한다(오프라인·앱 미실행 안전).
      * 절대 예외를 던지지 않는다 — 암호화 저장소 읽기/복호화가 실패해도 true(강등 안 함)로 떨어뜨려
-     * 알람이 무음화되지 않게 한다(fail-open). 구독 정보가 없으면(미조회·가족 구성원·transient) 강등하지
-     * 않고, '마지막으로 활성이던 구독의 만료시각이 지났을 때'만 무권한으로 본다.
+     * 알람이 무음화되지 않게 한다(fail-open). 캐시 응답 자체가 없으면(미조회·transient) 판단 불가로
+     * 강등하지 않는다. 캐시 응답이 '있는데' subscription 이 null 이면 서버가 '본인 구독 없음'이라고
+     * 답한 것 — 가족/커플 그룹 멤버(본인 구독 없이 그룹 접근)면 권한 유지, 아니면 무료로 보고
+     * 강등한다(만료 push 유실·오프라인 폴백, PlanChangeSyncWorker 의 genuinelyFree 판정과 동일 기준).
+     * 본인 구독이 있으면 기존대로 만료시각까지 검사한다(그룹 체크로 만료 게이트를 우회하지 않게
+     * subscription==null 분기에만 적용 — stale 캐시의 만료된 family 소유자 오통과 방지).
      */
     private fun isPaidVoiceEntitledFromCache(): Boolean = runCatching {
         val userId = AuthSessionStore(applicationContext).read()?.user?.id ?: return@runCatching true
-        val sub = AccessSnapshotStore(applicationContext).read(userId).subscriptionResponse
-        if (sub?.subscription == null) return@runCatching true
+        val snapshot = AccessSnapshotStore(applicationContext).read(userId)
+        val sub = snapshot.subscriptionResponse ?: return@runCatching true
+        if (sub.subscription == null) {
+            return@runCatching hasCoupleOrFamilyAccess(sub, snapshot.familyGroup)
+        }
         isPaidVoiceEntitledNow(sub, System.currentTimeMillis())
     }.getOrDefault(true)
 


### PR DESCRIPTION
## 배경
릴리스 PR #638 에 올라온 Codex P1 지적 대응.

> `/billing/subscription` returns a successful `{ subscription: null, plan: null }` response after expiry, and `PlanChangeSyncWorker` persists that response before calling the local lock. However, this branch treats that known cached free response as entitled, so an expired user who misses the FCM or is offline before the worker runs will still play locally cached paid voice audio at ring time.

## 수정
`RingingService.isPaidVoiceEntitledFromCache()` 3분기로 재구성:

| 캐시 상태 | 기존 | 변경 |
|---|---|---|
| 응답 자체 없음(미조회·transient) | entitled (fail-open) | 동일 — 판단 불가로 강등 안 함 |
| 응답 있음 + `subscription: null` | **entitled (버그)** | 가족/커플 그룹 접근 있으면 유지, 없으면 **무권한 → 톤 강등** |
| 응답 있음 + 구독 있음 | 만료시각 검사 | 동일 |

## 판단 근거
- **가족/커플 멤버 보호**: 멤버는 본인 구독이 없어 `subscription: null` 이지만 그룹 접근으로 유료 목소리를 씀. 스냅샷의 `familyGroup` 으로 `hasCoupleOrFamilyAccess` 검사 — `PlanChangeSyncWorker` 의 genuinelyFree 판정과 동일 기준.
- **그룹 체크는 `subscription==null` 분기에만**: 조기 return 으로 전면 적용하면 stale 캐시의 만료된 family 소유자(plan=family + expiresAt 경과)가 만료 게이트를 우회하는 회귀가 생김.
- 강등돼도 알람은 기본 톤/진동/화면으로 계속 울림(무음화 없음).

## 검증
- `:app:compileDevDebugKotlin` BUILD SUCCESSFUL (기존 deprecation 경고만)