### PR TITLE
docs(qa): 계정 전환 소유권 스코프 실기기 검증 결과 기록

### DIFF
--- a/docs/qa/dev-test-handoff.md
+++ b/docs/qa/dev-test-handoff.md
@@ -29,8 +29,17 @@ B 로 같은 06:00 알람 생성 → A 로 복귀 → A32(rel dev)에서 A 에�
 앞 32,768바이트만 DB 본체), 결국 `.db` 만 꺼낸 것과 똑같은 '마지막 체크포인트 시점' 스냅샷이 된다.
 열리기는 하니 잘못된 줄 모르고 지나가기 쉽다.
 
+그리고 **꺼내기 전에 앱을 멈춰야 한다.** 세 파일을 한 줄씩 복사하는 동안 앱이 살아 있으면, `.db` 를
+복사한 뒤 `-wal` 을 복사하기 전에 Room 이 체크포인트·WAL 리셋을 할 수 있다. 그러면 서로 다른 시점의
+파일 셋이 만들어져 최근 알람이 통째로 빠지거나 `no such table` 이 난다 — 게다가 **그때도 에러가 안 나서**
+잘못된 줄 모른다. force-stop 이 프로세스를 정리하며 WAL 을 접어 주므로, 그 뒤로는 파일 셋이 얼어 있다.
+
+관찰하려던 동작이 **끝난 뒤에** 멈춰야 한다(force-stop 자체는 알람 예약을 지우지 않는다 —
+AlarmManager 예약과 Room 행은 그대로다).
+
 ```powershell
 $dst = '<받을 폴더>'
+adb -s <serial> shell am force-stop com.alarmtalk.app.dev   # ← 반드시 먼저
 foreach ($f in 'voice-alarm.db','voice-alarm.db-wal','voice-alarm.db-shm') {
   adb -s <serial> shell "run-as com.alarmtalk.app.dev cat /data/data/com.alarmtalk.app.dev/databases/$f > /data/local/tmp/$f"
   adb -s <serial> pull "/data/local/tmp/$f" "$dst\$f"

--- a/docs/qa/dev-test-handoff.md
+++ b/docs/qa/dev-test-handoff.md
@@ -19,8 +19,28 @@ B 로 같은 06:00 알람 생성 → A 로 복귀 → A32(rel dev)에서 A 에�
 | 가족알람 같은 시각 양보 스코프 | `Disabled same-time alarm id=f0dd66ab…`(=A 본인 행, 의도된 양보)만 발생. **B 소유 행은 `enabled=1` 유지** — 예전엔 여기서 꺼져 B 가 재로그인해도 영영 안 울렸다 |
 | 로그인/로그아웃 정리 | `Cancelled 1 alarm reservations owned by another account`, `Rescheduled 1 alarms after sign-in` 정상 |
 
-검증법 메모: Room DB 는 **WAL 까지 같이** 꺼내야 한다(`voice-alarm.db` 만 pull 하면 테이블이 비어 보임).
-`run-as ... cat databases/voice-alarm.db{,-wal,-shm} > /data/local/tmp/...` 3개 pull 후 python sqlite3.
+검증법 메모: Room DB 는 **WAL 까지 같이**, 그리고 **파일별로 따로** 꺼내야 한다. 아직 체크포인트되지
+않은 변경은 전부 `-wal` 에 있어서, `voice-alarm.db` 만 pull 하면 방금 만든 알람이 안 보인다(이 세션에서
+실제로 한 번 걸렸다 — 행 0개로 보였다). sqlite 는 세 파일이 **같은 폴더에 같은 이름으로 나란히** 있어야
+`-wal` 을 반영한다.
+
+주의: `cat ...voice-alarm.db{,-wal,-shm} > 한파일` 로 묶으면 **에러 없이 조용히 틀린다**. 합친 파일은
+헤더의 페이지 수만큼만 읽히고 뒤에 붙은 `-wal`·`-shm` 바이트는 통째로 무시돼(실측: 481,688바이트 중
+앞 32,768바이트만 DB 본체), 결국 `.db` 만 꺼낸 것과 똑같은 '마지막 체크포인트 시점' 스냅샷이 된다.
+열리기는 하니 잘못된 줄 모르고 지나가기 쉽다.
+
+```powershell
+$dst = '<받을 폴더>'
+foreach ($f in 'voice-alarm.db','voice-alarm.db-wal','voice-alarm.db-shm') {
+  adb -s <serial> shell "run-as com.alarmtalk.app.dev cat /data/data/com.alarmtalk.app.dev/databases/$f > /data/local/tmp/$f"
+  adb -s <serial> pull "/data/local/tmp/$f" "$dst\$f"
+}
+```
+
+`>` 는 반드시 **바깥 adb 셸**이 처리하게 둔다(위 형태). `run-as ... sh -c '... > /data/local/tmp/...'`
+로 감싸면 앱 uid 로 쓰게 돼 `Permission denied` 다 — /data/local/tmp 는 shell uid 만 쓸 수 있다.
+
+그 뒤 `python -c "import sqlite3; ..."` 로 `$dst\voice-alarm.db` 를 열면 -wal 이 자동 반영된다.
 
 **prod 마이그레이션**: #646 머지 후 main 배포에서 **79→86 전부 적용 확인**(무음 스킵 없음).
 
@@ -58,7 +78,7 @@ develop 은 #549 머지로 마이그레이션 #65, cron `MAX_CLIPS_PER_TICK=6`.
 ### ③ 울림화면(RingingActivity) 실발사
 - [ ] 실제 알람 발사로 잠금화면 위에 뜨는지(문구 표시·노브 화살표 포함). `am start` 는 exported=false 라 차단 — 실발사 필요.
 - **규칙: 18시 이전엔 알람 울리게 하지 말 것.** 설정은 OK, 발사는 18시 이후.
-- 무음·무진동 발사법: A32 알람볼륨 0 + 진동패턴 OFF로 생성 → `adb shell am broadcast -a com.alarmtalk.app.action.ALARM_TRIGGER --es com.alarmtalk.app.extra.ALARM_ID <id> -n com.alarmtalk.app.dev/com.alarmtalk.app.alarm.AlarmReceiver`. 로컬 id는 `adb exec-out run-as ... cat databases/voice-alarm.db` 로 뽑아 python sqlite3.
+- 무음·무진동 발사법: A32 알람볼륨 0 + 진동패턴 OFF로 생성 → `adb shell am broadcast -a com.alarmtalk.app.action.ALARM_TRIGGER --es com.alarmtalk.app.extra.ALARM_ID <id> -n com.alarmtalk.app.dev/com.alarmtalk.app.alarm.AlarmReceiver`. 로컬 id는 §0-1 의 DB 추출 블록(`.db`·`-wal`·`-shm` 세 파일)으로 뽑아 python sqlite3 — `.db` 만 꺼내면 방금 만든 알람이 안 보인다.
 
 ### ④ #549 머지 후 — 등록 미리듣기
 - [ ] 미리듣기 문구가 관계·호칭에 톤 적응돼 생성되는지.

--- a/docs/qa/dev-test-handoff.md
+++ b/docs/qa/dev-test-handoff.md
@@ -34,8 +34,22 @@ B 로 같은 06:00 알람 생성 → A 로 복귀 → A32(rel dev)에서 A 에�
 파일 셋이 만들어져 최근 알람이 통째로 빠지거나 `no such table` 이 난다 — 게다가 **그때도 에러가 안 나서**
 잘못된 줄 모른다. force-stop 이 프로세스를 정리하며 WAL 을 접어 주므로, 그 뒤로는 파일 셋이 얼어 있다.
 
-관찰하려던 동작이 **끝난 뒤에** 멈춰야 한다(force-stop 자체는 알람 예약을 지우지 않는다 —
-AlarmManager 예약과 Room 행은 그대로다).
+⚠ **force-stop 은 OS 알람 예약을 지운다.** Room 행은 남지만 AlarmManager 예약(PendingIntent)이
+날아가, 그대로 두면 그 알람은 **안 울린다**. Android 15 부터는 문서화된 동작이고
+([stopped state](https://developer.android.com/about/versions/15/behavior-changes-all#stopped-state):
+"the system also cancels all pending intents when the app enters the stopped state"), 실측해 보면
+**Android 13 에서도 이미 그렇다**.
+
+그래서 순서가 중요하다:
+
+1. 관찰하려던 동작을 **끝내고** (그 결과가 Room 에 써진 뒤에)
+2. force-stop → DB 3파일 추출
+3. **앱을 다시 실행해 예약을 되살린다.** 시작 시 복원 경로가 알아서 다시 건다 —
+   로그에 `Boot restore complete pending=N scheduled=N` 이 뜨는지, 그리고
+   `adb shell dumpsys alarm` 의 `Next alarm clock information` 에 시각이 돌아왔는지 확인할 것.
+
+2026-07-29 A32(Android 13) 실측: 07:00 알람 켬 → `Next alarm clock … 07:00` → force-stop →
+**해당 줄이 빔** → 앱 재실행 → `Boot restore complete pending=1 scheduled=1` 과 함께 07:00 복귀.
 
 ```powershell
 $dst = '<받을 폴더>'
