### PR TITLE
fix: 옛 반납 클론 evict 표식 백필 + 쓰는 중인 staging 스윕 제외 (Codex #646·#647 P2)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAudioStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmAudioStore.kt
@@ -609,8 +609,15 @@ class AlarmAudioStore(
         var deleted = 0
         audioDir.listFiles()?.forEach { file ->
             if (!file.isFile) return@forEach
-            // 쓰다 만 잔재는 나이와 무관하게 정리한다(다음 다운로드가 다시 받는다).
+            // 쓰다 만 잔재는 어떤 알람도 참조하지 않으니 TTL 을 기다리지 않고 정리한다
+            // (다음 다운로드가 다시 받는다). 단 '지금 쓰고 있는' staging 까지 지우면 그 쪽
+            // renameTo 가 실패해 프리페치나 알람 저장이 IOException("Failed to finalize
+            // cached audio")으로 죽는다 — 앱 시작 스윕은 StockClipPrefetchWorker·편집기
+            // 다운로드와 겹칠 수 있고, 워커는 별도 프로세스일 수 있어 키별 lock 으로도 못 막는다.
+            // 한 클립 쓰기는 순식간에 끝나므로 그보다 한참 긴 유예를 넘긴 것만 잔재로 본다.
             if (file.extension == PARTIAL_EXTENSION) {
+                val writtenAt = file.lastModified()
+                if (writtenAt <= 0L || writtenAt >= nowMillis - PARTIAL_STALE_AFTER_MILLIS) return@forEach
                 if (file.delete()) deleted += 1
                 return@forEach
             }
@@ -888,8 +895,15 @@ class AlarmAudioStore(
         private const val AUDIO_DIR = "alarm-audio"
         private const val META_EXTENSION = "meta"
 
-        /** 쓰기 도중 죽었을 때 남는 미완성 파일 확장자. sweep 이 나이와 무관하게 정리한다. */
+        /** 쓰기 도중 죽었을 때 남는 미완성 파일 확장자. sweep 이 [PARTIAL_STALE_AFTER_MILLIS] 뒤 정리한다. */
         private const val PARTIAL_EXTENSION = "part"
+
+        /**
+         * 이만큼 손대지 않은 .part 만 '쓰다 죽은 잔재'로 보고 스윕이 지운다.
+         * 정상 쓰기는 버퍼 한 번 flush 라 순식간에 끝나므로, 진행 중인 staging 을 지워
+         * renameTo 를 깨뜨리는 일이 없도록 넉넉히 잡은 값이다.
+         */
+        private const val PARTIAL_STALE_AFTER_MILLIS: Long = 60L * 60 * 1_000
 
         /**
          * 미리 내려받는 기본(시스템) 목소리 클립의 캐시 키 접두사.

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmAudioStoreSweepTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmAudioStoreSweepTest.kt
@@ -1,0 +1,90 @@
+package com.alarmtalk.app.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * 캐시 스윕이 '지금 쓰고 있는' staging(.part)까지 지우면 쓰던 쪽의 renameTo 가 실패해
+ * IOException("Failed to finalize cached audio")으로 프리페치나 알람 저장이 죽는다.
+ * 앱 시작 스윕은 StockClipPrefetchWorker·편집기 다운로드와 겹칠 수 있고, 워커는 별도
+ * 프로세스일 수 있어 키별 lock 으로도 못 막는다(Codex #646 P2).
+ *
+ * 갓 쓴 staging 은 살리고 죽어서 남은 잔재만 지우는지 고정한다.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AlarmAudioStoreSweepTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val store = AlarmAudioStore(context)
+
+    // AlarmAudioStore.AUDIO_DIR 과 같은 값(private 이라 여기서 직접 쓴다).
+    private val audioDir = File(context.filesDir, "alarm-audio").apply { mkdirs() }
+
+    private val now = System.currentTimeMillis()
+    private val oneHourMillis = 60L * 60 * 1_000
+
+    @Before
+    fun clearAudioDir() {
+        audioDir.listFiles()?.forEach { it.delete() }
+    }
+
+    /** cacheGeneratedAudioLocked 가 만드는 staging 이름 그대로: "<key>.<ext>.<nanos>.part" */
+    private fun staging(name: String) = File(audioDir, name).apply { writeBytes(ByteArray(16)) }
+
+    @Test
+    fun keepsPartialThatIsStillBeingWritten() {
+        val inFlight = staging("abc.mp3.123456789.part")
+
+        val deleted = store.sweepStaleCache(inUseFileNames = emptySet(), nowMillis = now)
+
+        assertTrue("쓰고 있는 staging 은 남아야 한다", inFlight.exists())
+        assertEquals(0, deleted)
+    }
+
+    @Test
+    fun sweepsPartialLeftBehindByACrash() {
+        val leftover = staging("abc.mp3.123456789.part")
+
+        // 파일을 만든 지 한참 뒤에 스윕이 돈 상황.
+        val deleted = store.sweepStaleCache(
+            inUseFileNames = emptySet(),
+            nowMillis = now + 2 * oneHourMillis,
+        )
+
+        assertFalse("죽어서 남은 잔재는 정리해야 한다", leftover.exists())
+        assertEquals(1, deleted)
+    }
+
+    @Test
+    fun sweepsStockStagingToo() {
+        // stock_ 접두사 예외는 '완성된 클립'을 오프라인 재생용으로 지키는 것이다.
+        // staging 은 재생할 수 없으니 그 예외에 걸리면 안 된다(.part 검사가 앞에 있어야 한다).
+        val leftover = staging("stock_abc.mp3.123456789.part")
+
+        store.sweepStaleCache(inUseFileNames = emptySet(), nowMillis = now + 2 * oneHourMillis)
+
+        assertFalse("완성 클립이 아닌 staging 은 stock 예외 대상이 아니다", leftover.exists())
+    }
+
+    @Test
+    fun keepsCompletedStockClipRegardlessOfAge() {
+        val clip = staging("stock_abc.mp3")
+
+        store.sweepStaleCache(
+            inUseFileNames = emptySet(),
+            maxAgeMillis = 0,
+            nowMillis = now + 365L * 24 * oneHourMillis,
+        )
+
+        assertTrue("미리 받아둔 기본 목소리 클립은 TTL 과 무관하게 남는다", clip.exists())
+    }
+}

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1835,6 +1835,39 @@ export const migrations: Migration[] = [
       `DROP TABLE IF EXISTS dub_jobs`,
     ],
   },
+  {
+    // Codex #647 P2: 이 수정 이전에 '해지로 반납된' 클론 행 복구.
+    //
+    // 옛 releaseClonedVoicesForUser 는 elevenlabs_voice_id 만 NULL 로 비우고 evicted_at 을
+    // 안 찍었다. tts.ts 의 복구 게이트는 `provider voice id 없음 AND evicted_at 있음` 이라,
+    // 그 행들은 3일 보관 안에 다시 구독해도 재클론 경로를 못 타고 NO_VOICE_ID 로 떨어진다 —
+    // 재클론에 쓸 원본(voice_uploads)은 멀쩡히 남아 있는데도. main 은 자동 배포라 이미
+    // 그 상태인 행이 dev/prod 에 남아 있을 수 있어 한 번 훑어 표식을 채운다.
+    // 옛 provider id 는 남아 있지 않으므로, 표식만 채우면 tts.ts 의 '프로브할 옛 id 가 없는
+    // evict 행' 분기가 곧바로 재클론한다(마이그레이션 76 이전 evict 분과 같은 취급).
+    //
+    // 대상은 세 조건으로 좁힌다 — 클론이 있던 적 없는 행이 잘못 되살아나지 않게:
+    //  - EXISTS voice_uploads: 재클론에 쓸 원본이 실제로 남아 있는 행만(원본 업로드가 없는
+    //    기본/시스템 목소리는 애초에 evict 대상이 아니다).
+    //  - status = 'ready': voice id 는 ready 로 전환될 때만 채워지므로, ready 인데 지금
+    //    비어 있다 = 나중에 누가 비웠다는 뜻. 진행 중(processing)·실패(failed: 슬롯 부족
+    //    회수분 등)은 되살리면 안 되는 행이라 제외한다.
+    //  - deleted_at IS NULL: 이미 지운 행 제외.
+    // 값은 실제 반납 시각인 updated_at 을 쓴다(그 UPDATE 가 이 행의 마지막 쓰기였다).
+    id: 86,
+    name: 'backfill-evicted-at-for-released-clones',
+    statements: [
+      `UPDATE voice_profiles
+          SET evicted_at = COALESCE(updated_at, datetime('now'))
+        WHERE elevenlabs_voice_id IS NULL
+          AND evicted_at IS NULL
+          AND deleted_at IS NULL
+          AND status = 'ready'
+          AND EXISTS (
+            SELECT 1 FROM voice_uploads vu WHERE vu.voice_profile_id = voice_profiles.id
+          )`,
+    ],
+  },
 ];
 
 // Errors that mean the statement was already applied — safe to ignore so

--- a/packages/backend/src/lib/migrations.ts
+++ b/packages/backend/src/lib/migrations.ts
@@ -1847,8 +1847,10 @@ export const migrations: Migration[] = [
     // evict 행' 분기가 곧바로 재클론한다(마이그레이션 76 이전 evict 분과 같은 취급).
     //
     // 대상은 세 조건으로 좁힌다 — 클론이 있던 적 없는 행이 잘못 되살아나지 않게:
-    //  - EXISTS voice_uploads: 재클론에 쓸 원본이 실제로 남아 있는 행만(원본 업로드가 없는
-    //    기본/시스템 목소리는 애초에 evict 대상이 아니다).
+    //  - EXISTS voice_uploads: 재클론에 쓸 원본이 실제로 남아 있는 행만.
+    //  - is_system = 0: 기본(시스템) 목소리는 애초에 evict/재클론 대상이 아니다. 지금은
+    //    원본 업로드가 없어 위 조건에도 안 걸리지만, 슬롯 카운트·LRU 후보 쿼리와 같은
+    //    가드를 함께 둬서 시드 방식이 바뀌어도 딸려오지 않게 한다(voice-slots.ts 와 동일).
     //  - status = 'ready': voice id 는 ready 로 전환될 때만 채워지므로, ready 인데 지금
     //    비어 있다 = 나중에 누가 비웠다는 뜻. 진행 중(processing)·실패(failed: 슬롯 부족
     //    회수분 등)은 되살리면 안 되는 행이라 제외한다.
@@ -1863,6 +1865,7 @@ export const migrations: Migration[] = [
           AND evicted_at IS NULL
           AND deleted_at IS NULL
           AND status = 'ready'
+          AND COALESCE(is_system, 0) = 0
           AND EXISTS (
             SELECT 1 FROM voice_uploads vu WHERE vu.voice_profile_id = voice_profiles.id
           )`,

--- a/packages/backend/test/migrations-evicted-backfill.test.ts
+++ b/packages/backend/test/migrations-evicted-backfill.test.ts
@@ -1,0 +1,141 @@
+// #86 백필 회귀 가드 (Codex #647 P2).
+//
+// #647 이전의 '해지 시 클론 반납'은 elevenlabs_voice_id 만 비우고 evicted_at 을 안 남겼다.
+// tts.ts 의 복구 게이트가 `voice id 없음 AND evicted_at 있음` 이라, 그 행들은 3일 보관 안에
+// 다시 구독해도 재클론 경로를 못 타고 NO_VOICE_ID 로 떨어진다 — 재클론에 쓸 원본은 남아 있는데도.
+//
+// 문자열 매칭이 아니라 실제 SQLite 에 행을 심고 결과 상태로 검증한다. 조건이 하나만 어긋나도
+// '클론이 있던 적 없는 행'이 evict 로 표시돼 애먼 재클론이 돌기 때문이다.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient, type Client } from '@libsql/client';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { runMigrationsRange } from '../src/lib/migrations';
+
+const DB_PATH = join(tmpdir(), `alarmtalk-evicted-backfill-${process.pid}.db`);
+const RELEASED_AT = '2026-07-20 00:00:00';
+let db: Client;
+
+/** 프로필 1개 + (원하면) 그 프로필에 연결된 원본 업로드 1개를 심는다. */
+async function seedProfile(opts: {
+  id: string;
+  status: 'ready' | 'processing' | 'failed';
+  voiceId: string | null;
+  evictedAt?: string | null;
+  deletedAt?: string | null;
+  withUpload: boolean;
+}) {
+  await db.execute({
+    sql: `INSERT INTO voice_profiles
+            (id, user_id, name, elevenlabs_voice_id, status, evicted_at, deleted_at, updated_at)
+          VALUES (?, 'u-1', ?, ?, ?, ?, ?, ?)`,
+    args: [
+      opts.id,
+      opts.id,
+      opts.voiceId,
+      opts.status,
+      opts.evictedAt ?? null,
+      opts.deletedAt ?? null,
+      RELEASED_AT,
+    ],
+  });
+  if (opts.withUpload) {
+    await db.execute({
+      sql: `INSERT INTO voice_uploads
+              (id, user_id, object_key, mime_type, size_bytes, voice_profile_id)
+            VALUES (?, 'u-1', ?, 'audio/mp4', 1000, ?)`,
+      args: [`up-${opts.id}`, `voices/${opts.id}.m4a`, opts.id],
+    });
+  }
+}
+
+async function evictedAtOf(id: string): Promise<string | null> {
+  const r = await db.execute({
+    sql: 'SELECT evicted_at FROM voice_profiles WHERE id = ?',
+    args: [id],
+  });
+  return (r.rows[0]?.evicted_at as string | null) ?? null;
+}
+
+beforeAll(async () => {
+  for (const suffix of ['', '-shm', '-wal']) rmSync(`${DB_PATH}${suffix}`, { force: true });
+  db = createClient({ url: `file:${DB_PATH}` });
+
+  // 백필 직전 상태까지만 적용해 두고 대상 행을 심는다.
+  await runMigrationsRange(db, 1, 85);
+  await db.execute(`INSERT INTO users (id, google_id, email) VALUES ('u-1', 'g-1', 'u1@test.com')`);
+
+  // 백필 대상: 해지로 반납된 행(ready + 원본 있음 + voice id 도 표식도 없음).
+  await seedProfile({ id: 'released', status: 'ready', voiceId: null, withUpload: true });
+  // 제외 대상들.
+  await seedProfile({ id: 'active', status: 'ready', voiceId: 'el-1', withUpload: true });
+  await seedProfile({ id: 'no-upload', status: 'ready', voiceId: null, withUpload: false });
+  await seedProfile({ id: 'processing', status: 'processing', voiceId: null, withUpload: true });
+  await seedProfile({ id: 'failed', status: 'failed', voiceId: null, withUpload: true });
+  await seedProfile({
+    id: 'deleted',
+    status: 'ready',
+    voiceId: null,
+    deletedAt: '2026-07-01 00:00:00',
+    withUpload: true,
+  });
+  await seedProfile({
+    id: 'already-evicted',
+    status: 'ready',
+    voiceId: null,
+    evictedAt: '2026-07-10 00:00:00',
+    withUpload: true,
+  });
+
+  await runMigrationsRange(db, 86, 86);
+});
+
+afterAll(() => {
+  db?.close();
+  // Windows 는 close 직후에도 핸들이 남아 EPERM 이 난다. 임시 파일이라 남아도 무해하고,
+  // 다음 실행의 beforeAll 이 어차피 지운다(schema-fresh.test.ts 와 같은 방식).
+  for (const suffix of ['', '-shm', '-wal']) {
+    try {
+      rmSync(`${DB_PATH}${suffix}`, { force: true });
+    } catch {
+      /* 무시 */
+    }
+  }
+});
+
+describe('#86 해지로 반납된 클론에 evicted_at 백필', () => {
+  it('원본이 남아 있는 반납 행에 표식을 채운다 — 재구독 시 재클론이 돈다', async () => {
+    // 값은 실제 반납 시각(updated_at)이어야 한다.
+    expect(await evictedAtOf('released')).toBe(RELEASED_AT);
+  });
+
+  it('클론이 살아 있는 행은 건드리지 않는다', async () => {
+    expect(await evictedAtOf('active')).toBeNull();
+  });
+
+  it('재클론에 쓸 원본이 없으면 표식을 찍지 않는다 (기본/시스템 목소리 보호)', async () => {
+    expect(await evictedAtOf('no-upload')).toBeNull();
+  });
+
+  it('진행 중·실패 프로필은 되살리지 않는다', async () => {
+    expect(await evictedAtOf('processing')).toBeNull();
+    expect(await evictedAtOf('failed')).toBeNull();
+  });
+
+  it('이미 지운 행은 건드리지 않는다', async () => {
+    expect(await evictedAtOf('deleted')).toBeNull();
+  });
+
+  it('기존 evict 표식을 덮어쓰지 않는다', async () => {
+    expect(await evictedAtOf('already-evicted')).toBe('2026-07-10 00:00:00');
+  });
+
+  it('재실행해도 아무것도 바뀌지 않는다 (원장 밖에서 다시 돌려도 안전)', async () => {
+    const before = await db.execute('SELECT id, evicted_at FROM voice_profiles ORDER BY id');
+    await db.execute({ sql: 'DELETE FROM _migrations WHERE id = ?', args: [86] });
+    await runMigrationsRange(db, 86, 86);
+    const after = await db.execute('SELECT id, evicted_at FROM voice_profiles ORDER BY id');
+    expect(after.rows).toEqual(before.rows);
+  });
+});

--- a/packages/backend/test/migrations-evicted-backfill.test.ts
+++ b/packages/backend/test/migrations-evicted-backfill.test.ts
@@ -24,12 +24,14 @@ async function seedProfile(opts: {
   voiceId: string | null;
   evictedAt?: string | null;
   deletedAt?: string | null;
+  isSystem?: boolean;
   withUpload: boolean;
 }) {
   await db.execute({
     sql: `INSERT INTO voice_profiles
-            (id, user_id, name, elevenlabs_voice_id, status, evicted_at, deleted_at, updated_at)
-          VALUES (?, 'u-1', ?, ?, ?, ?, ?, ?)`,
+            (id, user_id, name, elevenlabs_voice_id, status, evicted_at, deleted_at,
+             is_system, updated_at)
+          VALUES (?, 'u-1', ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       opts.id,
       opts.id,
@@ -37,6 +39,7 @@ async function seedProfile(opts: {
       opts.status,
       opts.evictedAt ?? null,
       opts.deletedAt ?? null,
+      opts.isSystem ? 1 : 0,
       RELEASED_AT,
     ],
   });
@@ -87,6 +90,14 @@ beforeAll(async () => {
     evictedAt: '2026-07-10 00:00:00',
     withUpload: true,
   });
+  // 다른 조건은 전부 통과하지만 기본(시스템) 목소리인 행 — is_system 가드만 남는 경우.
+  await seedProfile({
+    id: 'system',
+    status: 'ready',
+    voiceId: null,
+    isSystem: true,
+    withUpload: true,
+  });
 
   await runMigrationsRange(db, 86, 86);
 });
@@ -114,8 +125,12 @@ describe('#86 해지로 반납된 클론에 evicted_at 백필', () => {
     expect(await evictedAtOf('active')).toBeNull();
   });
 
-  it('재클론에 쓸 원본이 없으면 표식을 찍지 않는다 (기본/시스템 목소리 보호)', async () => {
+  it('재클론에 쓸 원본이 없으면 표식을 찍지 않는다', async () => {
     expect(await evictedAtOf('no-upload')).toBeNull();
+  });
+
+  it('기본(시스템) 목소리는 다른 조건을 다 만족해도 제외한다', async () => {
+    expect(await evictedAtOf('system')).toBeNull();
   });
 
   it('진행 중·실패 프로필은 되살리지 않는다', async () => {


### PR DESCRIPTION
Codex 가 #646 / #647 에 남긴 P2 두 건을 해결한다.

## 1. 해지로 반납된 옛 클론 행 백필 (Codex #647 P2)

#647 이전의 `releaseClonedVoicesForUser` 는 `elevenlabs_voice_id` 만 비우고 `evicted_at` 을
안 남겼다. `tts.ts` 의 복구 게이트는 `provider voice id 없음 AND evicted_at 있음` 이라,
그런 행은 3일 보관 안에 다시 구독해도 재클론 경로를 못 타고 `NO_VOICE_ID` 로 떨어진다 —
재클론에 쓸 원본(`voice_uploads`)은 멀쩡히 남아 있는데도.

마이그레이션 **#86** 이 그 행에만 표식을 채운다. 옛 provider id 는 남아 있지 않으므로,
표식만 채우면 `tts.ts` 의 *'프로브할 옛 id 가 없는 evict 행'* 분기가 곧바로 재클론한다
(마이그레이션 76 이전 evict 분과 같은 취급이라 새 경로가 아니다).

대상은 네 조건으로 좁혔다 — 클론이 있던 적 없는 행이 잘못 되살아나지 않게:

| 조건 | 막는 것 |
|---|---|
| `EXISTS voice_uploads` | 재클론에 쓸 원본이 없는 행 |
| `COALESCE(is_system,0)=0` | 기본(시스템) 목소리 |
| `status='ready'` | 진행 중(`processing`)·실패(`failed`, 슬롯 부족 회수분) |
| `deleted_at IS NULL` | 이미 지운 행 |

값은 실제 반납 시각인 `updated_at` 을 쓴다.

### 실제 영향 범위 — 지금은 0행

읽기 전용으로 두 DB 를 확인했다.

| | 원장 max id | voice_profiles | 백필 대상 | 클론 살아있음 |
|---|---|---|---|---|
| dev | 85 | 20 | **0** | 20 |
| prod | 78 | 6 | **0** | 6 |

`releaseClonedVoicesForUser` 를 도입한 `7be7305d` 이 아직 `main` 에 없어 **prod 는 옛 구현을
돌린 적이 없고**, dev 도 현재 해당 행이 0이다. 즉 이 마이그레이션은 지금은 no-op 인
안전망이다. 그래도 넣는 이유는 (a) 멱등한 UPDATE 한 번이라 비용이 없고, (b) 배포 전파 지연
창에서 옛 번들이 잠깐 더 서빙되는 상황이 이 저장소에서 실제로 관측됐으며, (c) 딸려오는
테스트가 *"어떤 행이 복구 가능한가"* 라는 불변식을 고정해 준다.

## 2. 쓰는 중인 staging(`.part`)을 캐시 스윕에서 살린다 (Codex #646 P2)

`sweepStaleCache` 가 `.part` 를 나이와 무관하게 지웠다. 앱 시작 스윕은
`StockClipPrefetchWorker`·편집기 다운로드와 겹칠 수 있고, **워커는 별도 프로세스일 수 있어
키별 lock 으로도 못 막는다**. 그 사이 staging 이 지워지면 `cacheGeneratedAudioLocked` 의
`renameTo` 가 실패하고, target 도 없으니 `IOException("Failed to finalize cached audio")` 로
프리페치가 밀리거나 알람 저장이 죽는다.

정상 쓰기는 버퍼 한 번 flush 라 순식간에 끝나므로 **1시간**을 넘긴 `.part` 만 '쓰다 죽은
잔재'로 보고 지운다. 타임스탬프를 못 읽는 파일은 완성 파일 분기와 같은 규칙으로 보존한다.

## 테스트

- `packages/backend/test/migrations-evicted-backfill.test.ts` (신규, 8건) — 실제 SQLite 에
  1~85 를 적용하고 대상/제외 행 8종을 심어 #86 결과를 **행 상태로** 검증한다. 문자열
  매칭이면 술어가 어긋나도 통과하기 때문. 재실행 멱등도 함께.
- `apps/android-native/.../AlarmAudioStoreSweepTest.kt` (신규, Robolectric 4건) — 갓 쓴
  staging 보존 / 오래된 잔재 정리 / `stock_` 예외가 staging 에는 적용되지 않음(= `.part`
  검사가 앞에 있어야 함) / 완성된 stock 클립은 TTL 무관 보존.
- 백엔드 전체 `npm test` 79파일 1211건 통과, `npm run typecheck` 통과.
- `:app:testDevDebugUnitTest` 통과.

## 참고 — prod 원장이 78 에 멈춰 있다

위 표에서 확인된 별건이다. #646(develop → main)이 머지되면 prod 에 79~86 이 한 번에
적용돼야 한다. 배포 워크플로가 "already applied" 로 조용히 넘길 수 있는 알려진 구멍이
있으므로(dev 에서 80~85 가 실제로 그렇게 건너뛰어졌다), 머지 후 prod 원장이 86 까지
올라갔는지 직접 확인이 필요하다.
