### PR TITLE
ci: PR 에서는 `ci` 라벨을 붙였을 때만 CI 를 돌린다

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,9 +13,11 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+# 그룹 설계 이유는 ci.yml 의 같은 블록 주석 참고 — 무관한 라벨이 진행 중인 ci 실행을 죽이는 것과,
+# 연속 푸시 때 가운데 커밋의 대기 실행이 밀려나는 것 둘 다 막는다.
 concurrency:
-  group: android-build-${{ github.ref }}
-  cancel-in-progress: true
+  group: android-build-${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.event.label.name) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.label.name == 'ci' }}
 
 jobs:
   android-build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,16 +1,16 @@
 name: Android Build
 
+# PR 에서는 `ci` 라벨을 붙였을 때만 돈다(ci.yml 과 같은 규칙 — 이유는 그쪽 주석 참고).
+# 작업 브랜치 푸시(feat/**·fix/** …) 트리거도 뺐다. PR 을 열기 전 단계에서 커밋마다 도는 게
+# 낭비였고, 필요하면 Actions 탭의 Run workflow 로 언제든 브랜치를 골라 돌릴 수 있다.
 on:
   push:
     branches:
       - develop
       - main
-      - "feat/**"
-      - "fix/**"
-      - "ci/**"
-      - "refactor/**"
   pull_request:
     branches: [develop, main]
+    types: [labeled]
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   android-build:
     name: AlarmTalk (Android devDebug)
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ name: CI
 # 돌리는 법: PR 에 `ci` 라벨 부착. 다시 돌리려면 뗐다가 다시 붙인다(또는 Actions 탭에서 Run workflow).
 # 라벨 뒤에 커밋을 더 올리면 체크는 옛 커밋에 남아 PR 이 머지 불가 상태가 된다 — 의도된 동작이니
 # 라벨을 다시 붙여 새 커밋으로 통과시킨다.
+#
+# ⚠ typecheck·test 의 매트릭스를 없애지 말 것.
+# GitHub 에는 `on:` 단계의 라벨 이름 필터가 없어서, 아무 라벨이나 붙으면 이 워크플로가 일단 뜨고
+# 잡은 아래 `if` 로 스킵된다. 그런데 **스킵된 필수 체크는 통과로 계산**되므로, 필수 체크 이름이
+# 그대로 보고되면 라벨 하나로 CI 없이 머지가 열린다. 지금 막히는 이유는 필수 8개가
+# `typecheck (packages/backend)` 처럼 매트릭스 전개 이름이라 스킵 시엔 `typecheck` 로만 보고돼
+# **이름이 안 맞아 미보고로 남기** 때문이다(2026-07-29 실측: 전부 SKIPPED 인데 mergeStateStatus=BLOCKED).
+# 매트릭스를 단일 잡으로 합치면 그 방어가 사라진다 — 합치려면 브랜치 보호의 필수 체크 목록을
+# 함께 손보거나, 라벨 대신 workflow_dispatch 로 바꿔야 한다.
 on:
   push:
     branches: [develop, main]
@@ -14,11 +23,19 @@ on:
     types: [labeled]
   workflow_dispatch:
 
-# 라벨을 연달아 붙였을 때 이전 실행만 정리한다. develop·main 푸시는 취소하지 않는다 —
-# 커밋별 실행 기록이 하나씩 남아야 "이 커밋에서 깨졌다"를 나중에 짚을 수 있다.
+# concurrency 는 잡의 `if` 보다 **먼저** 평가된다. 그래서 그룹을 ref 로만 잡으면, 라벨을 아무거나
+# (예: bug) 하나 더 붙이는 순간 그 이벤트가 같은 그룹에 들어와 **돌고 있던 진짜 ci 실행을 죽이고**
+# 자기 잡은 라벨 조건에 걸려 스킵된다 — 필수 체크가 사라진 채로 남는다(Codex #658).
+# 그래서 PR 그룹에 라벨 이름까지 넣어 `ci` 라벨끼리만 경쟁하게 한다.
+#
+# push·workflow_dispatch 는 실행마다 고유 그룹을 준다. 같은 그룹에 새 실행이 들어오면 취소를 끄더라도
+# **대기 중이던** 실행은 밀려나므로(3연속 푸시 시 가운데 커밋의 기록이 사라진다), 아예 경쟁을 없앤다.
+#
+# 표현식은 한 줄로 둔다. YAML 폴드 블록(`>-`)은 더 깊게 들여쓴 줄의 개행을 접지 않아
+# `${{ }}` 안에 줄바꿈이 남는다 — 굳이 시험할 이유가 없다.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.event.label.name) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.label.name == 'ci' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,20 @@ name: CI
 # 라벨 뒤에 커밋을 더 올리면 체크는 옛 커밋에 남아 PR 이 머지 불가 상태가 된다 — 의도된 동작이니
 # 라벨을 다시 붙여 새 커밋으로 통과시킨다.
 #
