### PR TITLE
chore(android): versionCode 20 / versionName 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ android/
 
 # Native Android local/generated files
 apps/android-native/.gradle/
+# Kotlin 2.x 빌드 세션 스크래치(errors/, sessions/) — 빌드할 때마다 생겨 git status 를 더럽힌다.
+apps/android-native/.kotlin/
 apps/android-native/build/
 apps/android-native/**/build/
 apps/android-native/local.properties

--- a/apps/android-native/app/build.gradle.kts
+++ b/apps/android-native/app/build.gradle.kts
@@ -100,9 +100,9 @@ android {
         minSdk = 26
         targetSdk = 36
         // 릴리스마다 수동으로 versionCode +1, versionName 갱신. (Play 는 업로드마다 더 큰
-        // versionCode 를 요구 — 이전 업로드값보다 반드시 크게.) 1.1.3 = 18, 다음 릴리스는 19.
-        versionCode = 18
-        versionName = "1.1.3"
+        // versionCode 를 요구 — 이전 업로드값보다 반드시 크게.) 1.1.3 = 18, 1.2.0 = 20.
+        versionCode = 20
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
AAB 릴리스용 버전 상향. 계정 전환 소유권 스코프 정리(#650·#654·#655) + 목소리 탭 재편·해지 3일 보관(#646)이 함께 나가므로 마이너를 올린다.

- versionCode 18 → **20**, versionName 1.1.3 → **1.2.0**
- versionCode 19 는 건너뛴다 → **#648(19 / 1.1.4)은 이 PR 로 대체되므로 닫아 주세요.**
- `app-version.ts` 의 `latest`(현재 7)는 1.2.0 이 Play 에 **라이브된 뒤** 20 으로 올린다(권장 업데이트 배너 기준).