### PR TITLE
fix(android): 자동 401 이 목소리 취향을 지우지 않게 + 지난 발사분 날씨 재시도 중단 (Codex #646)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -1296,6 +1296,11 @@ internal fun shouldResetWeatherVariant(
  */
 internal fun weatherVariantNeedsRefresh(alarm: AlarmEntity, nowMillis: Long): Boolean {
     if (alarm.fireAtMillis > nowMillis + WEATHER_PREPARE_WINDOW_MILLIS) return false
+    // 이미 지난 발사분은 준비할 게 없다. 울리는 중이거나 놓친 알람은 해제 전까지 enabled 로
+    // 남는데, 그 사이 조건 해결이 계속 실패하면 미해결 분기에 걸려 hasFailedWeatherRefresh 가
+    // 시간당 재시도를 무한정 다시 걸고 서버를 두드린다. 반복 알람은 재예약이 다음 발생으로
+    // 밀어 주고, 놓친 일회성은 재예약이 끄므로 여기서 걸러도 잃는 갱신이 없다.
+    if (alarm.fireAtMillis <= nowMillis) return false
     if (alarm.contextVariantIndex == null) return true
     if (alarm.fireAtMillis > nowMillis + WEATHER_RESOLVE_VALID_WINDOW_MILLIS) return false
     return (alarm.contextResolvedAtMillis ?: 0L) <

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/ui/main/MainViewModel.kt
@@ -157,12 +157,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val signedOutUserId = authSession?.user?.id?.takeIf { it.isNotBlank() }
         runCatching { repository.detachAlarmsOnSignOut(signedOutUserId) }
             .onFailure { error -> Log.w(TAG, "Failed to detach device alarms on session clear", error) }
+        // 기본 목소리 취향(마지막 쓴 목소리·'나중에 받기' 선택)은 계정을 명시적으로 끝낼 때만
+        // 지운다. 자동 401 은 같은 사람이 다시 로그인하는 경우가 대부분이라, 거기서 지우면
+        // 편집기가 쓰던 목소리를 잊고 기본 목소리 다운로드 안내를 다시 밟게 한다.
+        // (저장소가 계정별 키라 남겨 둬도 다음 계정에 새지 않는다.)
+        clearCurrentDefaultVoicePreferences()
         clearSessionKeepingAlarms()
     }
 
-    /** 세션만 정리한다(알람 예약은 그대로). 자동 401 처럼 사용자의 의도가 아닌 종료에 쓴다. */
+    /**
+     * 세션만 정리한다(알람 예약·기기 취향은 그대로). 자동 401 처럼 사용자의 의도가 아닌
+     * 종료에 쓴다 — 여기서 지우는 것은 '이 계정으로서의 세션 상태'까지다.
+     */
     private fun clearSessionKeepingAlarms() {
-        clearCurrentDefaultVoicePreferences()
         runCatching { authSessionStore.clear() }
         clearUserScopedRemoteState()
         authSession = null

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/WeatherVariantRefreshTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/WeatherVariantRefreshTest.kt
@@ -138,4 +138,35 @@ class WeatherVariantRefreshTest {
         val justResolved = alarm(fireInMillis = 2 * hour, resolvedAgoMillis = 1_000L)
         assertFalse(weatherVariantNeedsRefresh(justResolved, now))
     }
+
+    /**
+     * 울리는 중이거나 놓친 알람은 해제 전까지 enabled 로 남는다. 그 사이 조건 해결이 계속
+     * 실패하면 미해결 분기에 걸려 시간당 재시도가 영원히 이어지고 서버를 두드린다
+     * (이미 지난 발사분이라 준비할 것도 없는데도) — Codex #646.
+     */
+    @Test
+    fun 이미_지난_발사분은_재시도_대상이_아니다() {
+        assertFalse(
+            "미해결이어도 지난 발사분은 준비할 게 없다",
+            weatherVariantNeedsRefresh(
+                alarm(fireInMillis = -2 * hour, index = null, resolvedAgoMillis = null),
+                now,
+            ),
+        )
+        assertFalse(
+            "해결해 둔 지난 발사분도 마찬가지",
+            weatherVariantNeedsRefresh(alarm(fireInMillis = -2 * hour), now),
+        )
+    }
+
+    /** 경계: 아직 오지 않은 발사분은 코앞이어도 그대로 대상이다. */
+    @Test
+    fun 발사_직전_미해결_알람은_여전히_받는다() {
+        assertTrue(
+            weatherVariantNeedsRefresh(
+                alarm(fireInMillis = 5 * 60 * 1000L, index = null, resolvedAgoMillis = null),
+                now,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
#646 에 달린 Codex P2 두 건. (#646 은 develop → main 이므로 develop 에 올린다.)

## 1. 자동 401 이 목소리 취향까지 지웠다

`clearSessionKeepingAlarms` 는 이름과 주석대로 **'자동 401 처럼 사용자의 의도가 아닌 종료'**용인데,
그 안에서 `clearCurrentDefaultVoicePreferences()` 를 불러 **마지막 쓴 목소리**와 **'나중에 받기'
선택**까지 함께 날렸다.

결과: 토큰이 만료돼 다시 로그인하면 — 같은 사람인데도 — 편집기가 쓰던 목소리를 잊고, 기본
목소리를 아직 안 받은 사용자는 다운로드 안내를 다시 밟는다. 예약을 일부러 살려 두는 401
정책("알람 전달이 서버 인증 상태에 묶이면 안 된다")과도 방향이 어긋난다.

**수정**: 지우는 시점을 계정을 명시적으로 끝내는 `clearSignedInSession`(로그아웃·탈퇴)으로 옮겼다.

```diff
 internal suspend fun clearSignedInSession() {
     ...detachAlarmsOnSignOut...
+    clearCurrentDefaultVoicePreferences()
     clearSessionKeepingAlarms()
 }

 private fun clearSessionKeepingAlarms() {
-    clearCurrentDefaultVoicePreferences()
     runCatching { authSessionStore.clear() }
```

`DefaultVoicePreferenceStore` 는 `read(userId)`/`clear(userId)` 로 **계정별 키**라, 401 에서 남겨
둬도 다음 계정에 새지 않는다. 호출부는 이 한 곳뿐이다.

## 2. 지난 발사분에도 날씨 재해결을 계속 재시도했다

`weatherVariantNeedsRefresh` 는 상한(준비창 48h)만 보고 **하한이 없었다**.

```kotlin
if (alarm.fireAtMillis > nowMillis + WEATHER_PREPARE_WINDOW_MILLIS) return false
if (alarm.contextVariantIndex == null) return true   // ← 지난 발사분도 여기서 true
```

울리는 중이거나 놓친 알람은 해제 전까지 `enabled` 로 남는다. 그 사이 조건 해결이 계속 실패하면
이 분기에 걸려 `hasFailedWeatherRefresh` 가 **시간당 재시도를 무한정 다시 걸고 서버를 두드린다** —
이미 지난 발사분이라 준비할 것도 없는데도.

**수정**: 미해결 분기 앞에서 지난 발사분을 걸러낸다.

```diff
 if (alarm.fireAtMillis > nowMillis + WEATHER_PREPARE_WINDOW_MILLIS) return false
+if (alarm.fireAtMillis <= nowMillis) return false
 if (alarm.contextVariantIndex == null) return true
```

잃는 갱신은 없다 — 반복 알람은 `reschedulePendingAlarms` 가 다음 발생으로 밀어 주고(그러면 다시
미래라 대상), 놓친 일회성은 재예약이 끈다.

## 테스트

`WeatherVariantRefreshTest` 에 2건 추가:

- **지난 발사분은 미해결이어도 대상이 아닐 것** (가드를 빼면 이 테스트가 `FAILED` — 확인함)
- 경계: 발사 5분 전 미해결은 여전히 대상일 것

안드로이드 전체 22클래스 135건 통과. `:app:assembleDevDebug` 통과.

## 한계

두 폰이 세션 도중 분리돼 이번 건은 **실기기 확인을 못 했다.** 다만 (2)는 순수 함수라 유닛
테스트로 충분히 덮이고, (1)은 호출 위치를 옮긴 정책 변경이다. (1)을 실기기로 보려면:
목소리 선택 후 → 401 유발 → 재로그인 → 편집기가 그 목소리를 기억하는지 확인.
