### PR TITLE
fix(android): 알람 전체 훑는 작업을 지금 계정 소유로 한정한다 (Codex #646 P1 2건 + 형제 4건)

### DIFF
--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDao.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmDao.kt
@@ -88,15 +88,24 @@ interface AlarmDao {
         fireDateEndMillis: Long,
     ): Int
 
+    /**
+     * "한 시각에는 알람 하나" 정책의 충돌 개수. 대상은 **이 계정에 보이는 알람**으로 한정한다
+     * ([AlarmRepository.observeAlarms] 와 같은 규칙).
+     *
+     * 로컬 알람은 로그아웃해도 남으므로, 소유자를 안 보면 앞 계정 A 의 07:00 알람 때문에 B 가
+     * 07:00 을 못 쓴다 — 목록에는 안 보이니 지울 수도 없다. 게다가 교체 흐름으로 넘어가면
+     * A 의 알람과 음성 캐시가 영구 삭제된다(내 알람은 서버에서 되받는 경로가 없다).
+     */
     @Query(
         """
         SELECT COUNT(*) FROM alarms
         WHERE hour = :hour
           AND minute = :minute
           AND (:excludeId IS NULL OR id != :excludeId)
+          AND (ownerUserId IS NULL OR ownerUserId = :callerUserId)
         """,
     )
-    suspend fun countAtTime(hour: Int, minute: Int, excludeId: String? = null): Int
+    suspend fun countAtTime(hour: Int, minute: Int, callerUserId: String?, excludeId: String? = null): Int
 
     /** 같은 시각(HH:mm)의 기존 알람 1건. 중복 시각 교체 흐름에서 충돌 대상을 찾는 데 쓴다. */
     @Query(
@@ -105,10 +114,11 @@ interface AlarmDao {
         WHERE hour = :hour
           AND minute = :minute
           AND (:excludeId IS NULL OR id != :excludeId)
+          AND (ownerUserId IS NULL OR ownerUserId = :callerUserId)
         LIMIT 1
         """,
     )
-    suspend fun findAtTime(hour: Int, minute: Int, excludeId: String? = null): AlarmEntity?
+    suspend fun findAtTime(hour: Int, minute: Int, callerUserId: String?, excludeId: String? = null): AlarmEntity?
 
     @Query("SELECT COUNT(*) FROM alarms WHERE audioCacheKey = :cacheKey")
     suspend fun countByAudioCacheKey(cacheKey: String): Int

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -646,6 +646,10 @@ class AlarmRepository(
      */
     suspend fun lockPaidAlarmTalks(): Int {
         val currentUser = currentUserIdProvider() ?: return 0
+        // 미기록 행에 소유자를 '영구히' 새기는 경로다. 새기기 전에 임자를 먼저 확정하지 않으면
+        // 앞 계정 A 의 미기록 알람이 B 것으로 박히고, 뒤늦은 확정(claimUnownedAlarms 는 null 만
+        // 대상)이 더는 손댈 수 없어 A 는 그 알람을 영영 잃는다. reschedulePendingAlarms 와 같은 규칙.
+        val ownershipSettled = settlePendingAlarmOwnership()
         val now = System.currentTimeMillis()
         var lockedCount = 0
         alarmDao.getAllAlarms().forEach { alarm ->
@@ -655,12 +659,12 @@ class AlarmRepository(
                 !alarm.voiceProfileId.isNullOrBlank() ||
                 !alarm.ttsMessageId.isNullOrBlank()
             if (!usesVoice || alarm.usesFreeSystemVoiceAlarm()) return@forEach
-            // 다른 계정이 소유한(ownerUserId 불일치) 알람은 건드리지 않는다. 소유자 미기록(레거시 null)
-            // 음성 알람은 현재 활성 계정으로 소유권을 backfill 한다 — 잠금 시점에 소유자를 확정해,
+            // 다른 계정이 소유한(ownerUserId 불일치) 알람은 건드리지 않는다. 임자가 확정된 미기록
+            // (레거시 null) 음성 알람은 현재 활성 계정으로 소유권을 backfill 한다 — 잠금 시점에 소유자를 확정해,
             // 복원은 엄격히 ownerUserId 일치만 보고도 (1) 본인이 재유료 시 복원 가능(영구잠금 방지),
             // (2) 같은 기기의 다른 계정이 남의 잠긴 알람을 복원·스케줄하지 못하게 한다. 이미 잠긴
             // 레거시 행(구버전에서 소유자 없이 잠김)도 여기서 소유권만 backfill 해 복원 가능하게 만든다.
-            if (alarm.ownerUserId != null && alarm.ownerUserId != currentUser) return@forEach
+            if (!ownedByCurrentSession(alarm, currentUser, ownershipSettled)) return@forEach
             val needsLock = alarm.preLockPlayMode == null
             val needsClaim = alarm.ownerUserId == null
             if (!needsLock && !needsClaim) return@forEach
@@ -1157,7 +1161,15 @@ class AlarmRepository(
     }
 
     private suspend fun requireUniqueTime(hour: Int, minute: Int, excludeAlarmId: String? = null) {
-        require(alarmDao.countAtTime(hour, minute, excludeAlarmId) == 0) {
+        // 충돌 판정 대상은 '이 계정에 보이는 알람'이어야 한다 — 안 보이는 앞 계정 알람으로
+        // 시각을 막으면 사용자가 풀 방법이 없다(AlarmDao.countAtTime 주석 참고).
+        val conflicts = alarmDao.countAtTime(
+            hour = hour,
+            minute = minute,
+            callerUserId = currentUserIdProvider(),
+            excludeId = excludeAlarmId,
+        )
+        require(conflicts == 0) {
             context.getString(R.string.rd_duplicate_alarm_time_message)
         }
     }
@@ -1177,7 +1189,14 @@ class AlarmRepository(
         excludeAlarmId: String?,
         replaceExisting: Boolean,
     ): AlarmEntity? {
-        val existing = alarmDao.findAtTime(hour, minute, excludeAlarmId) ?: return null
+        // 교체 대상도 '이 계정에 보이는 알람'만이다. 앞 계정 알람을 고르면 사용자가 본 적도
+        // 없는 알람과 그 음성 캐시를 지우게 되는데, 내 알람은 서버에서 되받는 경로가 없다.
+        val existing = alarmDao.findAtTime(
+            hour = hour,
+            minute = minute,
+            callerUserId = currentUserIdProvider(),
+            excludeId = excludeAlarmId,
+        ) ?: return null
         if (!replaceExisting) {
             throw DuplicateAlarmTimeException(
                 existingAlarmId = existing.id,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmRepository.kt
@@ -502,6 +502,23 @@ class AlarmRepository(
     }
 
     /**
+     * 이 행을 '지금 계정 것'으로 다뤄도 되는가 — 파괴적/외부로 나가는 작업의 공통 게이트.
+     *
+     * 소유자 미기록(레거시 null)은 [observeAlarms]·[reschedulePendingAlarms]·lockPaidAlarmTalks 와
+     * 같은 규칙으로 현재 계정 것으로 본다. 단 [settlePendingAlarmOwnership] 이 실패한 회차에는
+     * 그 null 이 앞 계정 것일 수 있으므로 제외한다 — 표시가 남아 다음 기회에 다시 판정된다.
+     */
+    private fun ownedByCurrentSession(
+        alarm: AlarmEntity,
+        currentUserId: String,
+        ownershipSettled: Boolean,
+    ): Boolean = when (alarm.ownerUserId) {
+        null -> ownershipSettled
+        currentUserId -> true
+        else -> false
+    }
+
+    /**
      * 지금 로그인한 계정의 것이 아닌 알람의 OS 예약을 내린다.
      *
      * 자동 401(토큰 만료)은 알람을 그대로 두므로, 그 상태에서 다른 계정으로 로그인하면
@@ -529,6 +546,7 @@ class AlarmRepository(
      * 음성 알람을 sound-only 로 강등한다. [accessibleVoiceIds] 는 방금 '신선하게' 로드한 내 프로필 +
      * 가족 공유 프로필 id 집합이어야 한다 — 부분/실패 로드로 호출하면 정상 알람을 오강등할 수 있으므로
      * 호출부(refreshSocial 신선 성공)에서 가드한다. 버킷 회전·녹음(LOCAL_AUDIO)·수신 알람은 대상이 아니다.
+     * 대상은 **지금 계정 소유** 알람으로 한정된다(같은 기기에 남아 있는 앞 계정 알람은 건드리지 않는다).
      * 반환값은 강등된 알람 수.
      */
     suspend fun degradeAlarmsWithInaccessibleVoice(accessibleVoiceIds: Set<String>): Int =
@@ -548,9 +566,26 @@ class AlarmRepository(
         }
 
     private suspend fun degradeMatchingLocalOwnedVoiceAlarms(match: (AlarmEntity) -> Boolean): Int {
+        // 강등은 되돌릴 수 없다 — 목소리 참조를 지우고 캐시 오디오까지 정리한다. 그래서 '지금 계정
+        // 것'이라고 확신할 수 있는 행만 건드린다.
+        //
+        // 로컬 알람은 로그아웃해도 남으므로(원본이 기기다), 앞 계정 A 의 알람이 Room 에 그대로
+        // 있는 채로 계정 B 가 로그인한다. B 의 접근 가능 목소리 목록에 A 의 프로필이 없는 건
+        // 당연한데, 소유자를 안 보면 B 가 도는 refreshSocial·주기 워커가 그걸 '접근권 상실'로
+        // 읽어 A 의 알람에서 목소리를 영구히 벗긴다. VoiceAccessSyncWorker 의 토큰 재확인은
+        // 요청 중의 계정 전환만 잡지, 이미 앞 계정 것인 행은 못 지킨다(Codex #646 P1).
+        val ownershipSettled = settlePendingAlarmOwnership()
+        val currentUser = currentUserIdProvider()?.takeIf { it.isNotBlank() }
+        if (currentUser == null) {
+            // 비로그인 상태에서는 [accessibleVoiceIds] 가 누구의 목록인지 알 수 없다. 호출부가
+            // 모두 세션 안에서 도므로 정상 경로에서는 오지 않는 가지다.
+            Log.i(TAG, "Skipped voice degradation: no signed-in account")
+            return 0
+        }
         val candidates = alarmDao.getAllAlarms().filter { alarm ->
             alarm.origin == AlarmOrigins.LOCAL_OWNED &&
                 alarm.voiceSource == VoiceSources.TTS_PROFILE &&
+                ownedByCurrentSession(alarm, currentUser, ownershipSettled) &&
                 match(alarm)
         }
         var degraded = 0
@@ -937,8 +972,21 @@ class AlarmRepository(
         return scheduled
     }
 
-    suspend fun syncWithBackend(api: AlarmTalkApi, token: String): AlarmSyncResult =
-        alarmSyncService.syncWithBackend(api, token)
+    /**
+     * 아직 못 올린 내 알람을 서버에 올린다. **이 세션이 소유한 행만** 올린다 — 이유는
+     * [AlarmSyncService.syncWithBackend] 의 ownerUserId 설명 참고.
+     */
+    suspend fun syncWithBackend(api: AlarmTalkApi, token: String): AlarmSyncResult {
+        // 올리기 전에 임자 미정 행을 확정한다. 확정 전의 null 은 앞 계정 것일 수 있는데,
+        // 그걸 '내 것'으로 보고 올리면 이 계정 서버에 남의 알람이 생긴다.
+        val ownershipSettled = settlePendingAlarmOwnership()
+        return alarmSyncService.syncWithBackend(
+            api = api,
+            token = token,
+            ownerUserId = currentUserIdProvider()?.takeIf { it.isNotBlank() },
+            adoptOwnerlessAlarms = ownershipSettled,
+        )
+    }
 
     suspend fun pullReceivedAlarms(
         api: AlarmTalkApi,

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/AlarmSyncService.kt
@@ -18,20 +18,55 @@ data class AlarmSyncResult(
     val failed: Int,
 )
 
+/** 아직 서버에 반영되지 않은 상태들 — 이 상태의 행만 올릴 거리가 있다. */
+private val OUTBOUND_SYNC_STATES = setOf(
+    AlarmSyncStates.LOCAL_ONLY,
+    AlarmSyncStates.DIRTY,
+    AlarmSyncStates.FAILED,
+)
+
+/**
+ * 이 세션의 토큰으로 올려도 되는 행인가. 판정 규칙만 떼어 내 API 없이 검증한다.
+ * 인자 의미는 [AlarmSyncService.syncWithBackend] 참고.
+ */
+internal fun isOutboundSyncCandidate(
+    alarm: AlarmEntity,
+    ownerUserId: String?,
+    adoptOwnerlessAlarms: Boolean,
+): Boolean =
+    alarm.origin == AlarmOrigins.LOCAL_OWNED &&
+        alarm.syncState in OUTBOUND_SYNC_STATES &&
+        when (alarm.ownerUserId) {
+            // 소유자 미기록(레거시 null)은 임자 확정에 성공한 회차에만 내 것으로 본다.
+            null -> adoptOwnerlessAlarms
+            // 비로그인(ownerUserId == null)이면 이 가지에 걸리지 않아 남의 행은 그대로 제외된다.
+            ownerUserId -> true
+            else -> false
+        }
+
 internal class AlarmSyncService(
     private val alarmDao: AlarmDao,
 ) {
-    suspend fun syncWithBackend(api: AlarmTalkApi, token: String): AlarmSyncResult {
+    /**
+     * 아직 서버에 못 올린 '내 소유' 알람을 올린다.
+     *
+     * @param ownerUserId 이 세션의 계정. 로컬 알람은 로그아웃해도 Room 에 남으므로(원본이 기기다),
+     *   앞 계정 A 가 오프라인에서 만들거나 고친 행이 LOCAL_ONLY/DIRTY 인 채로 남는다. 소유자를 안
+     *   보면 다음 계정 B 가 알람 탭에 들어오는 순간 그 행이 **B 의 JWT** 로 올라가, B 계정에 A 의
+     *   알람이 생기거나 404 재생성 폴백이 A 의 remoteAlarmId 를 갈아치운다(Codex #646 P1).
+     *   다른 계정 소유 행은 DIRTY 인 채로 남겨 둔다 — 주인이 다시 로그인하면 그때 올라간다.
+     * @param adoptOwnerlessAlarms 소유자 미기록(레거시 null) 행을 이 세션 것으로 봐도 되는가.
+     *   AlarmRepository.settlePendingAlarmOwnership 이 성공한 회차에만 true 다.
+     */
+    suspend fun syncWithBackend(
+        api: AlarmTalkApi,
+        token: String,
+        ownerUserId: String?,
+        adoptOwnerlessAlarms: Boolean,
+    ): AlarmSyncResult {
         val authorization = AlarmTalkApiClient.bearer(token)
         val localAlarms = alarmDao.getAllAlarms()
-            .filter { alarm ->
-                alarm.origin == AlarmOrigins.LOCAL_OWNED &&
-                    alarm.syncState in setOf(
-                        AlarmSyncStates.LOCAL_ONLY,
-                        AlarmSyncStates.DIRTY,
-                        AlarmSyncStates.FAILED,
-                    )
-            }
+            .filter { alarm -> isOutboundSyncCandidate(alarm, ownerUserId, adoptOwnerlessAlarms) }
         var created = 0
         var updated = 0
         var failed = 0

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/data/RemoteAlarmPullSyncService.kt
@@ -34,6 +34,9 @@ internal class RemoteAlarmPullSyncService(
     // 직렬화로 레이스를 제거한다.
     private val pullMutex = kotlinx.coroutines.sync.Mutex()
 
+    private fun ownedByRecipient(alarm: AlarmEntity): Boolean =
+        isOwnedByRecipient(alarm, currentUserIdProvider())
+
     suspend fun pullReceivedAlarms(
         api: AlarmTalkApi,
         token: String,
@@ -115,6 +118,10 @@ internal class RemoteAlarmPullSyncService(
                 if (local.enabled) {
                     alarmDao.getEnabledAtTime(local.hour, local.minute, excludeId = local.id)
                         .filter { it.remoteAlarmId != remote.id }
+                        // 끄는 대상은 '이 수신자의' 알람만이다. 같은 기기에 남은 앞 계정 알람을
+                        // 끄면 그 계정은 영영 모른 채 알람이 안 울린다 — 재예약은 enabled=1 만
+                        // 훑으므로(getEnabledAlarms) 다시 로그인해도 되살아나지 않는다.
+                        .filter { ownedByRecipient(it) }
                         .forEach { conflicting ->
                             alarmScheduler.cancel(conflicting.id)
                             alarmDao.upsert(
@@ -171,6 +178,10 @@ internal class RemoteAlarmPullSyncService(
             alarmDao.getAllAlarms()
                 .filter {
                     it.origin == AlarmOrigins.RECEIVED_REMOTE &&
+                        // 서버 알람의 수신자는 한 명이라, 앞 계정이 받은 알람은 이 스냅샷에
+                        // 없는 게 당연하다. 소유자를 안 보면 B 의 첫 완전 pull 이 A 가 받은
+                        // 알람과 그 음성 캐시를 통째로 지운다.
+                        ownedByRecipient(it) &&
                         !it.remoteAlarmId.isNullOrBlank() &&
                         it.remoteAlarmId !in servedRemoteIds
                 }
@@ -318,6 +329,20 @@ internal class RemoteAlarmPullSyncService(
  */
 internal fun resolveReceivedOwner(existing: AlarmEntity?, currentUserId: String?): String? =
     existing?.ownerUserId ?: currentUserId
+
+/**
+ * 이 pull 이 건드려도 되는 행인가 — 지금 수신자 소유이거나 소유자 미기록(레거시)일 때만.
+ *
+ * pull 은 이 세션이 서버에서 받은 목록만 보고 로컬을 정리한다. 그런데 로컬 알람은 로그아웃해도
+ * 남으므로(원본이 기기다), 같은 기기에 앞 계정의 행이 함께 있다. 서버 알람의 수신자는 한 명이라
+ * 앞 계정이 받은 알람이 이 스냅샷에 없는 건 당연한데, 소유자를 안 보면 '서버에 없다 → 끄기/지우기'로
+ * 오판해 남의 알람을 죽인다. 특히 끄기는 치명적이다 — 재예약은 enabled=1 만 훑으므로(getEnabledAlarms)
+ * 주인이 다시 로그인해도 되살아나지 않는다. 판정 규칙은 AlarmRepository.observeAlarms 와 같다.
+ */
+internal fun isOwnedByRecipient(alarm: AlarmEntity, currentUserId: String?): Boolean {
+    val currentUser = currentUserId?.takeIf { it.isNotBlank() }
+    return alarm.ownerUserId == null || alarm.ownerUserId == currentUser
+}
 
 internal data class ReceivedLockState(val playMode: String, val preLockPlayMode: String?)
 

--- a/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
+++ b/apps/android-native/app/src/main/java/com/alarmtalk/app/sync/VoiceAccessSyncWorker.kt
@@ -56,9 +56,13 @@ class VoiceAccessSyncWorker(
                 withContext(Dispatchers.IO) { api.listFamilyVoiceProfiles(auth).profiles }
 
             // 네트워크 왕복 중 로그아웃/계정전환이 일어났을 수 있다. 쓰기 직전에 현재 세션이
-            // 아직 이 세션(같은 토큰)인지 재확인한다 — degradeAlarmsWithInaccessibleVoice 는
-            // 소유자 필터 없이 LOCAL_OWNED 전체를 훑으므로, 옛 계정의 목록을 그대로 적용하면
-            // 새 계정 알람의 목소리를 영구히 벗긴다. (PlanChangeSyncWorker 와 같은 가드.)
+            // 아직 이 세션(같은 토큰)인지 재확인한다 — 재확인이 없으면 방금 받은 '옛 계정의'
+            // 접근 가능 목록을 새 계정 기준으로 적용해, 새 계정 알람의 목소리를 영구히 벗긴다.
+            // (PlanChangeSyncWorker 와 같은 가드.)
+            //
+            // 반대 방향(같은 기기에 남아 있는 앞 계정 알람을 이 계정 목록으로 벗기는 것)은
+            // degradeAlarmsWithInaccessibleVoice 안의 소유자 게이트가 막는다 — 이 재확인은
+            // 요청 중의 계정 전환만 잡으므로 둘 다 필요하다(Codex #646 P1).
             val current = sessionStore.read()
             if (current == null || current.token != session.token) {
                 return@runCatching Result.success()

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmOwnerScopedOperationsTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmOwnerScopedOperationsTest.kt
@@ -1,0 +1,321 @@
+package com.alarmtalk.app.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.alarmtalk.app.alarm.AlarmScheduler
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * 같은 기기에 남아 있는 **앞 계정** 알람을, 지금 로그인한 계정 기준으로 건드리면 안 된다
+ * (Codex #646 P1 두 건).
+ *
+ * 로컬 알람은 로그아웃해도 지우지 않는다(원본이 기기다). 그래서 A 가 로그아웃하고 B 가
+ * 로그인해도 A 의 행이 Room 에 그대로 있고, 전체 테이블을 훑는 작업은 그걸 B 의 것으로
+ * 오인한다. 이 테스트는 두 경로를 막는다:
+ *
+ *  1. 목소리 강등 — B 의 접근 가능 목소리 목록에 A 의 프로필이 없는 건 당연한데, 그걸
+ *     '접근권 상실'로 읽으면 A 의 목소리·캐시가 **영구히** 지워진다(되돌릴 수 없다).
+ *  2. 아웃바운드 동기화 — A 가 오프라인에서 만든 LOCAL_ONLY 행을 B 의 JWT 로 올리면
+ *     B 계정에 A 의 알람이 생기거나 404 재생성이 A 의 remoteAlarmId 를 갈아치운다.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AlarmOwnerScopedOperationsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var db: AlarmDatabase
+    private lateinit var dao: AlarmDao
+    private var currentUser: String? = null
+
+    /** 아직 소유자를 못 새긴 알람의 임자(실제로는 AuthSessionStore prefs). */
+    private var pendingOwner: String? = null
+
+    private val repository by lazy { repositoryWith(dao) }
+
+    private fun repositoryWith(alarmDao: AlarmDao) = AlarmRepository(
+        alarmDao = alarmDao,
+        holidayCalendarStore = HolidayCalendarStore(db.holidayDao()),
+        holidayCountryPreferenceStore = HolidayCountryPreferenceStore(context),
+        alarmScheduler = AlarmScheduler(context),
+        alarmAudioStore = AlarmAudioStore(context),
+        context = context,
+        currentUserIdProvider = { currentUser },
+        pendingOwnerUserIdProvider = { pendingOwner },
+        onOwnershipSettled = { pendingOwner = null },
+    )
+
+    /** claimUnownedAlarms 만 실패하는 DAO — 임자 확정 실패 경로 재현용. */
+    private class ClaimFailingDao(real: AlarmDao) : AlarmDao by real {
+        override suspend fun claimUnownedAlarms(userId: String): Int =
+            throw android.database.sqlite.SQLiteException("disk full")
+    }
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, AlarmDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.alarmDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private suspend fun seedVoiceAlarm(
+        id: String,
+        owner: String?,
+        voiceProfileId: String = "clone-a",
+        syncState: String = AlarmSyncStates.SYNCED,
+    ): AlarmEntity {
+        val alarm = voiceAlarm(id, owner, voiceProfileId, syncState)
+        dao.upsert(alarm)
+        return alarm
+    }
+
+    private fun voiceAlarm(
+        id: String,
+        owner: String?,
+        voiceProfileId: String? = "clone-a",
+        syncState: String = AlarmSyncStates.SYNCED,
+    ) = AlarmEntity(
+        id = id,
+        label = "voice alarm",
+        hour = 7,
+        minute = 30,
+        fireAtMillis = 1_000L,
+        repeatDaysMask = 0x7f,
+        holidayOff = false,
+        snoozeEnabled = true,
+        snoozeMinutes = 5,
+        snoozeRepeatLimit = SnoozeRepeatLimits.THREE,
+        snoozeCount = 0,
+        vibrationPattern = VibrationPatterns.DEFAULT,
+        playMode = AlarmPlayModes.ALARM_VOICE,
+        defaultAlarmSoundId = DefaultAlarmSounds.BUNDLED_DEFAULT,
+        localAudioUri = null,
+        audioCacheKey = null,
+        rawAudioUri = null,
+        voiceSource = if (voiceProfileId == null) VoiceSources.LOCAL_AUDIO else VoiceSources.TTS_PROFILE,
+        voiceProfileId = voiceProfileId,
+        voiceListenerTitle = null,
+        voiceText = "좋은 아침",
+        voiceCategory = null,
+        voiceLanguage = null,
+        voiceRandomPrompt = false,
+        voiceRandomContext = null,
+        voiceWeatherCountry = null,
+        voiceWeatherCity = null,
+        voiceFortuneGender = null,
+        voiceFortuneBirthDate = null,
+        voiceFortuneBirthTime = null,
+        dynamicVoicePreparedForFireAtMillis = null,
+        voiceRepeat = true,
+        voiceVolumePercent = 100,
+        ttsMessageId = null,
+        remoteAlarmId = null,
+        lastSyncedAtMillis = null,
+        syncState = syncState,
+        origin = AlarmOrigins.LOCAL_OWNED,
+        alarmVolumePercent = 100,
+        alarmSoundUri = null,
+        alarmSoundLabel = null,
+        enabled = true,
+        state = AlarmStates.SCHEDULED,
+        createdAtMillis = 1_000L,
+        updatedAtMillis = 1_000L,
+        ownerUserId = owner,
+    )
+
+    private suspend fun voiceOf(id: String): String? = dao.getById(id)?.voiceProfileId
+
+    // ---------------------------------------------------------------- 목소리 강등
+
+    @Test
+    fun degradationSkipsAlarmsOwnedByAnotherAccount() = runBlocking {
+        // A 가 로그아웃하고 B 가 로그인. A 의 알람은 Room 에 그대로 남는다.
+        seedVoiceAlarm(id = "a-1", owner = "user-a", voiceProfileId = "clone-a")
+        currentUser = "user-b"
+
+        // B 의 접근 가능 목록에는 당연히 clone-a 가 없다.
+        val degraded = repository.degradeAlarmsWithInaccessibleVoice(setOf("clone-b"))
+
+        assertEquals(0, degraded)
+        assertEquals("clone-a", voiceOf("a-1"))
+    }
+
+    @Test
+    fun degradationStillAppliesToTheActiveAccountsAlarms() = runBlocking {
+        seedVoiceAlarm(id = "a-1", owner = "user-a", voiceProfileId = "clone-a")
+        seedVoiceAlarm(id = "b-1", owner = "user-b", voiceProfileId = "clone-gone")
+        currentUser = "user-b"
+
+        val degraded = repository.degradeAlarmsWithInaccessibleVoice(setOf("clone-b"))
+
+        assertEquals("B 의 접근 불가 목소리만 강등된다", 1, degraded)
+        assertNull(voiceOf("b-1"))
+        assertEquals("A 의 알람은 그대로", "clone-a", voiceOf("a-1"))
+        // 강등 마커(목록 배지)도 남아야 한다.
+        assertEquals(AlarmPlayModes.ALARM_ONLY, dao.getById("b-1")?.playMode)
+        assertEquals(AlarmPlayModes.ALARM_VOICE, dao.getById("b-1")?.preLockPlayMode)
+    }
+
+    @Test
+    fun degradationAdoptsOwnerlessAlarmsWhenOwnershipIsSettled() = runBlocking {
+        // 소유자 미기록(레거시) 행은 다른 규칙(observeAlarms·reschedulePendingAlarms)과 같이
+        // 현재 계정 것으로 본다 — 임자 표시가 없다면 물려받을 앞 계정도 없다.
+        seedVoiceAlarm(id = "legacy-1", owner = null, voiceProfileId = "clone-gone")
+        currentUser = "user-b"
+        pendingOwner = null
+
+        assertEquals(1, repository.degradeAlarmsWithInaccessibleVoice(setOf("clone-b")))
+        assertNull(voiceOf("legacy-1"))
+    }
+
+    @Test
+    fun degradationSettlesPendingOwnershipBeforeJudging() = runBlocking {
+        // 401 로 A 의 세션만 끊겨 미기록 행이 남았고, 임자 표시는 A 다. B 가 로그인해 강등이
+        // 돌면 먼저 A 로 새기고, 그 뒤엔 A 소유라 건드리지 않아야 한다.
+        seedVoiceAlarm(id = "legacy-1", owner = null, voiceProfileId = "clone-a")
+        currentUser = "user-b"
+        pendingOwner = "user-a"
+
+        val degraded = repository.degradeAlarmsWithInaccessibleVoice(setOf("clone-b"))
+
+        assertEquals(0, degraded)
+        assertEquals("user-a", dao.getById("legacy-1")?.ownerUserId)
+        assertEquals("clone-a", voiceOf("legacy-1"))
+        assertNull("정리가 끝났으니 표시는 지워진다", pendingOwner)
+    }
+
+    @Test
+    fun degradationSkipsOwnerlessAlarmsWhenSettlementFails() = runBlocking {
+        // 임자 확정이 실패하면 그 null 이 누구 것인지 모른다 — 되돌릴 수 없는 강등은 미룬다.
+        seedVoiceAlarm(id = "legacy-1", owner = null, voiceProfileId = "clone-a")
+        currentUser = "user-b"
+        pendingOwner = "user-a"
+
+        val degraded = repositoryWith(ClaimFailingDao(dao))
+            .degradeAlarmsWithInaccessibleVoice(setOf("clone-b"))
+
+        assertEquals(0, degraded)
+        assertEquals("clone-a", voiceOf("legacy-1"))
+        assertNull("소유자는 아직 미기록", dao.getById("legacy-1")?.ownerUserId)
+        assertEquals("표시가 남아 다음 기회에 다시 시도한다", "user-a", pendingOwner)
+    }
+
+    @Test
+    fun degradationDoesNothingWithoutASignedInAccount() = runBlocking {
+        seedVoiceAlarm(id = "a-1", owner = "user-a", voiceProfileId = "clone-a")
+        currentUser = null
+
+        assertEquals(0, repository.degradeAlarmsWithInaccessibleVoice(setOf("clone-b")))
+        assertEquals("clone-a", voiceOf("a-1"))
+    }
+
+    @Test
+    fun deletingAVoiceOnlyDegradesTheActiveAccountsAlarms() = runBlocking {
+        // 같은 목소리 id 를 쓰는 앞 계정 알람이 남아 있어도, 삭제한 계정의 알람만 강등한다.
+        seedVoiceAlarm(id = "a-1", owner = "user-a", voiceProfileId = "clone-x")
+        seedVoiceAlarm(id = "b-1", owner = "user-b", voiceProfileId = "clone-x")
+        currentUser = "user-b"
+
+        assertEquals(1, repository.degradeAlarmsUsingVoiceProfile("clone-x"))
+
+        assertNull(voiceOf("b-1"))
+        assertEquals("clone-x", voiceOf("a-1"))
+    }
+
+    @Test
+    fun systemVoiceAlarmsAreNeverDegraded() = runBlocking {
+        // 회귀 방지: 소유자 게이트를 넣으면서 시스템(스톡) 보이스 보존 규칙이 깨지면 안 된다.
+        val systemVoiceId = SYSTEM_VOICE_ID_PREFIX + "000000000001"
+        seedVoiceAlarm(id = "b-1", owner = "user-b", voiceProfileId = systemVoiceId)
+        currentUser = "user-b"
+
+        assertEquals(0, repository.degradeAlarmsWithInaccessibleVoice(emptySet()))
+        assertEquals(systemVoiceId, voiceOf("b-1"))
+    }
+
+    // ------------------------------------------------------------ 아웃바운드 동기화
+
+    @Test
+    fun outboundSyncSkipsRowsOwnedByAnotherAccount() {
+        val a = voiceAlarm("a-1", owner = "user-a", syncState = AlarmSyncStates.LOCAL_ONLY)
+
+        assertFalse(
+            isOutboundSyncCandidate(a, ownerUserId = "user-b", adoptOwnerlessAlarms = true),
+        )
+    }
+
+    @Test
+    fun outboundSyncSendsTheActiveAccountsDirtyRows() {
+        val mine = voiceAlarm("b-1", owner = "user-b", syncState = AlarmSyncStates.DIRTY)
+
+        assertTrue(
+            isOutboundSyncCandidate(mine, ownerUserId = "user-b", adoptOwnerlessAlarms = false),
+        )
+    }
+
+    @Test
+    fun outboundSyncAdoptsOwnerlessRowsOnlyWhenOwnershipIsSettled() {
+        val legacy = voiceAlarm("legacy-1", owner = null, syncState = AlarmSyncStates.FAILED)
+
+        assertTrue(
+            isOutboundSyncCandidate(legacy, ownerUserId = "user-b", adoptOwnerlessAlarms = true),
+        )
+        assertFalse(
+            "임자 미정인 행을 이 계정 서버에 올리면 안 된다",
+            isOutboundSyncCandidate(legacy, ownerUserId = "user-b", adoptOwnerlessAlarms = false),
+        )
+    }
+
+    @Test
+    fun outboundSyncWithoutASessionOnlyConsidersOwnerlessRows() {
+        val owned = voiceAlarm("a-1", owner = "user-a", syncState = AlarmSyncStates.LOCAL_ONLY)
+        val legacy = voiceAlarm("legacy-1", owner = null, syncState = AlarmSyncStates.LOCAL_ONLY)
+
+        assertFalse(isOutboundSyncCandidate(owned, ownerUserId = null, adoptOwnerlessAlarms = true))
+        assertTrue(isOutboundSyncCandidate(legacy, ownerUserId = null, adoptOwnerlessAlarms = true))
+    }
+
+    @Test
+    fun outboundSyncStillIgnoresSyncedAndReceivedRows() {
+        // 회귀 방지: 소유자 게이트를 넣으면서 원래 조건(미반영 상태 · 내 소유 origin)이 느슨해지면 안 된다.
+        val synced = voiceAlarm("b-1", owner = "user-b", syncState = AlarmSyncStates.SYNCED)
+        val received = voiceAlarm("r-1", owner = "user-b", syncState = AlarmSyncStates.DIRTY)
+            .copy(origin = AlarmOrigins.RECEIVED_REMOTE)
+
+        assertFalse(isOutboundSyncCandidate(synced, "user-b", adoptOwnerlessAlarms = true))
+        assertFalse(isOutboundSyncCandidate(received, "user-b", adoptOwnerlessAlarms = true))
+    }
+
+    @Test
+    fun ownerlessRowsStayPendingInsteadOfBeingClaimedByTheSyncPath() = runBlocking {
+        // syncWithBackend 는 올리기 전에 임자를 확정한다. 확정에 성공하면 그 행은 주인 것이 되고,
+        // 이번 세션의 후보에서 빠진다(위 isOutboundSyncCandidate 판정과 이어지는 부분).
+        seedVoiceAlarm(id = "legacy-1", owner = null, syncState = AlarmSyncStates.LOCAL_ONLY)
+        currentUser = "user-b"
+        pendingOwner = "user-a"
+
+        assertTrue(repository.settlePendingAlarmOwnership())
+
+        assertEquals("user-a", dao.getById("legacy-1")?.ownerUserId)
+        assertNotNull(dao.getById("legacy-1"))
+        assertFalse(
+            isOutboundSyncCandidate(dao.getById("legacy-1")!!, "user-b", adoptOwnerlessAlarms = true),
+        )
+    }
+}

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmOwnerScopedOperationsTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/AlarmOwnerScopedOperationsTest.kt
@@ -302,6 +302,70 @@ class AlarmOwnerScopedOperationsTest {
         assertFalse(isOutboundSyncCandidate(received, "user-b", adoptOwnerlessAlarms = true))
     }
 
+    // ------------------------------------------------- 같은 시각(HH:mm) 충돌 판정
+
+    @Test
+    fun anotherAccountsAlarmDoesNotBlockThisAccountsTimeSlot() = runBlocking {
+        // A 의 07:30 알람은 B 에게 보이지 않는다(observeAlarms). 그런데 충돌 판정이 그걸
+        // 세면 B 는 07:30 을 쓸 수 없고, 목록에 없으니 지울 수도 없다.
+        seedVoiceAlarm(id = "a-1", owner = "user-a")
+        currentUser = "user-b"
+
+        assertEquals(0, dao.countAtTime(hour = 7, minute = 30, callerUserId = "user-b"))
+        assertNull(dao.findAtTime(hour = 7, minute = 30, callerUserId = "user-b"))
+    }
+
+    @Test
+    fun sameAccountAndLegacyAlarmsStillBlockTheTimeSlot() = runBlocking {
+        // 회귀 방지: "한 시각에 알람 하나" 정책 자체는 그대로여야 한다.
+        seedVoiceAlarm(id = "b-1", owner = "user-b")
+        dao.upsert(voiceAlarm(id = "legacy-1", owner = null).copy(hour = 8))
+
+        assertEquals(1, dao.countAtTime(hour = 7, minute = 30, callerUserId = "user-b"))
+        assertEquals("b-1", dao.findAtTime(hour = 7, minute = 30, callerUserId = "user-b")?.id)
+        // 소유자 미기록(레거시) 행도 현재 계정 것으로 본다 — 목록 노출 규칙과 같다.
+        assertEquals(1, dao.countAtTime(hour = 8, minute = 30, callerUserId = "user-b"))
+        assertEquals("legacy-1", dao.findAtTime(hour = 8, minute = 30, callerUserId = "user-b")?.id)
+    }
+
+    @Test
+    fun excludingTheEditedAlarmStillWorksWithTheOwnerScope() = runBlocking {
+        // 편집 시 자기 자신은 충돌 대상에서 빠져야 한다(기존 동작).
+        seedVoiceAlarm(id = "b-1", owner = "user-b")
+
+        assertEquals(
+            0,
+            dao.countAtTime(hour = 7, minute = 30, callerUserId = "user-b", excludeId = "b-1"),
+        )
+    }
+
+    // -------------------------------------------- 무료 강등 잠금의 소유자 backfill
+
+    @Test
+    fun lockingDoesNotClaimAlarmsPendingForAnotherAccount() = runBlocking {
+        // 잠금은 미기록 행에 소유자를 '영구히' 새긴다. 임자가 A 인데 B 로 새겨 버리면
+        // 뒤늦은 확정(null 행만 대상)이 못 고쳐 A 가 알람을 영영 잃는다.
+        seedVoiceAlarm(id = "legacy-1", owner = null, voiceProfileId = "clone-a")
+        currentUser = "user-b"
+        pendingOwner = "user-a"
+
+        assertEquals(0, repository.lockPaidAlarmTalks())
+        assertEquals("user-a", dao.getById("legacy-1")?.ownerUserId)
+        assertNull(dao.getById("legacy-1")?.preLockPlayMode)
+    }
+
+    @Test
+    fun lockingStillClaimsGenuinelyOwnerlessAlarms() = runBlocking {
+        // 회귀 방지: 임자 표시가 없는 진짜 레거시 행은 예전대로 현재 계정으로 잠기고 새겨진다.
+        seedVoiceAlarm(id = "legacy-1", owner = null, voiceProfileId = "clone-a")
+        currentUser = "user-b"
+        pendingOwner = null
+
+        assertEquals(1, repository.lockPaidAlarmTalks())
+        assertEquals("user-b", dao.getById("legacy-1")?.ownerUserId)
+        assertEquals(AlarmPlayModes.ALARM_ONLY, dao.getById("legacy-1")?.playMode)
+    }
+
     @Test
     fun ownerlessRowsStayPendingInsteadOfBeingClaimedByTheSyncPath() = runBlocking {
         // syncWithBackend 는 올리기 전에 임자를 확정한다. 확정에 성공하면 그 행은 주인 것이 되고,

--- a/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
+++ b/apps/android-native/app/src/test/java/com/alarmtalk/app/data/RemoteAlarmPullSyncServiceTest.kt
@@ -69,6 +69,32 @@ class RemoteAlarmPullSyncServiceTest {
     }
 
     @Test
+    fun pullNeverTouchesAnotherAccountsRetainedAlarms() {
+        // 로컬 알람은 로그아웃해도 남는다. 서버 알람의 수신자는 한 명이라 앞 계정(A)이 받은/만든
+        // 알람이 B 의 스냅샷에 없는 건 당연한데, 그걸 '서버에 없다'로 읽으면 pull 이 A 의 알람을
+        // 끄거나(같은 시각 양보) 지운다(stale prune). 끄기는 특히 치명적이다 — 재예약은 enabled=1
+        // 만 훑으므로 A 가 다시 로그인해도 알람이 영영 안 울린다.
+        val leftBehind = alarm(enabled = true, origin = AlarmOrigins.LOCAL_OWNED)
+            .copy(ownerUserId = "account-a")
+
+        assertFalse(isOwnedByRecipient(leftBehind, currentUserId = "account-b"))
+        assertFalse("비로그인 세션도 남의 행을 건드리면 안 된다", isOwnedByRecipient(leftBehind, currentUserId = null))
+    }
+
+    @Test
+    fun pullStillManagesThisRecipientsOwnAndLegacyAlarms() {
+        // 회귀 방지: 같은 시각 양보·stale prune 은 내 알람에 대해서는 예전대로 동작해야 한다.
+        val mine = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(ownerUserId = "account-b")
+        val legacy = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
+            .copy(ownerUserId = null)
+
+        assertTrue(isOwnedByRecipient(mine, currentUserId = "account-b"))
+        assertTrue(isOwnedByRecipient(legacy, currentUserId = "account-b"))
+        assertTrue("소유자 미기록은 비로그인에서도 현재 계정 것으로 본다", isOwnedByRecipient(legacy, currentUserId = null))
+    }
+
+    @Test
     fun unlockedReceivedAlarmKeepsRebuiltRemoteVoiceMode() {
         val existing = alarm(enabled = true, origin = AlarmOrigins.RECEIVED_REMOTE)
 


### PR DESCRIPTION
## 배경

`develop`(#646) 에 올라온 Codex P1 2건을 고치고, 같은 계열(전체 알람 테이블을 훑으면서 `ownerUserId` 를 안 보는 작업)을 전수 조사해 나온 4건을 함께 막는다.

전제: **로컬 알람은 로그아웃해도 지우지 않는다**(원본이 기기고, 내 알람을 서버에서 되받는 경로가 없다). 그래서 A 가 로그아웃하고 B 가 로그인해도 A 의 행이 Room 에 그대로 남는다.

## Codex 지적 2건 (커밋 1)

| 위치 | 증상 |
| --- | --- |
| `degradeMatchingLocalOwnedVoiceAlarms` | B 의 접근 가능 목소리 목록에 A 의 프로필이 없는 건 당연한데, 그걸 '접근권 상실'로 읽어 A 의 목소리·캐시 오디오를 **영구히** 지우고(복원 경로 없음) A 의 예약까지 다시 걸었다. `VoiceAccessSyncWorker` 의 토큰 재확인은 요청 *중* 계정 전환만 잡는다. |
| `AlarmSyncService.syncWithBackend` | A 가 오프라인에서 만든 `LOCAL_ONLY`/`DIRTY` 행이 B 의 JWT 로 올라가, B 계정에 A 의 알람이 생기거나 404 재생성 폴백이 A 의 `remoteAlarmId` 를 갈아치웠다. |

둘 다 `reschedulePendingAlarms` 와 같은 규칙으로 막는다 — 임자 미정 행을 먼저 확정하고, 소유자 미기록(레거시 null)은 확정에 성공한 회차에만 내 것으로 본다. 다른 계정 소유 행은 상태를 안 건드리고 조용히 건너뛰어, 주인이 다시 로그인하면 그때 처리되게 한다.

## 형제 4건 (커밋 2)

1. **같은 시각(HH:mm) 충돌 판정** (`countAtTime`·`findAtTime`) — B 에게 보이지도 않는 A 의 07:00 알람이 07:00 을 막는다. 목록에 없으니 풀 방법이 없고, 교체 흐름으로 넘어가면 `deleteAlarm` 이 A 의 행과 음성 캐시를 영구 삭제한다. 판정 대상을 노출 규칙(`observeAlarms`)과 같게 맞춘다.
2. **받은 알람 pull 의 같은 시각 양보** — B 가 받은 가족 알람과 시각이 겹치면 A 의 알람을 `enabled=0` 으로 끈다. 재예약은 `enabled=1` 만 훑으므로 A 가 다시 로그인해도 **되살아나지 않는다**. 알람 앱에서 가장 나쁜 실패라 P1 로 본다.
3. **받은 알람 stale prune** — 서버 알람의 수신자는 한 명이라 A 가 받은 알람은 B 의 스냅샷에 없는 게 당연한데, '서버가 안 준다'로 읽어 A 의 받은 알람과 음성 캐시를 통째로 지운다.
4. **무료 강등 잠금**(`lockPaidAlarmTalks`) — 미기록 행에 소유자를 영구히 새기면서 임자를 먼저 확정하지 않았다. 임자가 A 인데 B 로 박히면 뒤늦은 확정(null 행만 대상)이 못 고친다.

커밋을 분리해 뒀으니, 형제 4건은 되돌리기 쉽다.

## 검증

- `:app:assembleDevDebug :app:testDevDebugUnitTest` (CI 와 동일 명령) 로컬 통과 — **156 tests, 0 failures**.
- 신규 테스트 21개: `AlarmOwnerScopedOperationsTest`(19) + `RemoteAlarmPullSyncServiceTest`(+2).
- 이빨 확인: 각 가드를 임시로 무력화해 해당 테스트가 실제로 깨지는 것을 확인했다(강등 5건, 시각충돌 1건, pull 1건, 잠금 1건).
- 실기기 검증은 아직. `voice_access_revoked` 푸시·주기 워커 경로는 폰 연결 후 확인이 필요하다.