### PR TITLE
fix(android): 알람 편집기에서 공유받은 목소리 미리듣기가 동작하게 (Codex #646)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/editor/AlarmEditorScreen.kt
@@ -1223,10 +1223,11 @@ internal fun AlarmEditorScreen(
                             editor = editor,
                                 voiceProfiles = visibleVoiceProfiles,
                                 familyVoices = familyVoices,
-                                onPreviewVoice = { voiceId ->
-                                    val profile = visibleVoiceProfiles.firstOrNull { it.id == voiceId }
-                                    if (profile != null) voicePreview.previewVoice(profile, stockClips)
-                                },
+                                // 선택 시트에는 내 목소리와 공유받은 목소리가 섞여 있는데, 공유분은
+                                // visibleVoiceProfiles 에 없고 familyVoices 에만 있다. 여기서 내 목록만
+                                // 뒤지면 공유 목소리 ▶ 가 조용히 아무것도 안 한다 — 미리듣기는 id 로
+                                // 인사말 클립을 찾으므로 id 를 그대로 넘겨 둘 다 같은 경로를 타게 한다.
+                                onPreviewVoice = { voiceId -> voicePreview.previewVoice(voiceId, stockClips) },
                                 previewPlayingVoiceId = voicePreview.playingVoiceId,
                                 previewPreparingVoiceId = voicePreview.preparingVoiceId,
                                 voiceProfileBusy = voiceProfileBusy,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/VoiceOnboardingPreviewState.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/onboarding/VoiceOnboardingPreviewState.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import com.alarmtalk.app.network.StockClip
 import com.alarmtalk.app.network.TtsMessageAudioResponse
-import com.alarmtalk.app.network.VoiceProfile
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,8 +43,16 @@ internal class VoiceOnboardingPreviewController(
         preparingVoiceId = null
     }
 
-    fun previewVoice(profile: VoiceProfile, stockClips: List<StockClip>) {
-        if (playingVoiceId == profile.id) {
+    /**
+     * 인사말 미리듣기. 프로필 객체가 아니라 **id** 를 받는다 — 내 목소리(VoiceProfile)와
+     * 공유받은 목소리(FamilyVoiceProfile)는 타입이 다르고 각각 다른 목록에 들어 있는데,
+     * 여기서 필요한 건 id 뿐이라 id 로 받아야 둘 다 같은 경로를 탄다. 알람 편집기의 선택
+     * 시트는 두 종류를 한 목록에 섞어 보여 준다(Codex #646).
+     *
+     * 모르는 id 면 인사말 클립을 못 찾아 조용히 아무것도 하지 않는다.
+     */
+    fun previewVoice(voiceProfileId: String, stockClips: List<StockClip>) {
+        if (playingVoiceId == voiceProfileId) {
             stopPreview()
             return
         }
@@ -56,30 +63,30 @@ internal class VoiceOnboardingPreviewController(
         )
         // 기본 목소리는 내장 인사말(res/raw)을 즉시 재생 — 스톡 매니페스트가 아직 안 왔거나
         // 네트워크가 없어도 '눌렀는데 아무 소리 없음'이 되지 않는다.
-        val bundledRes = com.alarmtalk.app.data.bundledSystemGreetingRes(profile.id, appLanguage)
+        val bundledRes = com.alarmtalk.app.data.bundledSystemGreetingRes(voiceProfileId, appLanguage)
         if (bundledRes != null) {
             previewRequestId += 1
             stopPreview(invalidateRequest = false)
             val player = MediaPlayer.create(context, bundledRes) ?: return
-            playingVoiceId = profile.id
+            playingVoiceId = voiceProfileId
             mediaPlayer = player.apply {
                 setOnCompletionListener {
                     it.release()
                     if (mediaPlayer === it) mediaPlayer = null
-                    if (playingVoiceId == profile.id) playingVoiceId = null
+                    if (playingVoiceId == voiceProfileId) playingVoiceId = null
                 }
                 start()
             }
             return
         }
-        val clip = com.alarmtalk.app.data.greetingStockClipFor(stockClips, profile.id, appLanguage)
+        val clip = com.alarmtalk.app.data.greetingStockClipFor(stockClips, voiceProfileId, appLanguage)
             ?: return
 
         val requestId = previewRequestId + 1
         previewRequestId = requestId
         scope.launch {
             stopPreview(invalidateRequest = false)
-            preparingVoiceId = profile.id
+            preparingVoiceId = voiceProfileId
             runCatching {
                 val response = downloadStockAudio(clip.messageId)
                 val file = withContext(Dispatchers.IO) {
@@ -94,19 +101,19 @@ internal class VoiceOnboardingPreviewController(
                     return@runCatching
                 }
                 preparingVoiceId = null
-                playingVoiceId = profile.id
+                playingVoiceId = voiceProfileId
                 mediaPlayer = player.apply {
                     setOnCompletionListener {
                         it.release()
                         if (mediaPlayer === it) mediaPlayer = null
-                        if (playingVoiceId == profile.id) playingVoiceId = null
+                        if (playingVoiceId == voiceProfileId) playingVoiceId = null
                     }
                     start()
                 }
             }.onFailure {
                 if (previewRequestId == requestId) {
                     preparingVoiceId = null
-                    if (playingVoiceId == profile.id) playingVoiceId = null
+                    if (playingVoiceId == voiceProfileId) playingVoiceId = null
                 }
             }
         }


### PR DESCRIPTION
#646 에 달린 Codex P2 를 해결한다. (#646 은 develop → main 이므로 develop 에 올린다.)

## 증상

알람 편집기의 **목소리 선택 시트에서 '공유받은 목소리'의 ▶ 를 눌러도 아무 일도 일어나지 않는다.**
내 목소리와 기본 목소리는 정상 재생된다.

## 원인

시트는 내 목소리와 공유받은 목소리를 **한 목록에 섞어** 보여 준다(`VoiceAudioCard` 의
`profileOptions = readyOwnProfiles + readyFamilyVoices`). 그런데 ▶ 콜백이 내 목록만 뒤졌다:

```kotlin
onPreviewVoice = { voiceId ->
    val profile = visibleVoiceProfiles.firstOrNull { it.id == voiceId }   // 공유분은 여기 없음
    if (profile != null) voicePreview.previewVoice(profile, stockClips)   // → 항상 null → no-op
},
```

공유받은 목소리는 `familyVoices`(타입도 `FamilyVoiceProfile` 로 다름)에만 있어 `firstOrNull` 이
늘 null 이었다. 실패 로그도 안 남아 '눌렀는데 아무 반응 없음'으로만 보인다.

## 수정

`previewVoice` 는 내부에서 **`profile.id` 만** 쓴다 — 인사말 클립을 id 로 찾고
(`greetingStockClipFor`), 기본 목소리 내장 인사말도 id 로 찾는다(`bundledSystemGreetingRes`).
그래서 인자를 프로필 객체 대신 **id** 로 바꿨다.

```diff
-fun previewVoice(profile: VoiceProfile, stockClips: List<StockClip>)
+fun previewVoice(voiceProfileId: String, stockClips: List<StockClip>)
```

```diff
-onPreviewVoice = { voiceId ->
-    val profile = visibleVoiceProfiles.firstOrNull { it.id == voiceId }
-    if (profile != null) voicePreview.previewVoice(profile, stockClips)
-},
+onPreviewVoice = { voiceId -> voicePreview.previewVoice(voiceId, stockClips) },
```

두 타입을 분기하거나 변환할 필요 없이 같은 경로를 탄다. `previewVoice` 호출부는 이 한 곳뿐이라
파급이 없고, 모르는 id 가 오면 클립을 못 찾아 조용히 no-op 이다(기존과 동일).

## 실기기 확인 — Galaxy A32 (devrel 계정, 가족 그룹 멤버)

편집기 → 목소리 카드 → 목소리 선택 시트에 **"고죠 / 김규원님에게 공유받은 목소리"** 행이 있다.
그 ▶ 를 누르면:

- 아이콘이 **정지(■)로 전환** (재생 상태)
- logcat: `MediaPlayerNative: Received media started message` + `AudioTrack` 활동

수정 전에는 아이콘도 안 바뀌고 로그도 없었다.

`:app:assembleDevDebug` + `:app:testDevDebugUnitTest` 통과.

## 한계

미리듣기 자체가 MediaPlayer·네트워크에 묶여 있어 단위 테스트를 붙이지 못했다. 대신 위 실기기
경로로 확인했다. 회귀가 걱정되는 지점은 `previewVoice` 의 인자 타입 하나뿐이고, 호출부가
단일이라 컴파일러가 잡는다.
