### PR TITLE
fix(billing): 해지로 반납한 클론에 evict 표식을 남겨 재구독 복구가 되게 (Codex #646)

### DIFF
--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -109,12 +109,18 @@ export async function deletePaidVoiceDataForUser(
 
 /**
  * 해지 즉시 '클론 목소리'만 반납한다 — 제공자(ElevenLabs) 보이스를 삭제 큐에 넣고
- * voice_profiles.elevenlabs_voice_id 를 비운다.
+ * voice_profiles 를 슬롯 상한 eviction 과 **같은 상태**로 만든다.
  *
  * 원본 업로드(voice_uploads)와 이미 만들어 둔 음성(generated_audio_assets)은 남긴다.
- * 유예 안에 다시 이용권을 등록하면 tts 경로의 recloneEvictedVoiceProfile 이 그 원본으로
- * 클론을 다시 만들어 주므로, 사용자에겐 목소리가 그대로 돌아온 것처럼 보인다.
- * 유예가 지나면 sweepPaidVoiceRetention 이 남은 원본·생성 음성까지 정리한다.
+ * 유예 안에 다시 이용권을 등록하면 tts 경로가 그 원본으로 클론을 다시 만들어 주므로,
+ * 사용자에겐 목소리가 그대로 돌아온 것처럼 보인다. 유예가 지나면 sweepPaidVoiceRetention
+ * 이 남은 원본·생성 음성까지 정리한다.
+ *
+ * 복구 경로가 요구하는 표식을 빠짐없이 남겨야 한다(voice-slots.ts 의 evict 와 동일):
+ *  - `evicted_at`: tts.ts 는 `elevenlabs_voice_id IS NULL` **이고** `evicted_at` 이 있을 때만
+ *    재클론·캐시프로브 경로를 탄다. 이걸 빼면 복구는커녕 NO_VOICE_ID 로 떨어진다.
+ *  - `evicted_provider_voice_id`: 캐시 키가 provider voice id 를 포함하므로, 옛 id 를 남겨
+ *    두면 보관 중인 오디오를 재클론 없이 그대로 서빙할 수 있다.
  */
 export async function releaseClonedVoicesForUser(
   db: DbExecutor,
@@ -132,12 +138,32 @@ export async function releaseClonedVoicesForUser(
   for (const row of voices.rows) {
     await enqueueExternalDeletion(db, 'elevenlabs_voice', row.elevenlabs_voice_id as string);
   }
-  // 비워 두면 다음 사용 시점에 재클론 경로가 자동으로 탄다(tts.ts 의 NO_VOICE_ID 폴백).
-  await db.execute({
-    sql: `UPDATE voice_profiles SET elevenlabs_voice_id = NULL, updated_at = datetime('now')
-          WHERE user_id IN (${ph}) AND elevenlabs_voice_id IS NOT NULL`,
-    args: ids,
-  });
+  // UPDATE 의 우변은 갱신 전 행 값으로 평가되므로(SQLite 의미론) 같은 문장에서 기존 id 를
+  // 안전하게 보관할 수 있다.
+  try {
+    await db.execute({
+      sql: `UPDATE voice_profiles
+            SET evicted_provider_voice_id = elevenlabs_voice_id,
+                elevenlabs_voice_id = NULL,
+                evicted_at = datetime('now'),
+                updated_at = datetime('now')
+            WHERE user_id IN (${ph}) AND elevenlabs_voice_id IS NOT NULL`,
+      args: ids,
+    });
+  } catch (err) {
+    // 배포 → 마이그레이션 순서라 #77 적용 전 짧은 창에서는 이 컬럼이 없다. 그 창에서 해지가
+    // 실패하지 않도록 구 스키마 폴백으로 반납 자체는 진행한다(캐시 프로브만 포기).
+    // evicted_at 은 이쪽에서도 반드시 찍는다 — 없으면 재클론 경로 자체가 막힌다.
+    if (!/no such column/i.test(String(err))) throw err;
+    await db.execute({
+      sql: `UPDATE voice_profiles
+            SET elevenlabs_voice_id = NULL,
+                evicted_at = datetime('now'),
+                updated_at = datetime('now')
+            WHERE user_id IN (${ph}) AND elevenlabs_voice_id IS NOT NULL`,
+      args: ids,
+    });
+  }
 }
 
 export async function deleteSensitiveVoiceDataForUser(

--- a/packages/backend/test/billing-cancel-play.test.ts
+++ b/packages/backend/test/billing-cancel-play.test.ts
@@ -31,6 +31,7 @@ import {
   processSubscriptionExpiry,
   sweepPaidVoiceRetention,
 } from '../src/lib/billing-cancel';
+import { releaseClonedVoicesForUser } from '../src/lib/paid-voice-cleanup';
 import { applyStoreEntitlement } from '../src/lib/store-billing';
 
 const PLAY_ENV = {
@@ -496,6 +497,48 @@ describe('cancelSubscriptionImmediate — plan 재정렬 (E2)', () => {
     expect(findCall("plan = 'free'")).toBeDefined();
     expect(findCall('UPDATE voice_profiles')).toBeDefined();
     expect(findCall('UPDATE alarms')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// releaseClonedVoicesForUser — 해지 즉시 클론만 반납하고, 복구 표식을 남긴다
+// ---------------------------------------------------------------------------
+describe('releaseClonedVoicesForUser (해지 시 클론 반납)', () => {
+  it('evicted_at 과 evicted_provider_voice_id 를 함께 남긴다 (재구독 복구 경로 조건)', async () => {
+    mockDB.pushResult([{ elevenlabs_voice_id: 'el-voice-1' }]); // 반납 대상 조회
+    mockDB.pushResult([], 1); // 제공자 보이스 삭제 큐 적재
+    mockDB.pushResult([], 1); // UPDATE voice_profiles
+
+    await releaseClonedVoicesForUser(mockDB.client as never, 'user-pk', 'login-id');
+
+    const update = findCall('UPDATE voice_profiles');
+    expect(update).toBeDefined();
+    // tts.ts 는 elevenlabs_voice_id IS NULL 이면서 evicted_at 이 있을 때만 재클론/캐시프로브
+    // 경로를 탄다. 셋 중 하나라도 빠지면 유예 안에 재구독해도 NO_VOICE_ID 로 떨어진다.
+    expect(update!.sql).toContain('elevenlabs_voice_id = NULL');
+    expect(update!.sql).toContain('evicted_at = ');
+    expect(update!.sql).toContain('evicted_provider_voice_id = elevenlabs_voice_id');
+    // 원본 업로드·생성 음성은 유예 동안 남는다(여기서 지우면 재클론할 원본이 사라진다).
+    expect(findCall('DELETE FROM voice_uploads')).toBeUndefined();
+    expect(findCall('DELETE FROM generated_audio_assets')).toBeUndefined();
+    // 제공자 보이스 자체는 즉시 반납한다.
+    const enqueued = findCall('INSERT OR IGNORE INTO pending_external_deletions');
+    expect(enqueued).toBeDefined();
+    expect(enqueued!.args).toContain('el-voice-1');
+  });
+
+  it('evicted_provider_voice_id 컬럼이 아직 없어도 evicted_at 은 찍고 반납을 마친다', async () => {
+    mockDB.pushResult([{ elevenlabs_voice_id: 'el-voice-1' }]); // 반납 대상 조회
+    mockDB.pushResult([], 1); // 제공자 보이스 삭제 큐 적재
+    mockDB.pushError(new Error('SQLITE_ERROR: no such column: evicted_provider_voice_id'));
+    mockDB.pushResult([], 1); // 구 스키마 폴백 UPDATE
+
+    await releaseClonedVoicesForUser(mockDB.client as never, 'user-pk', 'login-id');
+
+    const updates = mockDB.calls.filter((c) => c.sql.includes('UPDATE voice_profiles'));
+    const fallback = updates[updates.length - 1]!;
+    expect(fallback.sql).toContain('evicted_at = ');
+    expect(fallback.sql).not.toContain('evicted_provider_voice_id');
   });
 });
 

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -11,6 +11,9 @@ export interface MockExecuteResult {
   rowsAffected: number;
 }
 
+/** 결과 큐 항목 — 성공 결과이거나, 그 자리에서 던질 오류(pushError). */
+type MockQueueEntry = MockExecuteResult | { error: Error };
+
 export type ExecuteCall = { sql: string; args: (string | number | null)[] };
 
 /**
@@ -35,7 +38,7 @@ function assertBindingCount(query: { sql: string; args: unknown[] }) {
 
 export function createMockDB() {
   const calls: ExecuteCall[] = [];
-  const results: MockExecuteResult[] = [];
+  const results: MockQueueEntry[] = [];
   const transactions = {
     commits: 0,
     rollbacks: 0,
@@ -44,6 +47,23 @@ export function createMockDB() {
 
   function pushResult(rows: MockRow[] = [], rowsAffected = 0) {
     results.push({ rows, rowsAffected });
+  }
+
+  /**
+   * 다음 execute 를 성공 대신 이 오류로 실패시킨다 — 결과 큐와 같은 FIFO 자리를 차지한다.
+   * 구 스키마 폴백('no such column' 을 잡아 다른 SQL 로 재시도)처럼, 실패해야만 도달하는
+   * 분기를 검증하기 위한 것.
+   */
+  function pushError(error: Error) {
+    results.push({ error });
+  }
+
+  /** 큐에서 하나 꺼낸다 — 오류 항목이면 execute 가 실패한 것처럼 던진다. */
+  function takeNext(): MockExecuteResult {
+    const next = results.shift();
+    if (!next) return { rows: [], rowsAffected: 0 };
+    if ('error' in next) throw next.error;
+    return next;
   }
 
   function reset() {
@@ -88,7 +108,7 @@ export function createMockDB() {
       if (/FROM user_consents/i.test(query.sql)) {
         if (consentResultsAllowMissing) {
           calls.push({ sql: query.sql, args: query.args });
-          return results.shift() ?? { rows: [], rowsAffected: 0 };
+          return takeNext();
         }
         return {
           rows: CONSENT_TYPES_FOR_MOCK.map((t) => ({
@@ -107,7 +127,7 @@ export function createMockDB() {
         return { rows: [{ n: 0 }], rowsAffected: 0 };
       }
       calls.push({ sql: query.sql, args: query.args });
-      return results.shift() ?? { rows: [], rowsAffected: 0 };
+      return takeNext();
     },
     batch: async () => {},
     transaction: async () => {
@@ -135,7 +155,16 @@ export function createMockDB() {
     },
   };
 
-  return { client, calls, pushResult, reset, clearResults, transactions, setConsentMissing };
+  return {
+    client,
+    calls,
+    pushResult,
+    pushError,
+    reset,
+    clearResults,
+    transactions,
+    setConsentMissing,
+  };
 }
 
 /**


### PR DESCRIPTION
PR #646(develop → main) 에 달린 Codex P1 하나를 처리한다.

## 문제

해지 시 `releaseClonedVoicesForUser` 가 `elevenlabs_voice_id` 만 NULL 로 비우고 `evicted_at` 을
찍지 않았다. 그런데 `tts.ts` 는

```ts
const isEvictedWithoutVoice = !providerVoiceId && Boolean(vp.evicted_at);
```

처럼 **provider id 가 없고 `evicted_at` 이 있을 때만** 재클론·캐시프로브 경로를 탄다.
표식이 없으면 유예(3일) 안에 재구독해도 원본 업로드가 그대로 남아 있는데 복구가 시작되지
않고 `NO_VOICE_ID` 로 떨어진다 — 해지 안내에 적은 "그 안에 다시 등록하면 그대로 다시 쓸 수
있어요" 가 지켜지지 않는다.

## 수정

슬롯 상한 eviction(`voice-slots.ts`)과 **같은 상태**로 맞춘다.

- `evicted_provider_voice_id = elevenlabs_voice_id` — 캐시 키가 provider voice id 를 포함하므로,
  옛 id 를 남기면 보관 중인 오디오를 재클론 없이 그대로 서빙할 수 있다
- `evicted_at = datetime('now')` — 재클론 경로 진입 조건
- 마이그레이션 #77 미적용 창(배포 → 마이그레이션 순서)을 위한 구 스키마 폴백에서도
  `evicted_at` 은 반드시 찍는다. 폴백이 포기하는 건 캐시 프로브뿐

## 테스트

- 정상 경로: UPDATE 절에 세 조건이 모두 있고, 원본 업로드·생성 음성은 안 지우며,
  제공자 보이스는 삭제 큐에 적재되는지 단언
- 구 스키마 폴백: `no such column` 이후 재시도한 UPDATE 에 `evicted_at` 이 있고
  `evicted_provider_voice_id` 는 없는지 단언
- 실패 분기를 태우려고 목 DB 에 `pushError`(결과 큐와 같은 FIFO 자리에서 던짐) 추가

backend 1204 passed / 78 files, typecheck·lint 통과.