@@ -44,6 +58,7 @@ foreach ($f in 'voice-alarm.db','voice-alarm.db-wal','voice-alarm.db-shm') {
   adb -s <serial> shell "run-as com.alarmtalk.app.dev cat /data/data/com.alarmtalk.app.dev/databases/$f > /data/local/tmp/$f"
   adb -s <serial> pull "/data/local/tmp/$f" "$dst\$f"
 }
+adb -s <serial> shell monkey -p com.alarmtalk.app.dev -c android.intent.category.LAUNCHER 1  # ← 예약 복구
 ```
 
 `>` 는 반드시 **바깥 adb 셸**이 처리하게 둔다(위 형태). `run-as ... sh -c '... > /data/local/tmp/...'`

--- a/docs/qa/dev-test-handoff.md
+++ b/docs/qa/dev-test-handoff.md
@@ -1,6 +1,28 @@
-# Dev 테스트 핸드오프 (갱신 2026-07-21)
+# Dev 테스트 핸드오프 (갱신 2026-07-29)
 
 > 세션 재개용 라이브 문서. 상태가 바뀌면 이 파일을 갱신/정리한다. (다른 컴퓨터에서도 `git pull` 후 이 문서만 읽으면 이어서 진행 가능.)
+
+## 0-1. 2026-07-29 — 계정 전환 소유권 스코프(#655) 실기기 검증 완료
+
+#646/#650/#654 에서 이어진 "같은 기기에 앞 계정 알람이 남는다" 계열 결함 6건(Codex P1 2 + 형제 4)을
+#655 로 고치고, **S23 + A32 두 대로 계정 전환 시나리오를 실측**했다. 전부 통과.
+
+계정: **A = gyuwon05(김규원)**, **B = alpaka206(알파카)**, **가족 발신자 = devrel.365(rel dev)**.
+시나리오: A 로 06:00 클론목소리(고죠) 알람 생성(미업로드 `local_only`) → 로그아웃 → B 로그인 →
+B 로 같은 06:00 알람 생성 → A 로 복귀 → A32(rel dev)에서 A 에게 06:00 가족알람 발송.
+
+| 검증 항목 | 관측 결과 |
+|---|---|
+| 아웃바운드 동기화 소유자 스코프 | B 세션에서 `Backend alarm sync complete total=0` — A 의 `local_only` 행이 **B 의 JWT 로 안 올라감**. A 복귀 시 `total=1 created=1` 로 **A 계정에 정상 업로드**(유실 아님, 지연) |
+| 목소리 강등 소유자 스코프 | B 의 refreshSocial·주기 워커가 돌아도 A 행의 `voiceProfileId`·`playMode=alarm_voice`·캐시 mp3 **전부 무손상** |
+| 같은 시각 충돌 판정 스코프 | B 가 A 와 **같은 06:00 에 중복 경고 없이 저장** 성공(예전엔 안 보이는 A 알람이 시각을 막음) |
+| 가족알람 같은 시각 양보 스코프 | `Disabled same-time alarm id=f0dd66ab…`(=A 본인 행, 의도된 양보)만 발생. **B 소유 행은 `enabled=1` 유지** — 예전엔 여기서 꺼져 B 가 재로그인해도 영영 안 울렸다 |
+| 로그인/로그아웃 정리 | `Cancelled 1 alarm reservations owned by another account`, `Rescheduled 1 alarms after sign-in` 정상 |
+
+검증법 메모: Room DB 는 **WAL 까지 같이** 꺼내야 한다(`voice-alarm.db` 만 pull 하면 테이블이 비어 보임).
+`run-as ... cat databases/voice-alarm.db{,-wal,-shm} > /data/local/tmp/...` 3개 pull 후 python sqlite3.
+
+**prod 마이그레이션**: #646 머지 후 main 배포에서 **79→86 전부 적용 확인**(무음 스킵 없음).
 
 ## 0. 2026-07-21 — #599 목소리 슬롯 상한(F1/F2/F3) 머지 + 검증 완료
 


### PR DESCRIPTION
#655 로 고친 6건을 S23·A32 두 대로 실측한 결과를 dev-test-handoff 에 남긴다.

- 아웃바운드 동기화 / 목소리 강등 / 같은 시각 충돌 / 가족알람 같은 시각 양보 — 네 경로 모두 앞 계정 행을 안 건드리는 것을 로그·DB 로 확인.
- Room DB 를 pull 할 때 WAL 을 같이 안 가져오면 테이블이 비어 보이는 함정 메모.
- #646 머지 뒤 prod 마이그레이션 79~86 전부 적용된 것 확인.

문서만 바뀐다.