### PR TITLE
fix(android): 로그인 직후 알람 목록이 비어 보이던 문제 (세션 흐름 emission 유실)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
@@ -7,6 +7,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
 import java.util.Base64
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,13 @@ data class AuthSession(
  * SharedPreferences 변경 리스너를 쓰는 이유: 로그인·로그아웃이 어느 코드 경로를 타든
  * 결국 이 prefs 를 거치므로, 호출부가 "세션 바뀌었다"고 따로 알려 줄 필요가 없다.
  * 알람 목록 필터처럼 계정이 바뀌는 즉시 다시 계산돼야 하는 곳에서 쓴다.
+ *
+ * conflate 가 필요한 이유: callbackFlow 의 기본 채널은 랑데뷰(용량 0)라 수집자가 그 순간
+ * 받을 준비가 안 돼 있으면 trySend 가 **조용히 실패**한다. 로그인은 prefs 키를 한 번에
+ * 여러 개 쓰므로 리스너가 연달아 불리는데, 그 사이 수집자(알람 목록 combine)가 바쁘면
+ * 새 계정 id 가 전부 버려진다. 그러면 목록 필터가 로그아웃 시점 값(null)에 머물러
+ * '로그인했는데 내 알람이 하나도 안 보이는' 상태가 되고, 앱을 껐다 켜야 돌아온다
+ * (실기기에서 401 → 재로그인 중 재현). 최신값만 있으면 되는 흐름이라 conflate 로 충분하다.
  */
 fun AuthSessionStore.observeUserId(): Flow<String?> = callbackFlow {
     trySend(read()?.user?.id)
@@ -34,7 +42,7 @@ fun AuthSessionStore.observeUserId(): Flow<String?> = callbackFlow {
     }
     registerChangeListener(listener)
     awaitClose { unregisterChangeListener(listener) }
-}.distinctUntilChanged()
+}.conflate().distinctUntilChanged()
 
 class AuthSessionStore(context: Context) {
     private val prefs: SharedPreferences = run {

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/network/AuthSessionStore.kt
@@ -7,7 +7,6 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.alarmtalk.app.core.AlarmTalkLog.TAG
 import java.util.Base64
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.Flow
@@ -22,27 +21,38 @@ data class AuthSession(
 )
 
 /**
+ * prefs 변경을 흘리는 공통 뼈대 — 리스너를 **먼저** 걸고 그다음에 스냅샷을 읽는다.
+ *
+ * 순서가 핵심이다. 스냅샷을 먼저 읽으면 `read()` 와 `register()` 사이에 커밋된 변경을
+ * 아무도 못 본다: 리스너가 아직 없어 콜백이 안 오고, 이미 읽은 스냅샷은 옛 값이다. 로그인
+ * 직후 목록이 수집을 새로 시작하는 순간과 겹치면 계정 id 가 로그아웃 시점 값(null)에 머물러
+ * '로그인은 됐는데 내 알람이 하나도 안 보이는' 상태가 된다(앱을 껐다 켜야 돌아온다).
+ * 먼저 걸어 두면 그 구간의 변경도 콜백으로 잡히고, 스냅샷과 겹쳐 중복 방출되더라도
+ * [distinctUntilChanged] 가 접는다.
+ *
+ * 등록 자체를 놓치는 것과 달리 채널 용량은 문제가 아니다 — callbackFlow 의 기본 용량은
+ * 랑데뷰가 아니라 BUFFERED(64) 라, 이 정도 변경 수로는 trySend 가 실패하지 않는다.
+ */
+internal fun <T> prefsSnapshotFlow(
+    register: (SharedPreferences.OnSharedPreferenceChangeListener) -> Unit,
+    unregister: (SharedPreferences.OnSharedPreferenceChangeListener) -> Unit,
+    read: () -> T,
+): Flow<T> = callbackFlow {
+    val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ -> trySend(read()) }
+    register(listener)
+    trySend(read())
+    awaitClose { unregister(listener) }
+}.distinctUntilChanged()
+
+/**
  * 지금 로그인한 계정의 users.id 를 흘린다(비로그인 null).
  *
  * SharedPreferences 변경 리스너를 쓰는 이유: 로그인·로그아웃이 어느 코드 경로를 타든
  * 결국 이 prefs 를 거치므로, 호출부가 "세션 바뀌었다"고 따로 알려 줄 필요가 없다.
  * 알람 목록 필터처럼 계정이 바뀌는 즉시 다시 계산돼야 하는 곳에서 쓴다.
- *
- * conflate 가 필요한 이유: callbackFlow 의 기본 채널은 랑데뷰(용량 0)라 수집자가 그 순간
- * 받을 준비가 안 돼 있으면 trySend 가 **조용히 실패**한다. 로그인은 prefs 키를 한 번에
- * 여러 개 쓰므로 리스너가 연달아 불리는데, 그 사이 수집자(알람 목록 combine)가 바쁘면
- * 새 계정 id 가 전부 버려진다. 그러면 목록 필터가 로그아웃 시점 값(null)에 머물러
- * '로그인했는데 내 알람이 하나도 안 보이는' 상태가 되고, 앱을 껐다 켜야 돌아온다
- * (실기기에서 401 → 재로그인 중 재현). 최신값만 있으면 되는 흐름이라 conflate 로 충분하다.
  */
-fun AuthSessionStore.observeUserId(): Flow<String?> = callbackFlow {
-    trySend(read()?.user?.id)
-    val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
-        trySend(read()?.user?.id)
-    }
-    registerChangeListener(listener)
-    awaitClose { unregisterChangeListener(listener) }
-}.conflate().distinctUntilChanged()
+fun AuthSessionStore.observeUserId(): Flow<String?> =
+    prefsSnapshotFlow(::registerChangeListener, ::unregisterChangeListener) { read()?.user?.id }
 
 class AuthSessionStore(context: Context) {
     private val prefs: SharedPreferences = run {

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/network/PrefsSnapshotFlowTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/network/PrefsSnapshotFlowTest.kt
@@ -1,0 +1,85 @@
+package com.alarmtalk.app.network
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * 세션 흐름은 리스너를 **먼저** 걸고 스냅샷을 읽어야 한다.
+ *
+ * 순서를 뒤집으면 read() 와 등록 사이에 커밋된 로그인/로그아웃을 아무도 못 본다 — 리스너가
+ * 아직 없어 콜백이 안 오고, 이미 읽은 스냅샷은 옛 값이다. 그러면 알람 목록 필터가 로그아웃
+ * 시점 값에 머물러 '로그인은 됐는데 알람이 하나도 안 보이는' 상태가 된다(Codex #651).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PrefsSnapshotFlowTest {
+
+    private fun collectOn(scope: CoroutineScope) = scope
+
+    @Test
+    fun snapshotIsReadAfterTheListenerIsRegistered() = runBlocking {
+        var value = "signed-out"
+        // 등록이 일어나는 그 순간 로그인이 커밋된 상황.
+        val flow = prefsSnapshotFlow(
+            register = { value = "signed-in" },
+            unregister = {},
+            read = { value },
+        )
+
+        // 스냅샷을 먼저 읽는 구현이면 "signed-out" 이 나오고, 리스너가 없던 사이의 변경이라
+        // 뒤이은 콜백도 없어 영영 로그인 상태를 못 본다.
+        assertEquals("signed-in", flow.first())
+    }
+
+    @Test
+    fun changesAfterRegistrationAreDelivered() = runBlocking {
+        var value = "signed-out"
+        var listener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+        val flow = prefsSnapshotFlow(
+            register = { listener = it },
+            unregister = { listener = null },
+            read = { value },
+        )
+
+        val collected = mutableListOf<String>()
+        val job = collectOn(CoroutineScope(Dispatchers.Unconfined)).launch {
+            flow.take(2).toList(collected)
+        }
+        value = "signed-in"
+        listener?.onSharedPreferenceChanged(null, null)
+        job.join()
+
+        assertEquals(listOf("signed-out", "signed-in"), collected)
+    }
+
+    @Test
+    fun duplicateSnapshotsAreCollapsed() = runBlocking {
+        var listener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+        val flow = prefsSnapshotFlow(
+            register = { listener = it },
+            unregister = { listener = null },
+            read = { "same" },
+        )
+
+        val collected = mutableListOf<String>()
+        val job = collectOn(CoroutineScope(Dispatchers.Unconfined)).launch {
+            flow.take(1).toList(collected)
+        }
+        // 로그인은 prefs 키를 여러 개 쓰므로 콜백이 연달아 온다 — 같은 값은 한 번만 흘러야 한다.
+        repeat(5) { listener?.onSharedPreferenceChanged(null, null) }
+        job.join()
+
+        assertEquals(listOf("same"), collected)
+    }
+}


### PR DESCRIPTION
#650 실기기 검증 중 발견한 **별건 버그**다. #650 과 무관하며(그 브랜치 이전부터 있던 코드),
develop 기준으로 따로 올린다.

## 증상

로그인은 성공했는데 **알람 목록이 "알람이 없습니다"로 비어 보인다.** 앱을 껐다 켜면 돌아온다.
DB 행·소유자·예약은 전부 멀쩡하다 — 표시 계층만 어긋난다.

실기기(Galaxy A32)에서 401 → 재로그인 도중 재현했다. **타이밍 의존이라 매번 나지는 않는다**
(같은 빌드로 같은 절차를 반복하면 정상인 경우가 더 많다).

## 원인

```kotlin
fun AuthSessionStore.observeUserId(): Flow<String?> = callbackFlow {
    trySend(read()?.user?.id)
    val listener = OnSharedPreferenceChangeListener { _, _ -> trySend(read()?.user?.id) }
    ...
}.distinctUntilChanged()
```

`callbackFlow` 의 기본 채널은 **랑데뷰(용량 0)**다. `trySend` 는 수집자가 그 순간 받을 준비가
안 돼 있으면 **조용히 실패**한다(예외도, 로그도 없다).

로그인은 `save()` 가 prefs 키를 한 번에 여러 개 쓰므로 리스너가 연달아 불린다. 그 사이
수집자 — `observeAlarms()` 의 `combine(alarmDao.observeAlarms(), currentUserIdFlow)` — 가
바쁘면 새 계정 id 가 전부 버려진다.

그러면 combine 이 **로그아웃 시점 값(null)** 을 계속 쓰고, 필터가

```kotlin
alarms.filter { it.ownerUserId == null || it.ownerUserId == currentUser }
```

이므로 **소유자가 기록된 알람이 전부 걸러진다** → 빈 목록. 앱을 재시작하면 구독 시작 시점의
`trySend` 는 수집자가 대기 중이라 성공하므로 정상으로 돌아온다.

## 수정

```diff
-}.distinctUntilChanged()
+}.conflate().distinctUntilChanged()
```

최신값만 필요한 흐름이라 conflate 로 충분하다. 채널에 여유가 생겨 `trySend` 가 더는 실패하지
않고, 중간값이 합쳐져도 마지막 계정 id 는 반드시 전달된다.

## 검증

- 실기기(A32)에서 401 → 재로그인 사이클로 목록이 정상 표시되는 것 확인.
- 원인 규명 과정에서 develop 빌드와 이 브랜치 빌드를 번갈아 설치해, DB 행(`ownerUserId`)과
  예약(`Boot restore ... scheduled=N`)은 양쪽 다 정상이고 **화면만 어긋난다**는 것을 확인했다.
- `:app:assembleDevDebug` + `:app:testDevDebugUnitTest` 통과.

## 남은 한계

타이밍 의존이라 "고쳤다"를 재현 테스트로 증명하기는 어렵다. 근거는 채널 의미론이다 —
랑데뷰에서 `trySend` 는 실패할 수 있고 conflate 에서는 실패하지 않는다. 같은 패턴이 다른
곳에도 있으면 함께 봐야 한다(현재 저장소에서 `callbackFlow` 는 이 한 곳뿐).