-# ⚠ typecheck·test 의 매트릭스를 없애지 말 것.
-# GitHub 에는 `on:` 단계의 라벨 이름 필터가 없어서, 아무 라벨이나 붙으면 이 워크플로가 일단 뜨고
-# 잡은 아래 `if` 로 스킵된다. 그런데 **스킵된 필수 체크는 통과로 계산**되므로, 필수 체크 이름이
-# 그대로 보고되면 라벨 하나로 CI 없이 머지가 열린다. 지금 막히는 이유는 필수 8개가
-# `typecheck (packages/backend)` 처럼 매트릭스 전개 이름이라 스킵 시엔 `typecheck` 로만 보고돼
-# **이름이 안 맞아 미보고로 남기** 때문이다(2026-07-29 실측: 전부 SKIPPED 인데 mergeStateStatus=BLOCKED).
-# 매트릭스를 단일 잡으로 합치면 그 방어가 사라진다 — 합치려면 브랜치 보호의 필수 체크 목록을
-# 함께 손보거나, 라벨 대신 workflow_dispatch 로 바꿔야 한다.
+# 왜 잡을 `if` 로 스킵하지 않고 첫 스텝에서 실패시키는가:
+# GitHub 에는 `on:` 단계의 라벨 이름 필터가 없다. 그래서 아무 라벨이나(bug·documentation·봇 라벨)
+# 붙는 순간 이 워크플로가 일단 뜬다. 그때 잡을 `if` 로 스킵하면 **스킵된 필수 체크는 '통과'로
+# 계산돼서**(GitHub 문서: "A job that is skipped will report its status as Success. It will not
+# prevent a pull request from merging, even if it is a required check") 라벨 하나로 CI 없이 머지가
+# 열리고, 이미 빨간 체크도 초록으로 덮인다.
+#
+# 그래서 `ci` 가 아닌 라벨로 뜬 실행은 각 잡의 첫 스텝에서 **실패**시킨다. 실패는 통과로 계산되지
+# 않으므로 머지가 정직하게 막힌다("이 커밋으로는 CI 를 안 돌렸다"는 뜻이라 의미도 맞다).
+# 라벨을 `ci` 로 다시 붙이면 정상 실행된다.
+#
+# (2026-07-29 실측: 스킵 방식일 때 잡은 전부 SKIPPED 인데 mergeStateStatus 는 BLOCKED 였다. 필수 8개가
+#  `typecheck (packages/backend)` 같은 매트릭스 전개 이름이라 스킵 시엔 `typecheck` 로만 보고돼 이름이
+#  안 맞았을 뿐이고, 이름이 그대로인 `lint` 는 실제로 초록이 됐다 — 매트릭스에 기댄 우연한 방어였다.)
 on:
   push:
     branches: [develop, main]
@@ -39,10 +45,15 @@ concurrency:
 
 jobs:
   lint:
-    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
+      # `ci` 가 아닌 라벨로 뜬 실행은 스킵이 아니라 **실패**시킨다(이유는 위 on: 주석).
+      - name: Require the `ci` label
+        if: github.event_name == 'pull_request' && github.event.label.name != 'ci'
+        run: |
+          echo "::error::'ci' 라벨이 아니라 CI 를 돌리지 않았다. 'ci' 라벨을 붙여 다시 돌릴 것."
+          exit 1
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
@@ -58,13 +69,18 @@ jobs:
         run: npm run lint
 
   typecheck:
-    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         package: [packages/backend, packages/shared, packages/ui, packages/voice]
     steps:
+      # `ci` 가 아닌 라벨로 뜬 실행은 스킵이 아니라 **실패**시킨다(이유는 위 on: 주석).
+      - name: Require the `ci` label
+        if: github.event_name == 'pull_request' && github.event.label.name != 'ci'
+        run: |
+          echo "::error::'ci' 라벨이 아니라 CI 를 돌리지 않았다. 'ci' 라벨을 붙여 다시 돌릴 것."
+          exit 1
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
@@ -81,8 +97,6 @@ jobs:
         run: npm run typecheck
 
   test:
-    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,6 +110,13 @@ jobs:
           - package: packages/voice
             command: npm test
     steps:
+      # `ci` 가 아닌 라벨로 뜬 실행은 스킵이 아니라 **실패**시킨다(이유는 위 on: 주석).
+      - name: Require the `ci` label
+        if: github.event_name == 'pull_request' && github.event.label.name != 'ci'
+        run: |
+          echo "::error::'ci' 라벨이 아니라 CI 를 돌리지 않았다. 'ci' 라벨을 붙여 다시 돌릴 것."
+          exit 1
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,29 @@
 name: CI
 
