### PR TITLE
fix(billing): 보관 만료 정리에서 FK 자식 행·가족알람 음성 참조를 먼저 끊는다 (Codex #646)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/AlarmTalkApplication.kt
@@ -34,6 +34,10 @@ class AlarmTalkApplication : Application() {
             .onFailure { AlarmTalkLog.reportError("NotificationChannels init failed", it) }
         runCatching { RemoteAlarmSyncScheduler.ensurePeriodic(this) }
             .onFailure { AlarmTalkLog.reportError("RemoteAlarmSyncScheduler.ensurePeriodic failed", it) }
+        // 목소리 접근권(동의 철회·보관 만료) 주기 재확인 — 푸시 유실·앱 미실행에도 정확성을
+        // 지키는 비-FCM 폴백. 하루 한 번.
+        runCatching { com.alarmtalk.app.sync.VoiceAccessSyncWorker.ensurePeriodic(this) }
+            .onFailure { AlarmTalkLog.reportError("VoiceAccessSyncWorker.ensurePeriodic failed", it) }
         // 앱이 포그라운드로 올라올 때마다(cold start 포함, 어느 화면/탭이든) 즉시 원격 알람을 pull 한다.
         // 로그인 세션이 있을 때만, 60초 throttle 로 연속 복귀 중복을 막는다. 이전엔 cold start + '알람 탭
         // 진입' 에서만 즉시 pull 이었던 것을 포그라운드 복귀 전체로 확장 — FCM 없이도 "앱을 열면 바로"

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/fcm/AlarmTalkMessagingService.kt
@@ -41,6 +41,13 @@ class AlarmTalkMessagingService : FirebaseMessagingService() {
         // 구독/플랜/가족 재조회 후 '진짜 무료'면 유료 목소리 알람을 기본 알람으로 변환(강등 시점 반영).
         // 앱이 포그라운드로 살아 있으면 워커가 쓴 SharedPreferences 만으론 live UI(구독/플랜 state)가
         // 안 바뀌므로, 신호도 함께 emit 해 MainViewModel 이 즉시 재조회하게 한다(구독자 없으면 버려짐).
+        // 서버에서 목소리 접근권이 사라짐(동의 철회·보관 만료 정리) → 내 소유 알람 강등 신호.
+        // family_alarm 은 '받은 알람'만 갱신하고, plan_changed 는 '진짜 무료'일 때만 변환하므로
+        // 둘 다 이 경우를 못 덮는다. 프로세스가 죽어도 살아남게 WorkManager 로 큐잉.
+        if (message.data["type"] == "voice_access_revoked") {
+            runCatching { com.alarmtalk.app.sync.VoiceAccessSyncWorker.runOnce(applicationContext) }
+                .onFailure { AlarmTalkLog.reportError("voice_access_revoked handling failed", it) }
+        }
         if (message.data["type"] == "plan_changed") {
             runCatching { com.alarmtalk.app.sync.PlanChangeSyncWorker.runOnce(applicationContext) }
                 .onFailure { AlarmTalkLog.reportError("plan_changed handling failed", it) }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
@@ -39,7 +39,8 @@ class VoiceAccessSyncWorker(
     params: WorkerParameters,
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
-        val session = AuthSessionStore(applicationContext).read() ?: return Result.success()
+        val sessionStore = AuthSessionStore(applicationContext)
+        val session = sessionStore.read() ?: return Result.success()
         return runCatching {
             val api = AlarmTalkApiClient.create()
             val auth = AlarmTalkApiClient.bearer(session.token)
@@ -47,6 +48,15 @@ class VoiceAccessSyncWorker(
             val myVoices = withContext(Dispatchers.IO) { api.listVoiceProfiles(auth).profiles }
             val sharedVoices =
                 withContext(Dispatchers.IO) { api.listFamilyVoiceProfiles(auth).profiles }
+
+            // 네트워크 왕복 중 로그아웃/계정전환이 일어났을 수 있다. 쓰기 직전에 현재 세션이
+            // 아직 이 세션(같은 토큰)인지 재확인한다 — degradeAlarmsWithInaccessibleVoice 는
+            // 소유자 필터 없이 LOCAL_OWNED 전체를 훑으므로, 옛 계정의 목록을 그대로 적용하면
+            // 새 계정 알람의 목소리를 영구히 벗긴다. (PlanChangeSyncWorker 와 같은 가드.)
+            val current = sessionStore.read()
+            if (current == null || current.token != session.token) {
+                return@runCatching Result.success()
+            }
 
             val accessibleVoiceIds = (myVoices.map { it.id } + sharedVoices.map { it.id }).toSet()
             val degraded = AlarmAppContainer.repository(applicationContext)

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
@@ -3,9 +3,11 @@ package com.alarmtalk.app.sync
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import android.util.Log
@@ -15,6 +17,7 @@ import com.alarmtalk.app.data.AlarmAppContainer
 import com.alarmtalk.app.network.AlarmTalkApiClient
 import com.alarmtalk.app.network.AuthSessionStore
 import kotlinx.coroutines.Dispatchers
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.withContext
 
 /**
@@ -26,13 +29,16 @@ import kotlinx.coroutines.withContext
  *    내 소유 알람은 그 pull 대상이 아니라 서버가 목소리를 지워도 로컬은 그대로 남는다.
  *  - plan_changed 경로(PlanChangeSyncWorker)는 '진짜 무료'일 때만 변환한다. 동의 철회는
  *    users.plan 이 그대로라 그 게이트에 걸리지 않는다.
- *  - 울림 시점에 동의를 다시 보는 게이트는 없다. 그래서 앱을 열 때까지(refreshSocial)
+ *  - 울림 시점에 '이 목소리를 아직 쓸 수 있는가'를 보는 게이트는 없다(유료 권한 게이트는 있다 —
+ *    RingingService.isPaidVoiceEntitledFromCache). 그래서 앱을 열 때까지(refreshSocial)
  *    지워진 녹음이 계속 울린다.
  *
  * 판단 기준은 화면 경로와 같다: 내 목소리 + 공유받은 목소리를 **신선하게** 다시 받아, 그 목록에
  * 없는 목소리를 쓰는 내 알람만 강등한다(degradeAlarmsWithInaccessibleVoice). 한쪽이라도 조회에
  * 실패하면 목록을 믿을 수 없으므로 강등하지 않고 retry 한다 — 오강등이 미강등보다 나쁘다.
- * 놓쳐도 다음 앱 시작의 refreshSocial 이 폴백.
+ *
+ * 경로는 셋이고 서로 폴백이다: 푸시([runOnce], 즉시) → 하루 주기([ensurePeriodic], 푸시 유실·앱
+ * 미실행 대비) → 앱 시작 refreshSocial. 정확성은 뒤 둘이 보장하고 푸시는 즉시성만 맡는다.
  */
 class VoiceAccessSyncWorker(
     appContext: Context,
@@ -73,6 +79,7 @@ class VoiceAccessSyncWorker(
 
     companion object {
         private const val WORK_NAME = "voice_access_revoked_sync"
+        private const val PERIODIC_WORK_NAME = "voice_access_periodic_sync"
 
         private val networkConstraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -86,6 +93,25 @@ class VoiceAccessSyncWorker(
             WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
                 WORK_NAME,
                 ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+
+        /**
+         * FCM 과 무관한 주기 폴백. 푸시가 유실되고 사용자가 앱을 안 열면 refreshSocial 도 안 돌아,
+         * 접근권을 잃은 목소리가 그대로 남는다(발사는 로컬이라 서버가 막을 수 없다). 하루 한 번
+         * 조용히 맞춰 둔다 — 즉시성은 푸시가, 정확성은 이 폴백이 맡는 구조(AGENTS.md).
+         *
+         * 하루 주기인 이유: 목소리 목록 두 번을 부르는 작업이라 짧은 주기는 쿼터·배터리만 쓴다.
+         * 즉시 반영이 필요한 경우는 푸시가 이미 [runOnce] 로 처리한다.
+         */
+        fun ensurePeriodic(context: Context) {
+            val request = PeriodicWorkRequestBuilder<VoiceAccessSyncWorker>(1, TimeUnit.DAYS)
+                .setConstraints(networkConstraints)
+                .build()
+            WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+                PERIODIC_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
                 request,
             )
         }

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
@@ -1,0 +1,83 @@
+package com.alarmtalk.app.sync
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import android.util.Log
+import com.alarmtalk.app.core.AlarmTalkLog
+import com.alarmtalk.app.core.AlarmTalkLog.TAG
+import com.alarmtalk.app.data.AlarmAppContainer
+import com.alarmtalk.app.network.AlarmTalkApiClient
+import com.alarmtalk.app.network.AuthSessionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 서버 voice_access_revoked 푸시 처리 워커 — 목소리 접근권을 잃은 '내 소유' 알람을 기본 알람으로
+ * 강등한다.
+ *
+ * 왜 별도 경로가 필요한가:
+ *  - family_alarm 푸시는 **받은 알람**만 갱신한다(RemoteAlarmPullSyncService 가 그것만 훑는다).
+ *    내 소유 알람은 그 pull 대상이 아니라 서버가 목소리를 지워도 로컬은 그대로 남는다.
+ *  - plan_changed 경로(PlanChangeSyncWorker)는 '진짜 무료'일 때만 변환한다. 동의 철회는
+ *    users.plan 이 그대로라 그 게이트에 걸리지 않는다.
+ *  - 울림 시점에 동의를 다시 보는 게이트는 없다. 그래서 앱을 열 때까지(refreshSocial)
+ *    지워진 녹음이 계속 울린다.
+ *
+ * 판단 기준은 화면 경로와 같다: 내 목소리 + 공유받은 목소리를 **신선하게** 다시 받아, 그 목록에
+ * 없는 목소리를 쓰는 내 알람만 강등한다(degradeAlarmsWithInaccessibleVoice). 한쪽이라도 조회에
+ * 실패하면 목록을 믿을 수 없으므로 강등하지 않고 retry 한다 — 오강등이 미강등보다 나쁘다.
+ * 놓쳐도 다음 앱 시작의 refreshSocial 이 폴백.
+ */
+class VoiceAccessSyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val session = AuthSessionStore(applicationContext).read() ?: return Result.success()
+        return runCatching {
+            val api = AlarmTalkApiClient.create()
+            val auth = AlarmTalkApiClient.bearer(session.token)
+            // 둘 다 성공해야 판단한다 — 하나라도 실패하면 throw 시켜 아래 retry 로 넘긴다.
+            val myVoices = withContext(Dispatchers.IO) { api.listVoiceProfiles(auth).profiles }
+            val sharedVoices =
+                withContext(Dispatchers.IO) { api.listFamilyVoiceProfiles(auth).profiles }
+
+            val accessibleVoiceIds = (myVoices.map { it.id } + sharedVoices.map { it.id }).toSet()
+            val degraded = AlarmAppContainer.repository(applicationContext)
+                .degradeAlarmsWithInaccessibleVoice(accessibleVoiceIds)
+            if (degraded > 0) {
+                Log.i(TAG, "Degraded $degraded alarm(s) after voice access was revoked")
+            }
+            Result.success()
+        }.getOrElse { error ->
+            AlarmTalkLog.reportError("voice_access_revoked handling failed", error)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val WORK_NAME = "voice_access_revoked_sync"
+
+        private val networkConstraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        /** voice_access_revoked 푸시 수신 시 호출. 프로세스가 죽어도 살아남게 WorkManager 로 큐잉. */
+        fun runOnce(context: Context) {
+            val request = OneTimeWorkRequestBuilder<VoiceAccessSyncWorker>()
+                .setConstraints(networkConstraints)
+                .build()
+            WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+    }
+}

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -143,7 +143,12 @@ export async function clearPaidVoiceRetention(db: DbExecutor, userPk: string): P
  * 그래서 이 스윕은 하드삭제를 하지 않고, 유예가 지난 보관 행만 정리하는 청소부로 남는다.
  * (계정 삭제 같은 명시 경로는 여전히 deletePaidVoiceDataForUser 로 직접 삭제한다.)
  */
-export async function sweepPaidVoiceRetention(db: Client, now: Date = new Date()): Promise<void> {
+export async function sweepPaidVoiceRetention(
+  db: Client,
+  now: Date = new Date(),
+): Promise<string[]> {
+  // 이 정리로 알람이 강등된 사용자들 — 호출자가 plan_changed 푸시 대상에 넣는다.
+  const downgraded = new Set<string>();
   // 유예가 끝난 사용자의 남은 음성 데이터(원본 업로드·생성 오디오)를 정리한다.
   // 클론 자체는 해지 시점에 이미 반납했다(releaseClonedVoicesForUser).
   const due = await db.execute({
@@ -160,9 +165,15 @@ export async function sweepPaidVoiceRetention(db: Client, now: Date = new Date()
       await clearPaidVoiceRetention(db, userPk);
       continue;
     }
-    await deleteSensitiveVoiceDataForUser(db, userPk, await resolveUserLoginId(db, userPk));
+    const affected = await deleteSensitiveVoiceDataForUser(
+      db,
+      userPk,
+      await resolveUserLoginId(db, userPk),
+    );
+    for (const id of affected) downgraded.add(id);
     await clearPaidVoiceRetention(db, userPk);
   }
+  return Array.from(downgraded);
 }
 
 export async function downgradeUserToFree(
@@ -827,7 +838,11 @@ export async function processSubscriptionExpiry(
   }
 
   // 보관 유예가 끝난 유료 음성 데이터 정리 (같은 cron 주기에서 처리).
-  await sweepPaidVoiceRetention(db, now);
+  // 이 정리는 플랜 변경 3일 뒤에 도는데, 그때 강등되는 알람의 주인(공유 목소리·가족알람
+  // 수신자 포함)은 이번 주기의 만료 대상이 아니라 notifyUserPks 에 없다. 그대로 두면 이미
+  // 오디오를 캐시해 둔 백그라운드 수신자가 다음 앱 시작/주기 동기화까지 지워진 녹음으로
+  // 계속 울린다 — 그사이 알람이 먼저 울릴 수 있다. 반환된 대상을 푸시에 함께 태운다.
+  for (const id of await sweepPaidVoiceRetention(db, now)) notifyUserPks.add(id);
 
   // 강등된 사용자에게 plan_changed 푸시 — 클라가 '강등 시점'에 유료 목소리 알람을 기본 알람으로
   // 변환하게 한다(백그라운드 여도). 과다발송해도 클라가 재조회로 확인.

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -147,9 +147,12 @@ export async function clearPaidVoiceRetention(db: DbExecutor, userPk: string): P
 export async function sweepPaidVoiceRetention(
   db: Client,
   now: Date = new Date(),
-): Promise<DowngradedAlarm[]> {
+): Promise<{ targets: DowngradedAlarm[]; cleanedUserPks: string[] }> {
   // 이 정리로 강등된 알람들 — 호출자가 커밋 후 신호를 보낸다.
   const downgraded = new Map<string, DowngradedAlarm>();
+  // 실제로 음성 데이터를 정리한 사용자들. 알람 행을 못 찾아도 이 계정에는 접근권 상실을
+  // 알려야 한다(서버에 아직 동기화되지 않은 로컬 알람이 있을 수 있다).
+  const cleanedUserPks: string[] = [];
   // 유예가 끝난 사용자의 남은 음성 데이터(원본 업로드·생성 오디오)를 정리한다.
   // 클론 자체는 해지 시점에 이미 반납했다(releaseClonedVoicesForUser).
   const due = await db.execute({
@@ -172,9 +175,10 @@ export async function sweepPaidVoiceRetention(
       await resolveUserLoginId(db, userPk),
     );
     for (const target of affected) downgraded.set(target.alarmId, target);
+    cleanedUserPks.push(userPk);
     await clearPaidVoiceRetention(db, userPk);
   }
-  return Array.from(downgraded.values());
+  return { targets: Array.from(downgraded.values()), cleanedUserPks };
 }
 
 export async function downgradeUserToFree(
@@ -839,7 +843,7 @@ export async function processSubscriptionExpiry(
   }
 
   // 보관 유예가 끝난 유료 음성 데이터 정리 (같은 cron 주기에서 처리).
-  const downgradedAlarms = await sweepPaidVoiceRetention(db, now);
+  const sweptVoiceData = await sweepPaidVoiceRetention(db, now);
 
   // 강등된 사용자에게 plan_changed 푸시 — 클라가 '강등 시점'에 유료 목소리 알람을 기본 알람으로
   // 변환하게 한다(백그라운드 여도). 과다발송해도 클라가 재조회로 확인.
@@ -847,7 +851,7 @@ export async function processSubscriptionExpiry(
 
   // 보관 정리가 서버에서 바꾼 '알람 행'은 plan_changed 로는 안 따라온다 — 이유는
   // notifyDowngradedAlarms 참고. 강등된 알람마다 알람 동기화 신호를 보낸다.
-  await notifyDowngradedAlarms(db, env, downgradedAlarms);
+  await notifyDowngradedAlarms(db, env, sweptVoiceData.targets, sweptVoiceData.cleanedUserPks);
 }
 
 export { planTypeToUserPlan };

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -169,14 +169,26 @@ export async function sweepPaidVoiceRetention(
       await clearPaidVoiceRetention(db, userPk);
       continue;
     }
-    const affected = await deleteSensitiveVoiceDataForUser(
-      db,
-      userPk,
-      await resolveUserLoginId(db, userPk),
-    );
-    for (const target of affected) downgraded.set(target.alarmId, target);
-    cleanedUserPks.push(userPk);
-    await clearPaidVoiceRetention(db, userPk);
+    // 한 사용자에서 실패해도 나머지를 버리지 않는다. 예외가 위로 새면 호출부가
+    // notifyDowngradedAlarms 까지 못 가서, 이미 정리·마커 삭제까지 끝난 앞 사용자들의
+    // 알림이 통째로 사라진다 — 마커가 없으니 다음 크론이 복구할 수도 없다.
+    // 실패한 사용자는 마커를 그대로 둬(아래 clear 를 건너뛴다) 다음 크론이 다시 시도한다.
+    try {
+      const affected = await deleteSensitiveVoiceDataForUser(
+        db,
+        userPk,
+        await resolveUserLoginId(db, userPk),
+      );
+      for (const target of affected) downgraded.set(target.alarmId, target);
+      cleanedUserPks.push(userPk);
+      await clearPaidVoiceRetention(db, userPk);
+    } catch (err) {
+      logStructured('error', {
+        at: 'billing.paid_voice_retention_sweep',
+        action: 'RETENTION_CLEANUP_FAILED',
+        error: String(err),
+      });
+    }
   }
   return { targets: Array.from(downgraded.values()), cleanedUserPks };
 }

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -17,7 +17,7 @@ import {
   type SubscriptionV2Response,
 } from './play-subscriptions';
 import { PAID_PLAN_TYPES, planTypeToUserPlan, plannedMaxUses } from '../routes/billing-helpers';
-import { sendFamilyAlarmPush, sendPlanChangedPush } from './fcm';
+import { notifyDowngradedAlarms, sendPlanChangedPush } from './fcm';
 import type { Env } from '../types';
 
 // 만료 크론이 FCM(plan_changed) 을 쏘려면 Play env 외에 FIREBASE 설정도 필요하다. index.ts 의 scheduled
@@ -845,28 +845,9 @@ export async function processSubscriptionExpiry(
   // 변환하게 한다(백그라운드 여도). 과다발송해도 클라가 재조회로 확인.
   await notifyPlanChanged(db, env, Array.from(notifyUserPks));
 
-  // 보관 정리가 서버에서 바꾼 '알람 행'은 plan_changed 로는 안 따라온다 — 클라의
-  // PlanChangeSyncWorker 는 이용권을 다시 받아 '진짜 무료'일 때만 로컬 강등을 돌리고, 원격
-  // 알람 pull 은 하지 않는다. 그래서 아직 유료인 수신자는 이미 캐시한 녹음으로 계속 울린다.
-  // 알람을 다시 받아오게 하는 신호는 family_alarm 이므로 그걸 보낸다(수신자 앱은 기존 행을
-  // 업데이트만 하고 알림은 띄우지 않는다 — notifyReceivedAlarm 은 신규 임포트 전용).
-  if (env?.FIREBASE_PROJECT_ID && env?.FIREBASE_SERVICE_ACCOUNT_JSON) {
-    const pushEnv = {
-      FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
-      FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
-    };
-    for (const target of downgradedAlarms) {
-      try {
-        await sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId);
-      } catch (err) {
-        logStructured('error', {
-          at: 'billing.downgraded_alarm_push',
-          action: 'DOWNGRADED_ALARM_PUSH_FAILED',
-          error: String(err),
-        });
-      }
-    }
-  }
+  // 보관 정리가 서버에서 바꾼 '알람 행'은 plan_changed 로는 안 따라온다 — 이유는
+  // notifyDowngradedAlarms 참고. 강등된 알람마다 알람 동기화 신호를 보낸다.
+  await notifyDowngradedAlarms(db, env, downgradedAlarms);
 }
 
 export { planTypeToUserPlan };

--- a/packages/backend/src/lib/billing-cancel.ts
+++ b/packages/backend/src/lib/billing-cancel.ts
@@ -6,6 +6,7 @@ import {
   deletePaidVoiceDataForUser,
   deleteSensitiveVoiceDataForUser,
   releaseClonedVoicesForUser,
+  type DowngradedAlarm,
 } from './paid-voice-cleanup';
 import { logStructured } from './logger';
 import {
@@ -16,7 +17,7 @@ import {
   type SubscriptionV2Response,
 } from './play-subscriptions';
 import { PAID_PLAN_TYPES, planTypeToUserPlan, plannedMaxUses } from '../routes/billing-helpers';
-import { sendPlanChangedPush } from './fcm';
+import { sendFamilyAlarmPush, sendPlanChangedPush } from './fcm';
 import type { Env } from '../types';
 
 // 만료 크론이 FCM(plan_changed) 을 쏘려면 Play env 외에 FIREBASE 설정도 필요하다. index.ts 의 scheduled
@@ -146,9 +147,9 @@ export async function clearPaidVoiceRetention(db: DbExecutor, userPk: string): P
 export async function sweepPaidVoiceRetention(
   db: Client,
   now: Date = new Date(),
-): Promise<string[]> {
-  // 이 정리로 알람이 강등된 사용자들 — 호출자가 plan_changed 푸시 대상에 넣는다.
-  const downgraded = new Set<string>();
+): Promise<DowngradedAlarm[]> {
+  // 이 정리로 강등된 알람들 — 호출자가 커밋 후 신호를 보낸다.
+  const downgraded = new Map<string, DowngradedAlarm>();
   // 유예가 끝난 사용자의 남은 음성 데이터(원본 업로드·생성 오디오)를 정리한다.
   // 클론 자체는 해지 시점에 이미 반납했다(releaseClonedVoicesForUser).
   const due = await db.execute({
@@ -170,10 +171,10 @@ export async function sweepPaidVoiceRetention(
       userPk,
       await resolveUserLoginId(db, userPk),
     );
-    for (const id of affected) downgraded.add(id);
+    for (const target of affected) downgraded.set(target.alarmId, target);
     await clearPaidVoiceRetention(db, userPk);
   }
-  return Array.from(downgraded);
+  return Array.from(downgraded.values());
 }
 
 export async function downgradeUserToFree(
@@ -838,15 +839,34 @@ export async function processSubscriptionExpiry(
   }
 
   // 보관 유예가 끝난 유료 음성 데이터 정리 (같은 cron 주기에서 처리).
-  // 이 정리는 플랜 변경 3일 뒤에 도는데, 그때 강등되는 알람의 주인(공유 목소리·가족알람
-  // 수신자 포함)은 이번 주기의 만료 대상이 아니라 notifyUserPks 에 없다. 그대로 두면 이미
-  // 오디오를 캐시해 둔 백그라운드 수신자가 다음 앱 시작/주기 동기화까지 지워진 녹음으로
-  // 계속 울린다 — 그사이 알람이 먼저 울릴 수 있다. 반환된 대상을 푸시에 함께 태운다.
-  for (const id of await sweepPaidVoiceRetention(db, now)) notifyUserPks.add(id);
+  const downgradedAlarms = await sweepPaidVoiceRetention(db, now);
 
   // 강등된 사용자에게 plan_changed 푸시 — 클라가 '강등 시점'에 유료 목소리 알람을 기본 알람으로
   // 변환하게 한다(백그라운드 여도). 과다발송해도 클라가 재조회로 확인.
   await notifyPlanChanged(db, env, Array.from(notifyUserPks));
+
+  // 보관 정리가 서버에서 바꾼 '알람 행'은 plan_changed 로는 안 따라온다 — 클라의
+  // PlanChangeSyncWorker 는 이용권을 다시 받아 '진짜 무료'일 때만 로컬 강등을 돌리고, 원격
+  // 알람 pull 은 하지 않는다. 그래서 아직 유료인 수신자는 이미 캐시한 녹음으로 계속 울린다.
+  // 알람을 다시 받아오게 하는 신호는 family_alarm 이므로 그걸 보낸다(수신자 앱은 기존 행을
+  // 업데이트만 하고 알림은 띄우지 않는다 — notifyReceivedAlarm 은 신규 임포트 전용).
+  if (env?.FIREBASE_PROJECT_ID && env?.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    const pushEnv = {
+      FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
+      FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
+    };
+    for (const target of downgradedAlarms) {
+      try {
+        await sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId);
+      } catch (err) {
+        logStructured('error', {
+          at: 'billing.downgraded_alarm_push',
+          action: 'DOWNGRADED_ALARM_PUSH_FAILED',
+          error: String(err),
+        });
+      }
+    }
+  }
 }
 
 export { planTypeToUserPlan };

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -270,6 +270,49 @@ export async function sendVoiceAccessRevokedPush(
  * 반드시 **쓰기 트랜잭션 커밋 후에** 부를 것. 롤백될 수 있는 변경을 미리 알리면 안 된다.
  * 한 건 실패가 나머지를 막지 않도록 개별적으로 삼킨다(폴백 pull 이 정확성을 보장한다).
  */
+/**
+ * 강등 알림 메시지를 만든다 — **수신자 단위로 접어서**.
+ *
+ * 받은 알람은 수신자당 한 번만 보낸다. 클라 핸들러(AlarmTalkMessagingService)는 payload 의
+ * alarmId 를 쓰지 않고 원격 알람을 '전부' 다시 받으므로, 알람마다 보내면 토큰 조회와 FCM
+ * 왕복만 알람 수만큼 늘어난다 — 한 스윕이 여러 알람을 강등하면 Workers 서브리퀘스트 상한에
+ * 걸릴 수 있다(AGENTS.md). alarmId 는 형식 유지용으로 대표 하나만 싣는다.
+ *
+ * 토큰 조회를 인자로 받아 순수하게 유지한다 — 팬아웃 규칙을 DB 없이 단언할 수 있게.
+ */
+export async function buildDowngradeNotifications(
+  getTokens: (userId: string) => Promise<string[]>,
+  targets: Array<{ alarmId: string; ownerUserId: string; isReceived: boolean }>,
+  voiceAccessRevokedUserIds: string[] = [],
+): Promise<FcmMessage[]> {
+  const receivedRepresentative = new Map<string, string>();
+  for (const target of targets) {
+    if (!target.isReceived) continue;
+    if (!receivedRepresentative.has(target.ownerUserId)) {
+      receivedRepresentative.set(target.ownerUserId, target.alarmId);
+    }
+  }
+  // 본인 소유 알람은 pull 대상이 아니라 목소리 접근권 재확인이 필요하다. 알람 행을 못 찾은
+  // 계정도 포함한다(서버에 아직 동기화되지 않은 로컬 알람 때문에).
+  const voiceAccessOwners = new Set([
+    ...targets.filter((t) => !t.isReceived).map((t) => t.ownerUserId),
+    ...voiceAccessRevokedUserIds.filter(Boolean),
+  ]);
+
+  const messages: FcmMessage[] = [];
+  for (const [userId, alarmId] of receivedRepresentative) {
+    for (const token of await getTokens(userId)) {
+      messages.push({ token, title: '', body: '', data: { type: 'family_alarm', alarmId } });
+    }
+  }
+  for (const userId of voiceAccessOwners) {
+    for (const token of await getTokens(userId)) {
+      messages.push({ token, title: '', body: '', data: { type: 'voice_access_revoked' } });
+    }
+  }
+  return messages;
+}
+
 export async function notifyDowngradedAlarms(
   db: Client,
   env: Partial<Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>> | undefined,
@@ -283,33 +326,27 @@ export async function notifyDowngradedAlarms(
 ): Promise<void> {
   if (!env?.FIREBASE_PROJECT_ID || !env?.FIREBASE_SERVICE_ACCOUNT_JSON) return;
   if (targets.length === 0 && voiceAccessRevokedUserIds.length === 0) return;
-  const pushEnv = {
-    FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
-    FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
-  };
-  const send = async (at: string, run: () => Promise<unknown>) => {
-    try {
-      await run();
-    } catch (err) {
-      logStructured('error', { at, action: 'DOWNGRADED_ALARM_PUSH_FAILED', error: String(err) });
-    }
-  };
-  // 받은 알람: 원격 pull 이 그 행을 갱신한다(알람마다 보낸다 — 페이로드에 alarmId 가 들어간다).
-  for (const target of targets.filter((t) => t.isReceived)) {
-    await send('fcm.downgraded_alarm_push', () =>
-      sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId),
-    );
-  }
-  // 본인 소유 알람: pull 대상이 아니라 목소리 접근권 재확인이 필요하다. 사용자당 한 번이면 된다.
-  // 알람 행을 못 찾은 계정도 포함한다(미동기화 로컬 알람 때문에 — 위 인자 설명 참고).
-  const selfOwners = new Set([
-    ...targets.filter((t) => !t.isReceived).map((t) => t.ownerUserId),
-    ...voiceAccessRevokedUserIds.filter(Boolean),
-  ]);
-  for (const userId of selfOwners) {
-    await send('fcm.voice_access_revoked_push', () =>
-      sendVoiceAccessRevokedPush(db, pushEnv, userId),
-    );
+  // 메시지를 모아 **한 번에** 보낸다 — sendPushNotifications 는 호출마다 OAuth 토큰을 새로
+  // 받으므로, 대상마다 나눠 부르면 그만큼 왕복이 늘어난다.
+  const messages = await buildDowngradeNotifications(
+    (userId) => getTokensForUser(db, userId),
+    targets,
+    voiceAccessRevokedUserIds,
+  );
+  if (messages.length === 0) return;
+  try {
+    const results = await sendPushNotifications(messages, {
+      FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
+      FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
+    });
+    await pruneStaleTokens(db, results);
+  } catch (err) {
+    // 삼켜도 되는 이유: 즉시성만 잃는다. 정확성은 하루 주기 재확인과 앱 시작 재조회가 맡는다.
+    logStructured('error', {
+      at: 'fcm.downgraded_alarm_push',
+      action: 'DOWNGRADED_ALARM_PUSH_FAILED',
+      error: String(err),
+    });
   }
 }
 

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -231,6 +231,43 @@ export async function sendVoiceShareChangedPush(
  * 구독/플랜을 재조회해 '진짜 무료'면 유료 목소리 알람을 기본 알람으로 변환한다. 과다발송해도 클라가
  * 재조회로 확인(유료면 무시)하므로 안전. 놓쳐도 다음 앱 시작·울림 시점 게이트가 폴백.
  */
+/**
+ * 서버가 강등한 알람을 그 기기가 **즉시 다시 받아 가게** 하는 신호.
+ *
+ * plan_changed 로는 안 된다 — 클라의 PlanChangeSyncWorker 는 이용권을 다시 받아 '진짜 무료'일
+ * 때만 로컬 강등을 돌리고, 원격 알람 pull 은 하지 않는다. 그래서 아직 유료인 수신자는 서버가
+ * 알람을 바꿔도 주기/앱시작 폴백까지 캐시된 녹음으로 계속 울린다. 알람을 다시 받아오게 하는
+ * 신호는 family_alarm 이므로 그걸 보낸다(수신자 앱은 기존 행을 업데이트만 하고 알림은 띄우지
+ * 않는다 — notifyReceivedAlarm 은 신규 임포트 전용).
+ *
+ * 반드시 **쓰기 트랜잭션 커밋 후에** 부를 것. 롤백될 수 있는 변경을 미리 알리면 안 된다.
+ * 한 건 실패가 나머지를 막지 않도록 개별적으로 삼킨다(폴백 pull 이 정확성을 보장한다).
+ */
+export async function notifyDowngradedAlarms(
+  db: Client,
+  env: Partial<Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>> | undefined,
+  targets: Array<{ alarmId: string; ownerUserId: string }>,
+): Promise<void> {
+  if (!env?.FIREBASE_PROJECT_ID || !env?.FIREBASE_SERVICE_ACCOUNT_JSON || targets.length === 0) {
+    return;
+  }
+  const pushEnv = {
+    FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
+    FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
+  };
+  for (const target of targets) {
+    try {
+      await sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId);
+    } catch (err) {
+      logStructured('error', {
+        at: 'fcm.downgraded_alarm_push',
+        action: 'DOWNGRADED_ALARM_PUSH_FAILED',
+        error: String(err),
+      });
+    }
+  }
+}
+
 export async function sendPlanChangedPush(
   db: Client,
   env: Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>,

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -232,6 +232,33 @@ export async function sendVoiceShareChangedPush(
  * 재조회로 확인(유료면 무시)하므로 안전. 놓쳐도 다음 앱 시작·울림 시점 게이트가 폴백.
  */
 /**
+ * 목소리 접근권이 서버에서 사라졌음을 알리는 data-only 신호.
+ *
+ * 받은 알람은 원격 pull 로 갱신되지만 **본인 소유 알람은 그 pull 대상이 아니다**
+ * (RemoteAlarmPullSyncService 는 받은 알람만 훑는다). 그래서 본인 알람은 목소리 목록을
+ * 다시 받아 접근권을 잃은 것을 로컬에서 강등해야 한다 — 클라의 VoiceAccessSyncWorker 가
+ * 그 일을 한다. 플랜 만료와 달리 동의 철회는 users.plan 이 그대로라 plan_changed 경로의
+ * '진짜 무료' 게이트에 걸리지 않으므로, 별도 신호가 필요하다.
+ */
+export async function sendVoiceAccessRevokedPush(
+  db: Client,
+  env: Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>,
+  userId: string,
+): Promise<FcmSendResult[]> {
+  const tokens = await getTokensForUser(db, userId);
+  if (tokens.length === 0) return [];
+  const messages: FcmMessage[] = tokens.map((token) => ({
+    token,
+    title: '',
+    body: '',
+    data: { type: 'voice_access_revoked' },
+  }));
+  const results = await sendPushNotifications(messages, env);
+  await pruneStaleTokens(db, results);
+  return results;
+}
+
+/**
  * 서버가 강등한 알람을 그 기기가 **즉시 다시 받아 가게** 하는 신호.
  *
  * plan_changed 로는 안 된다 — 클라의 PlanChangeSyncWorker 는 이용권을 다시 받아 '진짜 무료'일
@@ -246,7 +273,7 @@ export async function sendVoiceShareChangedPush(
 export async function notifyDowngradedAlarms(
   db: Client,
   env: Partial<Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>> | undefined,
-  targets: Array<{ alarmId: string; ownerUserId: string }>,
+  targets: Array<{ alarmId: string; ownerUserId: string; isReceived: boolean }>,
 ): Promise<void> {
   if (!env?.FIREBASE_PROJECT_ID || !env?.FIREBASE_SERVICE_ACCOUNT_JSON || targets.length === 0) {
     return;
@@ -255,16 +282,25 @@ export async function notifyDowngradedAlarms(
     FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
     FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
   };
-  for (const target of targets) {
+  const send = async (at: string, run: () => Promise<unknown>) => {
     try {
-      await sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId);
+      await run();
     } catch (err) {
-      logStructured('error', {
-        at: 'fcm.downgraded_alarm_push',
-        action: 'DOWNGRADED_ALARM_PUSH_FAILED',
-        error: String(err),
-      });
+      logStructured('error', { at, action: 'DOWNGRADED_ALARM_PUSH_FAILED', error: String(err) });
     }
+  };
+  // 받은 알람: 원격 pull 이 그 행을 갱신한다(알람마다 보낸다 — 페이로드에 alarmId 가 들어간다).
+  for (const target of targets.filter((t) => t.isReceived)) {
+    await send('fcm.downgraded_alarm_push', () =>
+      sendFamilyAlarmPush(db, pushEnv, target.ownerUserId, target.alarmId),
+    );
+  }
+  // 본인 소유 알람: pull 대상이 아니라 목소리 접근권 재확인이 필요하다. 사용자당 한 번이면 된다.
+  const selfOwners = new Set(targets.filter((t) => !t.isReceived).map((t) => t.ownerUserId));
+  for (const userId of selfOwners) {
+    await send('fcm.voice_access_revoked_push', () =>
+      sendVoiceAccessRevokedPush(db, pushEnv, userId),
+    );
   }
 }
 

--- a/packages/backend/src/lib/fcm.ts
+++ b/packages/backend/src/lib/fcm.ts
@@ -274,10 +274,15 @@ export async function notifyDowngradedAlarms(
   db: Client,
   env: Partial<Pick<Env, 'FIREBASE_PROJECT_ID' | 'FIREBASE_SERVICE_ACCOUNT_JSON'>> | undefined,
   targets: Array<{ alarmId: string; ownerUserId: string; isReceived: boolean }>,
+  /**
+   * 목소리 접근권을 잃은 계정들 — 서버에서 찾은 알람 행과 **무관하게** 알려야 한다.
+   * 아직 서버로 동기화되지 않은 로컬 알람은 targets 에 안 잡히는데, 발사는 로컬이고
+   * 울림 시점 동의 게이트도 없어 그 기기는 지워진 녹음으로 계속 울린다.
+   */
+  voiceAccessRevokedUserIds: string[] = [],
 ): Promise<void> {
-  if (!env?.FIREBASE_PROJECT_ID || !env?.FIREBASE_SERVICE_ACCOUNT_JSON || targets.length === 0) {
-    return;
-  }
+  if (!env?.FIREBASE_PROJECT_ID || !env?.FIREBASE_SERVICE_ACCOUNT_JSON) return;
+  if (targets.length === 0 && voiceAccessRevokedUserIds.length === 0) return;
   const pushEnv = {
     FIREBASE_PROJECT_ID: env.FIREBASE_PROJECT_ID,
     FIREBASE_SERVICE_ACCOUNT_JSON: env.FIREBASE_SERVICE_ACCOUNT_JSON,
@@ -296,7 +301,11 @@ export async function notifyDowngradedAlarms(
     );
   }
   // 본인 소유 알람: pull 대상이 아니라 목소리 접근권 재확인이 필요하다. 사용자당 한 번이면 된다.
-  const selfOwners = new Set(targets.filter((t) => !t.isReceived).map((t) => t.ownerUserId));
+  // 알람 행을 못 찾은 계정도 포함한다(미동기화 로컬 알람 때문에 — 위 인자 설명 참고).
+  const selfOwners = new Set([
+    ...targets.filter((t) => !t.isReceived).map((t) => t.ownerUserId),
+    ...voiceAccessRevokedUserIds.filter(Boolean),
+  ]);
   for (const userId of selfOwners) {
     await send('fcm.voice_access_revoked_push', () =>
       sendVoiceAccessRevokedPush(db, pushEnv, userId),

--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -40,15 +40,22 @@ async function deleteRelationshipsForOwnedProfiles(db: DbExecutor, ids: string[]
  *
  * 오브젝트를 지우기 전에 알람을 sound-only 로 명시 강등하고 audio_url 을 비워, 서버 상태와
  * 클라 폴백이 같은 말을 하게 한다. 메시지 행 자체는 수신자 데이터라 지우지 않는다.
+ *
+ * @returns 강등된 알람의 주인들 — 호출자가 정리 커밋 후 plan_changed 푸시로 즉시 반영시킨다.
  */
 async function detachFamilyAlarmMessagesUsingOwnedUploads(
   db: DbExecutor,
   ids: string[],
   ph: string,
-) {
+): Promise<string[]> {
   const affectedMessages = `SELECT id FROM messages
      WHERE audio_url IS NOT NULL
        AND audio_url IN (SELECT object_key FROM voice_uploads WHERE user_id IN (${ph}))`;
+  // 강등 '전에' 주인을 모아 둔다 — UPDATE 가 message_id 를 끊고 나면 다시 찾을 수 없다.
+  const owners = await db.execute({
+    sql: `SELECT DISTINCT user_id FROM alarms WHERE message_id IN (${affectedMessages})`,
+    args: ids,
+  });
   await db.execute({
     sql: `UPDATE alarms
           SET mode = 'sound-only',
@@ -62,6 +69,7 @@ async function detachFamilyAlarmMessagesUsingOwnedUploads(
     sql: `UPDATE messages SET audio_url = NULL WHERE id IN (${affectedMessages})`,
     args: ids,
   });
+  return owners.rows.map((r) => String(r.user_id)).filter(Boolean);
 }
 
 export async function deletePaidVoiceDataForUser(
@@ -223,14 +231,21 @@ export async function releaseClonedVoicesForUser(
   }
 }
 
+/**
+ * @returns 이 정리로 알람이 sound-only 로 강등된 사용자들. 호출자가 커밋 후 plan_changed
+ *          data-only 푸시를 보내 즉시 반영시킨다 — 이 스윕은 플랜 변경 3일 뒤에 도는데,
+ *          그때까지 앱을 안 켠 수신자는 이미 캐시한 오디오로 계속 울린다. 다음 앱 시작/주기
+ *          동기화까지 기다리면 그사이 알람이 먼저 울릴 수 있다(AGENTS.md 의 FCM 상태 동기화).
+ */
 export async function deleteSensitiveVoiceDataForUser(
   db: DbExecutor,
   userPk: string,
   userLoginId?: string | null,
-): Promise<void> {
+): Promise<string[]> {
   const ids = uniqueIds([userPk, userLoginId]);
-  if (ids.length === 0) return;
+  if (ids.length === 0) return [];
   const ph = placeholders(ids);
+  const downgraded = new Set<string>();
 
   const providerVoices = await db.execute({
     sql: `SELECT elevenlabs_voice_id FROM voice_profiles
@@ -258,8 +273,25 @@ export async function deleteSensitiveVoiceDataForUser(
   for (const row of generatedObjects.rows) {
     await enqueueExternalDeletion(db, 'r2_object', row.audio_object_key as string);
   }
-  await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph);
+  for (const id of await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph)) {
+    downgraded.add(id);
+  }
 
+  // 공유 목소리를 참조하던 알람도 같은 이유로 주인을 모아 둔다(강등 전에 골라야 한다).
+  const sharedVoiceAlarmOwners = await db.execute({
+    sql: `SELECT DISTINCT user_id FROM alarms
+          WHERE voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (${ph}))
+             OR message_id IN (
+               SELECT id FROM messages
+               WHERE user_id IN (${ph}) OR voice_profile_id IN (
+                 SELECT id FROM voice_profiles WHERE user_id IN (${ph})
+               )
+             )`,
+    args: [...ids, ...ids, ...ids],
+  });
+  for (const row of sharedVoiceAlarmOwners.rows) {
+    if (row.user_id) downgraded.add(String(row.user_id));
+  }
   await db.execute({
     sql: `UPDATE alarms
           SET mode = 'sound-only', wake_mode = 'sound_then_voice',
@@ -303,4 +335,5 @@ export async function deleteSensitiveVoiceDataForUser(
   });
   await deleteRelationshipsForOwnedProfiles(db, ids, ph);
   await db.execute({ sql: `DELETE FROM voice_profiles WHERE user_id IN (${ph})`, args: ids });
+  return Array.from(downgraded);
 }

--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -9,6 +9,61 @@ function placeholders(ids: string[]): string {
   return ids.map(() => '?').join(',');
 }
 
+/**
+ * 삭제될 voice_profiles 를 가리키는 호칭/관계 행을 먼저 지운다.
+ *
+ * voice_profile_relationships.voice_profile_id 는 voice_profiles FK 라(마이그레이션 #37),
+ * 프로필을 먼저 지우면 FK 가 켜져 있을 때 삭제가 던져 보관 정리가 통째로 중단되고
+ * (paid_voice_retention 행이 안 지워져 만료 처리가 매번 같은 자리에서 멈춘다), 꺼져 있으면
+ * 사라진 프로필을 가리키는 호칭 행이 남는다. account-deletion.ts 가 같은 이유로 이미
+ * 자식-우선으로 지운다.
+ *
+ * 다만 스코프는 계정 삭제보다 좁다 — '삭제되는 프로필을 참조하는' 행만 지운다. 이 사용자가
+ * 남의 공유 목소리에 붙여 둔 호칭은 계정이 살아 있으므로 그대로 둔다.
+ */
+async function deleteRelationshipsForOwnedProfiles(db: DbExecutor, ids: string[], ph: string) {
+  await db.execute({
+    sql: `DELETE FROM voice_profile_relationships
+          WHERE voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (${ph}))`,
+    args: ids,
+  });
+}
+
+/**
+ * 이 사용자의 업로드 오브젝트를 참조하는 '수신자 소유' 가족알람 메시지를 끊는다.
+ *
+ * POST /family/alarms/voice 는 발신자의 voice_uploads.object_key 를 **수신자 소유**
+ * messages.audio_url 에 담는다(family-alarm.ts). 소유자 기준 강등/삭제는 발신자 id·발신자
+ * 프로필로만 고르므로 그 메시지를 건드리지 못하는데, 아래 정리는 그 오브젝트를 R2 에서
+ * 지운다. 그대로 두면 서버는 '음성 있음'으로 광고하지만 /tts/messages/:id/audio 가 실패해,
+ * 수신자 앱이 조용히 기본음 알람으로 되돌아간다(사용자에겐 목소리가 사라진 것처럼 보인다).
+ *
+ * 오브젝트를 지우기 전에 알람을 sound-only 로 명시 강등하고 audio_url 을 비워, 서버 상태와
+ * 클라 폴백이 같은 말을 하게 한다. 메시지 행 자체는 수신자 데이터라 지우지 않는다.
+ */
+async function detachFamilyAlarmMessagesUsingOwnedUploads(
+  db: DbExecutor,
+  ids: string[],
+  ph: string,
+) {
+  const affectedMessages = `SELECT id FROM messages
+     WHERE audio_url IS NOT NULL
+       AND audio_url IN (SELECT object_key FROM voice_uploads WHERE user_id IN (${ph}))`;
+  await db.execute({
+    sql: `UPDATE alarms
+          SET mode = 'sound-only',
+              wake_mode = 'sound_then_voice',
+              message_id = NULL,
+              voice_profile_id = NULL
+          WHERE message_id IN (${affectedMessages})`,
+    args: ids,
+  });
+  await db.execute({
+    sql: `UPDATE messages SET audio_url = NULL WHERE id IN (${affectedMessages})`,
+    args: ids,
+  });
+}
+
 export async function deletePaidVoiceDataForUser(
   db: DbExecutor,
   userPk: string,
@@ -21,6 +76,7 @@ export async function deletePaidVoiceDataForUser(
   // ElevenLabs 클론/R2 오디오 외부 삭제 참조를 행 삭제 전에 큐에 적재 —
   // 다운그레이드로 유료 음성 데이터가 사라질 때 클로닝 본체도 함께 사라지게 한다.
   await enqueueUserVoiceArtifacts(db, ids);
+  await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph);
 
   await db.execute({
     sql: `DELETE FROM generated_audio_assets
@@ -101,6 +157,7 @@ export async function deletePaidVoiceDataForUser(
     args: ids,
   });
 
+  await deleteRelationshipsForOwnedProfiles(db, ids, ph);
   await db.execute({
     sql: `DELETE FROM voice_profiles WHERE user_id IN (${ph})`,
     args: ids,
@@ -201,6 +258,7 @@ export async function deleteSensitiveVoiceDataForUser(
   for (const row of generatedObjects.rows) {
     await enqueueExternalDeletion(db, 'r2_object', row.audio_object_key as string);
   }
+  await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph);
 
   await db.execute({
     sql: `UPDATE alarms
@@ -243,5 +301,6 @@ export async function deleteSensitiveVoiceDataForUser(
     sql: `DELETE FROM voice_prerender_queue WHERE owner_user_id IN (${ph})`,
     args: ids,
   });
+  await deleteRelationshipsForOwnedProfiles(db, ids, ph);
   await db.execute({ sql: `DELETE FROM voice_profiles WHERE user_id IN (${ph})`, args: ids });
 }

--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -9,6 +9,34 @@ function placeholders(ids: string[]): string {
   return ids.map(() => '?').join(',');
 }
 
+/** 이 정리로 sound-only 로 강등된 알람 하나. 호출자가 커밋 후 신호를 보낸다. */
+export interface DowngradedAlarm {
+  alarmId: string;
+  /**
+   * 이 알람이 실제로 울리는 기기의 주인.
+   *
+   * 가족알람(POST /family/alarms/voice)은 alarms.user_id 가 **발신자**, target_user_id 가
+   * **수신자**다(family-alarm.ts). 캐시해 둔 녹음으로 울리는 쪽은 수신자이므로 target 을
+   * 우선한다. 일반 알람은 target 이 없어 소유자로 떨어진다.
+   */
+  ownerUserId: string;
+}
+
+/** 강등 대상 알람의 id 와 '울리는 기기의 주인'을 강등 전에 모은다. */
+async function collectDowngradeTargets(
+  db: DbExecutor,
+  sql: string,
+  args: string[],
+): Promise<DowngradedAlarm[]> {
+  const rows = await db.execute({ sql, args });
+  return rows.rows
+    .map((r) => ({
+      alarmId: String(r.id ?? ''),
+      ownerUserId: String(r.owner_user_id ?? ''),
+    }))
+    .filter((x) => x.alarmId && x.ownerUserId);
+}
+
 /**
  * 삭제될 voice_profiles 를 가리키는 호칭/관계 행을 먼저 지운다.
  *
@@ -41,21 +69,23 @@ async function deleteRelationshipsForOwnedProfiles(db: DbExecutor, ids: string[]
  * 오브젝트를 지우기 전에 알람을 sound-only 로 명시 강등하고 audio_url 을 비워, 서버 상태와
  * 클라 폴백이 같은 말을 하게 한다. 메시지 행 자체는 수신자 데이터라 지우지 않는다.
  *
- * @returns 강등된 알람의 주인들 — 호출자가 정리 커밋 후 plan_changed 푸시로 즉시 반영시킨다.
+ * @returns 강등된 알람들 — 호출자가 정리 커밋 후 신호를 보내 즉시 반영시킨다.
  */
 async function detachFamilyAlarmMessagesUsingOwnedUploads(
   db: DbExecutor,
   ids: string[],
   ph: string,
-): Promise<string[]> {
+): Promise<DowngradedAlarm[]> {
   const affectedMessages = `SELECT id FROM messages
      WHERE audio_url IS NOT NULL
        AND audio_url IN (SELECT object_key FROM voice_uploads WHERE user_id IN (${ph}))`;
-  // 강등 '전에' 주인을 모아 둔다 — UPDATE 가 message_id 를 끊고 나면 다시 찾을 수 없다.
-  const owners = await db.execute({
-    sql: `SELECT DISTINCT user_id FROM alarms WHERE message_id IN (${affectedMessages})`,
-    args: ids,
-  });
+  // 강등 '전에' 대상을 모아 둔다 — UPDATE 가 message_id 를 끊고 나면 다시 찾을 수 없다.
+  const owners = await collectDowngradeTargets(
+    db,
+    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id FROM alarms
+      WHERE message_id IN (${affectedMessages})`,
+    ids,
+  );
   await db.execute({
     sql: `UPDATE alarms
           SET mode = 'sound-only',
@@ -69,7 +99,7 @@ async function detachFamilyAlarmMessagesUsingOwnedUploads(
     sql: `UPDATE messages SET audio_url = NULL WHERE id IN (${affectedMessages})`,
     args: ids,
   });
-  return owners.rows.map((r) => String(r.user_id)).filter(Boolean);
+  return owners;
 }
 
 export async function deletePaidVoiceDataForUser(
@@ -232,20 +262,20 @@ export async function releaseClonedVoicesForUser(
 }
 
 /**
- * @returns 이 정리로 알람이 sound-only 로 강등된 사용자들. 호출자가 커밋 후 plan_changed
- *          data-only 푸시를 보내 즉시 반영시킨다 — 이 스윕은 플랜 변경 3일 뒤에 도는데,
- *          그때까지 앱을 안 켠 수신자는 이미 캐시한 오디오로 계속 울린다. 다음 앱 시작/주기
- *          동기화까지 기다리면 그사이 알람이 먼저 울릴 수 있다(AGENTS.md 의 FCM 상태 동기화).
+ * @returns 이 정리로 sound-only 로 강등된 알람들. 호출자가 커밋 후 신호를 보내 즉시
+ *          반영시킨다 — 이 스윕은 플랜 변경 3일 뒤에 도는데, 그때까지 앱을 안 켠 수신자는
+ *          이미 캐시한 오디오로 계속 울린다. 다음 앱 시작/주기 동기화까지 기다리면 그사이
+ *          알람이 먼저 울릴 수 있다(AGENTS.md 의 FCM 상태 동기화).
  */
 export async function deleteSensitiveVoiceDataForUser(
   db: DbExecutor,
   userPk: string,
   userLoginId?: string | null,
-): Promise<string[]> {
+): Promise<DowngradedAlarm[]> {
   const ids = uniqueIds([userPk, userLoginId]);
   if (ids.length === 0) return [];
   const ph = placeholders(ids);
-  const downgraded = new Set<string>();
+  const downgraded = new Map<string, DowngradedAlarm>();
 
   const providerVoices = await db.execute({
     sql: `SELECT elevenlabs_voice_id FROM voice_profiles
@@ -273,25 +303,24 @@ export async function deleteSensitiveVoiceDataForUser(
   for (const row of generatedObjects.rows) {
     await enqueueExternalDeletion(db, 'r2_object', row.audio_object_key as string);
   }
-  for (const id of await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph)) {
-    downgraded.add(id);
+  for (const target of await detachFamilyAlarmMessagesUsingOwnedUploads(db, ids, ph)) {
+    downgraded.set(target.alarmId, target);
   }
 
-  // 공유 목소리를 참조하던 알람도 같은 이유로 주인을 모아 둔다(강등 전에 골라야 한다).
-  const sharedVoiceAlarmOwners = await db.execute({
-    sql: `SELECT DISTINCT user_id FROM alarms
-          WHERE voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (${ph}))
-             OR message_id IN (
-               SELECT id FROM messages
-               WHERE user_id IN (${ph}) OR voice_profile_id IN (
-                 SELECT id FROM voice_profiles WHERE user_id IN (${ph})
-               )
-             )`,
-    args: [...ids, ...ids, ...ids],
-  });
-  for (const row of sharedVoiceAlarmOwners.rows) {
-    if (row.user_id) downgraded.add(String(row.user_id));
-  }
+  // 공유 목소리를 참조하던 알람도 같은 이유로 강등 전에 대상을 골라 둔다.
+  const sharedVoiceTargets = await collectDowngradeTargets(
+    db,
+    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id FROM alarms
+      WHERE voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (${ph}))
+         OR message_id IN (
+           SELECT id FROM messages
+           WHERE user_id IN (${ph}) OR voice_profile_id IN (
+             SELECT id FROM voice_profiles WHERE user_id IN (${ph})
+           )
+         )`,
+    [...ids, ...ids, ...ids],
+  );
+  for (const target of sharedVoiceTargets) downgraded.set(target.alarmId, target);
   await db.execute({
     sql: `UPDATE alarms
           SET mode = 'sound-only', wake_mode = 'sound_then_voice',
@@ -335,5 +364,5 @@ export async function deleteSensitiveVoiceDataForUser(
   });
   await deleteRelationshipsForOwnedProfiles(db, ids, ph);
   await db.execute({ sql: `DELETE FROM voice_profiles WHERE user_id IN (${ph})`, args: ids });
-  return Array.from(downgraded);
+  return Array.from(downgraded.values());
 }

--- a/packages/backend/src/lib/paid-voice-cleanup.ts
+++ b/packages/backend/src/lib/paid-voice-cleanup.ts
@@ -20,6 +20,14 @@ export interface DowngradedAlarm {
    * 우선한다. 일반 알람은 target 이 없어 소유자로 떨어진다.
    */
   ownerUserId: string;
+  /**
+   * 수신자에게 배달된 가족알람인가(target_user_id 존재).
+   *
+   * 보내야 할 신호가 다르다. 받은 알람은 원격 pull 로 갱신되지만(family_alarm →
+   * RemoteAlarmPullSyncService), **본인 소유 알람은 그 pull 대상이 아니다** — 받은 알람만
+   * 훑기 때문이다. 본인 알람은 목소리 접근권을 다시 확인해 로컬에서 강등해야 한다.
+   */
+  isReceived: boolean;
 }
 
 /** 강등 대상 알람의 id 와 '울리는 기기의 주인'을 강등 전에 모은다. */
@@ -33,6 +41,7 @@ async function collectDowngradeTargets(
     .map((r) => ({
       alarmId: String(r.id ?? ''),
       ownerUserId: String(r.owner_user_id ?? ''),
+      isReceived: Number(r.is_received ?? 0) === 1,
     }))
     .filter((x) => x.alarmId && x.ownerUserId);
 }
@@ -82,8 +91,9 @@ async function detachFamilyAlarmMessagesUsingOwnedUploads(
   // 강등 '전에' 대상을 모아 둔다 — UPDATE 가 message_id 를 끊고 나면 다시 찾을 수 없다.
   const owners = await collectDowngradeTargets(
     db,
-    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id FROM alarms
-      WHERE message_id IN (${affectedMessages})`,
+    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id,
+            target_user_id IS NOT NULL AS is_received
+       FROM alarms WHERE message_id IN (${affectedMessages})`,
     ids,
   );
   await db.execute({
@@ -310,7 +320,9 @@ export async function deleteSensitiveVoiceDataForUser(
   // 공유 목소리를 참조하던 알람도 같은 이유로 강등 전에 대상을 골라 둔다.
   const sharedVoiceTargets = await collectDowngradeTargets(
     db,
-    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id FROM alarms
+    `SELECT id, COALESCE(target_user_id, user_id) AS owner_user_id,
+            target_user_id IS NOT NULL AS is_received
+       FROM alarms
       WHERE voice_profile_id IN (SELECT id FROM voice_profiles WHERE user_id IN (${ph}))
          OR message_id IN (
            SELECT id FROM messages

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -3,6 +3,7 @@ import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { logRouteError } from '../lib/logger';
 import { deleteSensitiveVoiceDataForUser } from '../lib/paid-voice-cleanup';
+import { notifyDowngradedAlarms } from '../lib/fcm';
 import { purgeUserAccount, pseudonymizeBillingForRetention } from '../lib/account-deletion';
 import { withWriteTransaction } from '../lib/transactions';
 import {
@@ -301,6 +302,11 @@ user.post('/consents', async (c) => {
     });
   }
   try {
+    // 동의 철회로 강등된 알람들 — 커밋 후에 신호를 보내야 한다(롤백될 수 있는 변경을
+    // 미리 알리지 않는다). 보관 만료 스윕과 같은 이유로 알람 동기화 신호가 필요하다:
+    // 서버가 수신자의 가족알람을 sound-only 로 내리고 R2 오브젝트를 지워도, 신호가
+    // 없으면 수신자는 다음 폴백 pull 까지 캐시된 녹음으로 계속 울린다.
+    let downgradedAlarms: Array<{ alarmId: string; ownerUserId: string }> = [];
     await withWriteTransaction(db, async (tx) => {
       for (const r of rows) {
         await tx.execute({
@@ -314,9 +320,10 @@ user.post('/consents', async (c) => {
           (row) => !row.agreed && SENSITIVE_REQUIRED_CONSENTS.some((type) => type === row.type),
         )
       ) {
-        await deleteSensitiveVoiceDataForUser(tx, userPk, c.get('userLoginId'));
+        downgradedAlarms = await deleteSensitiveVoiceDataForUser(tx, userPk, c.get('userLoginId'));
       }
     });
+    await notifyDowngradedAlarms(db, c.env, downgradedAlarms);
     return c.json({ success: true, recorded: rows.length });
   } catch (err) {
     logRouteError(c, err);

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -309,6 +309,16 @@ user.post('/consents', async (c) => {
     // 미리 알리지 않는다). 보관 만료 스윕과 같은 이유로 알람 동기화 신호가 필요하다:
     // 서버가 수신자의 가족알람을 sound-only 로 내리고 R2 오브젝트를 지워도, 신호가
     // 없으면 수신자는 다음 폴백 pull 까지 캐시된 녹음으로 계속 울린다.
+    // 같은 유형이 여러 번 담겨 오면 **마지막 값이 유효 동의**다(GET /consents 가 삽입 순서
+    // 역순으로 최신을 고른다). 그러니 철회 판정도 마지막 값으로 해야 한다 — 'false 가 하나라도
+    // 있으면'으로 보면 [false, true] 처럼 결국 동의한 요청에도 민감 음성 데이터를 되돌릴 수 없게
+    // 지워 버린다.
+    const finalAgreedByType = new Map<string, boolean>();
+    for (const r of rows) finalAgreedByType.set(r.type, r.agreed);
+    const withdrewSensitiveConsent = SENSITIVE_REQUIRED_CONSENTS.some(
+      (type) => finalAgreedByType.get(type) === false,
+    );
+
     let downgradedAlarms: DowngradedAlarm[] = [];
     await withWriteTransaction(db, async (tx) => {
       for (const r of rows) {
@@ -318,15 +328,19 @@ user.post('/consents', async (c) => {
           args: [crypto.randomUUID(), userPk, r.type, r.version, r.agreed ? 1 : 0],
         });
       }
-      if (
-        rows.some(
-          (row) => !row.agreed && SENSITIVE_REQUIRED_CONSENTS.some((type) => type === row.type),
-        )
-      ) {
+      if (withdrewSensitiveConsent) {
         downgradedAlarms = await deleteSensitiveVoiceDataForUser(tx, userPk, c.get('userLoginId'));
       }
     });
-    await notifyDowngradedAlarms(db, c.env, downgradedAlarms);
+    // 철회했으면 알람 행을 못 찾았어도 이 계정에 목소리 접근권 상실을 알린다 — 서버에 아직
+    // 동기화되지 않은 로컬 알람은 여기서 안 잡히는데, 발사는 로컬이고 울림 시점 동의 게이트도
+    // 없어 그 기기는 지워진 녹음으로 계속 울린다.
+    await notifyDowngradedAlarms(
+      db,
+      c.env,
+      downgradedAlarms,
+      withdrewSensitiveConsent ? [userPk] : [],
+    );
     return c.json({ success: true, recorded: rows.length });
   } catch (err) {
     logRouteError(c, err);

--- a/packages/backend/src/routes/user.ts
+++ b/packages/backend/src/routes/user.ts
@@ -2,7 +2,10 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types';
 import { getDB } from '../lib/db';
 import { logRouteError } from '../lib/logger';
-import { deleteSensitiveVoiceDataForUser } from '../lib/paid-voice-cleanup';
+import {
+  deleteSensitiveVoiceDataForUser,
+  type DowngradedAlarm,
+} from '../lib/paid-voice-cleanup';
 import { notifyDowngradedAlarms } from '../lib/fcm';
 import { purgeUserAccount, pseudonymizeBillingForRetention } from '../lib/account-deletion';
 import { withWriteTransaction } from '../lib/transactions';
@@ -306,7 +309,7 @@ user.post('/consents', async (c) => {
     // 미리 알리지 않는다). 보관 만료 스윕과 같은 이유로 알람 동기화 신호가 필요하다:
     // 서버가 수신자의 가족알람을 sound-only 로 내리고 R2 오브젝트를 지워도, 신호가
     // 없으면 수신자는 다음 폴백 pull 까지 캐시된 녹음으로 계속 울린다.
-    let downgradedAlarms: Array<{ alarmId: string; ownerUserId: string }> = [];
+    let downgradedAlarms: DowngradedAlarm[] = [];
     await withWriteTransaction(db, async (tx) => {
       for (const r of rows) {
         await tx.execute({

--- a/packages/backend/test/notify-downgraded-alarms.test.ts
+++ b/packages/backend/test/notify-downgraded-alarms.test.ts
@@ -1,0 +1,98 @@
+// 강등 알림 팬아웃 가드 (Codex #654).
+//
+// 클라 핸들러(AlarmTalkMessagingService)는 family_alarm payload 의 alarmId 를 쓰지 않고 원격
+// 알람을 '전부' 다시 받는다. 그래서 알람마다 보내면 토큰 조회와 FCM 왕복만 알람 수만큼 늘고,
+// 한 스윕이 여러 알람을 강등하면 Workers 서브리퀘스트 상한에 걸린다.
+//
+// 팬아웃 규칙만 떼어 낸 buildDowngradeNotifications 를 직접 검증한다 — 토큰 조회를 인자로 받는
+// 순수 함수라 DB·네트워크 없이 '누구에게 몇 번' 나가는지 단언할 수 있다.
+import { describe, it, expect } from 'vitest';
+import { buildDowngradeNotifications } from '../src/lib/fcm';
+
+/** 사용자당 토큰 하나. 조회 횟수도 함께 센다 — 그게 곧 DB 서브리퀘스트 수다. */
+function tokenLookup(tokens: Record<string, string[]>) {
+  const lookups: string[] = [];
+  return {
+    lookups,
+    getTokens: async (userId: string) => {
+      lookups.push(userId);
+      return tokens[userId] ?? [];
+    },
+  };
+}
+
+describe('buildDowngradeNotifications 팬아웃', () => {
+  it('같은 수신자의 알람이 여러 개여도 한 번만 만든다', async () => {
+    const { lookups, getTokens } = tokenLookup({ recipient: ['tok-r'] });
+
+    const messages = await buildDowngradeNotifications(getTokens, [
+      { alarmId: 'al-1', ownerUserId: 'recipient', isReceived: true },
+      { alarmId: 'al-2', ownerUserId: 'recipient', isReceived: true },
+      { alarmId: 'al-3', ownerUserId: 'recipient', isReceived: true },
+    ]);
+
+    expect(lookups).toEqual(['recipient']); // 알람 3개여도 토큰 조회는 1회
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      token: 'tok-r',
+      data: { type: 'family_alarm', alarmId: 'al-1' },
+    });
+  });
+
+  it('수신자가 여럿이면 각자 한 번씩', async () => {
+    const { lookups, getTokens } = tokenLookup({ a: ['tok-a'], b: ['tok-b1', 'tok-b2'] });
+
+    const messages = await buildDowngradeNotifications(getTokens, [
+      { alarmId: 'al-1', ownerUserId: 'a', isReceived: true },
+      { alarmId: 'al-2', ownerUserId: 'b', isReceived: true },
+      { alarmId: 'al-3', ownerUserId: 'a', isReceived: true },
+    ]);
+
+    expect(lookups.sort()).toEqual(['a', 'b']);
+    // 기기가 둘인 사용자에게는 토큰 수만큼 나간다(그건 접을 수 없다).
+    expect(messages.map((m) => m.token).sort()).toEqual(['tok-a', 'tok-b1', 'tok-b2']);
+  });
+
+  it('받은 알람과 본인 소유 알람에 서로 다른 신호를 만든다', async () => {
+    const { getTokens } = tokenLookup({ recipient: ['tok-r'], owner: ['tok-o'] });
+
+    const messages = await buildDowngradeNotifications(getTokens, [
+      { alarmId: 'al-1', ownerUserId: 'recipient', isReceived: true },
+      { alarmId: 'al-2', ownerUserId: 'owner', isReceived: false },
+    ]);
+
+    expect(messages.map((m) => m.data?.type).sort()).toEqual([
+      'family_alarm',
+      'voice_access_revoked',
+    ]);
+  });
+
+  it('알람 행이 없어도 접근권 상실 계정에는 만든다', async () => {
+    const { getTokens } = tokenLookup({ 'user-1': ['tok-1'] });
+
+    const messages = await buildDowngradeNotifications(getTokens, [], ['user-1']);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ token: 'tok-1', data: { type: 'voice_access_revoked' } });
+  });
+
+  it('본인 소유 알람 주인과 접근권 상실 계정이 겹쳐도 한 번만', async () => {
+    const { lookups, getTokens } = tokenLookup({ me: ['tok-me'] });
+
+    const messages = await buildDowngradeNotifications(
+      getTokens,
+      [{ alarmId: 'al-1', ownerUserId: 'me', isReceived: false }],
+      ['me'],
+    );
+
+    expect(lookups).toEqual(['me']);
+    expect(messages).toHaveLength(1);
+  });
+
+  it('대상이 없으면 빈 목록', async () => {
+    const { lookups, getTokens } = tokenLookup({});
+
+    expect(await buildDowngradeNotifications(getTokens, [], [])).toEqual([]);
+    expect(lookups).toEqual([]);
+  });
+});

--- a/packages/backend/test/paid-voice-cleanup-fk.test.ts
+++ b/packages/backend/test/paid-voice-cleanup-fk.test.ts
@@ -122,6 +122,33 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
     expect(message).toBeDefined();
   });
 
+  /**
+   * 이 스윕은 플랜 변경 3일 뒤에 돈다. 그때 강등되는 수신자는 이번 주기의 만료 대상이 아니라
+   * 호출부의 푸시 목록에 없다 — 반환하지 않으면 이미 오디오를 캐시한 백그라운드 수신자가
+   * 다음 동기화까지 지워진 녹음으로 계속 울린다(그사이 알람이 먼저 울릴 수 있다).
+   */
+  it('강등된 알람 주인을 돌려줘 plan_changed 푸시 대상에 넣게 한다', async () => {
+    await db.execute(
+      `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-r', 'recipient', '수신자 목소리', 'ready')`,
+    );
+    await db.execute(
+      `INSERT INTO voice_uploads (id, user_id, object_key, mime_type, size_bytes)
+       VALUES ('up-1', 'sender', 'voices/sender/clip.m4a', 'audio/mp4', 100)`,
+    );
+    await db.execute(
+      `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+       VALUES ('msg-1', 'recipient', 'vp-r', '일어나', 'voices/sender/clip.m4a', 'family-voice')`,
+    );
+    await db.execute(
+      `INSERT INTO alarms (id, user_id, message_id, time, mode)
+       VALUES ('al-1', 'recipient', 'msg-1', '07:00', 'voice')`,
+    );
+
+    const downgraded = await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
+
+    expect(downgraded).toContain('recipient');
+  });
+
   it('내 업로드와 무관한 수신자 메시지는 건드리지 않는다', async () => {
     await db.execute(
       `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-r', 'recipient', '수신자 목소리', 'ready')`,

--- a/packages/backend/test/paid-voice-cleanup-fk.test.ts
+++ b/packages/backend/test/paid-voice-cleanup-fk.test.ts
@@ -150,7 +150,9 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
 
     // 울리는 기기의 주인은 target_user_id(수신자)다 — user_id(발신자)를 보내면
     // 정작 캐시된 녹음으로 울리는 기기는 신호를 못 받는다.
-    expect(downgraded).toEqual([{ alarmId: 'al-1', ownerUserId: 'recipient' }]);
+    expect(downgraded).toEqual([
+      { alarmId: 'al-1', ownerUserId: 'recipient', isReceived: true },
+    ]);
   });
 
   it('내 업로드와 무관한 수신자 메시지는 건드리지 않는다', async () => {

--- a/packages/backend/test/paid-voice-cleanup-fk.test.ts
+++ b/packages/backend/test/paid-voice-cleanup-fk.test.ts
@@ -1,0 +1,146 @@
+// 보관 만료 스윕(sweepPaidVoiceRetention → deleteSensitiveVoiceDataForUser) 회귀 가드.
+//
+// 목 DB 가 아니라 실제 SQLite 로 돌린다. 두 결함 다 '문장이 불렸는가'가 아니라 '스키마 제약과
+// 남은 행 상태'가 본질이라, 호출 문자열을 세는 방식으로는 잡히지 않는다(Codex #646).
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createClient, type Client } from '@libsql/client';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { runMigrations } from '../src/lib/migrations';
+import { deleteSensitiveVoiceDataForUser } from '../src/lib/paid-voice-cleanup';
+
+const DB_PATH = join(tmpdir(), `alarmtalk-cleanup-fk-${process.pid}.db`);
+let db: Client;
+
+async function reset() {
+  for (const t of [
+    'voice_profile_relationships',
+    'alarms',
+    'messages',
+    'voice_uploads',
+    'voice_profiles',
+    'users',
+  ]) {
+    await db.execute(`DELETE FROM ${t}`);
+  }
+  await db.execute(
+    `INSERT INTO users (id, google_id, email) VALUES
+       ('sender', 'sender', 's@test.com'),
+       ('recipient', 'recipient', 'r@test.com')`,
+  );
+}
+
+beforeEach(async () => {
+  if (!db) {
+    for (const suffix of ['', '-shm', '-wal']) rmSync(`${DB_PATH}${suffix}`, { force: true });
+    db = createClient({ url: `file:${DB_PATH}` });
+    await runMigrations(db);
+    // 운영에서 FK 가 켜져 있을 때의 동작을 재현한다 — 자식 행을 안 지우면 여기서 던진다.
+    await db.execute('PRAGMA foreign_keys = ON');
+  }
+  await reset();
+});
+
+afterAll(() => {
+  db?.close();
+  for (const suffix of ['', '-shm', '-wal']) {
+    try {
+      rmSync(`${DB_PATH}${suffix}`, { force: true });
+    } catch {
+      /* 임시 파일이라 남아도 무해 */
+    }
+  }
+});
+
+describe('보관 만료 정리 — 자식 행 먼저', () => {
+  it('공유 목소리에 붙은 호칭 행이 있어도 프로필 삭제가 끝까지 간다', async () => {
+    await db.execute(
+      `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-1', 'sender', '내 목소리', 'ready')`,
+    );
+    // 공유받은 사람이 붙여 둔 호칭 — voice_profiles FK 를 건다.
+    await db.execute(
+      `INSERT INTO voice_profile_relationships (id, user_id, voice_profile_id, relationship_label)
+       VALUES ('rel-1', 'recipient', 'vp-1', '아빠')`,
+    );
+
+    // 자식 행을 안 지우면 FK 로 여기서 던지고, 호출부(sweepPaidVoiceRetention)는
+    // paid_voice_retention 을 못 지워 만료 처리가 매번 같은 자리에서 멈춘다.
+    await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
+
+    const profiles = await db.execute(`SELECT id FROM voice_profiles`);
+    const rels = await db.execute(`SELECT id FROM voice_profile_relationships`);
+    expect(profiles.rows).toEqual([]);
+    expect(rels.rows).toEqual([]);
+  });
+
+  it('남의 공유 목소리에 내가 붙인 호칭은 남긴다 (계정은 살아 있다)', async () => {
+    await db.execute(
+      `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-other', 'recipient', '남의 목소리', 'ready')`,
+    );
+    await db.execute(
+      `INSERT INTO voice_profile_relationships (id, user_id, voice_profile_id, relationship_label)
+       VALUES ('rel-mine', 'sender', 'vp-other', '엄마')`,
+    );
+
+    await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
+
+    const rels = await db.execute(`SELECT id FROM voice_profile_relationships`);
+    expect(rels.rows.map((r) => r.id)).toEqual(['rel-mine']);
+  });
+});
+
+describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
+  it('수신자 메시지가 내 업로드 오브젝트를 가리키면 알람을 강등하고 URL 을 비운다', async () => {
+    await db.execute(
+      `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-r', 'recipient', '수신자 목소리', 'ready')`,
+    );
+    await db.execute(
+      `INSERT INTO voice_uploads (id, user_id, object_key, mime_type, size_bytes)
+       VALUES ('up-1', 'sender', 'voices/sender/clip.m4a', 'audio/mp4', 100)`,
+    );
+    // POST /family/alarms/voice 가 만드는 모양: 메시지는 수신자 소유인데 audio_url 은 발신자 오브젝트.
+    await db.execute(
+      `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+       VALUES ('msg-1', 'recipient', 'vp-r', '일어나', 'voices/sender/clip.m4a', 'family-voice')`,
+    );
+    await db.execute(
+      `INSERT INTO alarms (id, user_id, message_id, time, mode)
+       VALUES ('al-1', 'recipient', 'msg-1', '07:00', 'voice')`,
+    );
+
+    await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
+
+    const alarm = (await db.execute(`SELECT mode, message_id FROM alarms WHERE id = 'al-1'`))
+      .rows[0];
+    const message = (await db.execute(`SELECT audio_url FROM messages WHERE id = 'msg-1'`)).rows[0];
+    // 오브젝트가 사라졌으니 서버도 '음성 있음'이라고 광고하면 안 된다.
+    expect(alarm?.mode).toBe('sound-only');
+    expect(alarm?.message_id).toBeNull();
+    expect(message?.audio_url).toBeNull();
+    // 수신자 데이터라 메시지 행 자체는 남는다.
+    expect(message).toBeDefined();
+  });
+
+  it('내 업로드와 무관한 수신자 메시지는 건드리지 않는다', async () => {
+    await db.execute(
+      `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-r', 'recipient', '수신자 목소리', 'ready')`,
+    );
+    await db.execute(
+      `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
+       VALUES ('msg-keep', 'recipient', 'vp-r', '일어나', 'voices/someone-else/clip.m4a', 'family-voice')`,
+    );
+    await db.execute(
+      `INSERT INTO alarms (id, user_id, message_id, time, mode)
+       VALUES ('al-keep', 'recipient', 'msg-keep', '07:00', 'voice')`,
+    );
+
+    await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
+
+    const alarm = (await db.execute(`SELECT mode FROM alarms WHERE id = 'al-keep'`)).rows[0];
+    const message = (await db.execute(`SELECT audio_url FROM messages WHERE id = 'msg-keep'`))
+      .rows[0];
+    expect(alarm?.mode).toBe('voice');
+    expect(message?.audio_url).toBe('voices/someone-else/clip.m4a');
+  });
+});

--- a/packages/backend/test/paid-voice-cleanup-fk.test.ts
+++ b/packages/backend/test/paid-voice-cleanup-fk.test.ts
@@ -104,9 +104,10 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
       `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
        VALUES ('msg-1', 'recipient', 'vp-r', '일어나', 'voices/sender/clip.m4a', 'family-voice')`,
     );
+    // 실제 POST /family/alarms/voice 행 모양 — user_id 는 발신자, target_user_id 가 수신자다.
     await db.execute(
-      `INSERT INTO alarms (id, user_id, message_id, time, mode)
-       VALUES ('al-1', 'recipient', 'msg-1', '07:00', 'voice')`,
+      `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, mode)
+       VALUES ('al-1', 'sender', 'recipient', 'msg-1', '07:00', 'voice')`,
     );
 
     await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
@@ -127,7 +128,7 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
    * 호출부의 푸시 목록에 없다 — 반환하지 않으면 이미 오디오를 캐시한 백그라운드 수신자가
    * 다음 동기화까지 지워진 녹음으로 계속 울린다(그사이 알람이 먼저 울릴 수 있다).
    */
-  it('강등된 알람 주인을 돌려줘 plan_changed 푸시 대상에 넣게 한다', async () => {
+  it('강등된 알람과 울리는 기기의 주인을 돌려준다 (알람 동기화 신호용)', async () => {
     await db.execute(
       `INSERT INTO voice_profiles (id, user_id, name, status) VALUES ('vp-r', 'recipient', '수신자 목소리', 'ready')`,
     );
@@ -139,14 +140,17 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
       `INSERT INTO messages (id, user_id, voice_profile_id, text, audio_url, category)
        VALUES ('msg-1', 'recipient', 'vp-r', '일어나', 'voices/sender/clip.m4a', 'family-voice')`,
     );
+    // 실제 POST /family/alarms/voice 행 모양 — user_id 는 발신자, target_user_id 가 수신자다.
     await db.execute(
-      `INSERT INTO alarms (id, user_id, message_id, time, mode)
-       VALUES ('al-1', 'recipient', 'msg-1', '07:00', 'voice')`,
+      `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, mode)
+       VALUES ('al-1', 'sender', 'recipient', 'msg-1', '07:00', 'voice')`,
     );
 
     const downgraded = await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');
 
-    expect(downgraded).toContain('recipient');
+    // 울리는 기기의 주인은 target_user_id(수신자)다 — user_id(발신자)를 보내면
+    // 정작 캐시된 녹음으로 울리는 기기는 신호를 못 받는다.
+    expect(downgraded).toEqual([{ alarmId: 'al-1', ownerUserId: 'recipient' }]);
   });
 
   it('내 업로드와 무관한 수신자 메시지는 건드리지 않는다', async () => {
@@ -158,8 +162,8 @@ describe('보관 만료 정리 — 가족알람 음성 끊기', () => {
        VALUES ('msg-keep', 'recipient', 'vp-r', '일어나', 'voices/someone-else/clip.m4a', 'family-voice')`,
     );
     await db.execute(
-      `INSERT INTO alarms (id, user_id, message_id, time, mode)
-       VALUES ('al-keep', 'recipient', 'msg-keep', '07:00', 'voice')`,
+      `INSERT INTO alarms (id, user_id, target_user_id, message_id, time, mode)
+       VALUES ('al-keep', 'sender', 'recipient', 'msg-keep', '07:00', 'voice')`,
     );
 
     await deleteSensitiveVoiceDataForUser(db, 'sender', 'sender');

--- a/packages/backend/test/user-consent-downgrade-push.test.ts
+++ b/packages/backend/test/user-consent-downgrade-push.test.ts
@@ -71,6 +71,55 @@ describe('POST /user/consents — 민감 동의 철회', () => {
     ]);
   });
 
+  /**
+   * 서버에 아직 동기화되지 않은 로컬 알람은 정리 대상 조회에 안 잡힌다. 발사는 로컬이고
+   * 울림 시점 동의 게이트도 없으니, 알람 행을 못 찾아도 그 계정에는 접근권 상실을 알려야
+   * 한다 — 아니면 그 기기는 지워진 녹음으로 계속 울린다(Codex #654).
+   */
+  it('강등할 알람 행이 없어도 철회한 계정에는 접근권 상실을 알린다', async () => {
+    const app = buildApp();
+
+    const res = await app.request(
+      jsonReq('POST', '/user/consents', {
+        consents: [{ type: 'voice_biometric', agreed: false }],
+      }),
+      undefined,
+      {} as AppEnv['Bindings'],
+    );
+
+    expect(res.status).toBe(200);
+    expect(notifyDowngradedAlarms.mock.calls[0]![2]).toEqual([]);
+    expect(notifyDowngradedAlarms.mock.calls[0]![3]).toEqual(['user-1']);
+  });
+
+  /**
+   * 같은 유형이 여러 번 오면 마지막 값이 유효 동의다(GET /consents 규칙). 'false 가 하나라도
+   * 있으면'으로 보면 [false, true] 처럼 결국 동의한 요청에도 민감 음성 데이터를 되돌릴 수
+   * 없게 지워 버린다(Codex #654).
+   */
+  it('같은 유형이 중복되면 마지막 값으로 철회를 판정한다', async () => {
+    const app = buildApp();
+
+    const res = await app.request(
+      jsonReq('POST', '/user/consents', {
+        consents: [
+          { type: 'voice_biometric', agreed: false },
+          { type: 'voice_biometric', agreed: true },
+        ],
+      }),
+      undefined,
+      {} as AppEnv['Bindings'],
+    );
+
+    expect(res.status).toBe(200);
+    // 최종값이 동의이므로 삭제도 신호도 없어야 한다.
+    expect(notifyDowngradedAlarms.mock.calls[0]![3]).toEqual([]);
+    const deletedProfiles = mockDB.calls.some((call) =>
+      /DELETE FROM voice_profiles/.test(call.sql),
+    );
+    expect(deletedProfiles).toBe(false);
+  });
+
   it('철회가 아니면 정리도 신호도 없다', async () => {
     const app = buildApp();
 
@@ -83,6 +132,11 @@ describe('POST /user/consents — 민감 동의 철회', () => {
     );
 
     expect(res.status).toBe(200);
-    expect(notifyDowngradedAlarms).toHaveBeenCalledWith(expect.anything(), expect.anything(), []);
+    expect(notifyDowngradedAlarms).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      [],
+      [],
+    );
   });
 });

--- a/packages/backend/test/user-consent-downgrade-push.test.ts
+++ b/packages/backend/test/user-consent-downgrade-push.test.ts
@@ -38,7 +38,9 @@ beforeEach(() => {
 });
 
 /** 강등 대상 조회에만 행을 돌려주는 스텁 — FIFO 순서에 기대지 않는다. */
-function stubDowngradeTarget(row: { id: string; owner_user_id: string } | null) {
+function stubDowngradeTarget(
+  row: { id: string; owner_user_id: string; is_received: number } | null,
+) {
   const base = mockDB.client.execute;
   mockDB.client.execute = (async (q: { sql: string; args: (string | number | null)[] }) => {
     if (row && /COALESCE\(target_user_id, user_id\)/.test(q.sql) && /WHERE message_id IN/.test(q.sql)) {
@@ -50,7 +52,7 @@ function stubDowngradeTarget(row: { id: string; owner_user_id: string } | null) 
 
 describe('POST /user/consents — 민감 동의 철회', () => {
   it('강등된 알람의 주인에게 알람 동기화 신호를 보낸다', async () => {
-    stubDowngradeTarget({ id: 'al-1', owner_user_id: 'recipient' });
+    stubDowngradeTarget({ id: 'al-1', owner_user_id: 'recipient', is_received: 1 });
     const app = buildApp();
 
     const res = await app.request(
@@ -65,7 +67,7 @@ describe('POST /user/consents — 민감 동의 철회', () => {
     expect(notifyDowngradedAlarms).toHaveBeenCalledTimes(1);
     // 울리는 기기의 주인은 target_user_id(수신자)다.
     expect(notifyDowngradedAlarms.mock.calls[0]![2]).toEqual([
-      { alarmId: 'al-1', ownerUserId: 'recipient' },
+      { alarmId: 'al-1', ownerUserId: 'recipient', isReceived: true },
     ]);
   });
 

--- a/packages/backend/test/user-consent-downgrade-push.test.ts
+++ b/packages/backend/test/user-consent-downgrade-push.test.ts
@@ -1,0 +1,86 @@
+// 동의 철회로 알람이 강등되면 그 기기에 알람 동기화 신호가 나가는지 고정한다.
+//
+// deleteSensitiveVoiceDataForUser 는 강등된 알람을 돌려주는데, 호출부가 그 반환값을 흘려보내면
+// 서버는 수신자의 가족알람을 sound-only 로 내리고 R2 오브젝트까지 지웠는데도 수신자는 캐시된
+// 녹음으로 계속 울린다(다음 폴백 pull 까지). 실제로 보관 만료 스윕에서 한 번, 이 동의 철회
+// 경로에서 또 한 번 같은 식으로 빠졌다(Codex #654).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../src/types';
+import { createMockDB, fakeAuthMiddleware, jsonReq } from './helpers';
+
+const mockDB = createMockDB();
+
+vi.mock('../src/lib/db', () => ({
+  getDB: () => mockDB.client,
+}));
+
+const notifyDowngradedAlarms = vi.fn();
+vi.mock('../src/lib/fcm', () => ({
+  notifyDowngradedAlarms: (...args: unknown[]) => notifyDowngradedAlarms(...args),
+}));
+
+import userRoutes from '../src/routes/user';
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.use('*', fakeAuthMiddleware('user-1'));
+  app.route('/user', userRoutes);
+  return app;
+}
+
+const originalExecute = mockDB.client.execute;
+
+beforeEach(() => {
+  mockDB.reset();
+  mockDB.client.execute = originalExecute;
+  notifyDowngradedAlarms.mockClear();
+});
+
+/** 강등 대상 조회에만 행을 돌려주는 스텁 — FIFO 순서에 기대지 않는다. */
+function stubDowngradeTarget(row: { id: string; owner_user_id: string } | null) {
+  const base = mockDB.client.execute;
+  mockDB.client.execute = (async (q: { sql: string; args: (string | number | null)[] }) => {
+    if (row && /COALESCE\(target_user_id, user_id\)/.test(q.sql) && /WHERE message_id IN/.test(q.sql)) {
+      return { rows: [row], rowsAffected: 0 };
+    }
+    return base(q);
+  }) as typeof mockDB.client.execute;
+}
+
+describe('POST /user/consents — 민감 동의 철회', () => {
+  it('강등된 알람의 주인에게 알람 동기화 신호를 보낸다', async () => {
+    stubDowngradeTarget({ id: 'al-1', owner_user_id: 'recipient' });
+    const app = buildApp();
+
+    const res = await app.request(
+      jsonReq('POST', '/user/consents', {
+        consents: [{ type: 'voice_biometric', agreed: false }],
+      }),
+      undefined,
+      {} as AppEnv['Bindings'],
+    );
+
+    expect(res.status).toBe(200);
+    expect(notifyDowngradedAlarms).toHaveBeenCalledTimes(1);
+    // 울리는 기기의 주인은 target_user_id(수신자)다.
+    expect(notifyDowngradedAlarms.mock.calls[0]![2]).toEqual([
+      { alarmId: 'al-1', ownerUserId: 'recipient' },
+    ]);
+  });
+
+  it('철회가 아니면 정리도 신호도 없다', async () => {
+    const app = buildApp();
+
+    const res = await app.request(
+      jsonReq('POST', '/user/consents', {
+        consents: [{ type: 'voice_biometric', agreed: true }],
+      }),
+      undefined,
+      {} as AppEnv['Bindings'],
+    );
+
+    expect(res.status).toBe(200);
+    expect(notifyDowngradedAlarms).toHaveBeenCalledWith(expect.anything(), expect.anything(), []);
+  });
+});


### PR DESCRIPTION
#646 에 달린 Codex P1 + P2. 둘 다 `sweepPaidVoiceRetention` → `deleteSensitiveVoiceDataForUser` 경로다.

## 1. (P1) FK 자식 행을 안 지우고 프로필을 지웠다

`voice_profile_relationships.voice_profile_id` 는 `voice_profiles` FK 다(마이그레이션 #37).

- FK 가 **켜져 있으면**: 삭제가 던져 호출부가 `paid_voice_retention` 을 못 지우고
  `plan_changed` 알림 전에 중단된다 → **만료 처리가 매번 같은 자리에서 멈춘다.**
- FK 가 **꺼져 있으면**: 사라진 프로필을 가리키는 호칭 행이 그대로 남는다.

`account-deletion.ts:187-196` 은 같은 이유로 이미 자식-우선으로 지우고 있었다("관계/호칭 행은
voice_profiles FK 라 프로필 삭제 전에 지운다"). 이 경로만 빠져 있었다.

스코프는 계정 삭제보다 **좁게** 잡았다 — '삭제되는 프로필을 참조하는' 행만 지운다. 이 사용자가
남의 공유 목소리에 붙여 둔 호칭은 계정이 살아 있으므로 보존해야 한다.

## 2. (P2) 가족알람 음성이 가리키는 오브젝트를 말없이 지웠다

`POST /family/alarms/voice` 는 **발신자**의 `voice_uploads.object_key` 를 **수신자 소유**
`messages.audio_url` 에 담는다(`family-alarm.ts:246-256`).

이 정리는 발신자 업로드 오브젝트를 전부 R2 삭제 큐에 넣는데, 강등/삭제는 발신자 id·발신자
프로필로만 골라 **그 메시지를 못 건드린다.** 결과적으로 서버는 '음성 있음'으로 광고하지만
`/tts/messages/:id/audio` 는 실패하고, 수신자 앱은 조용히 기본음 알람으로 되돌아간다.

오브젝트를 지우기 전에 해당 알람을 `sound-only` 로 강등하고 `audio_url` 을 비워 서버 상태와
클라 폴백이 같은 말을 하게 했다. 메시지 행 자체는 수신자 데이터라 남긴다.

## 범위

같은 구멍이 `deletePaidVoiceDataForUser` 에도 있어(같은 `DELETE FROM voice_profiles`,
같은 업로드 삭제) 공통 헬퍼로 **양쪽에** 적용했다. 한쪽만 고치면 다음 라운드에 그대로 다시 나온다.

## 테스트

`test/paid-voice-cleanup-fk.test.ts` (신규 4건) — **목 DB 가 아니라 실제 SQLite** 에
`PRAGMA foreign_keys = ON` 으로 돌린다. 두 결함 다 '문장이 불렸는가'가 아니라 **스키마 제약과
남은 행 상태**가 본질이라, 호출 문자열을 세는 기존 방식으로는 잡히지 않는다.

- 호칭 행이 있어도 프로필 삭제가 끝까지 갈 것
- 남의 목소리에 붙인 내 호칭은 남을 것
- 수신자 메시지를 강등하고 URL 을 비울 것
- 내 업로드와 무관한 수신자 메시지는 건드리지 않을 것

두 수정을 빼면 해당 2건이 `FAILED` 되는 것까지 확인했다.

백엔드 전체 `npm test` 80파일 1216건 통과, `npm run typecheck` 통과.