### PR TITLE
chore(android): versionCode 19 / versionName 1.1.4

### DIFF
--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -100,9 +100,9 @@ android {
         minSdk = 26
         targetSdk = 36
         // 릴리스마다 수동으로 versionCode +1, versionName 갱신. (Play 는 업로드마다 더 큰
-        // versionCode 를 요구 — 이전 업로드값보다 반드시 크게.) 1.1.3 = 18, 다음 릴리스는 19.
-        versionCode = 18
-        versionName = "1.1.3"
+        // versionCode 를 요구 — 이전 업로드값보다 반드시 크게.) 1.1.4 = 19, 다음 릴리스는 20.
+        versionCode = 19
+        versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Play 업로드용 1.1.4 AAB 를 빌드하면서 올린 버전. 코드 변경 없음(버전 상수만).

- versionCode 18 → 19 (Play 는 업로드마다 더 큰 값을 요구)
- versionName 1.1.3 → 1.1.4

빌드 검증: `:app:bundleProdRelease` BUILD SUCCESSFUL, prodRelease BuildConfig 가
APPLICATION_ID=com.alarmtalk.app / VERSION_CODE=19 / VERSION_NAME=1.1.4 /
API=https://api.alarm-talk.com/api/ 로 나옴. AAB 는 릴리스 키(ALARMTAL)로 서명됨.