+# PR 에서는 **`ci` 라벨을 붙였을 때만** 돈다. 리뷰 지적을 고치며 푸시할 때마다 12개 잡이 통째로
+# 다시 도는 게 낭비라서, "이제 됐다" 시점을 사람이 정한다(보통 Codex 가 이슈 없다고 한 뒤).
+#
+# 돌리는 법: PR 에 `ci` 라벨 부착. 다시 돌리려면 뗐다가 다시 붙인다(또는 Actions 탭에서 Run workflow).
+# 라벨 뒤에 커밋을 더 올리면 체크는 옛 커밋에 남아 PR 이 머지 불가 상태가 된다 — 의도된 동작이니
+# 라벨을 다시 붙여 새 커밋으로 통과시킨다.
 on:
   push:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+    types: [labeled]
   workflow_dispatch:
+
+# 라벨을 연달아 붙였을 때 이전 실행만 정리한다. develop·main 푸시는 취소하지 않는다 —
+# 커밋별 실행 기록이 하나씩 남아야 "이 커밋에서 깨졌다"를 나중에 짚을 수 있다.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
+    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -26,6 +41,8 @@ jobs:
         run: npm run lint
 
   typecheck:
+    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,6 +64,8 @@ jobs:
         run: npm run typecheck
 
   test:
+    # 라벨 트리거일 때만 실행(위 on: 주석 참고). push·workflow_dispatch 는 그대로 돈다.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,21 @@
 name: "CodeQL"
 
+# PR 에서는 `ci` 라벨을 붙였을 때만 돈다(ci.yml 과 같은 규칙 — 이유는 그쪽 주석 참고).
+# 주간 스케줄과 develop·main 푸시 스캔은 그대로 두어, 라벨을 안 붙인 PR 이 있어도 보안 스캔
+# 자체가 끊기지는 않는다.
 on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [develop, main]
+    types: [labeled]
   schedule:
     - cron: '0 6 * * 1'
 
 jobs:
   analyze:
     name: Analyze
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:


### PR DESCRIPTION
리뷰 지적을 고치며 푸시할 때마다 **12개 잡**(lint + typecheck×4 + test×4 + Android + CodeQL)이 통째로 다시 돌았다. 리뷰-수정을 여러 번 반복하는 흐름에서는 마지막 한 번만 의미가 있으므로, "이제 됐다" 시점을 사람이 정하게 바꾼다.

## 쓰는 법

1. PR 을 연다 → **CI 가 안 돈다**(필수 체크 9개가 안 나타나 머지 불가 상태)
2. Codex 리뷰 받고 수정 푸시 반복 → **여전히 안 돈다**
3. 이슈 없다는 확인이 끝나면 PR 에 **`ci` 라벨 부착** → 12개 잡 1회 실행
4. 재실행이 필요하면 라벨을 뗐다 다시 붙인다 (또는 Actions 탭 → Run workflow)

라벨을 붙인 뒤 커밋을 더 올리면 체크가 옛 커밋에 남아 머지가 막힌다. **이건 의도된 동작**이다 — 검증 안 된 커밋이 머지되지 않게 하는 것이라, 라벨을 다시 붙여 새 커밋으로 통과시키면 된다.

## 바뀐 것

| 워크플로 | PR | develop·main 푸시 | 그 외 |
|---|---|---|---|
| CI | `ci` 라벨 시에만 | 그대로 | workflow_dispatch 유지 |
| Android Build | `ci` 라벨 시에만 | 그대로 | **작업 브랜치 푸시 트리거 제거**(feat/**·fix/** …) |
| CodeQL | `ci` 라벨 시에만 | 그대로 | 주간 스케줄 유지 |

- `ci.yml` 에 concurrency 추가 — 라벨을 연달아 붙였을 때 이전 실행만 정리한다. develop·main 푸시는 커밋별 실행 기록이 남아야 "이 커밋에서 깨졌다"를 짚을 수 있어 취소하지 않는다.
- 머지된 코드 검증(develop·main 푸시)과 보안 스캔(CodeQL 주간)은 끊지 않았다.

## 검증

- 세 워크플로 YAML 파싱 확인.
- `ci` 라벨을 레포에 생성해 뒀다.
- **이 PR 자체가 테스트다** — `pull_request` 이벤트는 머지 커밋의 워크플로를 쓰므로, 지금 이 PR 은 라벨을 붙이기 전까지 CI 가 돌지 않아야 한다.

## 참고

원래 요청은 "Actions 할당량 절약"이었는데, 확인해 보니 이 레포는 **PUBLIC + 표준 러너(ubuntu-latest)** 라 **Actions 분은 무제한 무료**다(분이 차감되는 건 비공개 레포이거나 large runner). 소진된 할당량은 다른 것일 가능성이 크다. 다만 푸시마다 12잡이 도는 건 실제 낭비가 맞아 그대로 진행했다.